### PR TITLE
Update strings for suggested edits and remove unused strings

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditLicenseView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditLicenseView.kt
@@ -21,6 +21,13 @@ class DescriptionEditLicenseView  @JvmOverloads constructor(
         licenseText!!.movementMethod = LinkMovementMethod()
     }
 
+    fun useSuggestedEditsLicenseNotice() {
+        licenseText!!.text = StringUtil.fromHtml(String
+                .format(context.getString(R.string.suggested_edits_license_notice),
+                        context.getString(R.string.terms_of_use_url),
+                        context.getString(R.string.cc_0_url)))
+    }
+
     fun removeUnderlinesFromLinks() {
         RichTextUtil.removeUnderlinesFromLinks(licenseText)
     }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditLicenseView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditLicenseView.kt
@@ -14,16 +14,13 @@ class DescriptionEditLicenseView  @JvmOverloads constructor(
 
     init {
         inflate(context, R.layout.view_description_edit_license, this)
-        licenseText!!.text = StringUtil.fromHtml(String
-                .format(context.getString(R.string.description_edit_license_notice),
-                        context.getString(R.string.terms_of_use_url),
-                        context.getString(R.string.cc_0_url)))
         licenseText!!.movementMethod = LinkMovementMethod()
+        buildLicenseNotice(true)
     }
 
-    fun useSuggestedEditsLicenseNotice() {
+    fun buildLicenseNotice(isGeneralNotice: Boolean) {
         licenseText!!.text = StringUtil.fromHtml(String
-                .format(context.getString(R.string.suggested_edits_license_notice),
+                .format(context.getString(if (isGeneralNotice) { R.string.description_edit_license_notice } else { R.string.suggested_edits_license_notice }),
                         context.getString(R.string.terms_of_use_url),
                         context.getString(R.string.cc_0_url)))
     }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
@@ -18,7 +18,7 @@ class DescriptionEditReviewView @JvmOverloads constructor(
 
     init {
         inflate(context, R.layout.view_description_edit_review, this)
-        licenseView.useSuggestedEditsLicenseNotice()
+        licenseView.buildLicenseNotice(false)
         licenseView.removeUnderlinesFromLinks()
     }
 

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
@@ -18,6 +18,7 @@ class DescriptionEditReviewView @JvmOverloads constructor(
 
     init {
         inflate(context, R.layout.view_description_edit_review, this)
+        licenseView.useSuggestedEditsLicenseNotice()
         licenseView.removeUnderlinesFromLinks()
     }
 

--- a/app/src/main/java/org/wikipedia/editactionfeed/EditTasksFragment.java
+++ b/app/src/main/java/org/wikipedia/editactionfeed/EditTasksFragment.java
@@ -215,12 +215,12 @@ public class EditTasksFragment extends Fragment {
             if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() < MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
                 if (Prefs.showTranslateDescriptionsTeaserTask()) {
                     displayedTasks.add(translateDescriptionsTeaserTask);
-                    translateDescriptionsTeaserTask.setDisabledDescriptionText(String.format(getString(R.string.image_caption_edit_disable_text), targetForTranslateDescriptions));
+                    translateDescriptionsTeaserTask.setDisabledDescriptionText(String.format(getString(R.string.translate_description_edit_disable_text), targetForTranslateDescriptions));
                     translateDescriptionsTeaserTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
                 }
             } else {
                 displayedTasks.add(translateDescriptionsTask);
-                translateDescriptionsTask.setDisabledDescriptionText(String.format(getString(R.string.image_caption_edit_disable_text), targetForTranslateDescriptions));
+                translateDescriptionsTask.setDisabledDescriptionText(String.format(getString(R.string.translate_description_edit_disable_text), targetForTranslateDescriptions));
                 translateDescriptionsTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
             }
 

--- a/app/src/main/java/org/wikipedia/editactionfeed/provider/MissingDescriptionProvider.kt
+++ b/app/src/main/java/org/wikipedia/editactionfeed/provider/MissingDescriptionProvider.kt
@@ -63,7 +63,7 @@ object MissingDescriptionProvider {
                             .getWikidataLabelsAndDescriptions(StringUtils.join(qNumbers, '|'))
                 }
                 .map<Pair<PageTitle, PageTitle>> { response ->
-                    var sourceDescriptionAndTargetTitle: Pair<PageTitle, PageTitle>? = null
+                    var sourceAndTargetPageTitles: Pair<PageTitle, PageTitle>? = null
                     for (q in response.entities()!!.keys) {
                         val entity = response.entities()!![q]
                         if (entity == null
@@ -73,14 +73,14 @@ object MissingDescriptionProvider {
                                 || !entity.sitelinks().containsKey(targetWiki.dbName())) {
                             continue
                         }
-                        sourceDescriptionAndTargetTitle = Pair(PageTitle(entity.sitelinks()[targetWiki.dbName()]!!.title, targetWiki),
+                        sourceAndTargetPageTitles = Pair(PageTitle(entity.sitelinks()[targetWiki.dbName()]!!.title, targetWiki),
                                 PageTitle(entity.sitelinks()[sourceWiki.dbName()]!!.title, sourceWiki))
                         break
                     }
-                    if (sourceDescriptionAndTargetTitle == null) {
+                    if (sourceAndTargetPageTitles == null) {
                         throw ListEmptyException()
                     }
-                    sourceDescriptionAndTargetTitle
+                    sourceAndTargetPageTitles
                 }
                 .flatMap { sourceAndTargetPageTitles: Pair<PageTitle, PageTitle> -> getSummary(sourceAndTargetPageTitles) }
                 .retry { t: Throwable -> t is ListEmptyException }
@@ -98,7 +98,7 @@ object MissingDescriptionProvider {
                             .getWikidataLabelsAndDescriptions(StringUtils.join(qNumbers, '|'))
                 }
                 .map<Pair<PageTitle, PageTitle>> { response ->
-                    var sourceDescriptionAndTargetTitle: Pair<PageTitle, PageTitle>? = null
+                    var sourceAndTargetPageTitles: Pair<PageTitle, PageTitle>? = null
                     for (q in response.entities()!!.keys) {
                         val entity = response.entities()!![q]
                         if (entity == null
@@ -108,14 +108,14 @@ object MissingDescriptionProvider {
                                 || !entity.sitelinks().containsKey(targetWiki.dbName())) {
                             continue
                         }
-                        sourceDescriptionAndTargetTitle = Pair(PageTitle(entity.sitelinks()[sourceWiki.dbName()]!!.title, sourceWiki),
+                        sourceAndTargetPageTitles = Pair(PageTitle(entity.sitelinks()[sourceWiki.dbName()]!!.title, sourceWiki),
                                 PageTitle(entity.sitelinks()[targetWiki.dbName()]!!.title, targetWiki))
                         break
                     }
-                    if (sourceDescriptionAndTargetTitle == null) {
+                    if (sourceAndTargetPageTitles == null) {
                         throw ListEmptyException()
                     }
-                    sourceDescriptionAndTargetTitle
+                    sourceAndTargetPageTitles
                 }
                 .flatMap { sourceAndTargetPageTitles: Pair<PageTitle, PageTitle> -> getSummary(sourceAndTargetPageTitles) }
                 .retry { t: Throwable -> t is ListEmptyException }

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -738,4 +738,5 @@
   <string name="suggested_edits_unlock_add_descriptions_notification_big_text">Short text\n\nLong text of the notification bar shown to user that the detail of this notification</string>
   <string name="suggested_edits_unlock_translate_descriptions_notification_big_text">Short text\n\nLong text of the notification bar shown to user that the detail of this notification</string>
   <string name="suggested_edits_unlock_notification_button">Action button text for the dialog action that goes to the suggested edits screen</string>
+  <string name="suggested_edits_license_notice">Disclaimer that specifies the Terms of Use and CC license that applies to add descriptions. Please preserve the %1$s and %2$s parameters, since these will be replaced with URLs.</string>
 </resources>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -280,7 +280,7 @@
   <string name="gallery_menu_share">Label for menu item to share the current image.\n{{Identical|Share}}</string>
   <string name="gallery_share_error">Error message shown when there was a problem with sharing the image. The \"%s\" symbol is replaced with the actual error message from the system.</string>
   <string name="gallery_save_progress">Message shown when the current media item is being downloaded.</string>
-  <string name="gallery_save_success">Mesajo montrata pos sucesoza kopiado di la nun arkivo en la lokala aparato (komputero, posh-telefonilo, \'tablet\'...).</string>
+  <string name="gallery_save_success">Message shown when the current media item is downloaded successfully.</string>
   <string name="gallery_error_video_failed">Error message displayed when a video fails to be played on the device.</string>
   <string name="gallery_save_image_write_permission_rationale">Message shown to explain that an extra write permission is needed to save an image.</string>
   <string name="err_cannot_save_file">Error message when we detect that a file cannot be written to storage.</string>
@@ -615,14 +615,9 @@
   <string name="description_edit_tutorial_button_label_start_editing">Label for a button the user can push when ready to start editing.</string>
   <string name="description_edit_tutorial_promise">A statement that the user promises not to misuse the feature.</string>
   <string name="editactionfeed_add_title_descriptions">Title of screen where the user chooses articles that are missing descriptions to be added.</string>
-  <string name="editactionfeed_translate_descriptions">Title of screen where the user chooses descriptions to translate from one article to another.</string>
   <string name="editactionfeed_review_title_description">Title of the review title description page.</string>
   <string name="editactionfeed_add_description_button">A button text for adding description. Appears next to {{msg-wm|Wikipedia-android-strings-onboarding skip}}. (See also [https://phabricator.wikimedia.org/T214786 bug T214786].)</string>
   <string name="editactionfeed_my_contributions">A overflow menu text that leads to my contributions page</string>
-  <string name="editactionfeed_from_language">A label shows that the current selected Wikipedia language for fetching articles.</string>
-  <string name="editactionfeed_add_title_dialog_learn_more">A button text for leading users to the help page of editing title descriptions.</string>
-  <string name="editactionfeed_translate_title_dialog_learn_more">Text on link to help page for translating title descriptions.\n{{Identical|Learn more}}</string>
-  <string name="editactionfeed_to_language">Label text indicating that the selected language is the one into which the description will be translated to.</string>
   <string name="editactionfeed_added_by_you">A label shows that the current article description was added by you.</string>
   <string name="editactionfeed_translated_by_you">A label shows that the current article description was translated by the user.</string>
   <string name="description_edit_revert_subtitle">Subtitle in the dialog that informs the user that their edit was reverted.</string>
@@ -715,7 +710,6 @@
   <string name="translate_description_edit_disable_text">Hint message to users about why the translation tasks are locked and how they can be unlocked by making valid edits. %d is the number of edits.</string>
   <string name="multilingual_task_negative">Negative action button text for editing tasks.</string>
   <string name="multilingual_task_positive">Positive action button text for editing tasks.</string>
-  <string name="translation_source_description">Label text that indicated that the description text shown is of the source language %1$s is the language and %2$s is the description</string>
   <string name="translate_caption_task_title">Image caption translation tasks heading.</string>
   <string name="translate_caption_task_description">Image caption translation tasks explanation given to user.</string>
   <plurals name="edit_action_contribution_count">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
     <string name="android_app_request_an_account_url">https://en.wikipedia.org/wiki/Wikipedia:Request_an_account</string>
     <string name="cc_by_sa_3_url">https://creativecommons.org/licenses/by-sa/3.0/</string>
     <string name="cc_0_url">https://creativecommons.org/publicdomain/zero/1.0/</string>
+    <string name="android_app_edit_help_url">https://m.mediawiki.org/wiki/Wikimedia_Apps/Suggested_edits</string>
     <string name="about_libraries_heading">Libraries used</string>
     <string name="about_contributors_heading">Contributors</string>
     <string name="about_translators_heading">Translators</string>
@@ -655,6 +656,7 @@
     <string name="suggested_edits_unlock_translate_descriptions_notification_big_text">Suggested edits\n\nCongratulations on your 50th contribution, we’re impressed! You’re using the app in multiple languages, so we’ve compiled a list of articles needing description translations. Could you continue to help us improving Wikipedia?</string>
     <string name="suggested_edits_unlock_notification_button">Yes, let’s go</string>
     <string name="suggested_edits_license_notice"><![CDATA[By adding the title description, I agree to the <a href="%1$s">Terms of Use</a> and to irrevocably release my contributions under the <a href="%2$s">Creative Commons CC0</a> license.]]></string>
+    <string name="suggested_edits_menu_info">Info</string>
     <string name="title_description_task_title">Add descriptions</string>
     <string name="title_description_task_description">Contribute to articles without descriptions</string>
     <string name="image_caption_task_title">Caption images</string>
@@ -675,8 +677,6 @@
     </plurals>
     <string name="description_edit_tutorial_message">Welcome to the new home for quick editing in the Wikipedia app. Your contributions are much appreciated. Happy editing!</string>
     <string name="edit_tasks_onboarding_get_started">Get started</string>
-    <string name="android_app_edit_help_url">https://m.mediawiki.org/wiki/Wikimedia_Apps/Suggested_edits</string>
-    <string name="suggested_edits_menu_info">Info</string>
     <!-- /Suggested edits -->
 
     <!-- Description editing revert help -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -637,14 +637,9 @@
 
     <!-- Suggested edits -->
     <string name="editactionfeed_add_title_descriptions">Add descriptions</string>
-    <string name="editactionfeed_translate_descriptions">Translate title descriptions</string>
     <string name="editactionfeed_review_title_description">Review description</string>
     <string name="editactionfeed_add_description_button">Add description</string>
     <string name="editactionfeed_my_contributions">My contributions</string>
-    <string name="editactionfeed_from_language">From: </string>
-    <string name="editactionfeed_add_title_dialog_learn_more">Learn more</string>
-    <string name="editactionfeed_translate_title_dialog_learn_more">Learn more</string>
-    <string name="editactionfeed_to_language">To: </string>
     <string name="editactionfeed_added_by_you">Added by you:</string>
     <string name="editactionfeed_translated_by_you">Translated by you:</string>
     <string name="suggested_edits_unlock_add_descriptions_dialog_title">You unlocked the “Add descriptions“ task</string>
@@ -660,6 +655,28 @@
     <string name="suggested_edits_unlock_translate_descriptions_notification_big_text">Suggested edits\n\nCongratulations on your 50th contribution, we’re impressed! You’re using the app in multiple languages, so we’ve compiled a list of articles needing description translations. Could you continue to help us improving Wikipedia?</string>
     <string name="suggested_edits_unlock_notification_button">Yes, let’s go</string>
     <string name="suggested_edits_license_notice"><![CDATA[By adding the title description, I agree to the <a href="%1$s">Terms of Use</a> and to irrevocably release my contributions under the <a href="%2$s">Creative Commons CC0</a> license.]]></string>
+    <string name="title_description_task_title">Add descriptions</string>
+    <string name="title_description_task_description">Contribute to articles without descriptions</string>
+    <string name="image_caption_task_title">Caption images</string>
+    <string name="image_caption_task_description">Add captions to images</string>
+    <string name="multilingual_task_title">More tasks for multilingual editors</string>
+    <string name="multilingual_task_description">Translation tasks are available if you read and write in more than one Wikipedia language.</string>
+    <string name="translation_task_title">Translate descriptions</string>
+    <string name="translation_task_description">Translate descriptions across article languages.</string>
+    <string name="image_caption_edit_disable_text">Locked until you’ve made %d verified contributions</string>
+    <string name="translate_description_edit_disable_text">Locked until you’ve made %d verified contributions</string>
+    <string name="multilingual_task_negative">Not for me</string>
+    <string name="multilingual_task_positive">Add languages</string>
+    <string name="translate_caption_task_title">Translate image captions</string>
+    <string name="translate_caption_task_description">Translate captions into other languages</string>
+    <plurals name="edit_action_contribution_count">
+        <item quantity="one">1 contribution</item>
+        <item quantity="other">%d contributions</item>
+    </plurals>
+    <string name="description_edit_tutorial_message">Welcome to the new home for quick editing in the Wikipedia app. Your contributions are much appreciated. Happy editing!</string>
+    <string name="edit_tasks_onboarding_get_started">Get started</string>
+    <string name="android_app_edit_help_url">https://m.mediawiki.org/wiki/Wikimedia_Apps/Suggested_edits</string>
+    <string name="suggested_edits_menu_info">Info</string>
     <!-- /Suggested edits -->
 
     <!-- Description editing revert help -->
@@ -759,27 +776,4 @@
     <string name="main_drawer_close">Close</string>
     <string name="main_drawer_help">Help</string>
     <string name="main_drawer_login">Log in / join Wikipedia</string>
-    <string name="title_description_task_title">Add descriptions</string>
-    <string name="title_description_task_description">Contribute to articles without descriptions</string>
-    <string name="image_caption_task_title">Caption images</string>
-    <string name="image_caption_task_description">Add captions to images</string>
-    <string name="multilingual_task_title">More tasks for multilingual editors</string>
-    <string name="multilingual_task_description">Translation tasks are available if you read and write in more than one Wikipedia language.</string>
-    <string name="translation_task_title">Translate descriptions</string>
-    <string name="translation_task_description">Translate descriptions across article languages.</string>
-    <string name="image_caption_edit_disable_text">Locked until you’ve made %d verified contributions</string>
-    <string name="translate_description_edit_disable_text">Locked until you’ve made %d verified contributions</string>
-    <string name="multilingual_task_negative">Not for me</string>
-    <string name="multilingual_task_positive">Add languages</string>
-    <string name="translation_source_description">%s description:\n</string>
-    <string name="translate_caption_task_title">Translate image captions</string>
-    <string name="translate_caption_task_description">Translate captions into other languages</string>
-    <plurals name="edit_action_contribution_count">
-        <item quantity="one">1 contribution</item>
-        <item quantity="other">%d contributions</item>
-    </plurals>
-    <string name="description_edit_tutorial_message">Welcome to the new home for quick editing in the Wikipedia app. Your contributions are much appreciated. Happy editing!</string>
-    <string name="edit_tasks_onboarding_get_started">Get started</string>
-    <string name="android_app_edit_help_url">https://m.mediawiki.org/wiki/Wikimedia_Apps/Suggested_edits</string>
-    <string name="suggested_edits_menu_info">Info</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -659,6 +659,7 @@
     <string name="suggested_edits_unlock_add_descriptions_notification_big_text">Suggested edits\n\nCongratulations on your third contribution. Since you’re super good at editing, we’ve compiled a list of articles missing descriptions. Could you help us to improve Wikipedia?</string>
     <string name="suggested_edits_unlock_translate_descriptions_notification_big_text">Suggested edits\n\nCongratulations on your 50th contribution, we’re impressed! You’re using the app in multiple languages, so we’ve compiled a list of articles needing description translations. Could you continue to help us improving Wikipedia?</string>
     <string name="suggested_edits_unlock_notification_button">Yes, let’s go</string>
+    <string name="suggested_edits_license_notice"><![CDATA[By adding the title description, I agree to the <a href="%1$s">Terms of Use</a> and to irrevocably release my contributions under the <a href="%2$s">Creative Commons CC0</a> license.]]></string>
     <!-- /Suggested edits -->
 
     <!-- Description editing revert help -->


### PR DESCRIPTION
## License notice string for SuggestedEdits
The general license notice is **_By changing the title description ..._** and in the `SuggestedEdits` we should use **_By adding the title description_**

Reference: https://app.zeplin.io/project/57a120b91998d8977642a238/screen/5c77d809981c3b6256b4521e

## Remove unused strings and move related strings to the same block
Move the related string into `<!-- Suggested edits -->` block.

## Bonus
When doing the clean-up in `values-qq/strings.xml`, I found there's a **translated** string in the file, which is not correct.