### PR TITLE
Remove onboarding dialogs and unused strings.

### DIFF
--- a/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentStatePagerAdapter
 import android.support.v4.view.ViewPager
-import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -33,11 +32,9 @@ import org.wikipedia.descriptions.DescriptionEditActivity
 import org.wikipedia.editactionfeed.AddTitleDescriptionsActivity.Companion.EXTRA_SOURCE
 import org.wikipedia.editactionfeed.AddTitleDescriptionsActivity.Companion.EXTRA_SOURCE_ADDED_DESCRIPTION
 import org.wikipedia.page.PageTitle
-import org.wikipedia.settings.Prefs
 import org.wikipedia.util.AnimationUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.log.L
-import org.wikipedia.views.DialogTitleWithImage
 
 class AddTitleDescriptionsFragment : Fragment() {
     private val viewPagerListener = ViewPagerListener()
@@ -122,8 +119,6 @@ class AddTitleDescriptionsFragment : Fragment() {
                 }
             }, postDelay)
         }
-
-        showOnboarding()
     }
 
     override fun onDestroyView() {
@@ -171,35 +166,6 @@ class AddTitleDescriptionsFragment : Fragment() {
             startActivityForResult(DescriptionEditActivity.newIntent(requireContext(), topTitle!!, null, true, topChild!!.sourceDescription, langFromCode, source),
                     ACTIVITY_REQUEST_DESCRIPTION_EDIT)
         }
-    }
-
-    private fun showOnboarding() {
-        if (Prefs.showEditActionAddTitleDescriptionsOnboarding() && source == InvokeSource.EDIT_FEED_TITLE_DESC) {
-            AlertDialog.Builder(requireActivity())
-                    .setCustomTitle(DialogTitleWithImage(requireActivity(), R.string.add_title_descriptions_dialog_title,
-                            R.drawable.ic_dialog_image_title_descriptions, false))
-                    .setMessage(R.string.add_title_descriptions_dialog_message)
-                    .setPositiveButton(R.string.title_descriptions_onboarding_got_it, null)
-                    .setNegativeButton(R.string.editactionfeed_add_title_dialog_learn_more) { _, _ ->
-                        FeedbackUtil.showAndroidAppEditingFAQ(context)
-                    }
-                    .show()
-            Prefs.setShowEditActionAddTitleDescriptionsOnboarding(false)
-        }
-
-        if (Prefs.showEditActionTranslateDescriptionsOnboarding() && source == InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC) {
-            AlertDialog.Builder(requireActivity())
-                    .setCustomTitle(DialogTitleWithImage(requireActivity(), R.string.add_translate_descriptions_dialog_title,
-                            R.drawable.ic_dialog_image_title_descriptions, false))
-                    .setMessage(R.string.add_translate_descriptions_dialog_message)
-                    .setPositiveButton(R.string.translate_descriptions_onboarding_got_it, null)
-                    .setNegativeButton(R.string.editactionfeed_translate_title_dialog_learn_more) { _, _ ->
-                        FeedbackUtil.showAndroidAppEditingFAQ(context)
-                    }
-                    .show()
-            Prefs.setShowEditActionTranslateDescriptionsOnboarding(false)
-        }
-
     }
 
     private fun requestLanguagesAndBuildSpinner() {

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -832,22 +832,6 @@ public final class Prefs {
         setBoolean(R.string.preference_key_history_offline_articles_toast, showToast);
     }
 
-    public static boolean showEditActionAddTitleDescriptionsOnboarding() {
-        return getBoolean(R.string.preference_key_show_edit_action_add_title_descriptions_onboarding, true);
-    }
-
-    public static void setShowEditActionAddTitleDescriptionsOnboarding(boolean enabled) {
-        setBoolean(R.string.preference_key_show_edit_action_add_title_descriptions_onboarding, enabled);
-    }
-
-    public static boolean showEditActionTranslateDescriptionsOnboarding() {
-        return getBoolean(R.string.preference_key_show_edit_action_translate_descriptions_onboarding, true);
-    }
-
-    public static void setShowEditActionTranslateDescriptionsOnboarding(boolean enabled) {
-        setBoolean(R.string.preference_key_show_edit_action_translate_descriptions_onboarding, enabled);
-    }
-
     public static boolean isEditActionTranslateDescriptionsUnlocked() {
         return getBoolean(R.string.preference_key_edit_action_translate_descriptions_unlocked, false);
     }

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -722,18 +722,8 @@
     <item quantity="one">Text suggesting that one in-app contribution was made.</item>
     <item quantity="other">Text suggesting that two or more in-app contributions were made.</item>
   </plurals>
-  <string name="add_title_descriptions_dialog_title">Title text of the dialog shown to first time title description editors.&lt;br /&gt;Under the title line, a short description is added.</string>
-  <string name="add_title_descriptions_dialog_message">Message text in the dialog shown to first time title description editors.</string>
-  <string name="add_translate_descriptions_dialog_title">Title text of the dialog shown to editors before their first time  translating descriptions.</string>
-  <string name="add_translate_descriptions_dialog_message">Message text in the dialog shown to editors before their first time translating descriptions.</string>
   <string name="description_edit_tutorial_message">Concise on-boarding message to the editor task list.</string>
-  <string name="title_description_editing_skip">Text on the button to skip onboarding screens for editing title descriptions.\n{{Identical|Skip}}</string>
-  <string name="title_description_get_started">Text on button to start editing title descriptions.\n{{Identical|Get started}}</string>
-  <string name="translate_description_get_started">Text on button to start translating title descriptions.\n{{Identical|Get started}}</string>
   <string name="edit_tasks_onboarding_get_started">Text on button to start tasks from edit action feed.\n{{Identical|Get started}}</string>
-  <string name="translate_descriptions_maybe_later">Text on the negative action button for starting translating title descriptions.\n{{Identical|Maybe later}}</string>
-  <string name="title_descriptions_onboarding_got_it">Text on the positive action button for starting editing title descriptions.\n{{Identical|Got it}}</string>
-  <string name="translate_descriptions_onboarding_got_it">Text on the positive action button for starting translating title descriptions.\n{{Identical|Got it}}</string>
   <string name="android_app_edit_help_url">URL leading to the help page for article editing from within the app. If you can find the appropriate language specific URL of the mobile site please do so.</string>
   <string name="suggested_edits_menu_info">Suggested edits menu label for accessing the editing FAQ.\n{{Identical|Info}}</string>
   <string name="suggested_edits_unlock_add_descriptions_dialog_title">Title text of the dialog shown to user that the “Add descriptions“ task has been unlocked.</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -106,7 +106,5 @@
     <string name="preference_key_show_action_feed_indicator">showActionFeedIndicator</string>
     <string name="preference_key_show_edit_tasks_onboarding">showEditTasksOnboarding</string>
     <string name="preference_key_show_multilingual_task">showMultilingualTask</string>
-    <string name="preference_key_show_edit_action_add_title_descriptions_onboarding">showEditActionAddTitleDescriptionsOnboarding</string>
-    <string name="preference_key_show_edit_action_translate_descriptions_onboarding">showEditActionTranslateDescriptionsOnboarding</string>
     <string name="preference_key_edit_action_translate_descriptions_unlocked">editActionTranslateDescriptionsUnlocked</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -777,17 +777,8 @@
         <item quantity="one">1 contribution</item>
         <item quantity="other">%d contributions</item>
     </plurals>
-    <string name="add_title_descriptions_dialog_title">Add title descriptions</string>
-    <string name="add_title_descriptions_dialog_message">You can now help to improve Wikipedia by adding descriptions that appear below titles in articles. You can configure your languages at any time.</string>
-    <string name="add_translate_descriptions_dialog_title">You are translating title descriptions for the first time</string>
-    <string name="add_translate_descriptions_dialog_message">You can now help to improve Wikipedia by translating title descriptions. You can configure your languages and set a translation direction at any time.</string>
     <string name="description_edit_tutorial_message">Welcome to the new home for quick editing in the Wikipedia app. Your contributions are much appreciated. Happy editing!</string>
-    <string name="title_description_editing_skip">Skip</string>
-    <string name="title_description_get_started">Get started</string>
-    <string name="translate_description_get_started">Get started</string>
     <string name="edit_tasks_onboarding_get_started">Get started</string>
-    <string name="title_descriptions_onboarding_got_it">Got it</string>
-    <string name="translate_descriptions_onboarding_got_it">Got it</string>
     <string name="android_app_edit_help_url">https://m.mediawiki.org/wiki/Wikimedia_Apps/Suggested_edits</string>
     <string name="suggested_edits_menu_info">Info</string>
 </resources>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -296,14 +296,6 @@
             android:key="@string/preference_key_edit_action_translate_descriptions_unlocked"
             android:title="@string/preference_key_edit_action_translate_descriptions_unlocked" />
 
-        <SwitchPreferenceCompat
-            android:key="@string/preference_key_show_edit_action_add_title_descriptions_onboarding"
-            android:title="@string/preference_key_show_edit_action_add_title_descriptions_onboarding" />
-
-        <SwitchPreferenceCompat
-            android:key="@string/preference_key_show_edit_action_translate_descriptions_onboarding"
-            android:title="@string/preference_key_show_edit_action_translate_descriptions_onboarding" />
-
         <Preference
             android:key="@string/preferences_developer_suggested_edits_add_description_dialog"
             android:title="@string/preferences_developer_suggested_edits_add_description_dialog"/>


### PR DESCRIPTION
Regarding the comment from Robin: 
https://phabricator.wikimedia.org/T215630#5077695

The onboarding dialogs are no longer needed, and related strings/preferences should be removed from the project.