### PR TITLE
Changing dropdown caret tint - Suggested Edits Translation 

### DIFF
--- a/app/src/main/res/layout/fragment_add_title_descriptions.xml
+++ b/app/src/main/res/layout/fragment_add_title_descriptions.xml
@@ -32,7 +32,8 @@
                     android:id="@+id/wikiFromLanguageSpinner"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"/>
+                    android:layout_gravity="center_vertical"
+                    android:backgroundTint="?attr/colorAccent" />
             </LinearLayout>
 
 
@@ -61,7 +62,8 @@
                     android:id="@+id/wikiToLanguageSpinner"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"/>
+                    android:layout_gravity="center_vertical"
+                    android:backgroundTint="?attr/colorAccent" />
 
             </LinearLayout>
 


### PR DESCRIPTION
Changing dropdown arrow caret tint to **colorAccent.**

Zeplin : https://app.zeplin.io/project/57a120b91998d8977642a238/screen/5c77d20a86d8b86292fd9750

**Phab:** https://phabricator.wikimedia.org/T217170

