### PR TITLE
Tweak: "find text" function when editing

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
@@ -53,6 +53,7 @@ import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 import org.wikipedia.views.PlainPasteEditText;
 import org.wikipedia.views.ViewAnimations;
+import org.wikipedia.views.ViewUtil;
 import org.wikipedia.views.WikiErrorView;
 import org.wikipedia.views.WikiTextKeyboardView;
 
@@ -534,6 +535,18 @@ public class EditSectionActivity extends BaseActivity {
         v.setEnabled(item.isEnabled());
         v.setOnClickListener((view) -> onOptionsItemSelected((MenuItem) view.getTag()));
         return true;
+    }
+
+    @Override
+    public void onActionModeStarted(ActionMode mode) {
+        super.onActionModeStarted(mode);
+        if (mode.getTag() == null) {
+            Menu menu = mode.getMenu();
+            menu.clear();
+            mode.getMenuInflater().inflate(R.menu.menu_text_select, menu);
+            // since we disabled the close button in the AndroidManifest.xml, we need to manually setup a close button when in an action mode if long pressed on texts.
+            ViewUtil.setCloseButtonInActionMode(EditSectionActivity.this, mode);
+        }
     }
 
     public void showError(@Nullable Throwable caught) {

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.java
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.java
@@ -36,6 +36,7 @@ public class SyntaxHighlighter {
     private EditText textBox;
     private List<SyntaxRule> syntaxRules;
     private String searchText;
+    private int selectedMatchResultPosition;
 
     private Handler handler;
     private CompositeDisposable disposables = new CompositeDisposable();
@@ -52,7 +53,7 @@ public class SyntaxHighlighter {
                     currentTask.cancel();
                 }
                 currentTask = new SyntaxHighlightTask(textBox.getText());
-                searchTask = new SyntaxHighlightSearchMatchesTask(textBox.getText(), searchText);
+                searchTask = new SyntaxHighlightSearchMatchesTask(textBox.getText(), searchText, selectedMatchResultPosition);
                 disposables.clear();
                 disposables.add(Observable.zip(Observable.fromCallable(currentTask),
                         Observable.fromCallable(searchTask), (f, s) -> {
@@ -172,6 +173,12 @@ public class SyntaxHighlighter {
     public void applyFindTextSyntax(@Nullable String searchText, @Nullable OnSyntaxHighlightListener listener) {
         this.searchText = searchText;
         this.syntaxHighlightListener = listener;
+        setSelectedMatchResultPosition(0);
+        postHighlightCallback();
+    }
+
+    public void setSelectedMatchResultPosition(int selectedMatchResultPosition) {
+        this.selectedMatchResultPosition = selectedMatchResultPosition;
         postHighlightCallback();
     }
 
@@ -301,12 +308,14 @@ public class SyntaxHighlighter {
     }
 
     private class SyntaxHighlightSearchMatchesTask implements Callable<List<SpanExtents>> {
-        SyntaxHighlightSearchMatchesTask(Editable text, String searchText) {
+        SyntaxHighlightSearchMatchesTask(Editable text, String searchText, int selectedMatchResultPosition) {
             this.text = StringUtils.lowerCase(text.toString());
             this.searchText = StringUtils.lowerCase(searchText);
+            this.selectedMatchResultPosition = selectedMatchResultPosition;
         }
 
         private String searchText;
+        private int selectedMatchResultPosition;
         private String text;
         private boolean cancelled;
 
@@ -323,14 +332,21 @@ public class SyntaxHighlighter {
 
             SyntaxRule syntaxItem = new SyntaxRule("", "", SyntaxRuleStyle.SEARCH_MATCHES);
             int position = 0;
+            int matches = 0;
             do {
                 position = text.indexOf(searchText, position);
                 if (position >= 0) {
-                    SpanExtents newSpanInfo = SyntaxRuleStyle.SEARCH_MATCHES.createSpan(context, position, syntaxItem);
+                    SpanExtents newSpanInfo;
+                    if (matches == selectedMatchResultPosition) {
+                        newSpanInfo = SyntaxRuleStyle.SEARCH_MATCH_SELECTED.createSpan(context, position, syntaxItem);
+                    } else {
+                        newSpanInfo = SyntaxRuleStyle.SEARCH_MATCHES.createSpan(context, position, syntaxItem);
+                    }
                     newSpanInfo.setStart(position);
                     newSpanInfo.setEnd(position + searchText.length());
                     spansToSet.add(newSpanInfo);
                     position += searchText.length();
+                    matches++;
                 }
                 if (cancelled) {
                     break;

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxRuleStyle.java
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxRuleStyle.java
@@ -59,10 +59,16 @@ public enum SyntaxRuleStyle {
         }
     },
     SEARCH_MATCHES {
-        @NonNull @Override public SpanExtents createSpan(@NonNull Context ctx, int spanStart,
-        SyntaxRule syntaxItem) {
-            @ColorInt int foreColor = getThemedColor(ctx, R.attr.primary_text_color);
-            @ColorInt int backColor = getThemedColor(ctx, R.attr.text_highlight_color_translucent);
+        @NonNull @Override public SpanExtents createSpan(@NonNull Context ctx, int spanStart, SyntaxRule syntaxItem) {
+            @ColorInt int foreColor = ctx.getResources().getColor(android.R.color.black);
+            @ColorInt int backColor = ctx.getResources().getColor(R.color.find_in_page);
+            return new ColorSpanEx(foreColor, backColor, spanStart, syntaxItem);
+        }
+    },
+    SEARCH_MATCH_SELECTED {
+        @NonNull @Override public SpanExtents createSpan(@NonNull Context ctx, int spanStart, SyntaxRule syntaxItem) {
+            @ColorInt int foreColor = ctx.getResources().getColor(android.R.color.black);
+            @ColorInt int backColor = ctx.getResources().getColor(R.color.find_in_page_active);
             return new ColorSpanEx(foreColor, backColor, spanStart, syntaxItem);
         }
     };

--- a/app/src/main/java/org/wikipedia/views/PlainPasteEditText.java
+++ b/app/src/main/java/org/wikipedia/views/PlainPasteEditText.java
@@ -30,6 +30,7 @@ public class PlainPasteEditText extends TextInputEditText {
     @Nullable private FindListener findListener;
     private List<Integer> findInPageTextPositionList = new ArrayList<>();
     private int findInPageCurrentTextPosition;
+    private SyntaxHighlighter syntaxHighlighter;
 
     public PlainPasteEditText(Context context) {
         super(context);
@@ -114,8 +115,8 @@ public class PlainPasteEditText extends TextInputEditText {
         if (findListener == null) {
             return;
         }
+        this.syntaxHighlighter = syntaxHighlighter;
         findInPageCurrentTextPosition = 0;
-        findInPageTextPositionList.clear();
         // apply find text syntax
         syntaxHighlighter.applyFindTextSyntax(targetText, new SyntaxHighlighter.OnSyntaxHighlightListener() {
             @Override
@@ -125,6 +126,7 @@ public class PlainPasteEditText extends TextInputEditText {
 
             @Override
             public void findTextMatches(List<SpanExtents> spanExtents) {
+                findInPageTextPositionList.clear();
                 for (SpanExtents spanExtent : spanExtents) {
                     findInPageTextPositionList.add(spanExtent.getStart());
                 }
@@ -152,6 +154,7 @@ public class PlainPasteEditText extends TextInputEditText {
             findInPageCurrentTextPosition = findInPageCurrentTextPosition == 0 ? findInPageTextPositionList.size() - 1 : --findInPageCurrentTextPosition;
             onFinished(true);
         }
+        syntaxHighlighter.setSelectedMatchResultPosition(findInPageCurrentTextPosition);
     }
 
     public void clearMatches(@NonNull SyntaxHighlighter syntaxHighlighter) {

--- a/app/src/main/res/layout/activity_edit_section.xml
+++ b/app/src/main/res/layout/activity_edit_section.xml
@@ -38,7 +38,8 @@
                 android:inputType="textMultiLine"
                 android:imeOptions="actionNone|flagNoExtractUi"
                 android:scrollbars="vertical"
-                android:textColor="?attr/primary_text_color" />
+                android:textColor="?attr/primary_text_color"
+                android:textColorHighlight="#FF9632"/>
         </ScrollView>
 
         <HorizontalScrollView

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -47,7 +47,6 @@
     <attr name="track_off_color" format="color" />
     <attr name="toc_h1_h2_color" format="color" />
     <attr name="text_highlight_color" format="color" />
-    <attr name="text_highlight_color_translucent" format="color" />
 
     <declare-styleable name="AutoFitRecyclerView">
         <attr name="minColumnWidth" format="dimension" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -32,9 +32,10 @@
     <color name="green50">#00af89</color> <!-- Foundation Green: B AA: Secondary link highlight, Positive messages -->
     <color name="green30">#14866d</color> <!-- W AA: -->
     <color name="yellow90">#fef6e7</color>
-    <color name="yellow90_translucent">#80FEF6E7</color>
     <color name="yellow50">#fc3</color> <!-- Foundation Yellow: B AAA: Warning messages -->
-    <color name="yellow50_translucent">#80FFCC33</color> <!-- Foundation Yellow: B AAA: Warning messages -->
+
+    <color name="find_in_page">#FFFF00</color>
+    <color name="find_in_page_active">#FF9632</color>
 
     <!-- Sepia -->
     <color name="amate">#e1dad1</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -49,6 +49,7 @@
         <item name="actionBarTheme">@style/PageToolbarTheme</item>
         <item name="actionBarStyle">@style/PageToolbarStyle</item>
         <item name="autoCompleteTextViewStyle">@style/PageSearchViewEditTextStyle</item>
+        <item name="actionModeCloseButtonStyle">@style/ActionModeCloseButtonStyle</item>
     </style>
 
     <style name="AppTheme.ActionBar.LanguagesList">

--- a/app/src/main/res/values/styles_dark.xml
+++ b/app/src/main/res/values/styles_dark.xml
@@ -81,7 +81,6 @@
         <item name="track_off_color">@color/base100</item>
         <item name="toc_h1_h2_color">@color/base100</item>
         <item name="text_highlight_color">@color/yellow90</item>
-        <item name="text_highlight_color_translucent">@color/yellow90_translucent</item>
 
         <!-- Background for cards, lists, and controls -->
         <item name="paper_color">@color/base14</item>

--- a/app/src/main/res/values/styles_light.xml
+++ b/app/src/main/res/values/styles_light.xml
@@ -81,7 +81,6 @@
         <item name="track_off_color">@color/base0</item>
         <item name="toc_h1_h2_color">@color/base0</item>
         <item name="text_highlight_color">@color/yellow50</item>
-        <item name="text_highlight_color_translucent">@color/yellow50_translucent</item>
 
         <!-- Background for cards, lists, and controls -->
         <item name="paper_color">@color/base100</item>

--- a/app/src/main/res/values/styles_sepia.xml
+++ b/app/src/main/res/values/styles_sepia.xml
@@ -25,7 +25,6 @@
         <item name="nav_tab_background_color">@color/amate</item>
 
         <item name="text_highlight_color">@color/osage</item>
-        <item name="text_highlight_color_translucent">@color/osage_translucent</item>
 
         <item name="chart_shade5">@color/kraft</item>
         <item name="green_highlight_color">@color/green50</item>


### PR DESCRIPTION
Tweak of "find text" function 
 - Using the SyntaxRuleStyle to apply the selected text style.
 - Remove the back arrow if is in the find in page action mode.
 - The selected text color will be changed after DateUtils.SECOND_IN_MILLIS / 2, which is the default behavior in our SyntaxHighlighter class

https://phabricator.wikimedia.org/T89202