### PR TITLE
Update margin above the divider - Suggested Edits 

### DIFF
--- a/app/src/main/res/layout-land/fragment_add_title_descriptions_item.xml
+++ b/app/src/main/res/layout-land/fragment_add_title_descriptions_item.xml
@@ -129,8 +129,7 @@
                     android:id="@+id/viewAddDescriptionButton"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="9dp"
-                    android:layout_marginBottom="5dp">
+                    android:layout_marginTop="9dp">
 
                     <ImageView
                         android:layout_width="20dp"
@@ -157,7 +156,7 @@
                 <View
                     android:layout_width="@dimen/divider_width_for_article"
                     android:layout_height="1dp"
-                    android:layout_marginTop="14dp"
+                    android:layout_marginTop="19dp"
                     android:background="?attr/material_theme_border_color"/>
 
                 <TextView

--- a/app/src/main/res/layout/fragment_add_title_descriptions_item.xml
+++ b/app/src/main/res/layout/fragment_add_title_descriptions_item.xml
@@ -130,8 +130,7 @@
                     android:id="@+id/viewAddDescriptionButton"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="5dp"
-                    android:layout_marginBottom="5dp">
+                    android:layout_marginTop="5dp">
 
                     <ImageView
                         android:layout_width="20dp"


### PR DESCRIPTION
'viewAddDescriptionButton' has a bottom marging of 5dp and in portrait mode we have 19dp for top margin on the divider, which makes it 24dp [expected 19dp], and in landscape mode, 14dp on top margin for divider, which makes it correctly 19dp. In this PR they have been synced both layouts to just have a top margin on divider to 19dp.