### PR TITLE
 Optimization: cache SimpleDateFormat objects.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/Funnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/Funnel.java
@@ -71,7 +71,7 @@ abstract class Funnel {
      * @return Event Data to be sent to server
      */
     protected JSONObject preprocessData(@NonNull JSONObject eventData) {
-        preprocessData(eventData, DEFAULT_TIMESTAMP_KEY, DateUtil.getIso8601LocalDateFormat().format(new Date()));
+        preprocessData(eventData, DEFAULT_TIMESTAMP_KEY, DateUtil.iso8601LocalDateFormat(new Date()));
         preprocessData(eventData, DEFAULT_APP_INSTALL_ID_KEY, app.getAppInstallID());
         preprocessSessionToken(eventData);
         return eventData;

--- a/app/src/main/java/org/wikipedia/feed/announcement/Announcement.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/Announcement.java
@@ -61,7 +61,7 @@ public class Announcement extends BaseModel {
 
     @Nullable Date startTime() {
         try {
-            return DateUtil.getIso8601DateFormat().parse(startTime);
+            return DateUtil.iso8601DateParse(startTime);
         } catch (ParseException e) {
             return null;
         }
@@ -69,7 +69,7 @@ public class Announcement extends BaseModel {
 
     @Nullable Date endTime() {
         try {
-            return DateUtil.getIso8601DateFormat().parse(endTime);
+            return DateUtil.iso8601DateParse(endTime);
         } catch (ParseException e) {
             return null;
         }

--- a/app/src/main/java/org/wikipedia/notifications/Notification.java
+++ b/app/src/main/java/org/wikipedia/notifications/Notification.java
@@ -130,7 +130,7 @@ public class Notification {
 
         public Date date() {
             try {
-                return DateUtil.getIso8601DateFormat().parse(utciso8601);
+                return DateUtil.iso8601DateParse(utciso8601);
             } catch (ParseException e) {
                 L.e(e);
                 return new Date();

--- a/app/src/main/java/org/wikipedia/page/PageProperties.java
+++ b/app/src/main/java/org/wikipedia/page/PageProperties.java
@@ -15,7 +15,7 @@ import java.text.ParseException;
 import java.util.Date;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
-import static org.wikipedia.util.DateUtil.getIso8601DateFormat;
+import static org.wikipedia.util.DateUtil.iso8601DateParse;
 
 /**
  * Immutable class that contains metadata associated with a PageTitle.
@@ -66,7 +66,7 @@ public class PageProperties implements Parcelable {
         String lastModifiedText = core.getLastModified();
         if (lastModifiedText != null) {
             try {
-                lastModified.setTime(getIso8601DateFormat().parse(lastModifiedText).getTime());
+                lastModified.setTime(iso8601DateParse(lastModifiedText).getTime());
             } catch (ParseException e) {
                 L.d("Failed to parse date: " + lastModifiedText);
             }

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
@@ -197,7 +197,7 @@ public class ReadingListSyncAdapter extends AbstractThreadedSyncAdapter {
                             // with the remote collection, or delete them.
                             // However, let's issue a request to the changes endpoint, so that
                             // it can throw an exception if lists are not set up for the user.
-                            client.getChangesSince(DateUtil.getIso8601DateFormat().format(new Date()));
+                            client.getChangesSince(DateUtil.iso8601DateFormat(new Date()));
                             // Exception wasn't thrown, so post the bus event.
                             WikipediaApp.getInstance().getBus().post(new ReadingListsMergeLocalDialogEvent());
                             return;
@@ -593,7 +593,7 @@ public class ReadingListSyncAdapter extends AbstractThreadedSyncAdapter {
         }
         try {
             Date date = DateUtil.getHttpLastModifiedDate(lastDateHeader);
-            return DateUtil.getIso8601DateFormat().format(date);
+            return DateUtil.iso8601DateFormat(date);
         } catch (ParseException e) {
             return lastSyncTime;
         }

--- a/app/src/main/java/org/wikipedia/util/DateUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.java
@@ -26,32 +26,15 @@ public final class DateUtil {
     // TODO: Switch to DateTimeFormatter when minSdk = 26.
 
     public static synchronized String iso8601DateFormat(Date date) {
-        String pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-        if (!DATE_FORMATS.containsKey(pattern)) {
-            SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ROOT);
-            df.setTimeZone(TimeZone.getTimeZone("UTC"));
-            DATE_FORMATS.put(pattern, df);
-        }
-        return DATE_FORMATS.get(pattern).format(date);
+        return getCachedDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT, true).format(date);
     }
 
     public static synchronized Date iso8601DateParse(String date) throws ParseException {
-        String pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-        if (!DATE_FORMATS.containsKey(pattern)) {
-            SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ROOT);
-            df.setTimeZone(TimeZone.getTimeZone("UTC"));
-            DATE_FORMATS.put(pattern, df);
-        }
-        return DATE_FORMATS.get(pattern).parse(date);
+        return getCachedDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT, true).parse(date);
     }
 
     public static synchronized String iso8601LocalDateFormat(Date date) {
-        String pattern = "yyyy-MM-dd'T'HH:mm:ssZ";
-        if (!DATE_FORMATS.containsKey(pattern)) {
-            SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ROOT);
-            DATE_FORMATS.put(pattern, df);
-        }
-        return DATE_FORMATS.get(pattern).format(date);
+        return getCachedDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ROOT, false).format(date);
     }
 
     public static String getFeedCardDayHeaderDate(int age) {
@@ -87,10 +70,18 @@ public final class DateUtil {
     }
 
     private static synchronized String getDateStringWithSkeletonPattern(@NonNull Date date, @NonNull String pattern) {
+        return getCachedDateFormat(android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault(), false).format(date);
+    }
+
+    private static SimpleDateFormat getCachedDateFormat(String pattern, Locale locale, boolean utc) {
         if (!DATE_FORMATS.containsKey(pattern)) {
-            DATE_FORMATS.put(pattern, new SimpleDateFormat(android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault()));
+            SimpleDateFormat df = new SimpleDateFormat(pattern, locale);
+            if (utc) {
+                df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            }
+            DATE_FORMATS.put(pattern, df);
         }
-        return DATE_FORMATS.get(pattern).format(date);
+        return DATE_FORMATS.get(pattern);
     }
 
     public static String getShortDateString(@NonNull Date date) {
@@ -114,13 +105,7 @@ public final class DateUtil {
     }
 
     public static synchronized Date getHttpLastModifiedDate(@NonNull String dateStr) throws ParseException {
-        String pattern = "EEE, dd MMM yyyy HH:mm:ss zzz";
-        if (!DATE_FORMATS.containsKey(pattern)) {
-            SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ENGLISH);
-            df.setTimeZone(TimeZone.getTimeZone("UTC"));
-            DATE_FORMATS.put(pattern, df);
-        }
-        return DATE_FORMATS.get(pattern).parse(dateStr);
+        return getCachedDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH, true).parse(dateStr);
     }
 
     public static String getReadingListsLastSyncDateString(@NonNull String dateStr) throws ParseException {

--- a/app/src/main/java/org/wikipedia/util/DateUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.java
@@ -15,25 +15,43 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 public final class DateUtil {
+    private static Map<String, SimpleDateFormat> DATE_FORMATS = new HashMap<>();
 
-    public static SimpleDateFormat getIso8601DateFormatShort() {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return simpleDateFormat;
+    // TODO: Switch to DateTimeFormatter when minSdk = 26.
+
+    public static synchronized String iso8601DateFormat(Date date) {
+        String pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+        if (!DATE_FORMATS.containsKey(pattern)) {
+            SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ROOT);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            DATE_FORMATS.put(pattern, df);
+        }
+        return DATE_FORMATS.get(pattern).format(date);
     }
 
-    public static SimpleDateFormat getIso8601DateFormat() {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT);
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return simpleDateFormat;
+    public static synchronized Date iso8601DateParse(String date) throws ParseException {
+        String pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+        if (!DATE_FORMATS.containsKey(pattern)) {
+            SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ROOT);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            DATE_FORMATS.put(pattern, df);
+        }
+        return DATE_FORMATS.get(pattern).parse(date);
     }
 
-    public static SimpleDateFormat getIso8601LocalDateFormat() {
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ROOT);
+    public static synchronized String iso8601LocalDateFormat(Date date) {
+        String pattern = "yyyy-MM-dd'T'HH:mm:ssZ";
+        if (!DATE_FORMATS.containsKey(pattern)) {
+            SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ROOT);
+            DATE_FORMATS.put(pattern, df);
+        }
+        return DATE_FORMATS.get(pattern).format(date);
     }
 
     public static String getFeedCardDayHeaderDate(int age) {
@@ -68,8 +86,11 @@ public final class DateUtil {
         return getDateStringWithSkeletonPattern(date, "MMM d");
     }
 
-    private static String getDateStringWithSkeletonPattern(@NonNull Date date, @NonNull String pattern) {
-        return new SimpleDateFormat(android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault()).format(date);
+    private static synchronized String getDateStringWithSkeletonPattern(@NonNull Date date, @NonNull String pattern) {
+        if (!DATE_FORMATS.containsKey(pattern)) {
+            DATE_FORMATS.put(pattern, new SimpleDateFormat(android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault()));
+        }
+        return DATE_FORMATS.get(pattern).format(date);
     }
 
     public static String getShortDateString(@NonNull Date date) {
@@ -92,14 +113,18 @@ public final class DateUtil {
         return calendar;
     }
 
-    public static Date getHttpLastModifiedDate(@NonNull String dateStr) throws ParseException {
-        SimpleDateFormat df = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
-        df.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return df.parse(dateStr);
+    public static synchronized Date getHttpLastModifiedDate(@NonNull String dateStr) throws ParseException {
+        String pattern = "EEE, dd MMM yyyy HH:mm:ss zzz";
+        if (!DATE_FORMATS.containsKey(pattern)) {
+            SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ENGLISH);
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            DATE_FORMATS.put(pattern, df);
+        }
+        return DATE_FORMATS.get(pattern).parse(dateStr);
     }
 
     public static String getReadingListsLastSyncDateString(@NonNull String dateStr) throws ParseException {
-        return getDateStringWithSkeletonPattern(getIso8601DateFormat().parse(dateStr), "d MMM yyyy HH:mm");
+        return getDateStringWithSkeletonPattern(iso8601DateParse(dateStr), "d MMM yyyy HH:mm");
     }
 
     @NonNull public static String yearToStringWithEra(int year) {

--- a/app/src/test/java/org/wikipedia/util/DateUtilTest.java
+++ b/app/src/test/java/org/wikipedia/util/DateUtilTest.java
@@ -4,9 +4,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -21,16 +18,11 @@ public class DateUtilTest {
 
     @Test
     public void testIso8601DateFormat() throws Throwable {
-        SimpleDateFormat format = DateUtil.getIso8601DateFormat();
-        assertThat(format.format(DateUtil.getHttpLastModifiedDate(HTTP_DATE_HEADER)), is("2017-05-25T21:13:47Z"));
+        assertThat(DateUtil.iso8601DateFormat(DateUtil.getHttpLastModifiedDate(HTTP_DATE_HEADER)), is("2017-05-25T21:13:47Z"));
     }
 
     @Test
-    public void testIso8601LocalDateFormat() throws Throwable {
-        SimpleDateFormat format = DateUtil.getIso8601LocalDateFormat();
-        format.setTimeZone(TimeZone.getTimeZone("GMT-4:00"));
-        assertThat(format.format(DateUtil.getHttpLastModifiedDate(HTTP_DATE_HEADER)), is("2017-05-25T17:13:47-0400"));
-        format.setTimeZone(TimeZone.getTimeZone("UTC"));
-        assertThat(format.format(DateUtil.getHttpLastModifiedDate(HTTP_DATE_HEADER)), is("2017-05-25T21:13:47+0000"));
+    public void testIso8601Identity() throws Throwable {
+        assertThat(DateUtil.iso8601DateFormat(DateUtil.iso8601DateParse("2017-05-25T21:13:47Z")), is("2017-05-25T21:13:47Z"));
     }
 }


### PR DESCRIPTION
Instantiating a new `SimpleDateFormat` object is actually a pretty expensive operation. Let's cache and reuse these objects.

However, note that `SimpleDateFormat` objects are not thread safe, so the methods that access them must be `synchronized`.