### PR TITLE
Fix collapsing of tables preference.

### DIFF
--- a/app/src/main/assets/bundle.js
+++ b/app/src/main/assets/bundle.js
@@ -334,9 +334,6 @@ bridge.registerListener( "displayLeadSection", function( payload ) {
     document.getElementById( "content" ).appendChild( content );
 
     applySectionTransforms(content, true);
-
-    transformer.transform( "hideTables", document );
-    lazyLoadTransformer.loadPlaceholders();
 });
 
 function clearContents() {

--- a/www/js/sections.js
+++ b/www/js/sections.js
@@ -115,9 +115,6 @@ bridge.registerListener( "displayLeadSection", function( payload ) {
     document.getElementById( "content" ).appendChild( content );
 
     applySectionTransforms(content, true);
-
-    transformer.transform( "hideTables", document );
-    lazyLoadTransformer.loadPlaceholders();
 });
 
 function clearContents() {


### PR DESCRIPTION
Currently, the preference to "collapse tables" is not working properly: if you turn it off, the lead infobox still gets collapsed (while other tables in the article are not collapsed).
This seems to be because we're calling the `hideTables` function twice: once for the lead section, and once for the remaining sections. This fixes the issue by calling `hideTables` only in the remaining-sections logic, which will automatically pick up the tables in the lead section as well. This also changes the lazyLoader to be called only once (in the remaining sections) for the same reason, which will be a slight improvement in efficiency.