### PR TITLE
Fix permissiveness in catching WebView update exception.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -20,6 +20,7 @@ import android.support.v4.view.ViewCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.view.ActionMode;
 import android.view.KeyEvent;
@@ -147,8 +148,9 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         try {
             setContentView(R.layout.activity_page);
         } catch (Exception e) {
-            if (e.getMessage().contains("WebView")
-                    || ThrowableUtil.getInnermostThrowable(e).getMessage().contains("WebView")) {
+            if ((!TextUtils.isEmpty(e.getMessage()) && e.getMessage().toLowerCase().contains("webview"))
+                    || (!TextUtils.isEmpty(ThrowableUtil.getInnermostThrowable(e).getMessage())
+                    && ThrowableUtil.getInnermostThrowable(e).getMessage().toLowerCase().contains("webview"))) {
                 // If the system failed to inflate our activity because of the WebView (which could
                 // be one of several types of exceptions), it likely means that the system WebView
                 // is in the process of being updated. In this case, show the user a message and


### PR DESCRIPTION
We still get a small number of crashes when the system WebView gets updated. This is because we're not catching all the possible ways in which this exception can manifest itself.