### PR TITLE
Follow up of update Info/help screen concept

### DIFF
--- a/app/src/main/java/org/wikipedia/editactionfeed/EditTasksFragment.java
+++ b/app/src/main/java/org/wikipedia/editactionfeed/EditTasksFragment.java
@@ -1,11 +1,9 @@
 package org.wikipedia.editactionfeed;
 
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -24,7 +22,6 @@ import org.wikipedia.language.LanguageSettingsInvokeSource;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity;
 import org.wikipedia.util.FeedbackUtil;
-import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.views.DefaultRecyclerAdapter;
 import org.wikipedia.views.DefaultViewHolder;
 import org.wikipedia.views.FooterMarginItemDecoration;
@@ -252,17 +249,13 @@ public class EditTasksFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        menu.findItem(R.id.edit_tasks_menu_help).setVisible(editOnboardingView.getVisibility() != View.VISIBLE);
-        Drawable drawable = menu.findItem(R.id.edit_tasks_menu_help).getIcon();
-        drawable = DrawableCompat.wrap(drawable);
-        DrawableCompat.setTint(drawable, ResourceUtil.getThemedColor(requireContext(), R.attr.main_toolbar_icon_color));
-        menu.findItem(R.id.edit_tasks_menu_help).setIcon(drawable);
+        menu.findItem(R.id.menu_help).setVisible(editOnboardingView.getVisibility() != View.VISIBLE);
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.edit_tasks_menu_help:
+            case R.id.menu_help:
                 FeedbackUtil.showAndroidAppEditingFAQ(requireContext());
                 return true;
             default:

--- a/app/src/main/res/drawable/ic_info_outline_themed_24dp.xml
+++ b/app/src/main/res/drawable/ic_info_outline_themed_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="?attr/main_toolbar_icon_color"
+        android:pathData="M11,17h2v-6h-2v6zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,9h2L13,7h-2v2z"/>
+</vector>

--- a/app/src/main/res/menu/menu_edit_tasks.xml
+++ b/app/src/main/res/menu/menu_edit_tasks.xml
@@ -5,10 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="AlwaysShowAction">
     <item
-        android:id="@+id/edit_tasks_menu_help"
+        android:id="@+id/menu_help"
         android:title="@string/main_drawer_help"
-        android:icon="@drawable/ic_info_outline_black_24dp"
-        android:iconTint="?attr/main_toolbar_icon_color"
-        android:iconTintMode="src_in"
+        android:icon="@drawable/ic_info_outline_themed_24dp"
         app:showAsAction="always" />
 </menu>


### PR DESCRIPTION
Looks like the 
`
android:iconTint="?attr/main_toolbar_icon_color"
`
Only works on `API 26` and above, and maybe we can just use a themed icon and skip the manual setup the tint in code.