### PR TITLE
Follow-up to API 21 (Clean up WebView details)

### DIFF
--- a/app/src/main/assets/bundle.js
+++ b/app/src/main/assets/bundle.js
@@ -415,9 +415,8 @@ bridge.registerListener( "queueRemainingSections", function ( payload ) {
     remainingRequest.open('GET', payload.url);
     remainingRequest.sequence = payload.sequence;
     remainingRequest.fragment = payload.fragment;
-    if (window.apiLevel > 19 && window.responseType !== 'json') {
-        remainingRequest.responseType = 'json';
-    }
+    remainingRequest.responseType = 'json';
+
     remainingRequest.onreadystatechange = function() {
         if (this.readyState !== XMLHttpRequest.DONE || this.status === 0 || this.sequence !== window.sequence) {
             return;
@@ -427,9 +426,7 @@ bridge.registerListener( "queueRemainingSections", function ( payload ) {
             return;
         }
         try {
-            // On API <20, the XMLHttpRequest does not support responseType = json,
-            // so we have to call JSON.parse() ourselves.
-            var sectionsObj = window.apiLevel > 19 ? this.response : JSON.parse(this.response);
+            var sectionsObj = this.response;
             if (sectionsObj.mobileview) {
                 // If it's a mobileview response, the "sections" object will be one level deeper.
                 sectionsObj = sectionsObj.mobileview;

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
@@ -553,11 +553,9 @@ public class ReadingListFragment extends Fragment implements
             recyclerView.post(() -> {
                 if (isAdded()) {
                     DeviceUtil.updateStatusBarTheme(requireActivity(), toolbar, toolbarExpanded && transparentStatusBarEnabled);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                        requireActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-                        requireActivity().getWindow().setStatusBarColor(transparentStatusBarEnabled
-                                ? Color.TRANSPARENT : ResourceUtil.getThemedColor(requireActivity(), R.attr.main_status_bar_color));
-                    }
+                    requireActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+                    requireActivity().getWindow().setStatusBarColor(transparentStatusBarEnabled
+                            ? Color.TRANSPARENT : ResourceUtil.getThemedColor(requireActivity(), R.attr.main_status_bar_color));
                 }
             });
             // prevent swiping when collapsing the view

--- a/www/js/sections.js
+++ b/www/js/sections.js
@@ -196,9 +196,8 @@ bridge.registerListener( "queueRemainingSections", function ( payload ) {
     remainingRequest.open('GET', payload.url);
     remainingRequest.sequence = payload.sequence;
     remainingRequest.fragment = payload.fragment;
-    if (window.apiLevel > 19 && window.responseType !== 'json') {
-        remainingRequest.responseType = 'json';
-    }
+    remainingRequest.responseType = 'json';
+
     remainingRequest.onreadystatechange = function() {
         if (this.readyState !== XMLHttpRequest.DONE || this.status === 0 || this.sequence !== window.sequence) {
             return;
@@ -208,9 +207,7 @@ bridge.registerListener( "queueRemainingSections", function ( payload ) {
             return;
         }
         try {
-            // On API <20, the XMLHttpRequest does not support responseType = json,
-            // so we have to call JSON.parse() ourselves.
-            var sectionsObj = window.apiLevel > 19 ? this.response : JSON.parse(this.response);
+            var sectionsObj = this.response;
             if (sectionsObj.mobileview) {
                 // If it's a mobileview response, the "sections" object will be one level deeper.
                 sectionsObj = sectionsObj.mobileview;


### PR DESCRIPTION
There's a callback from the WebView that is only made in API 19, and also some Javascript-level items that can now go away.