### PR TITLE
Beginnings of analytics for Suggested Edits

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.java
+++ b/app/src/main/java/org/wikipedia/Constants.java
@@ -52,7 +52,7 @@ public final class Constants {
     public static final int MAX_READING_LIST_ARTICLE_LIMIT = 5000;
     public static final int MAX_READING_LISTS_LIMIT = 100;
 
-    public static final int MULTILUNGUAL_LANGUAGES_COUNT_MINIMUM = 2;
+    public static final int MIN_LANGUAGES_TO_UNLOCK_TRANSLATION = 2;
     public static final int ACTION_DESCRIPTION_EDIT_UNLOCK_THRESHOLD = 1; // TODO: increase to 50 when ready for prime-time.
 
     public enum InvokeSource {

--- a/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
@@ -12,7 +12,8 @@ public class SuggestedEditsFunnel extends TimedFunnel {
     private static final String SUGGESTED_EDITS_UI_VERSION = "1.0";
     private static final String SUGGESTED_EDITS_API_VERSION = "1.0";
 
-    public static final String SUGGESTED_EDITS_COMMENT = "Added from Suggested Edits " + SUGGESTED_EDITS_UI_VERSION;
+    public static final String SUGGESTED_EDITS_ADD_COMMENT = "#suggestededit-add " + SUGGESTED_EDITS_UI_VERSION;
+    public static final String SUGGESTED_EDITS_TRANSLATE_COMMENT = "#suggestededit-translate " + SUGGESTED_EDITS_UI_VERSION;
 
     public SuggestedEditsFunnel(WikipediaApp app) {
         super(app, SCHEMA_NAME, REV_ID, Funnel.SAMPLE_LOG_ALL);

--- a/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
@@ -1,0 +1,35 @@
+package org.wikipedia.analytics;
+
+import android.support.annotation.NonNull;
+
+import org.json.JSONObject;
+import org.wikipedia.WikipediaApp;
+
+public class SuggestedEditsFunnel extends TimedFunnel {
+    private static final String SCHEMA_NAME = "MobileWikiAppSuggestedEdits";
+    private static final int REV_ID = 0; // TODO
+
+    private static final String SUGGESTED_EDITS_UI_VERSION = "1.0";
+    private static final String SUGGESTED_EDITS_API_VERSION = "1.0";
+
+    public static final String SUGGESTED_EDITS_COMMENT = "Added from Suggested Edits " + SUGGESTED_EDITS_UI_VERSION;
+
+    public SuggestedEditsFunnel(WikipediaApp app) {
+        super(app, SCHEMA_NAME, REV_ID, Funnel.SAMPLE_LOG_ALL);
+    }
+
+    @Override protected void preprocessSessionToken(@NonNull JSONObject eventData) {
+        // TODO: preprocessData(eventData, "session_token", token);
+    }
+
+    @Override
+    protected JSONObject preprocessData(@NonNull JSONObject eventData) {
+        preprocessData(eventData, "ui_version", SUGGESTED_EDITS_UI_VERSION);
+        preprocessData(eventData, "api_version", SUGGESTED_EDITS_API_VERSION);
+        return super.preprocessData(eventData);
+    }
+
+    public void log() {
+        // TODO
+    }
+}

--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -303,22 +303,26 @@ public interface Service {
     @Headers("Cache-Control: no-cache")
     @POST(MW_API_PREFIX + "action=wbsetdescription&errorlang=uselang")
     @FormUrlEncoded
+    @SuppressWarnings("checkstyle:parameternumber")
     Observable<MwPostResponse> postDescriptionEdit(@NonNull @Field("language") String language,
                                                    @NonNull @Field("uselang") String useLang,
                                                    @NonNull @Field("site") String site,
                                                    @NonNull @Field("title") String title,
                                                    @NonNull @Field("value") String newDescription,
+                                                   @Nullable @Field("summary") String summary,
                                                    @NonNull @Field("token") String token,
                                                    @Nullable @Field("assert") String user);
 
     @Headers("Cache-Control: no-cache")
     @POST(MW_API_PREFIX + "action=wbsetlabel&errorlang=uselang")
     @FormUrlEncoded
+    @SuppressWarnings("checkstyle:parameternumber")
     Observable<MwPostResponse> postLabelEdit(@NonNull @Field("language") String language,
                                              @NonNull @Field("uselang") String useLang,
                                              @NonNull @Field("site") String site,
                                              @NonNull @Field("title") String title,
                                              @NonNull @Field("value") String newDescription,
+                                             @Nullable @Field("summary") String summary,
                                              @NonNull @Field("token") String token,
                                              @Nullable @Field("assert") String user);
 }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
@@ -269,7 +269,8 @@ public class DescriptionEditFragment extends Fragment {
                         return ServiceFactory.get(wikiData).postDescriptionEdit(languageCode,
                                 pageTitle.getWikiSite().languageCode(), pageTitle.getWikiSite().dbName(),
                                 pageTitle.getConvertedText(), editView.getDescription(),
-                                (invokeSource == InvokeSource.EDIT_FEED_TITLE_DESC || invokeSource == InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC) ? SuggestedEditsFunnel.SUGGESTED_EDITS_COMMENT : null,
+                                invokeSource == InvokeSource.EDIT_FEED_TITLE_DESC ? SuggestedEditsFunnel.SUGGESTED_EDITS_ADD_COMMENT
+                                        : invokeSource == InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC ? SuggestedEditsFunnel.SUGGESTED_EDITS_TRANSLATE_COMMENT : null,
                                 editToken, AccountUtil.isLoggedIn() ? "user" : null);
                     })
                     .subscribeOn(Schedulers.io())

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
@@ -14,6 +14,7 @@ import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.FragmentUtil;
 import org.wikipedia.analytics.DescriptionEditFunnel;
+import org.wikipedia.analytics.SuggestedEditsFunnel;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.csrf.CsrfTokenClient;
 import org.wikipedia.dataclient.Service;
@@ -71,6 +72,7 @@ public class DescriptionEditFragment extends Fragment {
     @Nullable private String highlightText;
     @Nullable private CsrfTokenClient csrfClient;
     @Nullable private DescriptionEditFunnel funnel;
+    private InvokeSource invokeSource;
     private CompositeDisposable disposables = new CompositeDisposable();
 
     private Runnable successRunnable = new Runnable() {
@@ -122,6 +124,7 @@ public class DescriptionEditFragment extends Fragment {
                 ? DescriptionEditFunnel.Type.NEW
                 : DescriptionEditFunnel.Type.EXISTING;
         highlightText = getArguments().getString(ARG_HIGHLIGHT_TEXT);
+        invokeSource = (InvokeSource) getArguments().getSerializable(ARG_INVOKE_SOURCE);
         funnel = new DescriptionEditFunnel(WikipediaApp.getInstance(), pageTitle, type);
         funnel.logStart();
     }
@@ -132,7 +135,7 @@ public class DescriptionEditFragment extends Fragment {
         super.onCreateView(inflater, container, savedInstanceState);
         View view = inflater.inflate(R.layout.fragment_description_edit, container, false);
         unbinder = ButterKnife.bind(this, view);
-        editView.setTranslationEdit(getArguments().getSerializable(ARG_INVOKE_SOURCE) == InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC);
+        editView.setTranslationEdit(invokeSource == InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC);
         editView.setTranslationSourceLanguageDescription(getArguments().getCharSequence(ARG_TRANSLATION_SOURCE_LANG_DESC));
         editView.setPageTitle(pageTitle);
         editView.setHighlightText(highlightText);
@@ -265,8 +268,9 @@ public class DescriptionEditFragment extends Fragment {
                                 ? response.query().siteInfo().lang() : pageTitle.getWikiSite().languageCode();
                         return ServiceFactory.get(wikiData).postDescriptionEdit(languageCode,
                                 pageTitle.getWikiSite().languageCode(), pageTitle.getWikiSite().dbName(),
-                                pageTitle.getConvertedText(), editView.getDescription(), editToken,
-                                AccountUtil.isLoggedIn() ? "user" : null);
+                                pageTitle.getConvertedText(), editView.getDescription(),
+                                (invokeSource == InvokeSource.EDIT_FEED_TITLE_DESC || invokeSource == InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC) ? SuggestedEditsFunnel.SUGGESTED_EDITS_COMMENT : null,
+                                editToken, AccountUtil.isLoggedIn() ? "user" : null);
                     })
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsActivity.kt
+++ b/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsActivity.kt
@@ -90,7 +90,7 @@ class AddTitleDescriptionsActivity : SingleFragmentActivity<AddTitleDescriptions
         }
 
         fun maybeShowTranslationEdit(context: Context) {
-            if (WikipediaApp.getInstance().language().appLanguageCodes.size < MULTILUNGUAL_LANGUAGES_COUNT_MINIMUM || Prefs.getTotalUserDescriptionsEdited() <= ACTION_DESCRIPTION_EDIT_UNLOCK_THRESHOLD || !Prefs.showEditActionTranslateDescriptionsUnlockedDialog()) {
+            if (WikipediaApp.getInstance().language().appLanguageCodes.size < MIN_LANGUAGES_TO_UNLOCK_TRANSLATION || Prefs.getTotalUserDescriptionsEdited() <= ACTION_DESCRIPTION_EDIT_UNLOCK_THRESHOLD || !Prefs.showEditActionTranslateDescriptionsUnlockedDialog()) {
                 return
             }
             Prefs.setShowEditActionTranslateDescriptionsUnlockedDialog(false)

--- a/app/src/main/java/org/wikipedia/editactionfeed/EditTasksFragment.java
+++ b/app/src/main/java/org/wikipedia/editactionfeed/EditTasksFragment.java
@@ -38,7 +38,7 @@ import butterknife.Unbinder;
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_ADD_A_LANGUAGE;
 import static org.wikipedia.Constants.InvokeSource;
 import static org.wikipedia.Constants.InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC;
-import static org.wikipedia.Constants.MULTILUNGUAL_LANGUAGES_COUNT_MINIMUM;
+import static org.wikipedia.Constants.MIN_LANGUAGES_TO_UNLOCK_TRANSLATION;
 
 public class EditTasksFragment extends Fragment {
     private Unbinder unbinder;
@@ -145,7 +145,7 @@ public class EditTasksFragment extends Fragment {
             }
         });
 
-        if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() < MULTILUNGUAL_LANGUAGES_COUNT_MINIMUM) {
+        if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() < MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
             EditTask multilingualTask = new EditTask();
             multilingualTask.setTitle(getString(R.string.multilingual_task_title));
             multilingualTask.setDescription(getString(R.string.multilingual_task_description));
@@ -182,7 +182,7 @@ public class EditTasksFragment extends Fragment {
             });
         }
 
-        if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MULTILUNGUAL_LANGUAGES_COUNT_MINIMUM) {
+        if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
             EditTask multilingualTask = new EditTask();
             multilingualTask.setTitle(getString(R.string.translation_task_title));
             multilingualTask.setDescription(getString(R.string.translation_task_description));

--- a/app/src/test/java/org/wikipedia/descriptions/DescriptionEditClientTest.java
+++ b/app/src/test/java/org/wikipedia/descriptions/DescriptionEditClientTest.java
@@ -121,7 +121,7 @@ public class DescriptionEditClientTest extends MockRetrofitTest {
         final PageTitle pageTitle = new PageTitle("foo", WikiSite.forLanguageCode("en"));
         getApiService().postDescriptionEdit(pageTitle.getWikiSite().languageCode(),
                 pageTitle.getWikiSite().languageCode(), pageTitle.getWikiSite().dbName(),
-                pageTitle.getPrefixedText(), "some new description", MOCK_EDIT_TOKEN, null)
+                pageTitle.getPrefixedText(), "some new description", "summary", MOCK_EDIT_TOKEN, null)
                 .subscribe(observer);
     }
 }


### PR DESCRIPTION
This adds a stub Funnel that will be used for the Suggested Edits feature. This also adds the `summary` parameter to our API functions so that the edits submitted from the app will be made with a comment that contains the version number of the feature.