### PR TITLE
Use plain double quotes in all the English strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,7 +260,7 @@
     <string name="preference_summary_show_images">Enable or disable loading of images in pages. Uncheck this setting if your Internet connection is slow, or if your data plan is limited.</string>
     <string name="preference_title_download_only_over_wifi">Download only over Wi-Fi</string>
     <string name="dialog_title_download_only_over_wifi">Confirm download using mobile data?</string>
-    <string name="dialog_text_download_only_over_wifi">You have “Download only over Wi-Fi” turned on in settings. Do you want to allow using your mobile data plan for this download only?</string>
+    <string name="dialog_text_download_only_over_wifi">You have "Download only over Wi-Fi" turned on in settings. Do you want to allow using your mobile data plan for this download only?</string>
     <string name="dialog_title_download_only_over_wifi_allow">Allow</string>
     <string name="read_more_section">Read more</string>
     <string name="about_article_section">About this article</string>
@@ -644,14 +644,14 @@
     <string name="suggested_edits_my_contributions">My contributions</string>
     <string name="suggested_edits_added_by_you">Added by you:</string>
     <string name="suggested_edits_translated_by_you">Translated by you:</string>
-    <string name="suggested_edits_unlock_add_descriptions_dialog_title">You unlocked the “Add descriptions“ task</string>
+    <string name="suggested_edits_unlock_add_descriptions_dialog_title">You unlocked the "Add descriptions" task</string>
     <string name="suggested_edits_unlock_add_descriptions_dialog_message">Congratulations on your third contribution! Since you’re super good at editing, we’ve compiled a list of articles missing descriptions. Could you help us to improve Wikipedia?</string>
-    <string name="suggested_edits_unlock_translate_descriptions_dialog_title">You unlocked the “Translate descriptions“ task</string>
+    <string name="suggested_edits_unlock_translate_descriptions_dialog_title">You unlocked the "Translate descriptions" task</string>
     <string name="suggested_edits_unlock_translate_descriptions_dialog_message">Congratulations on your 50th contribution, we’re impressed! You’re using the app in multiple languages, so we’ve compiled a list of articles needing description translations. Could you continue to help us improving Wikipedia?</string>
     <string name="suggested_edits_unlock_dialog_no">Maybe later</string>
     <string name="suggested_edits_unlock_dialog_yes">Yes, let’s go</string>
-    <string name="suggested_edits_unlock_add_descriptions_notification_title">You unlocked “Add descriptions“</string>
-    <string name="suggested_edits_unlock_translate_descriptions_notification_title">You unlocked “Translate descriptions“</string>
+    <string name="suggested_edits_unlock_add_descriptions_notification_title">You unlocked "Add descriptions"</string>
+    <string name="suggested_edits_unlock_translate_descriptions_notification_title">You unlocked "Translate descriptions"</string>
     <string name="suggested_edits_unlock_notification_text">Suggested edits</string>
     <string name="suggested_edits_unlock_add_descriptions_notification_big_text">Suggested edits\n\nCongratulations on your third contribution. Since you’re super good at editing, we’ve compiled a list of articles missing descriptions. Could you help us to improve Wikipedia?</string>
     <string name="suggested_edits_unlock_translate_descriptions_notification_big_text">Suggested edits\n\nCongratulations on your 50th contribution, we’re impressed! You’re using the app in multiple languages, so we’ve compiled a list of articles needing description translations. Could you continue to help us improving Wikipedia?</string>


### PR DESCRIPTION
Elegant quotes are actually good, but the current file uses
them inconsistently, so it's better to use plain quotes
until there's an agreement about standard usage of elegant quotes.