### PR TITLE
Add confirmation dialog when logging out.

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainActivity.java
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.java
@@ -10,6 +10,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.view.ActionMode;
 import android.support.v7.widget.Toolbar;
 import android.view.Gravity;
@@ -250,18 +251,23 @@ public class MainActivity extends SingleFragmentActivity<MainFragment>
 
     private class DrawerViewCallback implements MainDrawerView.Callback {
         @Override public void loginLogoutClick() {
-            if (AccountUtil.isLoggedIn()) {
-                WikipediaApp.getInstance().logOut();
-                FeedbackUtil.showMessage(MainActivity.this, R.string.toast_logout_complete);
-                if (Prefs.isReadingListSyncEnabled() && !ReadingListDbHelper.instance().isEmpty()) {
-                    ReadingListSyncBehaviorDialogs.removeExistingListsOnLogoutDialog(MainActivity.this);
-                }
-                Prefs.setReadingListsLastSyncTime(null);
-                Prefs.setReadingListSyncEnabled(false);
-            } else {
-                getFragment().onLoginRequested();
-            }
-            closeMainDrawer();
+            new AlertDialog.Builder(MainActivity.this)
+                    .setMessage(R.string.logout_prompt)
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .setPositiveButton(R.string.preference_title_logout, (dialog, which) -> {
+                        if (AccountUtil.isLoggedIn()) {
+                            WikipediaApp.getInstance().logOut();
+                            FeedbackUtil.showMessage(MainActivity.this, R.string.toast_logout_complete);
+                            if (Prefs.isReadingListSyncEnabled() && !ReadingListDbHelper.instance().isEmpty()) {
+                                ReadingListSyncBehaviorDialogs.removeExistingListsOnLogoutDialog(MainActivity.this);
+                            }
+                            Prefs.setReadingListsLastSyncTime(null);
+                            Prefs.setReadingListSyncEnabled(false);
+                        } else {
+                            getFragment().onLoginRequested();
+                        }
+                        closeMainDrawer();
+                    }).show();
         }
 
         @Override public void notificationsClick() {

--- a/app/src/main/java/org/wikipedia/main/MainActivity.java
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.java
@@ -251,11 +251,11 @@ public class MainActivity extends SingleFragmentActivity<MainFragment>
 
     private class DrawerViewCallback implements MainDrawerView.Callback {
         @Override public void loginLogoutClick() {
-            new AlertDialog.Builder(MainActivity.this)
-                    .setMessage(R.string.logout_prompt)
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .setPositiveButton(R.string.preference_title_logout, (dialog, which) -> {
-                        if (AccountUtil.isLoggedIn()) {
+            if (AccountUtil.isLoggedIn()) {
+                new AlertDialog.Builder(MainActivity.this)
+                        .setMessage(R.string.logout_prompt)
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .setPositiveButton(R.string.preference_title_logout, (dialog, which) -> {
                             WikipediaApp.getInstance().logOut();
                             FeedbackUtil.showMessage(MainActivity.this, R.string.toast_logout_complete);
                             if (Prefs.isReadingListSyncEnabled() && !ReadingListDbHelper.instance().isEmpty()) {
@@ -263,11 +263,11 @@ public class MainActivity extends SingleFragmentActivity<MainFragment>
                             }
                             Prefs.setReadingListsLastSyncTime(null);
                             Prefs.setReadingListSyncEnabled(false);
-                        } else {
-                            getFragment().onLoginRequested();
-                        }
-                        closeMainDrawer();
-                    }).show();
+                        }).show();
+            } else {
+                getFragment().onLoginRequested();
+            }
+            closeMainDrawer();
         }
 
         @Override public void notificationsClick() {

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -136,6 +136,7 @@
   <string name="reset_password_button">Button label for setting a new password and logging in with it.</string>
   <string name="preference_title_logout">{{Identical|Log out}}</string>
   <string name="toast_logout_complete">Toast popup message notifying the user that they have been logged out.\n{{Identical|Logged out}}</string>
+  <string name="logout_prompt">Message that asks the user whether they really want to log out.</string>
   <string name="history_empty_title">Used in \"Browsing history\" page if there is nothing to show.</string>
   <string name="history_empty_message">Brief explanation that there are currently no History entries to look at. Just to fill an empty screen. This usually happens when a user just deleted history entries.</string>
   <string name="history_offline_articles_toast">Message shown in a toast when some articles in the history page may not be viewable while offline.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
     <string name="reset_password_button">Save and log in</string>
     <string name="preference_title_logout">Log out</string>
     <string name="toast_logout_complete">Logged out</string>
+    <string name="logout_prompt">Are you sure you want to log out?</string>
     <string name="history_empty_title">No recently viewed articles</string>
     <string name="history_empty_message">Track what you\'ve been reading here.</string>
     <string name="history_offline_articles_toast">Some articles in history may not be viewable while offline.</string>


### PR DESCRIPTION
The "log out" button in our Navigation menu is pretty easy to tap, and is rather abrupt in logging out the user. It would be nice to have a confirmation message that asks if you actually want to log out.