### PR TITLE
Tweak the logic of login/logout for SuggestedEdits

### DIFF
--- a/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsActivity.kt
+++ b/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsActivity.kt
@@ -12,7 +12,6 @@ import org.wikipedia.R
 import org.wikipedia.activity.SingleFragmentActivity
 import org.wikipedia.analytics.SuggestedEditsFunnel
 import org.wikipedia.editactionfeed.AddTitleDescriptionsFragment.Companion.newInstance
-import org.wikipedia.settings.Prefs
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.views.DialogTitleWithImage
 
@@ -58,33 +57,27 @@ class AddTitleDescriptionsActivity : SingleFragmentActivity<AddTitleDescriptions
         }
 
         fun showEditUnlockDialog(context: Context) {
-            if (!Prefs.isSuggestedEditsAddDescriptionsMessageShown()) {
-                Prefs.setSuggestedEditsAddDescriptionsMessageShown(true)
-                AlertDialog.Builder(context)
-                        .setCustomTitle(DialogTitleWithImage(context, R.string.suggested_edits_unlock_add_descriptions_dialog_title, R.drawable.ic_illustration_description_edit_trophy, true))
-                        .setMessage(R.string.suggested_edits_unlock_add_descriptions_dialog_message)
-                        .setPositiveButton(R.string.suggested_edits_unlock_dialog_yes) { _, _ ->
-                            SuggestedEditsFunnel.get(ONBOARDING_DIALOG)
-                            context.startActivity(EditTasksActivity.newIntent(context, EDIT_FEED_TITLE_DESC))
-                        }
-                        .setNegativeButton(R.string.suggested_edits_unlock_dialog_no, null)
-                        .show()
-            }
+            AlertDialog.Builder(context)
+                    .setCustomTitle(DialogTitleWithImage(context, R.string.suggested_edits_unlock_add_descriptions_dialog_title, R.drawable.ic_illustration_description_edit_trophy, true))
+                    .setMessage(R.string.suggested_edits_unlock_add_descriptions_dialog_message)
+                    .setPositiveButton(R.string.suggested_edits_unlock_dialog_yes) { _, _ ->
+                        SuggestedEditsFunnel.get(ONBOARDING_DIALOG)
+                        context.startActivity(EditTasksActivity.newIntent(context, EDIT_FEED_TITLE_DESC))
+                    }
+                    .setNegativeButton(R.string.suggested_edits_unlock_dialog_no, null)
+                    .show()
         }
 
         fun showTranslateUnlockDialog(context: Context) {
-            if (!Prefs.isSuggestedEditsTranslateDescriptionsMessageShown()) {
-                Prefs.setSuggestedEditsTranslateDescriptionsMessageShown(true)
-                AlertDialog.Builder(context)
-                        .setCustomTitle(DialogTitleWithImage(context, R.string.suggested_edits_unlock_translate_descriptions_dialog_title, R.drawable.ic_illustration_description_edit_trophy, true))
-                        .setMessage(R.string.suggested_edits_unlock_translate_descriptions_dialog_message)
-                        .setPositiveButton(R.string.suggested_edits_unlock_dialog_yes) { _, _ ->
-                            SuggestedEditsFunnel.get(ONBOARDING_DIALOG)
-                            context.startActivity(EditTasksActivity.newIntent(context, EDIT_FEED_TRANSLATE_TITLE_DESC))
-                        }
-                        .setNegativeButton(R.string.suggested_edits_unlock_dialog_no, null)
-                        .show()
-            }
+            AlertDialog.Builder(context)
+                    .setCustomTitle(DialogTitleWithImage(context, R.string.suggested_edits_unlock_translate_descriptions_dialog_title, R.drawable.ic_illustration_description_edit_trophy, true))
+                    .setMessage(R.string.suggested_edits_unlock_translate_descriptions_dialog_message)
+                    .setPositiveButton(R.string.suggested_edits_unlock_dialog_yes) { _, _ ->
+                        SuggestedEditsFunnel.get(ONBOARDING_DIALOG)
+                        context.startActivity(EditTasksActivity.newIntent(context, EDIT_FEED_TRANSLATE_TITLE_DESC))
+                    }
+                    .setNegativeButton(R.string.suggested_edits_unlock_dialog_no, null)
+                    .show()
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsActivity.kt
+++ b/app/src/main/java/org/wikipedia/editactionfeed/AddTitleDescriptionsActivity.kt
@@ -3,17 +3,16 @@ package org.wikipedia.editactionfeed
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.support.v4.app.NavUtils
 import android.support.v7.app.AlertDialog
 import android.view.Menu
 import android.view.MenuItem
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.Constants.InvokeSource.*
 import org.wikipedia.R
-import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.SingleFragmentActivity
 import org.wikipedia.analytics.SuggestedEditsFunnel
 import org.wikipedia.editactionfeed.AddTitleDescriptionsFragment.Companion.newInstance
+import org.wikipedia.settings.Prefs
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.views.DialogTitleWithImage
 
@@ -59,27 +58,33 @@ class AddTitleDescriptionsActivity : SingleFragmentActivity<AddTitleDescriptions
         }
 
         fun showEditUnlockDialog(context: Context) {
-            AlertDialog.Builder(context)
-                    .setCustomTitle(DialogTitleWithImage(context, R.string.suggested_edits_unlock_add_descriptions_dialog_title, R.drawable.ic_illustration_description_edit_trophy, true))
-                    .setMessage(R.string.suggested_edits_unlock_add_descriptions_dialog_message)
-                    .setPositiveButton(R.string.suggested_edits_unlock_dialog_yes) { _, _ ->
-                        SuggestedEditsFunnel.get(ONBOARDING_DIALOG)
-                        context.startActivity(EditTasksActivity.newIntent(context, EDIT_FEED_TITLE_DESC))
-                    }
-                    .setNegativeButton(R.string.suggested_edits_unlock_dialog_no, null)
-                    .show()
+            if (!Prefs.isSuggestedEditsAddDescriptionsMessageShown()) {
+                Prefs.setSuggestedEditsAddDescriptionsMessageShown(true)
+                AlertDialog.Builder(context)
+                        .setCustomTitle(DialogTitleWithImage(context, R.string.suggested_edits_unlock_add_descriptions_dialog_title, R.drawable.ic_illustration_description_edit_trophy, true))
+                        .setMessage(R.string.suggested_edits_unlock_add_descriptions_dialog_message)
+                        .setPositiveButton(R.string.suggested_edits_unlock_dialog_yes) { _, _ ->
+                            SuggestedEditsFunnel.get(ONBOARDING_DIALOG)
+                            context.startActivity(EditTasksActivity.newIntent(context, EDIT_FEED_TITLE_DESC))
+                        }
+                        .setNegativeButton(R.string.suggested_edits_unlock_dialog_no, null)
+                        .show()
+            }
         }
 
         fun showTranslateUnlockDialog(context: Context) {
-            AlertDialog.Builder(context)
-                    .setCustomTitle(DialogTitleWithImage(context, R.string.suggested_edits_unlock_translate_descriptions_dialog_title, R.drawable.ic_illustration_description_edit_trophy, true))
-                    .setMessage(R.string.suggested_edits_unlock_translate_descriptions_dialog_message)
-                    .setPositiveButton(R.string.suggested_edits_unlock_dialog_yes) { _, _ ->
-                        SuggestedEditsFunnel.get(ONBOARDING_DIALOG)
-                        context.startActivity(EditTasksActivity.newIntent(context, EDIT_FEED_TRANSLATE_TITLE_DESC))
-                    }
-                    .setNegativeButton(R.string.suggested_edits_unlock_dialog_no, null)
-                    .show()
+            if (!Prefs.isSuggestedEditsTranslateDescriptionsMessageShown()) {
+                Prefs.setSuggestedEditsTranslateDescriptionsMessageShown(true)
+                AlertDialog.Builder(context)
+                        .setCustomTitle(DialogTitleWithImage(context, R.string.suggested_edits_unlock_translate_descriptions_dialog_title, R.drawable.ic_illustration_description_edit_trophy, true))
+                        .setMessage(R.string.suggested_edits_unlock_translate_descriptions_dialog_message)
+                        .setPositiveButton(R.string.suggested_edits_unlock_dialog_yes) { _, _ ->
+                            SuggestedEditsFunnel.get(ONBOARDING_DIALOG)
+                            context.startActivity(EditTasksActivity.newIntent(context, EDIT_FEED_TRANSLATE_TITLE_DESC))
+                        }
+                        .setNegativeButton(R.string.suggested_edits_unlock_dialog_no, null)
+                        .show()
+            }
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/editactionfeed/EditTasksFragment.java
+++ b/app/src/main/java/org/wikipedia/editactionfeed/EditTasksFragment.java
@@ -172,7 +172,7 @@ public class EditTasksFragment extends Fragment {
         translateDescriptionsTeaserTask.setDescription(getString(R.string.multilingual_task_description));
         translateDescriptionsTeaserTask.setImagePlaceHolderShown(false);
         translateDescriptionsTeaserTask.setNoActionLayout(false);
-        translateDescriptionsTeaserTask.setDisabled(!Prefs.isEditActionTranslateDescriptionsUnlocked());
+        translateDescriptionsTeaserTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
         translateDescriptionsTeaserTask.setEnabledPositiveActionString(getString(R.string.multilingual_task_positive));
         translateDescriptionsTeaserTask.setEnabledNegativeActionString(getString(R.string.multilingual_task_negative));
 
@@ -182,8 +182,8 @@ public class EditTasksFragment extends Fragment {
         translateDescriptionsTask.setImagePlaceHolderShown(true);
         translateDescriptionsTask.setNoActionLayout(true);
         translateDescriptionsTask.setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.ic_icon_translate_title_descriptions));
-        translateDescriptionsTask.setNoActionLayout(Prefs.isEditActionTranslateDescriptionsUnlocked());
-        translateDescriptionsTask.setDisabled(!Prefs.isEditActionTranslateDescriptionsUnlocked());
+        translateDescriptionsTask.setNoActionLayout(Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
+        translateDescriptionsTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
 
         addImageCaptionsTask = new EditTask();
         addImageCaptionsTask.setTitle(getString(R.string.image_caption_task_title));
@@ -210,18 +210,18 @@ public class EditTasksFragment extends Fragment {
             int targetForTranslateDescriptions = editorTaskCounts.getDescriptionEditTargets().get(1);
 
             displayedTasks.add(addDescriptionsTask);
-            addDescriptionsTask.setDisabled(!Prefs.isEditActionAddDescriptionsUnlocked());
+            addDescriptionsTask.setDisabled(!Prefs.isSuggestedEditsAddDescriptionsUnlocked());
 
             if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() < MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
                 if (Prefs.showTranslateDescriptionsTeaserTask()) {
                     displayedTasks.add(translateDescriptionsTeaserTask);
                     translateDescriptionsTeaserTask.setDisabledDescriptionText(String.format(getString(R.string.image_caption_edit_disable_text), targetForTranslateDescriptions));
-                    translateDescriptionsTeaserTask.setDisabled(!Prefs.isEditActionTranslateDescriptionsUnlocked());
+                    translateDescriptionsTeaserTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
                 }
             } else {
                 displayedTasks.add(translateDescriptionsTask);
                 translateDescriptionsTask.setDisabledDescriptionText(String.format(getString(R.string.image_caption_edit_disable_text), targetForTranslateDescriptions));
-                translateDescriptionsTask.setDisabled(!Prefs.isEditActionTranslateDescriptionsUnlocked());
+                translateDescriptionsTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
             }
 
             // TODO: enable image caption tasks.

--- a/app/src/main/java/org/wikipedia/login/LoginActivity.java
+++ b/app/src/main/java/org/wikipedia/login/LoginActivity.java
@@ -21,6 +21,7 @@ import org.wikipedia.activity.BaseActivity;
 import org.wikipedia.analytics.LoginFunnel;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.createaccount.CreateAccountActivity;
+import org.wikipedia.notifications.NotificationPollBroadcastReceiver;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.readinglist.sync.ReadingListSyncAdapter;
 import org.wikipedia.settings.Prefs;
@@ -180,6 +181,7 @@ public class LoginActivity extends BaseActivity {
         Prefs.setReadingListPagesDeletedIds(Collections.emptySet());
         Prefs.setReadingListsDeletedIds(Collections.emptySet());
         ReadingListSyncAdapter.manualSyncWithForce();
+        NotificationPollBroadcastReceiver.pollEditorTaskCounts(this);
         finish();
     }
 

--- a/app/src/main/java/org/wikipedia/main/MainActivity.java
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.java
@@ -263,6 +263,8 @@ public class MainActivity extends SingleFragmentActivity<MainFragment>
                             }
                             Prefs.setReadingListsLastSyncTime(null);
                             Prefs.setReadingListSyncEnabled(false);
+                            Prefs.setSuggestedEditsAddDescriptionsUnlocked(false);
+                            Prefs.setSuggestedEditsTranslateDescriptionsUnlocked(false);
                         }).show();
             } else {
                 getFragment().onLoginRequested();

--- a/app/src/main/java/org/wikipedia/main/MainDrawerView.java
+++ b/app/src/main/java/org/wikipedia/main/MainDrawerView.java
@@ -70,7 +70,7 @@ public class MainDrawerView extends ScrollView {
             accountAvatar.setVisibility(View.VISIBLE);
             accountWikiGlobe.setVisibility(View.GONE);
             notificationsContainer.setVisibility(View.VISIBLE);
-            if (ReleaseUtil.isPreBetaRelease() && Prefs.isEditActionAddDescriptionsUnlocked()) {
+            if (ReleaseUtil.isPreBetaRelease() && Prefs.isSuggestedEditsAddDescriptionsUnlocked()) {
                 editTasksContainer.setVisibility(VISIBLE);
             }
             maybeShowIndicatorDots();

--- a/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
@@ -78,7 +78,7 @@ public final class NotificationEditorTasksHandler {
     }
 
     public static void maybeShowTranslateDescriptionUnlockNotification(@NonNull Context context, boolean forced) {
-        if (!WikipediaApp.getInstance().isAnyActivityResumed() && !Prefs.isSuggestedEditsTranslateDescriptionsMessageShown()  || forced) {
+        if (!WikipediaApp.getInstance().isAnyActivityResumed() && !Prefs.isSuggestedEditsTranslateDescriptionsMessageShown() || forced) {
             Prefs.setSuggestedEditsTranslateDescriptionsMessageShown(true);
             SuggestedEditsFunnel.get(Constants.InvokeSource.NOTIFICATION).pause();
             Intent intent = EditTasksActivity.newIntent(context, Constants.InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC);

--- a/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
@@ -24,35 +24,36 @@ public final class NotificationEditorTasksHandler {
         Object eventToDispatch = null;
 
         if (numTargetsPassed > 1) {
-            if (!Prefs.isEditActionAddDescriptionsUnlocked()) {
-                Prefs.setEditActionAddDescriptionsUnlocked(true);
+            if (!Prefs.isSuggestedEditsAddDescriptionsUnlocked()) {
+                Prefs.setSuggestedEditsAddDescriptionsUnlocked(true);
                 Prefs.setShowActionFeedIndicator(true);
                 Prefs.setShowEditMenuOptionIndicator(true);
                 maybeShowEditDescriptionUnlockNotification(context, false);
                 eventToDispatch = new EditorTaskUnlockEvent(1);
             }
-            if (!Prefs.isEditActionTranslateDescriptionsUnlocked() && WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
-                Prefs.setEditActionTranslateDescriptionsUnlocked(true);
+            if (!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked()
+                    && WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
+                Prefs.setSuggestedEditsTranslateDescriptionsUnlocked(true);
                 maybeShowTranslateDescriptionUnlockNotification(context, false);
                 eventToDispatch = new EditorTaskUnlockEvent(numTargetsPassed);
             }
         } else if (numTargetsPassed > 0) {
-            if (!Prefs.isEditActionAddDescriptionsUnlocked()) {
-                Prefs.setEditActionAddDescriptionsUnlocked(true);
+            if (!Prefs.isSuggestedEditsAddDescriptionsUnlocked()) {
+                Prefs.setSuggestedEditsAddDescriptionsUnlocked(true);
                 Prefs.setShowActionFeedIndicator(true);
                 Prefs.setShowEditMenuOptionIndicator(true);
                 maybeShowEditDescriptionUnlockNotification(context, false);
                 eventToDispatch = new EditorTaskUnlockEvent(numTargetsPassed);
             }
-            if (Prefs.isEditActionTranslateDescriptionsUnlocked()) {
-                Prefs.setEditActionTranslateDescriptionsUnlocked(false);
+            if (Prefs.isSuggestedEditsTranslateDescriptionsUnlocked()) {
+                Prefs.setSuggestedEditsTranslateDescriptionsUnlocked(false);
             }
         } else {
-            if (Prefs.isEditActionAddDescriptionsUnlocked()) {
-                Prefs.setEditActionAddDescriptionsUnlocked(false);
+            if (Prefs.isSuggestedEditsAddDescriptionsUnlocked()) {
+                Prefs.setSuggestedEditsAddDescriptionsUnlocked(false);
             }
-            if (Prefs.isEditActionTranslateDescriptionsUnlocked()) {
-                Prefs.setEditActionTranslateDescriptionsUnlocked(false);
+            if (Prefs.isSuggestedEditsTranslateDescriptionsUnlocked()) {
+                Prefs.setSuggestedEditsTranslateDescriptionsUnlocked(false);
             }
         }
 
@@ -62,7 +63,8 @@ public final class NotificationEditorTasksHandler {
     }
 
     public static void maybeShowEditDescriptionUnlockNotification(@NonNull Context context, boolean forced) {
-        if (!WikipediaApp.getInstance().isAnyActivityResumed() || forced) {
+        if (!WikipediaApp.getInstance().isAnyActivityResumed() && !Prefs.isSuggestedEditsAddDescriptionsMessageShown() || forced) {
+            Prefs.setSuggestedEditsAddDescriptionsMessageShown(true);
             SuggestedEditsFunnel.get(Constants.InvokeSource.NOTIFICATION).pause();
             Intent intent = EditTasksActivity.newIntent(context, Constants.InvokeSource.EDIT_FEED_TITLE_DESC);
             NotificationCompat.Builder builder = NotificationPresenter.getDefaultBuilder(context);
@@ -76,7 +78,8 @@ public final class NotificationEditorTasksHandler {
     }
 
     public static void maybeShowTranslateDescriptionUnlockNotification(@NonNull Context context, boolean forced) {
-        if (!WikipediaApp.getInstance().isAnyActivityResumed() || forced) {
+        if (!WikipediaApp.getInstance().isAnyActivityResumed() && !Prefs.isSuggestedEditsTranslateDescriptionsMessageShown()  || forced) {
+            Prefs.setSuggestedEditsTranslateDescriptionsMessageShown(true);
             SuggestedEditsFunnel.get(Constants.InvokeSource.NOTIFICATION).pause();
             Intent intent = EditTasksActivity.newIntent(context, Constants.InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC);
             NotificationCompat.Builder builder = NotificationPresenter.getDefaultBuilder(context);

--- a/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
@@ -63,8 +63,7 @@ public final class NotificationEditorTasksHandler {
     }
 
     public static void maybeShowEditDescriptionUnlockNotification(@NonNull Context context, boolean forced) {
-        if (!WikipediaApp.getInstance().isAnyActivityResumed() && !Prefs.isSuggestedEditsAddDescriptionsMessageShown() || forced) {
-            Prefs.setSuggestedEditsAddDescriptionsMessageShown(true);
+        if (!WikipediaApp.getInstance().isAnyActivityResumed() || forced) {
             SuggestedEditsFunnel.get(Constants.InvokeSource.NOTIFICATION).pause();
             Intent intent = EditTasksActivity.newIntent(context, Constants.InvokeSource.EDIT_FEED_TITLE_DESC);
             NotificationCompat.Builder builder = NotificationPresenter.getDefaultBuilder(context);
@@ -78,8 +77,7 @@ public final class NotificationEditorTasksHandler {
     }
 
     public static void maybeShowTranslateDescriptionUnlockNotification(@NonNull Context context, boolean forced) {
-        if (!WikipediaApp.getInstance().isAnyActivityResumed() && !Prefs.isSuggestedEditsTranslateDescriptionsMessageShown() || forced) {
-            Prefs.setSuggestedEditsTranslateDescriptionsMessageShown(true);
+        if (!WikipediaApp.getInstance().isAnyActivityResumed() || forced) {
             SuggestedEditsFunnel.get(Constants.InvokeSource.NOTIFICATION).pause();
             Intent intent = EditTasksActivity.newIntent(context, Constants.InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC);
             NotificationCompat.Builder builder = NotificationPresenter.getDefaultBuilder(context);

--- a/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.java
+++ b/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.java
@@ -226,6 +226,7 @@ class DeveloperSettingsPreferenceLoader extends BasePreferenceLoader {
 
         findPreference(context.getString(R.string.preferences_developer_suggested_edits_add_description_dialog))
                 .setOnPreferenceClickListener(preference -> {
+                    Prefs.setSuggestedEditsAddDescriptionsMessageShown(false);
                     AddTitleDescriptionsActivity.Companion.showEditUnlockDialog(getActivity());
                     return true;
                 });
@@ -238,6 +239,7 @@ class DeveloperSettingsPreferenceLoader extends BasePreferenceLoader {
 
         findPreference(context.getString(R.string.preferences_developer_suggested_edits_translate_description_dialog))
                 .setOnPreferenceClickListener(preference -> {
+                    Prefs.setSuggestedEditsTranslateDescriptionsMessageShown(false);
                     AddTitleDescriptionsActivity.Companion.showTranslateUnlockDialog(getActivity());
                     return true;
                 });

--- a/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.java
+++ b/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.java
@@ -226,7 +226,6 @@ class DeveloperSettingsPreferenceLoader extends BasePreferenceLoader {
 
         findPreference(context.getString(R.string.preferences_developer_suggested_edits_add_description_dialog))
                 .setOnPreferenceClickListener(preference -> {
-                    Prefs.setSuggestedEditsAddDescriptionsMessageShown(false);
                     AddTitleDescriptionsActivity.Companion.showEditUnlockDialog(getActivity());
                     return true;
                 });
@@ -239,7 +238,6 @@ class DeveloperSettingsPreferenceLoader extends BasePreferenceLoader {
 
         findPreference(context.getString(R.string.preferences_developer_suggested_edits_translate_description_dialog))
                 .setOnPreferenceClickListener(preference -> {
-                    Prefs.setSuggestedEditsTranslateDescriptionsMessageShown(false);
                     AddTitleDescriptionsActivity.Companion.showTranslateUnlockDialog(getActivity());
                     return true;
                 });

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -816,14 +816,6 @@ public final class Prefs {
         setBoolean(R.string.preference_key_show_edit_tasks_onboarding, showOnboarding);
     }
 
-    public static boolean isEditActionAddDescriptionsUnlocked() {
-        return getBoolean(R.string.preference_key_action_edit_descriptions_unlocked, false);
-    }
-
-    public static void setEditActionAddDescriptionsUnlocked(boolean unlocked) {
-        setBoolean(R.string.preference_key_action_edit_descriptions_unlocked, unlocked);
-    }
-
     public static boolean shouldShowHistoryOfflineArticlesToast() {
         return getBoolean(R.string.preference_key_history_offline_articles_toast, true);
     }
@@ -832,12 +824,36 @@ public final class Prefs {
         setBoolean(R.string.preference_key_history_offline_articles_toast, showToast);
     }
 
-    public static boolean isEditActionTranslateDescriptionsUnlocked() {
-        return getBoolean(R.string.preference_key_edit_action_translate_descriptions_unlocked, false);
+    public static boolean isSuggestedEditsAddDescriptionsUnlocked() {
+        return getBoolean(R.string.preference_key_suggested_edits_add_descriptions_unlocked, false);
     }
 
-    public static void setEditActionTranslateDescriptionsUnlocked(boolean enabled) {
-        setBoolean(R.string.preference_key_edit_action_translate_descriptions_unlocked, enabled);
+    public static void setSuggestedEditsAddDescriptionsUnlocked(boolean unlocked) {
+        setBoolean(R.string.preference_key_suggested_edits_add_descriptions_unlocked, unlocked);
+    }
+
+    public static boolean isSuggestedEditsTranslateDescriptionsUnlocked() {
+        return getBoolean(R.string.preference_key_suggested_edits_translate_descriptions_unlocked, false);
+    }
+
+    public static void setSuggestedEditsTranslateDescriptionsUnlocked(boolean enabled) {
+        setBoolean(R.string.preference_key_suggested_edits_translate_descriptions_unlocked, enabled);
+    }
+
+    public static boolean isSuggestedEditsAddDescriptionsMessageShown() {
+        return getBoolean(R.string.preference_key_suggested_edits_add_descriptions_message_shown, false);
+    }
+
+    public static void setSuggestedEditsAddDescriptionsMessageShown(boolean unlocked) {
+        setBoolean(R.string.preference_key_suggested_edits_add_descriptions_message_shown, unlocked);
+    }
+
+    public static boolean isSuggestedEditsTranslateDescriptionsMessageShown() {
+        return getBoolean(R.string.preference_key_suggested_edits_translate_descriptions_message_shown, false);
+    }
+
+    public static void setSuggestedEditsTranslateDescriptionsMessageShown(boolean unlocked) {
+        setBoolean(R.string.preference_key_suggested_edits_translate_descriptions_message_shown, unlocked);
     }
 
     public static boolean showTranslateDescriptionsTeaserTask() {

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -840,22 +840,6 @@ public final class Prefs {
         setBoolean(R.string.preference_key_suggested_edits_translate_descriptions_unlocked, enabled);
     }
 
-    public static boolean isSuggestedEditsAddDescriptionsMessageShown() {
-        return getBoolean(R.string.preference_key_suggested_edits_add_descriptions_message_shown, false);
-    }
-
-    public static void setSuggestedEditsAddDescriptionsMessageShown(boolean unlocked) {
-        setBoolean(R.string.preference_key_suggested_edits_add_descriptions_message_shown, unlocked);
-    }
-
-    public static boolean isSuggestedEditsTranslateDescriptionsMessageShown() {
-        return getBoolean(R.string.preference_key_suggested_edits_translate_descriptions_message_shown, false);
-    }
-
-    public static void setSuggestedEditsTranslateDescriptionsMessageShown(boolean unlocked) {
-        setBoolean(R.string.preference_key_suggested_edits_translate_descriptions_message_shown, unlocked);
-    }
-
     public static boolean showTranslateDescriptionsTeaserTask() {
         return getBoolean(R.string.preference_key_show_multilingual_task, true);
     }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -101,10 +101,12 @@
     <string name="preference_key_show_bookmark_tooltip">showBookmarkTooltip</string>
     <string name="preference_key_overflow_reading_lists_option_click_count">overflowReadingListsClickCount</string>
     <string name="preference_key_history_offline_articles_toast">historyOfflineArticlesToast</string>
-    <string name="preference_key_action_edit_descriptions_unlocked">actionEditDescriptionsUnlocked</string>
+    <string name="preference_key_suggested_edits_add_descriptions_unlocked">suggestedEditsAddDescriptionsUnlocked</string>
+    <string name="preference_key_suggested_edits_translate_descriptions_unlocked">suggestedEditsTranslateDescriptionsUnlocked</string>
+    <string name="preference_key_suggested_edits_add_descriptions_message_shown">suggestedEditsAddDescriptionsMessageShown</string>
+    <string name="preference_key_suggested_edits_translate_descriptions_message_shown">suggestedEditsTranslateDescriptionsMessageShown</string>
     <string name="preference_key_show_edit_menu_option_indicator">showEditMenuOptionIndicator</string>
     <string name="preference_key_show_action_feed_indicator">showActionFeedIndicator</string>
     <string name="preference_key_show_edit_tasks_onboarding">showEditTasksOnboarding</string>
     <string name="preference_key_show_multilingual_task">showMultilingualTask</string>
-    <string name="preference_key_edit_action_translate_descriptions_unlocked">editActionTranslateDescriptionsUnlocked</string>
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -103,8 +103,6 @@
     <string name="preference_key_history_offline_articles_toast">historyOfflineArticlesToast</string>
     <string name="preference_key_suggested_edits_add_descriptions_unlocked">suggestedEditsAddDescriptionsUnlocked</string>
     <string name="preference_key_suggested_edits_translate_descriptions_unlocked">suggestedEditsTranslateDescriptionsUnlocked</string>
-    <string name="preference_key_suggested_edits_add_descriptions_message_shown">suggestedEditsAddDescriptionsMessageShown</string>
-    <string name="preference_key_suggested_edits_translate_descriptions_message_shown">suggestedEditsTranslateDescriptionsMessageShown</string>
     <string name="preference_key_show_edit_menu_option_indicator">showEditMenuOptionIndicator</string>
     <string name="preference_key_show_action_feed_indicator">showActionFeedIndicator</string>
     <string name="preference_key_show_edit_tasks_onboarding">showEditTasksOnboarding</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -289,12 +289,20 @@
     <PreferenceCategory android:title="@string/preferences_developer_suggested_edits_category">
 
         <SwitchPreferenceCompat
-            android:key="@string/preference_key_action_edit_descriptions_unlocked"
-            android:title="@string/preference_key_action_edit_descriptions_unlocked" />
+            android:key="@string/preference_key_suggested_edits_add_descriptions_unlocked"
+            android:title="@string/preference_key_suggested_edits_add_descriptions_unlocked" />
 
         <SwitchPreferenceCompat
-            android:key="@string/preference_key_edit_action_translate_descriptions_unlocked"
-            android:title="@string/preference_key_edit_action_translate_descriptions_unlocked" />
+            android:key="@string/preference_key_suggested_edits_translate_descriptions_unlocked"
+            android:title="@string/preference_key_suggested_edits_translate_descriptions_unlocked" />
+
+        <SwitchPreferenceCompat
+            android:key="@string/preference_key_suggested_edits_add_descriptions_message_shown"
+            android:title="@string/preference_key_suggested_edits_add_descriptions_message_shown" />
+
+        <SwitchPreferenceCompat
+            android:key="@string/preference_key_suggested_edits_translate_descriptions_message_shown"
+            android:title="@string/preference_key_suggested_edits_translate_descriptions_message_shown" />
 
         <Preference
             android:key="@string/preferences_developer_suggested_edits_add_description_dialog"

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -296,14 +296,6 @@
             android:key="@string/preference_key_suggested_edits_translate_descriptions_unlocked"
             android:title="@string/preference_key_suggested_edits_translate_descriptions_unlocked" />
 
-        <SwitchPreferenceCompat
-            android:key="@string/preference_key_suggested_edits_add_descriptions_message_shown"
-            android:title="@string/preference_key_suggested_edits_add_descriptions_message_shown" />
-
-        <SwitchPreferenceCompat
-            android:key="@string/preference_key_suggested_edits_translate_descriptions_message_shown"
-            android:title="@string/preference_key_suggested_edits_translate_descriptions_message_shown" />
-
         <Preference
             android:key="@string/preferences_developer_suggested_edits_add_description_dialog"
             android:title="@string/preferences_developer_suggested_edits_add_description_dialog"/>


### PR DESCRIPTION
If a current user has an account that has unlocked the `SuggestedEdits`, and then the user logs out to another account that has not unlocked the `SuggestedEdits`, the preferences and the item in drawer menu should be changed right after the user logged in.

Also, I've renamed some preferences and methods to `SuggestedEdits`