### PR TITLE
Fix drawee base placeholder background color.

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -341,7 +341,7 @@
         <item name="failureImage">@drawable/ic_image_gray_24dp</item>
         <item name="failureImageScaleType">fitCenter</item>
         <item name="fadeDuration">0</item>
-        <item name="backgroundImage">@color/base80</item>
+        <item name="backgroundImage">?attr/paper_color</item>
     </style>
 
     <style name="SimpleDraweeViewPlaceholder.Article">


### PR DESCRIPTION
When scrolling quickly through the Feed in dark mode, you'll notice that the images briefly start with a bright white background before loading the actual image. This corrects the temporary background to use the current theme.