### PR TITLE
Fix audio playback.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -1,7 +1,6 @@
 package org.wikipedia.bridge;
 
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
@@ -52,6 +51,7 @@ public class CommunicationBridge {
 
         webView.getSettings().setJavaScriptEnabled(true);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(true);
+        webView.getSettings().setMediaPlaybackRequiresUserGesture(false);
         webView.setWebChromeClient(new CommunicatingChrome());
         webView.addJavascriptInterface(marshaller, "marshaller");
         eventListeners = new HashMap<>();
@@ -63,7 +63,7 @@ public class CommunicationBridge {
         });
     }
 
-    public void resetHtml(@NonNull Context context, @NonNull String assetFileName, @NonNull String wikiUrl) {
+    public void resetHtml(@NonNull String assetFileName, @NonNull String wikiUrl) {
         String html = "";
         try {
             html = FileUtil.readFile(WikipediaApp.getInstance().getAssets().open(assetFileName))

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -89,7 +89,7 @@ public class EditPreviewFragment extends Fragment {
         model.setTitle(pageTitle);
         model.setTitleOriginal(pageTitle);
         model.setCurEntry(new HistoryEntry(pageTitle, HistoryEntry.SOURCE_INTERNAL_LINK));
-        bridge.resetHtml(requireActivity(), "preview.html", pageTitle.getWikiSite().url());
+        bridge.resetHtml("preview.html", pageTitle.getWikiSite().url());
         funnel = WikipediaApp.getInstance().getFunnelManager().getEditFunnel(pageTitle);
 
         /*

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -140,7 +140,7 @@ public class PageFragmentLoadState {
 
         // Reload the stub index.html into the WebView, which will cause any wiki-specific
         // CSS to be loaded automatically.
-        bridge.resetHtml(fragment.requireActivity(), "index.html", model.getTitle().getWikiSite().url());
+        bridge.resetHtml("index.html", model.getTitle().getWikiSite().url());
 
         pageLoadCheckReadingLists();
     }


### PR DESCRIPTION
Recently the app has been unable to play audio elements. (This has been reported in OTRS, and verified locally.)  It's possible that some additional updates to the System Webview have changed the default behavior with regard to audio tags.

It looks like the WebView has a setting called `setMediaPlaybackRequiresUserGesture`, and if we set this to `false`, the audio seems to work again.