### PR TITLE
Tweak of "find text" feature in the editor screen

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.java
+++ b/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.java
@@ -3,6 +3,7 @@ package org.wikipedia.edit;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.view.ActionMode;
+import android.view.View;
 import android.widget.ScrollView;
 
 import org.wikipedia.edit.richtext.SyntaxHighlighter;
@@ -18,6 +19,7 @@ public class FindInEditorActionProvider extends FindInPageActionProvider
     @NonNull private final SyntaxHighlighter syntaxHighlighter;
 
     private ScrollView scrollView;
+    private String searchQuery;
 
     public FindInEditorActionProvider(@NonNull ScrollView scrollView,
                                       @NonNull PlainPasteEditText textView,
@@ -29,6 +31,13 @@ public class FindInEditorActionProvider extends FindInPageActionProvider
         this.syntaxHighlighter = syntaxHighlighter;
         this.actionMode = actionMode;
         setListener(this);
+    }
+
+    @Override
+    public View onCreateActionView() {
+        View view = super.onCreateActionView();
+        setSearchViewQuery((String) textView.getTag());
+        return view;
     }
 
     public void findInPage(String s) {
@@ -68,6 +77,7 @@ public class FindInEditorActionProvider extends FindInPageActionProvider
 
     @Override
     public void onCloseClicked() {
+        textView.setTag(searchQuery);
         actionMode.finish();
     }
 
@@ -79,5 +89,6 @@ public class FindInEditorActionProvider extends FindInPageActionProvider
             textView.clearMatches(syntaxHighlighter);
             syntaxHighlighter.applyFindTextSyntax(text, null);
         }
+        searchQuery = text;
     }
 }

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.java
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.java
@@ -187,7 +187,7 @@ public class SyntaxHighlighter {
         // if the user adds more text within 1/2 second, the previous request
         // is cancelled, and a new one is placed.
         handler.removeCallbacks(syntaxHighlightCallback);
-        handler.postDelayed(syntaxHighlightCallback, DateUtils.SECOND_IN_MILLIS / 2);
+        handler.postDelayed(syntaxHighlightCallback, TextUtils.isEmpty(searchText) ? DateUtils.SECOND_IN_MILLIS / 2 : 0);
     }
 
     public void cleanup() {

--- a/app/src/main/java/org/wikipedia/views/FindInPageActionProvider.java
+++ b/app/src/main/java/org/wikipedia/views/FindInPageActionProvider.java
@@ -78,6 +78,10 @@ public class FindInPageActionProvider extends ActionProvider {
         this.listener = listener;
     }
 
+    public void setSearchViewQuery(@NonNull String searchQuery) {
+        searchView.setQuery(searchQuery, true);
+    }
+
     public void setMatchesResults(int activeMatchOrdinal, int numberOfMatches) {
         if (numberOfMatches > 0) {
             findInPageMatch.setText(context.getString(R.string.find_in_page_result,


### PR DESCRIPTION
- Reduce the 0.5s delay when only on the **Find in text** mode since the texts are not actually changed.
- Save the search query into the `PlainPasteEditText` view to reduce a `static` or` perferences` value.