### PR TITLE
Fix WebView/OkHttp caching clash.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.java
@@ -175,6 +175,11 @@ public abstract class OkHttpWebViewClient extends WebViewClient {
                 .url(request.getUrl().toString())
                 .cacheControl(getModel().getCacheControl());
         for (String header : request.getRequestHeaders().keySet()) {
+            if (header.equals("If-None-Match") || header.equals("If-Modified-Since")) {
+                // Strip away conditional headers from the request coming from the WebView, since
+                // we want control of caching for ourselves (it can break OkHttp's caching internals).
+                continue;
+            }
             builder.header(header, request.getRequestHeaders().get(header));
         }
         return OkHttpConnectionFactory.getClient().newCall(addHeaders(builder).build()).execute();


### PR DESCRIPTION
It looks like the newest version of the Android WebView is trying to be a little too smart, and is adding conditional caching headers which are interfering with OkHttp's internal caching logic. Stripping away these headers (and allowing OkHttp to do all the caching work) fixes the issue.

https://phabricator.wikimedia.org/T218623
