### PR TITLE
Add/update developer preference

### DIFF
--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -251,10 +251,6 @@
             android:key="@string/preference_key_show_remove_chinese_variant_prompt"
             android:title="@string/preference_key_show_remove_chinese_variant_prompt" />
 
-        <SwitchPreferenceCompat
-            android:key="@string/preference_key_show_edit_action_add_title_descriptions_onboarding"
-            android:title="@string/preference_key_show_edit_action_add_title_descriptions_onboarding" />
-
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/preferences_developer_reading_list_category">
@@ -299,6 +295,14 @@
         <SwitchPreferenceCompat
             android:key="@string/preference_key_edit_action_translate_descriptions_unlocked"
             android:title="@string/preference_key_edit_action_translate_descriptions_unlocked" />
+
+        <SwitchPreferenceCompat
+            android:key="@string/preference_key_show_edit_action_add_title_descriptions_onboarding"
+            android:title="@string/preference_key_show_edit_action_add_title_descriptions_onboarding" />
+
+        <SwitchPreferenceCompat
+            android:key="@string/preference_key_show_edit_action_translate_descriptions_onboarding"
+            android:title="@string/preference_key_show_edit_action_translate_descriptions_onboarding" />
 
         <Preference
             android:key="@string/preferences_developer_suggested_edits_add_description_dialog"


### PR DESCRIPTION
Add `translate description onboarding` preference into the developer preference xml, and also moved the related items into the group.