### PR TITLE
Whoops: make WikiText button strings translateable.

### DIFF
--- a/app/src/main/res/layout/view_wikitext_keyboard.xml
+++ b/app/src/main/res/layout/view_wikitext_keyboard.xml
@@ -13,21 +13,21 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:buttonImage="@drawable/ic_format_bold_black_24dp"
-        app:buttonHint="Bold"/>
+        app:buttonHint="@string/wikitext_bold"/>
 
     <org.wikipedia.views.WikitextKeyboardButtonView
         android:id="@+id/wikitext_button_italic"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:buttonImage="@drawable/ic_format_italic_black_24dp"
-        app:buttonHint="Italic"/>
+        app:buttonHint="@string/wikitext_italic"/>
 
     <org.wikipedia.views.WikitextKeyboardButtonView
         android:id="@+id/wikitext_button_link"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:buttonImage="@drawable/ic_link_black_24dp"
-        app:buttonHint="Link"/>
+        app:buttonHint="@string/wikitext_link"/>
 
     <View
         android:layout_width="0.5dp"
@@ -43,14 +43,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:buttonImage="@drawable/ic_format_list_bulleted_black_24dp"
-        app:buttonHint="Bulleted list"/>
+        app:buttonHint="@string/wikitext_bulleted_list"/>
 
     <org.wikipedia.views.WikitextKeyboardButtonView
         android:id="@+id/wikitext_button_list_numbered"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:buttonImage="@drawable/ic_format_list_numbered_black_24dp"
-        app:buttonHint="Numbered list"/>
+        app:buttonHint="@string/wikitext_numbered_list"/>
 
     <View
         android:layout_width="0.5dp"
@@ -66,14 +66,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:buttonText="{{}}"
-        app:buttonHint="Template"/>
+        app:buttonHint="@string/wikitext_template"/>
 
     <org.wikipedia.views.WikitextKeyboardButtonView
         android:id="@+id/wikitext_button_ref"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:buttonText="&lt;ref&gt;"
-        app:buttonHint="Reference"/>
+        app:buttonHint="@string/wikitext_reference"/>
 
     <View
         android:layout_width="0.5dp"
@@ -107,7 +107,7 @@
             android:layout_marginBottom="2dp"
             android:textColor="?attr/material_theme_secondary_color"
             android:textSize="9sp"
-            android:text="Preview link"/>
+            android:text="@string/wikitext_preview_link"/>
     </FrameLayout>
 
 </LinearLayout>

--- a/app/src/main/res/menu/menu_edit_section.xml
+++ b/app/src/main/res/menu/menu_edit_section.xml
@@ -4,7 +4,7 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
     <item android:id="@+id/menu_find_in_editor"
         android:icon="@drawable/ic_find_in_page_themed"
-        android:title="@string/edit_undo"
+        android:title="@string/menu_page_find_in_page"
         app:showAsAction="always" />
     <item android:id="@+id/menu_edit_undo"
         android:icon="@drawable/ic_undo_themed_24dp"

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -668,6 +668,14 @@
     <item quantity="one">Text indicating that the event occurred one year ago.</item>
     <item quantity="other">Text indicating that the event occurred two or more years ago.\"%d\" is the number of years.</item>
   </plurals>
+  <string name="wikitext_bold">Button label for making the selected text bold.</string>
+  <string name="wikitext_italic">Button label for making the selected text italic.</string>
+  <string name="wikitext_link">Button label for making the selected text into a link.</string>
+  <string name="wikitext_bulleted_list">Button label for starting a bulleted list at the current cursor position.</string>
+  <string name="wikitext_numbered_list">Button label for starting a numbered list at the current cursor position.</string>
+  <string name="wikitext_template">Button label for making the selected text into a template.</string>
+  <string name="wikitext_reference">Button label for adding a reference at the current cursor position.</string>
+  <string name="wikitext_preview_link">Button label for showing a preview of the link that is at the current cursor position.</string>
   <string name="languages_list_activity_title">Title shown at the top of the activity for selecting a wikipedia language.</string>
   <string name="languages_list_suggested_text">Section header of the suggested languages in the languages list.</string>
   <string name="languages_list_all_text">Section header of all languages in the languages list.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,6 +731,15 @@
     <string name="dialog_of_remove_chinese_variants_from_app_lang_no">No thanks</string>
     <!-- /MultiLingual -->
 
+    <string name="wikitext_bold">Bold</string>
+    <string name="wikitext_italic">Italic</string>
+    <string name="wikitext_link">Link</string>
+    <string name="wikitext_bulleted_list">Bulleted list</string>
+    <string name="wikitext_numbered_list">Numbered list</string>
+    <string name="wikitext_template">Template</string>
+    <string name="wikitext_reference">Reference</string>
+    <string name="wikitext_preview_link">Preview link</string>
+
     <string name="main_drawer_open">Open</string>
     <string name="main_drawer_close">Close</string>
     <string name="main_drawer_help">Help</string>


### PR DESCRIPTION
The new WikiText keyboard overlay buttons actually had some hard-coded text in them, and didn't actually use string resources!

This also fixes an incorrect hint provided for the "find-in-page" menu icon when editing.