### PR TITLE
Migrate dialog styles to MaterialComponents theme.

### DIFF
--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -99,8 +99,7 @@
         <org.wikipedia.views.LanguageScrollView
             android:id="@+id/lang_scroll"
             android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:theme="@style/PageToolbarTheme" />
+            android:layout_height="48dp" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/view_language_scroll.xml
+++ b/app/src/main/res/layout/view_language_scroll.xml
@@ -14,6 +14,7 @@
         android:paddingRight="8dp"
         android:clipToPadding="false"
         android:clipChildren="false"
+        android:background="?attr/page_toolbar_color"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -80,7 +80,7 @@
         <item name="actionModeStyle">@style/ActionModeGreen</item>
     </style>
 
-    <style name="AlertDialogButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+    <style name="AlertDialogButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
         <item name="android:textAlignment">textEnd</item>
         <item name="android:minWidth">0dp</item>
         <item name="android:paddingStart">16dp</item>

--- a/app/src/main/res/values/styles_dark.xml
+++ b/app/src/main/res/values/styles_dark.xml
@@ -88,7 +88,7 @@
 
     </style>
 
-    <style name="AlertDialogDark" parent="Theme.AppCompat.Dialog.Alert">
+    <style name="AlertDialogDark" parent="Theme.MaterialComponents.Dialog.Alert">
         <item name="colorAccent">@color/accent75</item>
         <item name="android:colorBackground">?attr/paper_color</item>
         <item name="android:textColorPrimary">?attr/material_theme_secondary_color</item>
@@ -103,7 +103,7 @@
         <item name="android:background">?attr/paper_color</item>
     </style>
 
-    <style name="DialogDark" parent="Theme.AppCompat.Dialog">
+    <style name="DialogDark" parent="Theme.MaterialComponents.Dialog">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="colorAccent">@color/accent75</item>
@@ -115,7 +115,7 @@
         <item name="overlapAnchor">true</item>
     </style>
 
-    <style name="BottomSheetDialogDark" parent="Theme.Design.BottomSheetDialog">
+    <style name="BottomSheetDialogDark" parent="Theme.MaterialComponents.BottomSheetDialog">
         <item name="bottomSheetStyle">@style/AppBottomSheetModalStyle</item>
         <item name="colorAccent">@color/accent75</item>
         <item name="colorSwitchThumbNormal">@color/base90</item>

--- a/app/src/main/res/values/styles_light.xml
+++ b/app/src/main/res/values/styles_light.xml
@@ -88,7 +88,7 @@
 
     </style>
 
-    <style name="AlertDialogLight" parent="Theme.AppCompat.Light.Dialog.Alert">
+    <style name="AlertDialogLight" parent="Theme.MaterialComponents.Light.Dialog.Alert">
         <item name="colorAccent">@color/accent50</item>
         <item name="android:colorBackground">?attr/paper_color</item>
         <item name="android:textColorPrimary">?attr/material_theme_secondary_color</item>
@@ -103,7 +103,7 @@
         <item name="android:background">?attr/paper_color</item>
     </style>
 
-    <style name="DialogLight" parent="Theme.AppCompat.Light.Dialog">
+    <style name="DialogLight" parent="Theme.MaterialComponents.Light.Dialog">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="colorAccent">@color/accent50</item>
@@ -115,7 +115,7 @@
         <item name="overlapAnchor">true</item>
     </style>
 
-    <style name="BottomSheetDialogLight" parent="Theme.Design.Light.BottomSheetDialog">
+    <style name="BottomSheetDialogLight" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="bottomSheetStyle">@style/AppBottomSheetModalStyle</item>
         <item name="colorAccent">@color/accent50</item>
         <item name="colorSwitchThumbNormal">@color/base90</item>


### PR DESCRIPTION
This moves our Dialog styles to use the MaterialComponents theme instead of the older AppCompat. No visual differences are expected. This also sets an explicit background color on the search language selection bar, since this is now required.