### PR TITLE
Use correct way of testing observable calls in GalleryClientTest

### DIFF
--- a/app/src/test/java/org/wikipedia/gallery/GalleryClientTest.java
+++ b/app/src/test/java/org/wikipedia/gallery/GalleryClientTest.java
@@ -3,14 +3,12 @@ package org.wikipedia.gallery;
 import com.google.gson.stream.MalformedJsonException;
 
 import org.junit.Test;
-import org.wikipedia.dataclient.okhttp.HttpStatusException;
 import org.wikipedia.test.MockRetrofitTest;
 
 import java.util.List;
 
-import static junit.framework.Assert.assertTrue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import io.reactivex.Observable;
+import io.reactivex.observers.TestObserver;
 
 public class GalleryClientTest extends MockRetrofitTest {
     private static final String RAW_JSON_FILE = "gallery.json";
@@ -20,35 +18,36 @@ public class GalleryClientTest extends MockRetrofitTest {
     public void testRequestAllSuccess() throws Throwable {
         enqueueFromFile(RAW_JSON_FILE);
 
-        getRestService().getMedia("foo").subscribe(gallery -> {
-            List<GalleryItem> result = gallery.getAllItems();
+        TestObserver<Gallery> observer = new TestObserver<>();
+        getObservable().subscribe(observer);
 
-            assertThat(result != null, is(true));
-            assertThat(result.size(), is(5));
-            assertThat(result.get(0).getType(), is("image"));
-            assertThat(result.get(2).getType(), is("audio"));
-            assertThat(result.get(4).getType(), is("video"));
-        }, throwable -> assertTrue(false));
+        observer.assertComplete().assertNoErrors()
+                .assertValue(gallery -> {
+                    List<GalleryItem> result = gallery.getAllItems();
+                    return result != null
+                            && result.get(0).getType().equals("image")
+                            && result.get(2).getType().equals("audio")
+                            && result.get(4).getType().equals("video");
+                });
     }
 
     @Test
     public void testRequestImageSuccess() throws Throwable {
         enqueueFromFile(RAW_JSON_FILE);
 
-        getRestService().getMedia("foo").subscribe(gallery -> {
-            List<GalleryItem> result = gallery.getItems("image");
+        TestObserver<Gallery> observer = new TestObserver<>();
+        getObservable().subscribe(observer);
 
-            assertThat(result.size(), is(2));
-            assertThat(result.get(0).getType(), is("image"));
-            assertThat(result.get(0).getTitles().getCanonical(),
-                    is("File:Flag_of_the_United_States.svg"));
-            assertThat(result.get(0).getThumbnail().getSource(),
-                    is("http://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/320px-Flag_of_the_United_States.svg.png"));
-            assertThat(result.get(0).getThumbnailUrl(),
-                    is("http://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/320px-Flag_of_the_United_States.svg.png"));
-            assertThat(result.get(0).getPreferredSizedImageUrl(),
-                    is("http://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/1280px-Flag_of_the_United_States.svg.png"));
-        }, throwable -> assertTrue(false));
+        observer.assertComplete().assertNoErrors()
+                .assertValue(gallery -> {
+                    List<GalleryItem> result = gallery.getItems("image");
+                    return result.size() == 2
+                            && result.get(0).getType().equals("image")
+                            && result.get(0).getTitles().getCanonical().equals("File:Flag_of_the_United_States.svg")
+                            && result.get(0).getThumbnail().getSource().equals("http://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/320px-Flag_of_the_United_States.svg.png")
+                            && result.get(0).getThumbnailUrl().equals("http://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/320px-Flag_of_the_United_States.svg.png")
+                            && result.get(0).getPreferredSizedImageUrl().equals("http://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/1280px-Flag_of_the_United_States.svg.png");
+                });
     }
 
     @Test
@@ -56,19 +55,18 @@ public class GalleryClientTest extends MockRetrofitTest {
     public void testRequestVideoSuccess() throws Throwable {
         enqueueFromFile(RAW_JSON_FILE);
 
-        getRestService().getMedia("foo").subscribe(gallery -> {
-            List<GalleryItem> result = gallery.getItems("video");
+        TestObserver<Gallery> observer = new TestObserver<>();
+        getObservable().subscribe(observer);
 
-            assertThat(result.size(), is(1));
-            assertThat(result.get(0).getType(), is("video"));
-            assertThat(result.get(0).getTitles().getCanonical(),
-                    is("File:Curiosity's_Seven_Minutes_of_Terror.ogv"));
-            assertThat(result.get(0).getFilePage(),
-                    is("https://commons.wikimedia.org/wiki/File:Curiosity%27s_Seven_Minutes_of_Terror.ogv"));
-            assertThat(result.get(0).getSources().size(), is(6));
-            assertThat(result.get(0).getOriginalVideoSource().getOriginalUrl(),
-                    is("https://upload.wikimedia.org/wikipedia/commons/transcoded/9/96/Curiosity%27s_Seven_Minutes_of_Terror.ogv/Curiosity%27s_Seven_Minutes_of_Terror.ogv.720p.webm"));
-        }, throwable -> assertTrue(false));
+        observer.assertComplete().assertNoErrors()
+                .assertValue(gallery -> {
+                    List<GalleryItem> result = gallery.getItems("video");
+                    return result.get(0).getSources().size() == 6
+                            && result.get(0).getType().equals("video")
+                            && result.get(0).getTitles().getCanonical().equals("File:Curiosity's_Seven_Minutes_of_Terror.ogv")
+                            && result.get(0).getFilePage().equals("https://commons.wikimedia.org/wiki/File:Curiosity%27s_Seven_Minutes_of_Terror.ogv")
+                            && result.get(0).getOriginalVideoSource().getOriginalUrl().equals("https://upload.wikimedia.org/wikipedia/commons/transcoded/9/96/Curiosity%27s_Seven_Minutes_of_Terror.ogv/Curiosity%27s_Seven_Minutes_of_Terror.ogv.720p.webm");
+                });
     }
 
     @Test
@@ -76,29 +74,35 @@ public class GalleryClientTest extends MockRetrofitTest {
     public void testRequestAudioSuccess() throws Throwable {
         enqueueFromFile(RAW_JSON_FILE);
 
-        getRestService().getMedia("foo").subscribe(gallery -> {
-            List<GalleryItem> result = gallery.getItems("audio");
+        TestObserver<Gallery> observer = new TestObserver<>();
+        getObservable().subscribe(observer);
 
-            assertThat(result.size(), is(2));
-            assertThat(result.get(0).getType(), is("audio"));
-            assertThat(result.get(1).getTitles().getCanonical(),
-                    is("File:March,_Colonel_John_R._Bourgeois,_Director_·_John_Philip_Sousa_·_United_States_Marine_Band.ogg"));
-            assertThat(result.get(1).getDuration(), is(226.51766666667));
-            assertThat(result.get(0).getAudioType(), is("generic"));
-        }, throwable -> assertTrue(false));
+        observer.assertComplete().assertNoErrors()
+                .assertValue(gallery -> {
+                    List<GalleryItem> result = gallery.getItems("audio");
+                    return result.size() == 2
+                            && result.get(0).getType().equals("audio")
+                            && result.get(1).getTitles().getCanonical().equals("File:March,_Colonel_John_R._Bourgeois,_Director_·_John_Philip_Sousa_·_United_States_Marine_Band.ogg")
+                            && result.get(1).getDuration() == 226.51766666667
+                            && result.get(0).getAudioType().equals("generic");
+                });
     }
 
     @Test public void testRequestResponseFailure() throws Throwable {
         enqueue404();
-
-        getRestService().getMedia("foo").subscribe(gallery -> assertTrue(false),
-                throwable -> assertTrue(throwable instanceof HttpStatusException));
+        TestObserver<Gallery> observer = new TestObserver<>();
+        getObservable().subscribe(observer);
+        observer.assertError(Exception.class);
     }
 
     @Test public void testRequestResponseMalformed() throws Throwable {
         server().enqueue("'");
+        TestObserver<Gallery> observer = new TestObserver<>();
+        getObservable().subscribe(observer);
+        observer.assertError(MalformedJsonException.class);
+    }
 
-        getRestService().getMedia("foo").subscribe(gallery -> assertTrue(false),
-                throwable -> assertTrue(throwable instanceof MalformedJsonException));
+    private Observable<Gallery> getObservable() {
+        return getRestService().getMedia("foo");
     }
 }


### PR DESCRIPTION
The previous test cases in `GalleryClientTest` were testing in an incorrect way.