### PR TITLE
Fix: incorrect dotted line background on API 19

### DIFF
--- a/app/src/main/res/layout/activity_page.xml
+++ b/app/src/main/res/layout/activity_page.xml
@@ -111,15 +111,17 @@
             android:scrollbars="none"
             android:listSelector="?android:attr/selectableItemBackground" />
 
-        <View
+        <ImageView
             android:layout_width="37dp"
             android:layout_height="match_parent"
             android:layout_gravity="end"
             android:layout_marginTop="-4dp"
             android:layout_marginBottom="-4dp"
             android:layout_marginEnd="-2dp"
-            android:background="@drawable/toc_dotted_line"
+            android:src="@drawable/toc_dotted_line"
+            android:contentDescription="@null"
             android:layerType="software"/>
+
     </FrameLayout>
 
     <org.wikipedia.views.PageScrollerView


### PR DESCRIPTION
The background of the ToC dotted line is showing incorrectly on API 19 devices. 

![screenshot_2019-02-25-11-15-09](https://user-images.githubusercontent.com/2435576/53378162-79af2d80-3919-11e9-89e0-5f5f965293e8.png)
![screenshot_2019-02-25-11-15-18](https://user-images.githubusercontent.com/2435576/53378163-79af2d80-3919-11e9-8c17-3eec0713b0aa.png)
