### PR TITLE
Remove unused methods of showing tool bar in PageActivity/PageFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -247,7 +247,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
     @Override
     public boolean onSearchRequested() {
-        showToolbar();
         openSearchActivity(SearchInvokeSource.TOOLBAR, null);
         return true;
     }
@@ -268,10 +267,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         } else {
             supportFinishAfterTransition();
         }
-    }
-
-    public void showToolbar() {
-        // TODO: make toolbar visible, via CoordinatorLayout
     }
 
     /** @return True if the contextual action bar is open. */
@@ -539,11 +534,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     @Override
     public void onPageStartSupportActionMode(@NonNull ActionMode.Callback callback) {
         startActionMode(callback);
-    }
-
-    @Override
-    public void onPageShowToolbar() {
-        showToolbar();
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -121,7 +121,6 @@ public class PageFragment extends Fragment implements BackPressedHandler {
         void onPageUpdateProgressBar(boolean visible, boolean indeterminate, int value);
         void onPageShowThemeChooser();
         void onPageStartSupportActionMode(@NonNull ActionMode.Callback callback);
-        void onPageShowToolbar();
         void onPageHideSoftKeyboard();
         void onPageAddToReadingList(@NonNull PageTitle title,
                                     @NonNull AddToReadingListDialog.InvokeSource source);
@@ -730,7 +729,6 @@ public class PageFragment extends Fragment implements BackPressedHandler {
                 funnel.setPageHeight(webView.getContentHeight());
                 funnel.logDone();
                 webView.clearMatches();
-                showToolbar();
                 hideSoftKeyboard();
                 setToolbarElevationEnabled(true);
             }
@@ -1136,13 +1134,6 @@ public class PageFragment extends Fragment implements BackPressedHandler {
     public void startSupportActionMode(@NonNull ActionMode.Callback actionModeCallback) {
         if (callback() != null) {
             callback().onPageStartSupportActionMode(actionModeCallback);
-        }
-    }
-
-    public void showToolbar() {
-        Callback callback = callback();
-        if (callback != null) {
-            callback.onPageShowToolbar();
         }
     }
 


### PR DESCRIPTION
A minor clean up of removing the unused methods since we are calling the SearchActivity when searching article.