### PR TITLE
Use ScrollView for the EditText in add description screen

### DIFF
--- a/app/src/main/res/layout/view_description_edit.xml
+++ b/app/src/main/res/layout/view_description_edit.xml
@@ -114,7 +114,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toTopOf="@+id/view_description_edit_bottom_views_container"
+                app:layout_constraintBottom_toTopOf="@+id/view_description_edit_read_article_bar_container"
                 app:layout_constraintVertical_weight="1">
 
                 <LinearLayout
@@ -215,32 +215,26 @@
                             app:tint="?attr/material_theme_secondary_color" />
 
                     </FrameLayout>
+
+                    <org.wikipedia.descriptions.DescriptionEditLicenseView
+                        android:id="@+id/view_description_edit_license_container"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="8dp"
+                        android:layout_marginRight="8dp"
+                        android:layout_marginBottom="16dp"/>
                 </LinearLayout>
             </ScrollView>
 
-            <FrameLayout
-                android:id="@+id/view_description_edit_bottom_views_container"
+            <org.wikipedia.descriptions.DescriptionEditReadArticleBarView
+                android:id="@+id/view_description_edit_read_article_bar_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?android:attr/selectableItemBackground"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/view_description_edit_text_container">
-
-                <org.wikipedia.descriptions.DescriptionEditLicenseView
-                    android:id="@+id/view_description_edit_license_container"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="8dp"
-                    android:layout_marginRight="8dp"
-                    android:layout_marginBottom="16dp"/>
-
-                <org.wikipedia.descriptions.DescriptionEditReadArticleBarView
-                    android:id="@+id/view_description_edit_read_article_bar_container"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:background="?android:attr/selectableItemBackground"/>
-            </FrameLayout>
+                app:layout_constraintTop_toBottomOf="@+id/view_description_edit_text_container"/>
 
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/view_description_edit.xml
+++ b/app/src/main/res/layout/view_description_edit.xml
@@ -110,7 +110,7 @@
             android:layout_height="match_parent">
 
             <ScrollView
-                android:id="@+id/view_description_edit_text_container"
+                android:id="@+id/view_description_edit_scrollview"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 app:layout_constraintTop_toTopOf="parent"
@@ -234,7 +234,7 @@
                 android:focusable="true"
                 android:background="?android:attr/selectableItemBackground"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/view_description_edit_text_container"/>
+                app:layout_constraintTop_toBottomOf="@+id/view_description_edit_scrollview"/>
 
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/view_description_edit.xml
+++ b/app/src/main/res/layout/view_description_edit.xml
@@ -109,121 +109,138 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <LinearLayout
-                android:id="@+id/view_description_edit_page_summary_container"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingEnd="@dimen/list_item_horizontal_padding"
-                android:paddingStart="@dimen/list_item_horizontal_padding"
-                android:background="?attr/selectableItemBackground"
-                android:orientation="vertical"
-                android:paddingTop="15dp"
-                android:visibility="gone"
-                app:layout_constraintTop_toTopOf="parent">
-
-                <TextView
-                    android:id="@+id/label_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/description_edit_article"
-                    android:textSize="12sp"
-                    android:fontFamily="sans-serif-medium"
-                    android:textColor="?attr/material_theme_de_emphasised_color"
-                    tools:text="Article"/>
-
-                <TextView
-                    android:id="@+id/view_description_edit_page_summary"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:textSize="14sp"
-                    android:lineSpacingExtra="6sp"
-                    android:textColor="?attr/material_theme_primary_color"
-                    android:maxLines="4"
-                    android:ellipsize="end"
-                    android:gravity="start"
-                    tools:text="Lorem ipsum"/>
-
-                <View
-                    android:layout_width="@dimen/divider_width_for_article"
-                    android:layout_height="1dp"
-                    android:layout_marginTop="19dp"
-                    android:layout_marginBottom="2dp"
-                    android:background="?attr/material_theme_border_color"/>
-
-            </LinearLayout>
-
-            <FrameLayout
+            <ScrollView
                 android:id="@+id/view_description_edit_text_container"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@+id/view_description_edit_page_summary_container"
-                android:paddingTop="7dp">
+                android:layout_height="0dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/view_description_edit_bottom_views_container"
+                app:layout_constraintVertical_weight="1">
 
-                <!-- todo: this class has a lot of ViewGroups. TextInputLayout (a subclass of LinearLayout)
-                           adds another. try to collapse this group into others. the same change should
-                           probably be attempted for other TextInputLayout usages -->
-                <android.support.design.widget.TextInputLayout
-                    android:id="@+id/view_description_edit_text_layout"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginRight="16dp"
-                    android:layout_marginLeft="16dp"
-                    android:textAlignment="viewStart"
-                    android:gravity="start"
-                    app:counterEnabled="true"
-                    app:counterMaxLength="@integer/description_max_chars"
-                    app:counterOverflowTextAppearance="@style/CounterOverflowTextAppearance">
-                    <org.wikipedia.views.PlainPasteEditText
-                        android:id="@+id/view_description_edit_text"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:id="@+id/view_description_edit_page_summary_container"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:imeOptions="actionDone"
-                        android:inputType="textMultiLine|textCapSentences"
-                        android:textSize="16sp"
-                        android:hint="@string/description_edit_text_hint">
-                        <requestFocus />
-                    </org.wikipedia.views.PlainPasteEditText>
-                </android.support.design.widget.TextInputLayout>
+                        android:paddingEnd="@dimen/list_item_horizontal_padding"
+                        android:paddingStart="@dimen/list_item_horizontal_padding"
+                        android:background="?attr/selectableItemBackground"
+                        android:orientation="vertical"
+                        android:paddingTop="15dp"
+                        android:visibility="gone"
+                        app:layout_constraintTop_toTopOf="parent">
 
