### PR TITLE
Use CardView for floating queue view and fix bottom view behavior.

### DIFF
--- a/app/src/main/java/org/wikipedia/main/floatingqueue/FloatingQueueBottomViewBehavior.java
+++ b/app/src/main/java/org/wikipedia/main/floatingqueue/FloatingQueueBottomViewBehavior.java
@@ -5,20 +5,14 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.google.android.material.snackbar.Snackbar;
-
 import org.wikipedia.R;
+import org.wikipedia.random.BottomViewBehavior;
 
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
-public class FloatingQueueBottomViewBehavior extends CoordinatorLayout.Behavior<ViewGroup> {
+public class FloatingQueueBottomViewBehavior extends BottomViewBehavior {
     public FloatingQueueBottomViewBehavior(Context context, AttributeSet attrs) {
         super(context, attrs);
-    }
-
-    @Override
-    public boolean layoutDependsOn(CoordinatorLayout parent, ViewGroup child, View dependency) {
-        return dependency instanceof Snackbar.SnackbarLayout;
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/main/floatingqueue/FloatingQueueBottomViewBehavior.java
+++ b/app/src/main/java/org/wikipedia/main/floatingqueue/FloatingQueueBottomViewBehavior.java
@@ -1,0 +1,31 @@
+package org.wikipedia.main.floatingqueue;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.google.android.material.snackbar.Snackbar;
+
+import org.wikipedia.R;
+
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+public class FloatingQueueBottomViewBehavior extends CoordinatorLayout.Behavior<ViewGroup> {
+    public FloatingQueueBottomViewBehavior(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean layoutDependsOn(CoordinatorLayout parent, ViewGroup child, View dependency) {
+        return dependency instanceof Snackbar.SnackbarLayout;
+    }
+
+    @Override
+    public boolean onDependentViewChanged(CoordinatorLayout parent, ViewGroup child, View dependency) {
+        float translationY = Math.min(0, dependency.getTranslationY() - dependency.getHeight() - dependency.getResources()
+                .getDimension(R.dimen.floating_queue_container_margin_top_bottom));
+        child.setTranslationY(translationY);
+        return true;
+    }
+}

--- a/app/src/main/java/org/wikipedia/main/floatingqueue/FloatingQueueView.kt
+++ b/app/src/main/java/org/wikipedia/main/floatingqueue/FloatingQueueView.kt
@@ -4,26 +4,22 @@ import android.content.Context
 import android.net.Uri
 import android.text.TextUtils
 import android.util.AttributeSet
-import android.widget.FrameLayout
+import androidx.cardview.widget.CardView
 import kotlinx.android.synthetic.main.view_floating_queue.view.*
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.page.PageTitle
-import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.UriUtil
 import org.wikipedia.views.FaceAndColorDetectImageView
 
 class FloatingQueueView @JvmOverloads constructor(
-        context: Context, attrs: AttributeSet? = null, defStyle: Int = 0) : FrameLayout(context, attrs, defStyle) {
+        context: Context, attrs: AttributeSet? = null, defStyle: Int = 0) : CardView(context, attrs, defStyle) {
 
     init {
         inflate(context, R.layout.view_floating_queue, this)
 
         // This fix the invisible issue when returning back from the PageActivity
         floatingQueueThumbnail.setLegacyVisibilityHandlingEnabled(true)
-
-        // TODO: remove as soon as we drop support for API 19, and replace with CardView with elevation.
-        setBackgroundResource(ResourceUtil.getThemedAttributeId(context, R.attr.shadow_background_drawable))
     }
 
     var callback: Callback? = null

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -34,9 +34,13 @@
                     android:layout_gravity="bottom"
                     android:clickable="true"
                     android:focusable="true"
-                    android:layout_marginStart="@dimen/floating_queue_container_margin"
-                    android:layout_marginEnd="@dimen/floating_queue_container_margin"
-                    app:layout_behavior="org.wikipedia.random.BottomViewBehavior"/>
+                    android:layout_marginTop="@dimen/floating_queue_container_margin_top_bottom"
+                    android:layout_marginBottom="@dimen/floating_queue_container_margin_top_bottom"
+                    android:layout_marginStart="@dimen/floating_queue_container_margin_start_end"
+                    android:layout_marginEnd="@dimen/floating_queue_container_margin_start_end"
+                    app:cardCornerRadius="2dp"
+                    app:cardElevation="10dp"
+                    app:layout_behavior="org.wikipedia.main.floatingqueue.FloatingQueueBottomViewBehavior"/>
             </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
         </FrameLayout>

--- a/app/src/main/res/layout/fragment_reading_list.xml
+++ b/app/src/main/res/layout/fragment_reading_list.xml
@@ -87,9 +87,13 @@
             android:layout_gravity="bottom"
             android:clickable="true"
             android:focusable="true"
-            android:layout_marginStart="@dimen/floating_queue_container_margin"
-            android:layout_marginEnd="@dimen/floating_queue_container_margin"
-            app:layout_behavior="org.wikipedia.random.BottomViewBehavior"/>
+            android:layout_marginTop="@dimen/floating_queue_container_margin_top_bottom"
+            android:layout_marginBottom="@dimen/floating_queue_container_margin_top_bottom"
+            android:layout_marginStart="@dimen/floating_queue_container_margin_start_end"
+            android:layout_marginEnd="@dimen/floating_queue_container_margin_start_end"
+            app:cardCornerRadius="2dp"
+            app:cardElevation="10dp"
+            app:layout_behavior="org.wikipedia.main.floatingqueue.FloatingQueueBottomViewBehavior"/>
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -23,7 +23,6 @@
     <attr name="nav_tab_item_color_state" format="reference" />
     <attr name="button_highlight_border_shape" format="reference" />
     <attr name="randomizer_dice_icon_color" format="reference" />
-    <attr name="shadow_background_drawable" format="reference" />
     <attr name="tab_counts_shape_border" format="reference" />
     <attr name="page_tab_counts_shape_border" format="reference" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -95,8 +95,9 @@
     <dimen name="dialog_line_spacing_extra">5sp</dimen>
 
     <!-- Floating Queue -->
-    <dimen name="floating_queue_container_height">64dp</dimen>
-    <dimen name="floating_queue_container_margin">8dp</dimen>
+    <dimen name="floating_queue_container_height">48dp</dimen>
+    <dimen name="floating_queue_container_margin_top_bottom">8dp</dimen>
+    <dimen name="floating_queue_container_margin_start_end">16dp</dimen>
 
     <!-- Article bottom toolbar -->
     <dimen name="bottom_toolbar_item_padding">16dp</dimen>

--- a/app/src/main/res/values/styles_dark.xml
+++ b/app/src/main/res/values/styles_dark.xml
@@ -70,7 +70,6 @@
         <item name="chart_shade7">@color/base10</item>
         <item name="green_highlight_color">@color/green50</item>
         <item name="randomizer_dice_icon_color">@color/accent50</item>
-        <item name="shadow_background_drawable">@android:drawable/dialog_holo_dark_frame</item>
         <item name="tab_counts_shape_border">@drawable/tab_counts_shape_border_dark</item>
         <item name="page_tab_counts_shape_border">@drawable/page_tab_counts_shape_border_dark</item>
         <item name="thumb_off_color">@color/base70</item>

--- a/app/src/main/res/values/styles_light.xml
+++ b/app/src/main/res/values/styles_light.xml
@@ -70,7 +70,6 @@
         <item name="chart_shade7">@color/base100</item>
         <item name="green_highlight_color">@color/green30</item>
         <item name="randomizer_dice_icon_color">@android:color/white</item>
-        <item name="shadow_background_drawable">@android:drawable/dialog_holo_light_frame</item>
         <item name="tab_counts_shape_border">@drawable/tab_counts_shape_border_light</item>
         <item name="page_tab_counts_shape_border">@drawable/page_tab_counts_shape_border_light</item>
         <item name="thumb_off_color">@color/base90</item>


### PR DESCRIPTION
Uses CardView so that we can show the elevation properly.

Also, fixes the issue that floating queue view stick when the Snackbar showing.

![Screenshot_1555031075](https://user-images.githubusercontent.com/2435576/56005313-9d89c100-5c84-11e9-83df-7f533896d197.png)
