### PR TITLE
Change help label verbiage

### DIFF
--- a/app/src/main/res/menu/menu_edit_action_feed.xml
+++ b/app/src/main/res/menu/menu_edit_action_feed.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="AlwaysShowAction">
     <item android:id="@+id/menu_help"
-        android:title="@string/main_drawer_help"
+        android:title="@string/suggested_edits_menu_info"
         app:showAsAction="never"/>
     <item android:id="@+id/menu_my_contributions"
         android:title="@string/editactionfeed_my_contributions"

--- a/app/src/main/res/menu/menu_edit_tasks.xml
+++ b/app/src/main/res/menu/menu_edit_tasks.xml
@@ -6,7 +6,7 @@
     tools:ignore="AlwaysShowAction">
     <item
         android:id="@+id/menu_help"
-        android:title="@string/main_drawer_help"
+        android:title="@string/suggested_edits_menu_info"
         android:icon="@drawable/ic_info_outline_themed_24dp"
         app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -728,4 +728,5 @@
   <string name="title_descriptions_onboarding_got_it">Text on the positive action button for starting editing title descriptions.\n{{Identical|Got it}}</string>
   <string name="translate_descriptions_onboarding_got_it">Text on the positive action button for starting translating title descriptions.\n{{Identical|Got it}}</string>
   <string name="android_app_edit_help_url">URL leading to the help page for article editing from within the app. If you can find the appropriate language specific URL of the mobile site please do so.</string>
+  <string name="suggested_edits_menu_info">Suggested edits menu label for accessing the editing FAQ.\n{{Identical|Info}}</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -770,4 +770,5 @@
     <string name="title_descriptions_onboarding_got_it">Got it</string>
     <string name="translate_descriptions_onboarding_got_it">Got it</string>
     <string name="android_app_edit_help_url">https://m.mediawiki.org/wiki/Wikimedia_Apps/Suggested_edits</string>
+    <string name="suggested_edits_menu_info">Info</string>
 </resources>


### PR DESCRIPTION
Renamed “Help“ to “Info“ in the overflow menu so the label text is aligned with the icon 
Phab: https://phabricator.wikimedia.org/T217562