-                <ImageView
-                    android:id="@+id/view_description_edit_help_button"
-                    android:layout_width="48dp"
-                    android:layout_height="48dp"
-                    android:layout_gravity="end"
-                    android:background="?attr/selectableItemBackgroundBorderless"
-                    android:clickable="true"
-                    android:contentDescription="@string/description_edit_help_title"
-                    android:padding="12dp"
-                    android:layout_marginTop="-10dp"
-                    android:layout_marginStart="8dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginBottom="8dp"
-                    app:srcCompat="@drawable/ic_info_outline_black_24dp"
-                    app:tint="?attr/material_theme_secondary_color" />
+                        <TextView
+                            android:id="@+id/label_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/description_edit_article"
+                            android:textSize="12sp"
+                            android:fontFamily="sans-serif-medium"
+                            android:textColor="?attr/material_theme_de_emphasised_color"
+                            tools:text="Article"/>
 
-            </FrameLayout>
+                        <TextView
+                            android:id="@+id/view_description_edit_page_summary"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:textSize="14sp"
+                            android:lineSpacingExtra="6sp"
+                            android:textColor="?attr/material_theme_primary_color"
+                            android:maxLines="4"
+                            android:ellipsize="end"
+                            android:gravity="start"
+                            tools:text="Lorem ipsum"/>
 
-            <org.wikipedia.descriptions.DescriptionEditLicenseView
-                android:id="@+id/view_description_edit_license_container"
+                        <View
+                            android:layout_width="@dimen/divider_width_for_article"
+                            android:layout_height="1dp"
+                            android:layout_marginTop="19dp"
+                            android:layout_marginBottom="2dp"
+                            android:background="?attr/material_theme_border_color"/>
+
+                    </LinearLayout>
+
+                    <FrameLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="7dp"
+                        android:paddingBottom="7dp">
+                        <!-- todo: this class has a lot of ViewGroups. TextInputLayout (a subclass of LinearLayout)
+                                   adds another. try to collapse this group into others. the same change should
+                                   probably be attempted for other TextInputLayout usages -->
+                        <android.support.design.widget.TextInputLayout
+                            android:id="@+id/view_description_edit_text_layout"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:layout_marginRight="16dp"
+                            android:layout_marginLeft="16dp"
+                            android:textAlignment="viewStart"
+                            android:gravity="start"
+                            app:counterEnabled="true"
+                            app:counterMaxLength="@integer/description_max_chars"
+                            app:counterOverflowTextAppearance="@style/CounterOverflowTextAppearance">
+                            <org.wikipedia.views.PlainPasteEditText
+                                android:id="@+id/view_description_edit_text"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:imeOptions="actionDone"
+                                android:inputType="textMultiLine|textCapSentences"
+                                android:textSize="16sp"
+                                android:hint="@string/description_edit_text_hint">
+                                <requestFocus />
+                            </org.wikipedia.views.PlainPasteEditText>
+                        </android.support.design.widget.TextInputLayout>
+
+                        <ImageView
+                            android:id="@+id/view_description_edit_help_button"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
+                            android:layout_gravity="end"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/description_edit_help_title"
+                            android:padding="12dp"
+                            android:layout_marginTop="-10dp"
+                            android:layout_marginStart="8dp"
+                            android:layout_marginEnd="8dp"
+                            android:layout_marginBottom="8dp"
+                            app:srcCompat="@drawable/ic_info_outline_black_24dp"
+                            app:tint="?attr/material_theme_secondary_color" />
+
+                    </FrameLayout>
+                </LinearLayout>
+            </ScrollView>
+
+            <FrameLayout
+                android:id="@+id/view_description_edit_bottom_views_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="8dp"
-                android:layout_marginRight="8dp"
-                android:layout_marginBottom="16dp"
-                app:layout_constraintTop_toBottomOf="@+id/view_description_edit_text_container"/>
-
-            <org.wikipedia.descriptions.DescriptionEditReadArticleBarView
-                android:id="@+id/view_description_edit_read_article_bar_container"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:clickable="true"
-                android:focusable="true"
-                android:background="?android:attr/selectableItemBackground"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/view_description_edit_license_container"
-                app:layout_constraintVertical_bias="1.0" />
+                app:layout_constraintTop_toBottomOf="@+id/view_description_edit_text_container">
+
+                <org.wikipedia.descriptions.DescriptionEditLicenseView
+                    android:id="@+id/view_description_edit_license_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="8dp"
+                    android:layout_marginRight="8dp"
+                    android:layout_marginBottom="16dp"/>
+
+                <org.wikipedia.descriptions.DescriptionEditReadArticleBarView
+                    android:id="@+id/view_description_edit_read_article_bar_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:background="?android:attr/selectableItemBackground"/>
+            </FrameLayout>
 
         </android.support.constraint.ConstraintLayout>
 


### PR DESCRIPTION
If using the landscape mode in Tablet, or using large font size, the `EditText` view will be covered by the bottom view.
![Screenshot_20190404-161437](https://user-images.githubusercontent.com/2435576/55594741-a4995800-56f5-11e9-8567-025c29f06440.jpg)
