### PR TITLE
Fix: Empty sourceDescription

### DIFF
--- a/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsFragment.kt
@@ -51,7 +51,6 @@ class AddTitleDescriptionsFragment : Fragment() {
     var langFromCode: String = app.language().appLanguageCode
     var langToCode: String = if (app.language().appLanguageCodes.size == 1) "" else app.language().appLanguageCodes[1]
     var source: InvokeSource = InvokeSource.EDIT_FEED_TITLE_DESC
-    var sourceDescription: CharSequence = ""
 
     private val topTitle: PageTitle?
         get() {
@@ -169,7 +168,7 @@ class AddTitleDescriptionsFragment : Fragment() {
 
     fun onSelectPage() {
         if (topTitle != null) {
-            startActivityForResult(DescriptionEditActivity.newIntent(requireContext(), topTitle!!, null, true, sourceDescription.toString(), langFromCode, source),
+            startActivityForResult(DescriptionEditActivity.newIntent(requireContext(), topTitle!!, null, true, topChild!!.sourceDescription, langFromCode, source),
                     ACTIVITY_REQUEST_DESCRIPTION_EDIT)
         }
     }

--- a/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsItemFragment.kt
@@ -32,7 +32,7 @@ class AddTitleDescriptionsItemFragment : Fragment() {
     private val disposables = CompositeDisposable()
     private var summary: RbPageSummary? = null
     private val app = WikipediaApp.getInstance()
-    private var sourceDescription: String = ""
+    var sourceDescription: String = ""
     var addedDescription: String = ""
         internal set
 
@@ -66,7 +66,9 @@ class AddTitleDescriptionsItemFragment : Fragment() {
         }
 
         cardView.setOnClickListener {
-            parent().onSelectPage()
+            if (!TextUtils.isEmpty(sourceDescription)) {
+                parent().onSelectPage()
+            }
         }
 
     }
@@ -162,7 +164,6 @@ class AddTitleDescriptionsItemFragment : Fragment() {
         if (parent().source == InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC) {
             val spannableDescription = SpannableString(sourceDescription)
             spannableDescription.setSpan(ForegroundColorSpan(ResourceUtil.getThemedColor(requireContext(), R.attr.primary_text_color)), 0, sourceDescription.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-            parent().sourceDescription = sourceDescription
         }
     }
 


### PR DESCRIPTION
- Because we do not check for empty sourceDescription on card click, sometimes we end-up with empty text field for it . This fixes the issue by adding the check.

Bug: https://drive.google.com/open?id=13GP_tCvoeb65lJDL892e1q60VpZfwEDD

