### PR TITLE
Fix swiping-to-delete of history items.

### DIFF
--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.java
@@ -105,7 +105,8 @@ public class HistoryFragment extends Fragment implements BackPressedHandler {
 
         searchEmptyView.setEmptyText(R.string.search_history_no_results);
 
-        ItemTouchHelper.Callback touchCallback = new SwipeableItemTouchHelperCallback(requireContext());
+        SwipeableItemTouchHelperCallback touchCallback = new SwipeableItemTouchHelperCallback(requireContext());
+        touchCallback.setSwipeableEnabled(true);
         ItemTouchHelper itemTouchHelper = new ItemTouchHelper(touchCallback);
         itemTouchHelper.attachToRecyclerView(historyList);
 


### PR DESCRIPTION
The recent updates to SwipeableItemTouchHelper have broken the ability to swipe History items. This adds the necessary function to enable swiping again.