### PR TITLE
Fix incorrect null check when clicking on description card view

### DIFF
--- a/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsItemFragment.kt
@@ -66,7 +66,7 @@ class AddTitleDescriptionsItemFragment : Fragment() {
         }
 
         cardView.setOnClickListener {
-            if (!TextUtils.isEmpty(sourceDescription)) {
+            if (summary != null) {
                 parent().onSelectPage()
             }
         }


### PR DESCRIPTION
Change to summary so Title Descriptions click doesn't get locked.