### PR TITLE
Follow-up to theme change flicker.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -15,7 +15,6 @@ import android.webkit.WebView;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
-import org.wikipedia.theme.Theme;
 import org.wikipedia.util.FileUtil;
 
 import java.io.IOException;
@@ -69,7 +68,7 @@ public class CommunicationBridge {
         try {
             html = FileUtil.readFile(WikipediaApp.getInstance().getAssets().open(assetFileName))
                     .replace("$wikiurl", wikiUrl)
-                    .replace("$pageLibThemeClass", Theme.getThemePageLibClass(WikipediaApp.getInstance().getCurrentTheme()))
+                    .replace("$pageLibThemeClass", WikipediaApp.getInstance().getCurrentTheme().getPageLibClass())
                     .replace("$pageLibDimImgClass", WikipediaApp.getInstance().getCurrentTheme().isDark() ? "pagelib_dim_images" : "");
 
         } catch (IOException e) {

--- a/app/src/main/java/org/wikipedia/theme/Theme.java
+++ b/app/src/main/java/org/wikipedia/theme/Theme.java
@@ -9,15 +9,16 @@ import org.wikipedia.R;
 import org.wikipedia.model.EnumCode;
 
 public enum Theme implements EnumCode {
-    LIGHT(0, "light", R.style.ThemeLight, R.string.color_theme_light),
-    DARK(1, "dark", R.style.ThemeDark, R.string.color_theme_dark),
-    BLACK(2, "black", R.style.ThemeBlack, R.string.color_theme_black),
-    SEPIA(3, "sepia", R.style.ThemeSepia, R.string.color_theme_sepia);
+    LIGHT(0, "light", R.style.ThemeLight, R.string.color_theme_light, "pagelib_theme_light"),
+    DARK(1, "dark", R.style.ThemeDark, R.string.color_theme_dark, "pagelib_theme_dark"),
+    BLACK(2, "black", R.style.ThemeBlack, R.string.color_theme_black, "pagelib_theme_black"),
+    SEPIA(3, "sepia", R.style.ThemeSepia, R.string.color_theme_sepia, "pagelib_theme_sepia");
 
     private final int marshallingId;
     private final String funnelName;
     @StyleRes private final int resourceId;
     @StringRes private final int nameId;
+    private final String pageLibClass;
 
     public static Theme getFallback() {
         return LIGHT;
@@ -54,6 +55,10 @@ public enum Theme implements EnumCode {
         return nameId;
     }
 
+    public String getPageLibClass() {
+        return pageLibClass;
+    }
+
     public boolean isDefault() {
         return this == getFallback();
     }
@@ -62,24 +67,11 @@ public enum Theme implements EnumCode {
         return this == DARK || this == BLACK;
     }
 
-    Theme(int marshallingId, String funnelName, @StyleRes int resourceId, @StringRes int nameId) {
+    Theme(int marshallingId, String funnelName, @StyleRes int resourceId, @StringRes int nameId, String pageLibClass) {
         this.marshallingId = marshallingId;
         this.funnelName = funnelName;
         this.resourceId = resourceId;
         this.nameId = nameId;
-    }
-
-    public static String getThemePageLibClass(Theme theme) {
-        switch (theme.getFunnelName()) {
-            case "dark":
-                return "pagelib_theme_dark";
-            case "black":
-                return "pagelib_theme_black";
-            case "sepia":
-                return "pagelib_theme_sepia";
-            default:
-                return "pagelib_theme_light";
-        }
-
+        this.pageLibClass = pageLibClass;
     }
 }


### PR DESCRIPTION
This places the theme's CSS class as an actual member field, rather than needing to look it up using its own funnel name.