### PR TITLE
Expand the width of "More like this" view

### DIFF
--- a/app/src/main/res/layout/view_list_card.xml
+++ b/app/src/main/res/layout/view_list_card.xml
@@ -28,7 +28,7 @@
 
     <LinearLayout
         android:id="@+id/view_list_card_more_container"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="48dp"
         android:paddingLeft="16dp"
         android:paddingRight="16dp"
@@ -50,8 +50,9 @@
 
         <TextView
             android:id="@+id/view_list_card_more_text"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="match_parent"
+            android:layout_weight="1"
             android:layout_marginStart="8dp"
             android:fontFamily="sans-serif-medium"
             android:textAllCaps="true"


### PR DESCRIPTION
Not sure why the "More like this" item in a list of a card only is not a full-width clickable view. It might be good if expands it to full-width.