### PR TITLE
Fix: set proper margin on tablets in landscape mode

### DIFF
--- a/app/src/main/assets/bundle.js
+++ b/app/src/main/assets/bundle.js
@@ -230,6 +230,10 @@ bridge.registerListener( "clearContents", function() {
     clearContents();
 });
 
+bridge.registerListener( "setMargins", function( payload ) {
+    document.getElementById( "content" ).style.marginTop = payload.marginTop + "px";
+});
+
 bridge.registerListener( "setPaddingTop", function( payload ) {
     document.body.style.paddingTop = payload.paddingTop + "px";
 });

--- a/app/src/main/assets/bundle.js
+++ b/app/src/main/assets/bundle.js
@@ -230,12 +230,6 @@ bridge.registerListener( "clearContents", function() {
     clearContents();
 });
 
-bridge.registerListener( "setMargins", function( payload ) {
-    document.getElementById( "content" ).style.marginTop = payload.marginTop + "px";
-    document.getElementById( "content" ).style.marginLeft = payload.marginLeft + "px";
-    document.getElementById( "content" ).style.marginRight = payload.marginRight + "px";
-});
-
 bridge.registerListener( "setPaddingTop", function( payload ) {
     document.body.style.paddingTop = payload.paddingTop + "px";
 });

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -491,7 +491,6 @@ public class PageFragment extends Fragment implements BackPressedHandler {
         // but only if we've finished fetching the page.
         if (!pageFragmentLoadState.isLoading() && !errorState) {
             pageFragmentLoadState.layoutLeadImage();
-            pageFragmentLoadState.sendMarginPayload();
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -491,6 +491,7 @@ public class PageFragment extends Fragment implements BackPressedHandler {
         // but only if we've finished fetching the page.
         if (!pageFragmentLoadState.isLoading() && !errorState) {
             pageFragmentLoadState.layoutLeadImage();
+            pageFragmentLoadState.sendMarginPayload();
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -35,6 +35,7 @@ import org.wikipedia.pageimages.PageImage;
 import org.wikipedia.readinglist.database.ReadingListDbHelper;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.DateUtil;
+import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.L10nUtil;
 import org.wikipedia.util.ReleaseUtil;
 import org.wikipedia.util.ResourceUtil;
@@ -366,6 +367,7 @@ public class PageFragmentLoadState {
     private void pageLoadDisplayLeadSection() {
         Page page = model.getPage();
 
+        sendMarginPayload();
 
         sendLeadSectionPayload(page);
 
@@ -378,6 +380,21 @@ public class PageFragmentLoadState {
         refreshView.setRefreshing(false);
         if (fragment.callback() != null) {
             fragment.callback().onPageUpdateProgressBar(true, true, 0);
+        }
+    }
+
+    void sendMarginPayload() {
+        JSONObject marginPayload = marginPayload();
+        bridge.sendMessage("setMargins", marginPayload);
+    }
+
+    private JSONObject marginPayload() {
+        int verticalMargin = DimenUtil.roundedPxToDp(getDimension(R.dimen.activity_vertical_margin));
+        try {
+            return new JSONObject()
+                    .put("marginTop", verticalMargin);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -35,7 +35,6 @@ import org.wikipedia.pageimages.PageImage;
 import org.wikipedia.readinglist.database.ReadingListDbHelper;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.DateUtil;
-import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.L10nUtil;
 import org.wikipedia.util.ReleaseUtil;
 import org.wikipedia.util.ResourceUtil;

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -383,7 +383,7 @@ public class PageFragmentLoadState {
         }
     }
 
-    private void sendMarginPayload() {
+    void sendMarginPayload() {
         JSONObject marginPayload = marginPayload();
         bridge.sendMessage("setMargins", marginPayload);
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -367,7 +367,6 @@ public class PageFragmentLoadState {
     private void pageLoadDisplayLeadSection() {
         Page page = model.getPage();
 
-        sendMarginPayload();
 
         sendLeadSectionPayload(page);
 
@@ -380,24 +379,6 @@ public class PageFragmentLoadState {
         refreshView.setRefreshing(false);
         if (fragment.callback() != null) {
             fragment.callback().onPageUpdateProgressBar(true, true, 0);
-        }
-    }
-
-    void sendMarginPayload() {
-        JSONObject marginPayload = marginPayload();
-        bridge.sendMessage("setMargins", marginPayload);
-    }
-
-    private JSONObject marginPayload() {
-        int horizontalMargin = DimenUtil.roundedPxToDp(getDimension(R.dimen.content_margin));
-        int verticalMargin = DimenUtil.roundedPxToDp(getDimension(R.dimen.activity_vertical_margin));
-        try {
-            return new JSONObject()
-                    .put("marginTop", verticalMargin)
-                    .put("marginLeft", horizontalMargin)
-                    .put("marginRight", horizontalMargin);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -36,7 +36,6 @@
     <dimen name="leadImageWidth">640dp</dimen>
     <item type="dimen" format="float" name="articleHeaderViewScreenHeightRatio">0.4</item>
 
-    <dimen name="content_margin">@dimen/activity_horizontal_margin</dimen>
 
     <dimen name="drawer_drag_margin">16dp</dimen>
 

--- a/www/js/sections.js
+++ b/www/js/sections.js
@@ -11,12 +11,6 @@ bridge.registerListener( "clearContents", function() {
     clearContents();
 });
 
-bridge.registerListener( "setMargins", function( payload ) {
-    document.getElementById( "content" ).style.marginTop = payload.marginTop + "px";
-    document.getElementById( "content" ).style.marginLeft = payload.marginLeft + "px";
-    document.getElementById( "content" ).style.marginRight = payload.marginRight + "px";
-});
-
 bridge.registerListener( "setPaddingTop", function( payload ) {
     document.body.style.paddingTop = payload.paddingTop + "px";
 });

--- a/www/js/sections.js
+++ b/www/js/sections.js
@@ -11,6 +11,10 @@ bridge.registerListener( "clearContents", function() {
     clearContents();
 });
 
+bridge.registerListener( "setMargins", function( payload ) {
+    document.getElementById( "content" ).style.marginTop = payload.marginTop + "px";
+});
+
 bridge.registerListener( "setPaddingTop", function( payload ) {
     document.body.style.paddingTop = payload.paddingTop + "px";
 });


### PR DESCRIPTION
**Root cause and fix**

When we load the page, we set a custom horizontal margin on the page, customized on screen size.
Removed all margin setting code, since this is handled by the css upstream.

Before: https://drive.google.com/open?id=1snAS2L0LkknD2LJsTRgF36M1__RsRbuB
Fixed: https://drive.google.com/open?id=1bmvnwfeBD-jxbZb93NvRAXsTqoBDo0KY

Phab: https://phabricator.wikimedia.org/T216856