### PR TITLE
Fix image dimming in dark mode(s).

### DIFF
--- a/app/src/main/assets/bundle.js
+++ b/app/src/main/assets/bundle.js
@@ -295,6 +295,7 @@ function setWindowAttributes( payload ) {
     window.siteLanguage = payload.siteLanguage;
     window.showImages = payload.showImages;
     window.collapseTables = payload.collapseTables;
+    window.dimImages = payload.dimImages;
 }
 
 function setTitleElement( parentNode, section ) {
@@ -317,6 +318,7 @@ bridge.registerListener( "displayLeadSection", function( payload ) {
     setWindowAttributes(payload);
     window.offline = false;
 
+    pagelib.DimImagesTransform.dim( window, window.dimImages );
 
     var contentElem = document.getElementById( "content" );
     contentElem.setAttribute( "dir", window.directionality );

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -420,7 +420,7 @@ public class PageFragmentLoadState {
                 .put("showImages", Prefs.isImageDownloadEnabled())
                 .put("collapseTables", Prefs.isCollapseTablesEnabled())
                 .put("theme", app.getCurrentTheme().getMarshallingId())
-                .put("dimImages", Prefs.shouldDimDarkModeImages());
+                .put("dimImages", app.getCurrentTheme().isDark() && Prefs.shouldDimDarkModeImages());
     }
 
     private JSONObject leadSectionPayload(@NonNull Page page) {

--- a/www/js/sections.js
+++ b/www/js/sections.js
@@ -76,6 +76,7 @@ function setWindowAttributes( payload ) {
     window.siteLanguage = payload.siteLanguage;
     window.showImages = payload.showImages;
     window.collapseTables = payload.collapseTables;
+    window.dimImages = payload.dimImages;
 }
 
 function setTitleElement( parentNode, section ) {
@@ -98,6 +99,7 @@ bridge.registerListener( "displayLeadSection", function( payload ) {
     setWindowAttributes(payload);
     window.offline = false;
 
+    pagelib.DimImagesTransform.dim( window, window.dimImages );
 
     var contentElem = document.getElementById( "content" );
     contentElem.setAttribute( "dir", window.directionality );


### PR DESCRIPTION
The changes made in #31 seems to have removed too much functionality, and broke image dimming. This restores the explicit call into the page-library to dim the images when necessary.