### PR TITLE
Add custom shadow to ToC scroller for API 19 devices.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/ToCHandler.java
+++ b/app/src/main/java/org/wikipedia/page/ToCHandler.java
@@ -2,7 +2,9 @@ package org.wikipedia.page;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
+import android.graphics.PorterDuff;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.SparseIntArray;
 import android.util.TypedValue;
@@ -29,6 +31,7 @@ import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.L10nUtil;
+import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 import org.wikipedia.views.ObservableWebView;
@@ -121,6 +124,14 @@ public class ToCHandler implements ObservableWebView.OnClickListener,
                 // ignore
             }
         });
+
+        // TODO: remove after no longer support API19 and use the elevation
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            scrollerView.setBackgroundResource(ResourceUtil.getThemedAttributeId(fragment.requireContext(), R.attr.toc_scroller_button_drawable));
+        } else {
+            scrollerView.setBackgroundResource(R.drawable.shape_circle);
+            scrollerView.getBackground().setColorFilter(ResourceUtil.getThemedColor(fragment.requireContext(), R.attr.toc_scroller_button_color), PorterDuff.Mode.SRC_IN);
+        }
 
         scrollerView.setCallback(new ScrollerCallback());
         setScrollerPosition();

--- a/app/src/main/res/drawable/shape_circle_black.xml
+++ b/app/src/main/res/drawable/shape_circle_black.xml
@@ -2,16 +2,16 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="oval">
-            <solid android:color="#BDBDBD"/>
+            <solid android:color="@color/base0"/>
         </shape>
     </item>
     <item
-        android:left="0dp"
-        android:right="0dp"
+        android:left="1dp"
+        android:right="1dp"
         android:top="0dp"
         android:bottom="2dp">
         <shape android:shape="oval">
-            <solid android:color="@color/base100"/>
+            <solid android:color="@color/base14"/>
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/drawable/shape_circle_dark.xml
+++ b/app/src/main/res/drawable/shape_circle_dark.xml
@@ -2,16 +2,16 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="oval">
-            <solid android:color="#BDBDBD"/>
+            <solid android:color="@color/base10"/>
         </shape>
     </item>
     <item
-        android:left="0dp"
-        android:right="0dp"
+        android:left="1dp"
+        android:right="1dp"
         android:top="0dp"
         android:bottom="2dp">
         <shape android:shape="oval">
-            <solid android:color="@color/base100"/>
+            <solid android:color="@color/base18"/>
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/drawable/shape_circle_light.xml
+++ b/app/src/main/res/drawable/shape_circle_light.xml
@@ -2,12 +2,12 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="oval">
-            <solid android:color="#BDBDBD"/>
+            <solid android:color="@color/base70"/>
         </shape>
     </item>
     <item
-        android:left="0dp"
-        android:right="0dp"
+        android:left="1dp"
+        android:right="1dp"
         android:top="0dp"
         android:bottom="2dp">
         <shape android:shape="oval">

--- a/app/src/main/res/drawable/shape_circle_sepia.xml
+++ b/app/src/main/res/drawable/shape_circle_sepia.xml
@@ -2,16 +2,16 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="oval">
-            <solid android:color="#BDBDBD"/>
+            <solid android:color="@color/base70"/>
         </shape>
     </item>
     <item
-        android:left="0dp"
-        android:right="0dp"
+        android:left="1dp"
+        android:right="1dp"
         android:top="0dp"
         android:bottom="2dp">
         <shape android:shape="oval">
-            <solid android:color="@color/base100"/>
+            <solid android:color="@color/parchment"/>
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/layout/activity_page.xml
+++ b/app/src/main/res/layout/activity_page.xml
@@ -130,8 +130,6 @@
         android:layout_height="48dp"
         android:layout_gravity="end"
         android:elevation="8dp"
-        android:background="@drawable/shape_circle"
-        app:backgroundTint="?attr/toc_scroller_button_color"
         app:srcCompat="@drawable/ic_unfold_more_black_24dp"
         app:tint="?attr/colorAccent"
         android:scaleType="center"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -47,6 +47,7 @@
     <attr name="thumb_off_color" format="color" />
     <attr name="track_off_color" format="color" />
     <attr name="toc_h1_h2_color" format="color" />
+    <attr name="toc_scroller_button_drawable" format="reference" />
     <attr name="toc_scroller_button_color" format="color" />
     <attr name="button_background_color" format="color" />
     <attr name="text_highlight_color" format="color" />

--- a/app/src/main/res/values/styles_black.xml
+++ b/app/src/main/res/values/styles_black.xml
@@ -17,6 +17,7 @@
         <item name="themed_icon_color">@android:color/white</item>
         <item name="nav_tab_background_color">@color/base14</item>
         <item name="randomizer_dice_icon_color">@color/accent50</item>
+        <item name="toc_scroller_button_drawable">@drawable/shape_circle_black</item>
         <item name="toc_scroller_button_color">@color/base14</item>
         <item name="button_background_color">@color/base18</item>
         <item name="tab_placeholder_text_color">@color/base4</item>

--- a/app/src/main/res/values/styles_dark.xml
+++ b/app/src/main/res/values/styles_dark.xml
@@ -76,6 +76,7 @@
         <item name="thumb_off_color">@color/base70</item>
         <item name="track_off_color">@color/base100</item>
         <item name="toc_h1_h2_color">@color/base100</item>
+        <item name="toc_scroller_button_drawable">@drawable/shape_circle_dark</item>
         <item name="toc_scroller_button_color">@color/base18</item>
         <item name="button_background_color">@color/base14</item>
         <item name="text_highlight_color">@color/yellow90</item>

--- a/app/src/main/res/values/styles_light.xml
+++ b/app/src/main/res/values/styles_light.xml
@@ -76,6 +76,7 @@
         <item name="thumb_off_color">@color/base90</item>
         <item name="track_off_color">@color/base0</item>
         <item name="toc_h1_h2_color">@color/base0</item>
+        <item name="toc_scroller_button_drawable">@drawable/shape_circle_light</item>
         <item name="toc_scroller_button_color">@color/base100</item>
         <item name="button_background_color">@color/base100</item>
         <item name="text_highlight_color">@color/yellow50</item>

--- a/app/src/main/res/values/styles_sepia.xml
+++ b/app/src/main/res/values/styles_sepia.xml
@@ -23,6 +23,7 @@
         <item name="secondary_text_color">@color/masi</item>
         <item name="searchItemBackground">@color/parchment</item>
         <item name="nav_tab_background_color">@color/amate</item>
+        <item name="toc_scroller_button_drawable">@drawable/shape_circle_sepia</item>
         <item name="toc_scroller_button_color">@color/parchment</item>
         <item name="button_background_color">@color/parchment</item>
         <item name="tab_placeholder_text_color">@color/amate</item>


### PR DESCRIPTION
The ToC scroller can be barely seen if it does not have a shadow.
It might be good to add a custom "shadow" to the ToC scroller before we officially move up to 21.

![Screenshot_1553215289](https://user-images.githubusercontent.com/2435576/54793747-33d84300-4c01-11e9-90cc-7e522fe902e4.png)
![Screenshot_1553215279](https://user-images.githubusercontent.com/2435576/54793748-35a20680-4c01-11e9-8a2a-8de5acb950b5.png)
