### PR TITLE
Update checkstyle ImportOrder rule with the new 'androidx' imports

### DIFF
--- a/app/src/androidTest/java/org/wikipedia/WikipediaTestRunner.java
+++ b/app/src/androidTest/java/org/wikipedia/WikipediaTestRunner.java
@@ -4,6 +4,9 @@ import android.content.SharedPreferences;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnitRunner;
+
 import org.wikipedia.dataclient.okhttp.TestStubInterceptor;
 import org.wikipedia.espresso.MockInstrumentationInterceptor;
 import org.wikipedia.espresso.util.ConfigurationTools;
@@ -12,9 +15,6 @@ import org.wikipedia.settings.PrefsIoUtil;
 import org.wikipedia.util.log.L;
 
 import java.io.File;
-
-import androidx.test.InstrumentationRegistry;
-import androidx.test.runner.AndroidJUnitRunner;
 
 import static org.wikipedia.espresso.Constants.TEST_COMPARISON_OUTPUT_FOLDER;
 

--- a/app/src/androidTest/java/org/wikipedia/edit/richtext/SyntaxHighlighterTest.java
+++ b/app/src/androidTest/java/org/wikipedia/edit/richtext/SyntaxHighlighterTest.java
@@ -3,13 +3,13 @@ package org.wikipedia.edit.richtext;
 import android.view.ContextThemeWrapper;
 import android.widget.EditText;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Test;
 import org.wikipedia.R;
 import org.wikipedia.testlib.TestLatch;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/app/src/androidTest/java/org/wikipedia/espresso/MockInstrumentationInterceptor.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/MockInstrumentationInterceptor.java
@@ -3,6 +3,8 @@ package org.wikipedia.espresso;
 import android.content.Context;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.dataclient.okhttp.TestStubInterceptor;
 import org.wikipedia.util.FileUtil;
 
@@ -10,7 +12,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.Protocol;

--- a/app/src/androidTest/java/org/wikipedia/espresso/feed/ExploreFeedTest.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/feed/ExploreFeedTest.java
@@ -5,14 +5,6 @@ import android.app.Activity;
 import android.content.pm.ActivityInfo;
 import android.text.TextUtils;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.wikipedia.R;
-import org.wikipedia.espresso.util.ScreenshotTools;
-import org.wikipedia.espresso.util.ViewTools;
-import org.wikipedia.main.MainActivity;
-
 import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.PerformException;
 import androidx.test.espresso.ViewInteraction;
@@ -20,6 +12,14 @@ import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wikipedia.R;
+import org.wikipedia.espresso.util.ScreenshotTools;
+import org.wikipedia.espresso.util.ViewTools;
+import org.wikipedia.main.MainActivity;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;

--- a/app/src/androidTest/java/org/wikipedia/espresso/history/HistoryTabTest.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/history/HistoryTabTest.java
@@ -3,6 +3,13 @@ package org.wikipedia.espresso.history;
 import android.Manifest;
 import android.content.Intent;
 
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.PerformException;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,13 +19,6 @@ import org.wikipedia.espresso.util.ScreenshotTools;
 import org.wikipedia.espresso.util.ViewTools;
 import org.wikipedia.main.MainActivity;
 import org.wikipedia.navtab.NavTab;
-
-import androidx.test.espresso.NoMatchingViewException;
-import androidx.test.espresso.PerformException;
-import androidx.test.espresso.ViewInteraction;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;

--- a/app/src/androidTest/java/org/wikipedia/espresso/main/overflow/CustomizeFeedTest.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/main/overflow/CustomizeFeedTest.java
@@ -3,6 +3,12 @@ package org.wikipedia.espresso.main.overflow;
 import android.Manifest;
 import android.view.View;
 
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,12 +17,6 @@ import org.wikipedia.R;
 import org.wikipedia.espresso.util.ScreenshotTools;
 import org.wikipedia.espresso.util.ViewTools;
 import org.wikipedia.main.MainActivity;
-
-import androidx.test.espresso.ViewInteraction;
-import androidx.test.espresso.contrib.RecyclerViewActions;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;

--- a/app/src/androidTest/java/org/wikipedia/espresso/main/overflow/LoginScreenTest.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/main/overflow/LoginScreenTest.java
@@ -6,18 +6,18 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 
+import androidx.test.InstrumentationRegistry;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wikipedia.R;
 import org.wikipedia.espresso.util.ScreenshotTools;
 import org.wikipedia.login.LoginActivity;
-
-import androidx.test.InstrumentationRegistry;
-import androidx.test.espresso.ViewInteraction;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;

--- a/app/src/androidTest/java/org/wikipedia/espresso/main/overflow/SettingsScreenTest.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/main/overflow/SettingsScreenTest.java
@@ -3,18 +3,18 @@ package org.wikipedia.espresso.main.overflow;
 
 import android.Manifest;
 
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wikipedia.R;
 import org.wikipedia.espresso.util.ScreenshotTools;
 import org.wikipedia.settings.SettingsActivity;
-
-import androidx.test.espresso.ViewInteraction;
-import androidx.test.espresso.contrib.RecyclerViewActions;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;

--- a/app/src/androidTest/java/org/wikipedia/espresso/page/PageActivityTest.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/page/PageActivityTest.java
@@ -2,6 +2,11 @@ package org.wikipedia.espresso.page;
 
 import android.Manifest;
 
+import androidx.test.espresso.DataInteraction;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,11 +14,6 @@ import org.wikipedia.R;
 import org.wikipedia.espresso.search.SearchBehaviors;
 import org.wikipedia.espresso.util.ScreenshotTools;
 import org.wikipedia.page.PageActivity;
-
-import androidx.test.espresso.DataInteraction;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.action.ViewActions.click;

--- a/app/src/androidTest/java/org/wikipedia/espresso/reading/ReadingListsTest.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/reading/ReadingListsTest.java
@@ -5,6 +5,12 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import androidx.test.espresso.DataInteraction;
+import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,12 +24,6 @@ import org.wikipedia.main.MainActivity;
 import org.wikipedia.navtab.NavTab;
 import org.wikipedia.readinglist.database.ReadingListDbHelper;
 import org.wikipedia.settings.PrefsIoUtil;
-
-import androidx.test.espresso.DataInteraction;
-import androidx.test.espresso.contrib.RecyclerViewActions;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;

--- a/app/src/androidTest/java/org/wikipedia/espresso/search/SearchBehaviors.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/search/SearchBehaviors.java
@@ -1,11 +1,11 @@
 package org.wikipedia.espresso.search;
 
+import androidx.annotation.NonNull;
+import androidx.test.espresso.ViewInteraction;
+
 import org.wikipedia.R;
 import org.wikipedia.espresso.util.ScreenshotTools;
 import org.wikipedia.espresso.util.ViewTools;
-
-import androidx.annotation.NonNull;
-import androidx.test.espresso.ViewInteraction;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;

--- a/app/src/androidTest/java/org/wikipedia/espresso/util/ConfigurationTools.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/util/ConfigurationTools.java
@@ -5,9 +5,9 @@ import android.util.DisplayMetrics;
 import android.view.ViewConfiguration;
 import android.view.WindowManager;
 
-import java.util.Locale;
-
 import androidx.annotation.NonNull;
+
+import java.util.Locale;
 
 import static org.wikipedia.espresso.Constants.DEFAULT_LANGUAGE_OF_TESTING_DEVICE;
 import static org.wikipedia.espresso.Constants.HEIGHT_OF_TESTING_DEVICE;

--- a/app/src/androidTest/java/org/wikipedia/espresso/util/InstrumentationViewUtils.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/util/InstrumentationViewUtils.java
@@ -1,9 +1,9 @@
 package org.wikipedia.espresso.util;
 
-import org.wikipedia.R;
-
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.ViewInteraction;
+
+import org.wikipedia.R;
 
 import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;

--- a/app/src/androidTest/java/org/wikipedia/espresso/util/ScreenshotTools.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/util/ScreenshotTools.java
@@ -4,6 +4,9 @@ import android.graphics.Bitmap;
 import android.os.Environment;
 import android.view.View;
 
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
 import org.hamcrest.Matcher;
 import org.wikipedia.util.log.L;
 
@@ -12,9 +15,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-
-import androidx.test.espresso.UiController;
-import androidx.test.espresso.ViewAction;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;

--- a/app/src/androidTest/java/org/wikipedia/espresso/util/ViewTools.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/util/ViewTools.java
@@ -6,6 +6,10 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.widget.TextView;
 
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.action.ViewActions;
+
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.tabs.TabLayout;
 
@@ -13,10 +17,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-
-import androidx.test.espresso.UiController;
-import androidx.test.espresso.ViewAction;
-import androidx.test.espresso.action.ViewActions;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;

--- a/app/src/main/java/org/wikipedia/LongPressHandler.java
+++ b/app/src/main/java/org/wikipedia/LongPressHandler.java
@@ -9,13 +9,13 @@ import android.webkit.WebView;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.Constants.InvokeSource;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.Constants.InvokeSource.CONTEXT_MENU;
 import static org.wikipedia.util.DeviceUtil.hideSoftKeyboard;
@@ -25,7 +25,8 @@ public class LongPressHandler implements View.OnCreateContextMenuListener,
         MenuItem.OnMenuItemClickListener {
     private final ContextMenuListener contextMenuListener;
     private final int historySource;
-    @Nullable private final String referrer;
+    @Nullable
+    private final String referrer;
 
     private PageTitle title;
     private HistoryEntry entry;

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -11,6 +11,10 @@ import android.text.TextUtils;
 import android.view.Window;
 import android.webkit.WebView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatDelegate;
+
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.squareup.leakcanary.LeakCanary;
@@ -57,9 +61,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatDelegate;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.plugins.RxJavaPlugins;

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.java
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.java
@@ -12,6 +12,13 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.view.MenuItem;
 
+import androidx.annotation.ColorRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
 import com.google.android.material.snackbar.Snackbar;
 
 import org.wikipedia.Constants;
@@ -38,12 +45,6 @@ import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.PermissionUtil;
 import org.wikipedia.util.log.L;
 
-import androidx.annotation.ColorRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;

--- a/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.java
+++ b/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.java
@@ -2,11 +2,11 @@ package org.wikipedia.activity;
 
 import android.os.Bundle;
 
-import org.wikipedia.R;
-
 import androidx.annotation.IdRes;
 import androidx.annotation.LayoutRes;
 import androidx.fragment.app.Fragment;
+
+import org.wikipedia.R;
 
 /**
  * Boilerplate for a FragmentActivity containing a single stack of

--- a/app/src/main/java/org/wikipedia/activity/SingleFragmentActivityTransparent.java
+++ b/app/src/main/java/org/wikipedia/activity/SingleFragmentActivityTransparent.java
@@ -2,12 +2,12 @@ package org.wikipedia.activity;
 
 import android.os.Bundle;
 
-import org.wikipedia.R;
-import org.wikipedia.theme.Theme;
-
 import androidx.annotation.IdRes;
 import androidx.annotation.LayoutRes;
 import androidx.fragment.app.Fragment;
+
+import org.wikipedia.R;
+import org.wikipedia.theme.Theme;
 
 /**
  * Boilerplate for a FragmentActivity containing a single stack of

--- a/app/src/main/java/org/wikipedia/alphaupdater/AlphaUpdateChecker.java
+++ b/app/src/main/java/org/wikipedia/alphaupdater/AlphaUpdateChecker.java
@@ -8,6 +8,9 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory;
 import org.wikipedia.recurring.RecurringTask;
@@ -17,8 +20,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import androidx.annotation.NonNull;
-import androidx.core.app.NotificationCompat;
 import okhttp3.Request;
 import okhttp3.Response;
 

--- a/app/src/main/java/org/wikipedia/analytics/AppLanguageSearchingFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/AppLanguageSearchingFunnel.java
@@ -1,9 +1,9 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
-
-import androidx.annotation.NonNull;
 
 public class AppLanguageSearchingFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppLanguageSearching";

--- a/app/src/main/java/org/wikipedia/analytics/AppearanceChangeFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/AppearanceChangeFunnel.java
@@ -1,11 +1,11 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.theme.Theme;
-
-import androidx.annotation.NonNull;
 
 public class AppearanceChangeFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppAppearanceSettings";

--- a/app/src/main/java/org/wikipedia/analytics/CreateAccountFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/CreateAccountFunnel.java
@@ -1,9 +1,9 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
-
-import androidx.annotation.NonNull;
 
 public class CreateAccountFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppCreateAccount";

--- a/app/src/main/java/org/wikipedia/analytics/DailyStatsFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/DailyStatsFunnel.java
@@ -3,14 +3,14 @@ package org.wikipedia.analytics;
 import android.content.Context;
 import android.content.pm.PackageManager;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.util.StringUtil;
 
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
 
 // https://meta.wikimedia.org/wiki/Schema:MobileWikiAppDailyStats
 public class DailyStatsFunnel extends Funnel {

--- a/app/src/main/java/org/wikipedia/analytics/DescriptionEditFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/DescriptionEditFunnel.java
@@ -1,9 +1,9 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
 
 public class DescriptionEditFunnel extends EditFunnel {
 

--- a/app/src/main/java/org/wikipedia/analytics/EditFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/EditFunnel.java
@@ -1,12 +1,12 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
 
 public class EditFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppEdit";

--- a/app/src/main/java/org/wikipedia/analytics/FeedConfigureFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/FeedConfigureFunnel.java
@@ -1,5 +1,7 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
@@ -10,8 +12,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
 
 public class FeedConfigureFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppFeedConfigure";

--- a/app/src/main/java/org/wikipedia/analytics/FeedFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/FeedFunnel.java
@@ -1,12 +1,12 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.model.CardType;
 
 import java.util.Arrays;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public class FeedFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppFeed";

--- a/app/src/main/java/org/wikipedia/analytics/FindInPageFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/FindInPageFunnel.java
@@ -1,10 +1,10 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
-
-import androidx.annotation.NonNull;
 
 public class FindInPageFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppFindInPage";

--- a/app/src/main/java/org/wikipedia/analytics/Funnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/Funnel.java
@@ -1,5 +1,9 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.json.JSONException;
@@ -12,10 +16,6 @@ import org.wikipedia.util.log.L;
 
 import java.util.Date;
 import java.util.UUID;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 /** Schemas for this abstract funnel are expected to have appInstallID and sessionToken fields. When
  * these fields are not present or differently named, preprocess* or get*Field should be overridden. */

--- a/app/src/main/java/org/wikipedia/analytics/GalleryFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/GalleryFunnel.java
@@ -1,11 +1,11 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
 
 public class GalleryFunnel extends TimedFunnel {
     public static final int SOURCE_LEAD_IMAGE = 0;

--- a/app/src/main/java/org/wikipedia/analytics/InstallReceiver.java
+++ b/app/src/main/java/org/wikipedia/analytics/InstallReceiver.java
@@ -6,14 +6,14 @@ import android.content.Intent;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.page.PageActivity;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.ReleaseUtil;
 import org.wikipedia.util.ShareUtil;
 import org.wikipedia.util.log.L;
-
-import androidx.annotation.NonNull;
 
 public final class InstallReceiver extends BroadcastReceiver {
     private static final String INSTALL_ACTION = "com.android.vending.INSTALL_REFERRER";

--- a/app/src/main/java/org/wikipedia/analytics/InstallReferrerFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/InstallReferrerFunnel.java
@@ -1,10 +1,10 @@
 package org.wikipedia.analytics;
 
-import org.json.JSONObject;
-import org.wikipedia.WikipediaApp;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.json.JSONObject;
+import org.wikipedia.WikipediaApp;
 
 public class InstallReferrerFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppInstallReferrer";

--- a/app/src/main/java/org/wikipedia/analytics/IntentFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/IntentFunnel.java
@@ -1,9 +1,9 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
-
-import androidx.annotation.NonNull;
 
 public class IntentFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppIntents";

--- a/app/src/main/java/org/wikipedia/analytics/LinkPreviewFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/LinkPreviewFunnel.java
@@ -1,10 +1,10 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.settings.Prefs;
-
-import androidx.annotation.NonNull;
 
 
 public class LinkPreviewFunnel extends TimedFunnel {

--- a/app/src/main/java/org/wikipedia/analytics/NotificationFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/NotificationFunnel.java
@@ -1,11 +1,11 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.notifications.Notification;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class NotificationFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppNotificationInteraction";

--- a/app/src/main/java/org/wikipedia/analytics/NotificationPreferencesFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/NotificationPreferencesFunnel.java
@@ -1,5 +1,7 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -9,8 +11,6 @@ import org.wikipedia.settings.Prefs;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
 
 public class NotificationPreferencesFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppNotificationPreferences";

--- a/app/src/main/java/org/wikipedia/analytics/OnThisDayFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/OnThisDayFunnel.java
@@ -1,10 +1,10 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
-
-import androidx.annotation.NonNull;
 
 public class OnThisDayFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppOnThisDay";

--- a/app/src/main/java/org/wikipedia/analytics/PageScrollFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/PageScrollFunnel.java
@@ -1,11 +1,11 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.ReleaseUtil;
-
-import androidx.annotation.NonNull;
 
 public class PageScrollFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppPageScroll";

--- a/app/src/main/java/org/wikipedia/analytics/ProtectedEditAttemptFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/ProtectedEditAttemptFunnel.java
@@ -1,10 +1,10 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
-
-import androidx.annotation.NonNull;
 
 public class ProtectedEditAttemptFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppProtectedEditAttempt";

--- a/app/src/main/java/org/wikipedia/analytics/RandomizerFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/RandomizerFunnel.java
@@ -1,10 +1,10 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
-
-import androidx.annotation.NonNull;
 
 public class RandomizerFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppRandomizer";

--- a/app/src/main/java/org/wikipedia/analytics/ReadingListsFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/ReadingListsFunnel.java
@@ -1,13 +1,13 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.Constants.InvokeSource;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.readinglist.database.ReadingList;
 import org.wikipedia.settings.Prefs;
-
-import androidx.annotation.NonNull;
 
 public class ReadingListsFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppReadingLists";

--- a/app/src/main/java/org/wikipedia/analytics/SearchFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/SearchFunnel.java
@@ -1,11 +1,11 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.search.SearchInvokeSource;
 import org.wikipedia.util.StringUtil;
-
-import androidx.annotation.NonNull;
 
 public class SearchFunnel extends Funnel {
     /**

--- a/app/src/main/java/org/wikipedia/analytics/ShareAFactFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/ShareAFactFunnel.java
@@ -1,11 +1,11 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.settings.Prefs;
-
-import androidx.annotation.NonNull;
 
 // https://meta.wikimedia.org/wiki/Schema:MobileWikiAppShareAFact
 public class ShareAFactFunnel extends Funnel {

--- a/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
@@ -1,5 +1,7 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.json.JSONObject;
@@ -9,8 +11,6 @@ import org.wikipedia.json.GsonUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 import static org.wikipedia.Constants.InvokeSource.EDIT_FEED_TITLE_DESC;
 import static org.wikipedia.Constants.InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC;

--- a/app/src/main/java/org/wikipedia/analytics/SuggestedPagesFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/SuggestedPagesFunnel.java
@@ -2,14 +2,14 @@ package org.wikipedia.analytics;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 import org.wikipedia.page.PageTitle;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public class SuggestedPagesFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppArticleSuggestions";

--- a/app/src/main/java/org/wikipedia/analytics/TabFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/TabFunnel.java
@@ -1,11 +1,11 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.Nullable;
+
 import org.wikipedia.WikipediaApp;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.Nullable;
 
 public class TabFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppTabs";

--- a/app/src/main/java/org/wikipedia/analytics/TimedFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/TimedFunnel.java
@@ -1,12 +1,12 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
 
 /*package*/ abstract class TimedFunnel extends Funnel {
     private long startTime;

--- a/app/src/main/java/org/wikipedia/analytics/ToCInteractionFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/ToCInteractionFunnel.java
@@ -1,12 +1,12 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 
 import java.util.UUID;
-
-import androidx.annotation.NonNull;
 
 public class ToCInteractionFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppToCInteraction";

--- a/app/src/main/java/org/wikipedia/analytics/WiktionaryDialogFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/WiktionaryDialogFunnel.java
@@ -1,10 +1,10 @@
 package org.wikipedia.analytics;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.ReleaseUtil;
-
-import androidx.annotation.NonNull;
 
 // https://meta.wikimedia.org/wiki/Schema:MobileWikiAppWiktionaryPopup
 public class WiktionaryDialogFunnel extends TimedFunnel {

--- a/app/src/main/java/org/wikipedia/auth/AccountUtil.java
+++ b/app/src/main/java/org/wikipedia/auth/AccountUtil.java
@@ -7,6 +7,9 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.reflect.TypeToken;
 
 import org.wikipedia.R;
@@ -21,9 +24,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public final class AccountUtil {
 

--- a/app/src/main/java/org/wikipedia/auth/WikimediaAuthenticator.java
+++ b/app/src/main/java/org/wikipedia/auth/WikimediaAuthenticator.java
@@ -10,13 +10,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.BuildConfig;
 import org.wikipedia.R;
 import org.wikipedia.analytics.LoginFunnel;
 import org.wikipedia.login.LoginActivity;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class WikimediaAuthenticator extends AbstractAccountAuthenticator {
     private static final String[] SYNC_AUTHORITIES = {BuildConfig.READING_LISTS_AUTHORITY};

--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -9,6 +9,8 @@ import android.webkit.JavascriptInterface;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wikipedia.WikipediaApp;
@@ -20,8 +22,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
 
 /**
  * Two-way communications bridge between JS in a WebView and Java.

--- a/app/src/main/java/org/wikipedia/captcha/Captcha.java
+++ b/app/src/main/java/org/wikipedia/captcha/Captcha.java
@@ -1,8 +1,8 @@
 package org.wikipedia.captcha;
 
-import org.wikipedia.dataclient.mwapi.MwResponse;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.dataclient.mwapi.MwResponse;
 
 public class Captcha extends MwResponse {
     @SuppressWarnings("unused,NullableProblems") @NonNull private FancyCaptchaReload fancycaptchareload;

--- a/app/src/main/java/org/wikipedia/captcha/CaptchaHandler.java
+++ b/app/src/main/java/org/wikipedia/captcha/CaptchaHandler.java
@@ -9,6 +9,10 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.controller.BaseControllerListener;
 import com.facebook.drawee.view.SimpleDraweeView;
@@ -25,9 +29,6 @@ import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.views.ViewAnimations;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/concurrency/RxBus.java
+++ b/app/src/main/java/org/wikipedia/concurrency/RxBus.java
@@ -1,6 +1,7 @@
 package org.wikipedia.concurrency;
 
 import androidx.annotation.NonNull;
+
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.annotations.CheckReturnValue;

--- a/app/src/main/java/org/wikipedia/connectivity/NetworkConnectivityReceiver.java
+++ b/app/src/main/java/org/wikipedia/connectivity/NetworkConnectivityReceiver.java
@@ -6,13 +6,13 @@ import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
+import androidx.annotation.Nullable;
+import androidx.core.net.ConnectivityManagerCompat;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.events.NetworkConnectEvent;
 
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.Nullable;
-import androidx.core.net.ConnectivityManagerCompat;
 
 public class NetworkConnectivityReceiver extends BroadcastReceiver {
     private static long ONLINE_CHECK_THRESHOLD_MILLIS = TimeUnit.MINUTES.toMillis(1);

--- a/app/src/main/java/org/wikipedia/crash/CrashReportActivity.java
+++ b/app/src/main/java/org/wikipedia/crash/CrashReportActivity.java
@@ -3,10 +3,10 @@ package org.wikipedia.crash;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.annotation.Nullable;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.SingleFragmentActivity;
-
-import androidx.annotation.Nullable;
 
 public class CrashReportActivity extends SingleFragmentActivity<CrashReportFragment>
         implements CrashReportFragment.Callback {

--- a/app/src/main/java/org/wikipedia/crash/CrashReportFragment.java
+++ b/app/src/main/java/org/wikipedia/crash/CrashReportFragment.java
@@ -5,12 +5,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.wikipedia.R;
-import org.wikipedia.activity.FragmentUtil;
-
 import androidx.annotation.IdRes;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
+import org.wikipedia.R;
+import org.wikipedia.activity.FragmentUtil;
 
 public class CrashReportFragment extends Fragment {
     public interface Callback {

--- a/app/src/main/java/org/wikipedia/crash/RemoteLogException.java
+++ b/app/src/main/java/org/wikipedia/crash/RemoteLogException.java
@@ -1,12 +1,12 @@
 package org.wikipedia.crash;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /** Wrapper around {@link Exception} used to send a JSON payload via {@link CrashReporter}. */
 public class RemoteLogException extends Exception {

--- a/app/src/main/java/org/wikipedia/crash/hockeyapp/HockeyAppCrashReporter.java
+++ b/app/src/main/java/org/wikipedia/crash/hockeyapp/HockeyAppCrashReporter.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
 import net.hockeyapp.android.CrashManager;
 import net.hockeyapp.android.ExceptionHandler;
 
@@ -16,8 +18,6 @@ import org.wikipedia.util.log.RemoteExceptionLogger;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
 
 import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK;
 import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;

--- a/app/src/main/java/org/wikipedia/crash/hockeyapp/HockeyAppExceptionHandler.java
+++ b/app/src/main/java/org/wikipedia/crash/hockeyapp/HockeyAppExceptionHandler.java
@@ -1,10 +1,10 @@
 package org.wikipedia.crash.hockeyapp;
 
+import androidx.annotation.Nullable;
+
 import net.hockeyapp.android.ExceptionHandler;
 
 import org.wikipedia.util.log.L;
-
-import androidx.annotation.Nullable;
 
 /** Wrapper around {@link ExceptionHandler} that calls {@link HockeyAppCrashListener#onCrash()}. */
 class HockeyAppExceptionHandler extends ExceptionHandler {

--- a/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.java
+++ b/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.java
@@ -12,6 +12,9 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+
 import com.google.android.material.textfield.TextInputLayout;
 
 import org.wikipedia.R;
@@ -34,8 +37,6 @@ import org.wikipedia.views.WikiErrorView;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/csrf/CsrfTokenClient.java
+++ b/app/src/main/java/org/wikipedia/csrf/CsrfTokenClient.java
@@ -3,6 +3,10 @@ package org.wikipedia.csrf;
 import android.text.TextUtils;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
@@ -17,9 +21,6 @@ import org.wikipedia.util.log.L;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import retrofit2.Call;
 import retrofit2.Response;
 

--- a/app/src/main/java/org/wikipedia/database/AppContentProvider.java
+++ b/app/src/main/java/org/wikipedia/database/AppContentProvider.java
@@ -8,14 +8,14 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.database.contract.AppContentProviderContract;
 import org.wikipedia.util.log.L;
 
 import java.util.Arrays;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class AppContentProvider extends ContentProvider {
     private static final boolean LOG = false;

--- a/app/src/main/java/org/wikipedia/database/AppContentProviderEndpoint.java
+++ b/app/src/main/java/org/wikipedia/database/AppContentProviderEndpoint.java
@@ -4,6 +4,9 @@ import android.content.ContentValues;
 import android.content.UriMatcher;
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.database.contract.AppContentProviderContract;
 import org.wikipedia.database.contract.EditHistoryContract;
 import org.wikipedia.database.contract.PageHistoryContract;
@@ -11,9 +14,6 @@ import org.wikipedia.database.contract.PageImageHistoryContract;
 import org.wikipedia.database.contract.SearchHistoryContract;
 import org.wikipedia.model.EnumCode;
 import org.wikipedia.model.EnumCodeMap;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public enum AppContentProviderEndpoint implements EnumCode {
     HISTORY_PAGE(100, PageHistoryContract.Page.PATH, PageHistoryContract.Page.TABLES,

--- a/app/src/main/java/org/wikipedia/database/DatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/database/DatabaseTable.java
@@ -8,11 +8,11 @@ import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.database.column.Column;
 import org.wikipedia.util.ArrayUtils;
 import org.wikipedia.util.log.L;
-
-import androidx.annotation.NonNull;
 
 public abstract class DatabaseTable<T> {
     protected static final int INITIAL_DB_VERSION = 1;

--- a/app/src/main/java/org/wikipedia/database/DbUtil.java
+++ b/app/src/main/java/org/wikipedia/database/DbUtil.java
@@ -4,13 +4,13 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.database.column.Column;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-
-import androidx.annotation.NonNull;
 
 public final class DbUtil {
     public static String namesCsv(Column<?>... cols) {

--- a/app/src/main/java/org/wikipedia/database/column/CodeEnumColumn.java
+++ b/app/src/main/java/org/wikipedia/database/column/CodeEnumColumn.java
@@ -2,9 +2,9 @@ package org.wikipedia.database.column;
 
 import android.database.Cursor;
 
-import org.wikipedia.model.CodeEnum;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.model.CodeEnum;
 
 public class CodeEnumColumn<T> extends Column<T> {
     @NonNull private final CodeEnum<T> codeEnum;

--- a/app/src/main/java/org/wikipedia/database/column/CsvColumn.java
+++ b/app/src/main/java/org/wikipedia/database/column/CsvColumn.java
@@ -3,15 +3,15 @@ package org.wikipedia.database.column;
 import android.content.ContentValues;
 import android.database.Cursor;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.text.StrMatcher;
 import org.apache.commons.lang3.text.StrTokenizer;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 // TODO: replace with table constraints when the database layer is more flexible.
 public abstract class CsvColumn<T> extends Column<T> {

--- a/app/src/main/java/org/wikipedia/database/column/DateColumn.java
+++ b/app/src/main/java/org/wikipedia/database/column/DateColumn.java
@@ -2,9 +2,9 @@ package org.wikipedia.database.column;
 
 import android.database.Cursor;
 
-import java.util.Date;
-
 import androidx.annotation.NonNull;
+
+import java.util.Date;
 
 public class DateColumn extends Column<Date> {
     public DateColumn(@NonNull String tbl, @NonNull String name, @NonNull String type) {

--- a/app/src/main/java/org/wikipedia/database/column/NamespaceColumn.java
+++ b/app/src/main/java/org/wikipedia/database/column/NamespaceColumn.java
@@ -1,8 +1,8 @@
 package org.wikipedia.database.column;
 
-import org.wikipedia.page.Namespace;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.page.Namespace;
 
 public class NamespaceColumn extends CodeEnumColumn<Namespace> {
     public NamespaceColumn(@NonNull String tbl, @NonNull String name) {

--- a/app/src/main/java/org/wikipedia/database/contract/OldReadingListPageContract.java
+++ b/app/src/main/java/org/wikipedia/database/contract/OldReadingListPageContract.java
@@ -1,5 +1,8 @@
 package org.wikipedia.database.contract;
 
+import androidx.annotation.NonNull;
+import androidx.collection.ArraySet;
+
 import org.wikipedia.database.column.CsvColumn;
 import org.wikipedia.database.column.IdColumn;
 import org.wikipedia.database.column.IntColumn;
@@ -9,9 +12,6 @@ import org.wikipedia.database.column.StrColumn;
 
 import java.util.Collection;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.collection.ArraySet;
 
 @SuppressWarnings("checkstyle:interfaceistype")
 public interface OldReadingListPageContract {

--- a/app/src/main/java/org/wikipedia/dataclient/RestService.java
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.java
@@ -1,5 +1,8 @@
 package org.wikipedia.dataclient;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.okhttp.OfflineCacheInterceptor;
 import org.wikipedia.dataclient.restbase.RbDefinition;
 import org.wikipedia.dataclient.restbase.RbRelatedPages;
@@ -15,8 +18,6 @@ import org.wikipedia.readinglist.sync.SyncedReadingLists;
 
 import java.util.Map;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.Observable;
 import retrofit2.Call;
 import retrofit2.Response;

--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -1,5 +1,8 @@
 package org.wikipedia.dataclient;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.captcha.Captcha;
 import org.wikipedia.dataclient.mwapi.CreateAccountResponse;
 import org.wikipedia.dataclient.mwapi.MwPostResponse;
@@ -15,8 +18,6 @@ import org.wikipedia.login.LoginClient;
 import org.wikipedia.search.PrefixSearchResponse;
 import org.wikipedia.wikidata.Entities;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.Observable;
 import retrofit2.Call;
 import retrofit2.Response;

--- a/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.java
+++ b/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.java
@@ -2,6 +2,9 @@ package org.wikipedia.dataclient;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.collection.LruCache;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory;
 import org.wikipedia.json.GsonUtil;
@@ -9,8 +12,6 @@ import org.wikipedia.settings.Prefs;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
-import androidx.collection.LruCache;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/app/src/main/java/org/wikipedia/dataclient/SharedPreferenceCookieManager.java
+++ b/app/src/main/java/org/wikipedia/dataclient/SharedPreferenceCookieManager.java
@@ -2,6 +2,9 @@ package org.wikipedia.dataclient;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.log.L;
 
@@ -11,8 +14,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
 import okhttp3.HttpUrl;

--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.java
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.java
@@ -5,13 +5,13 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.language.AppLanguageLookUpTable;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.UriUtil;
-
-import androidx.annotation.NonNull;
 
 /**
  * The base URL and Wikipedia language code for a MediaWiki site. Examples:

--- a/app/src/main/java/org/wikipedia/dataclient/fresco/DisabledCache.java
+++ b/app/src/main/java/org/wikipedia/dataclient/fresco/DisabledCache.java
@@ -1,5 +1,7 @@
 package org.wikipedia.dataclient.fresco;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.binaryresource.BinaryResource;
 import com.facebook.cache.common.CacheKey;
 import com.facebook.cache.common.WriterCallback;
@@ -9,8 +11,6 @@ import com.facebook.cache.disk.FileCache;
 import com.facebook.imagepipeline.core.FileCacheFactory;
 
 import java.io.IOException;
-
-import androidx.annotation.NonNull;
 
 /**
  * A disabled dummy cache to provide to Fresco in order to prevent unwanted redundant disk caching.

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
@@ -1,5 +1,7 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.Nullable;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
@@ -9,8 +11,6 @@ import org.wikipedia.json.GsonUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.Nullable;
 
 @SuppressWarnings("unused")
 public class EditorTaskCounts {

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/ListUserResponse.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/ListUserResponse.java
@@ -1,5 +1,9 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.collection.ArraySet;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
@@ -7,10 +11,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.collection.ArraySet;
 
 @SuppressWarnings("unused")
 public class ListUserResponse {

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwAuthManagerInfo.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwAuthManagerInfo.java
@@ -1,12 +1,12 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.model.BaseModel;
 
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 class MwAuthManagerInfo extends BaseModel {
     @SuppressWarnings("unused,NullableProblems") @NonNull private List<Request> requests;

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
@@ -1,5 +1,8 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
@@ -10,9 +13,6 @@ import org.wikipedia.page.Namespace;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * A class representing a standard page object as returned by the MediaWiki API.

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResponse.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResponse.java
@@ -1,11 +1,11 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Map;
-
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 public class MwQueryResponse extends MwResponse {
 

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
@@ -1,5 +1,8 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
@@ -16,9 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 @SuppressWarnings("unused")
 public class MwQueryResult extends BaseModel implements PostProcessingTypeAdapter.PostProcessable {

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwResponse.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwResponse.java
@@ -1,14 +1,14 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.json.PostProcessingTypeAdapter;
 import org.wikipedia.model.BaseModel;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public abstract class MwResponse extends BaseModel implements PostProcessingTypeAdapter.PostProcessable {
     @SuppressWarnings({"unused"}) @Nullable private List<MwServiceError> errors;

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwServiceError.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwServiceError.java
@@ -1,13 +1,13 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.dataclient.ServiceError;
 import org.wikipedia.model.BaseModel;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * Gson POJO for a MediaWiki API error.

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/NearbyPage.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/NearbyPage.java
@@ -2,14 +2,14 @@ package org.wikipedia.dataclient.mwapi;
 
 import android.location.Location;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.PageTitle;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class NearbyPage {
     @NonNull private PageTitle title;

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/SiteMatrix.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/SiteMatrix.java
@@ -1,13 +1,13 @@
 package org.wikipedia.dataclient.mwapi;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.JsonObject;
 
 import org.wikipedia.json.GsonUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public class SiteMatrix extends MwResponse {
     @SuppressWarnings("unused,NullableProblems") @NonNull private JsonObject sitematrix;

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
@@ -1,10 +1,10 @@
 package org.wikipedia.dataclient.mwapi;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings("unused")
 public class UserInfo {

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/page/MwMobileViewPageLead.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/page/MwMobileViewPageLead.java
@@ -2,6 +2,10 @@ package org.wikipedia.dataclient.mwapi.page;
 
 import android.location.Location;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.dataclient.mwapi.MwQueryPage;
@@ -19,10 +23,6 @@ import org.wikipedia.util.UriUtil;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import static org.wikipedia.dataclient.Service.PREFERRED_THUMB_SIZE;
 import static org.wikipedia.util.ImageUrlUtil.getUrlForSize;

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/page/MwMobileViewPageRemaining.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/page/MwMobileViewPageRemaining.java
@@ -1,13 +1,13 @@
 package org.wikipedia.dataclient.mwapi.page;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.page.PageRemaining;
 import org.wikipedia.page.Section;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * Gson POJO for loading remaining page content.

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/page/MwPageClient.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/page/MwPageClient.java
@@ -1,12 +1,13 @@
 package org.wikipedia.dataclient.mwapi.page;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.page.PageClient;
 import org.wikipedia.dataclient.page.PageSummary;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.Observable;
 import okhttp3.CacheControl;
 import okhttp3.Request;

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/page/MwQueryPageSummary.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/page/MwQueryPageSummary.java
@@ -2,12 +2,12 @@ package org.wikipedia.dataclient.mwapi.page;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.mwapi.MwQueryResponse;
 import org.wikipedia.dataclient.page.PageSummary;
 import org.wikipedia.page.Namespace;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * Useful for link previews coming from MW API.

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/AvailableInputStream.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/AvailableInputStream.java
@@ -1,9 +1,9 @@
 package org.wikipedia.dataclient.okhttp;
 
+import androidx.annotation.NonNull;
+
 import java.io.IOException;
 import java.io.InputStream;
-
-import androidx.annotation.NonNull;
 
 /**
  * This is a subclass of InputStream that implements the available() method reliably enough

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/CacheControlInterceptor.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/CacheControlInterceptor.java
@@ -1,9 +1,10 @@
 package org.wikipedia.dataclient.okhttp;
 
+import androidx.annotation.NonNull;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import androidx.annotation.NonNull;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/CommonHeaderRequestInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/CommonHeaderRequestInterceptor.kt
@@ -1,14 +1,10 @@
 package org.wikipedia.dataclient.okhttp
 
-import org.wikipedia.WikipediaApp
-
-import java.io.IOException
-
 import okhttp3.Interceptor
-import okhttp3.Request
 import okhttp3.Response
-
+import org.wikipedia.WikipediaApp
 import org.wikipedia.settings.Prefs.isEventLoggingEnabled
+import java.io.IOException
 
 internal class CommonHeaderRequestInterceptor : Interceptor {
     @Throws(IOException::class)

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/DefaultMaxStaleRequestInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/DefaultMaxStaleRequestInterceptor.kt
@@ -1,14 +1,12 @@
 package org.wikipedia.dataclient.okhttp
 
-import org.wikipedia.WikipediaApp
-import org.wikipedia.settings.Prefs
-
-import java.io.IOException
-import java.util.concurrent.TimeUnit
-
 import okhttp3.CacheControl
 import okhttp3.Interceptor
 import okhttp3.Response
+import org.wikipedia.WikipediaApp
+import org.wikipedia.settings.Prefs
+import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 /**
  * This interceptor adds a `max-stale` parameter to the Cache-Control header that directs

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/HttpStatusException.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/HttpStatusException.java
@@ -1,13 +1,14 @@
 package org.wikipedia.dataclient.okhttp;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.ServiceError;
 import org.wikipedia.dataclient.restbase.RbServiceError;
 import org.wikipedia.util.log.L;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import okhttp3.Response;
 
 public class HttpStatusException extends IOException {

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OfflineCacheInterceptor.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OfflineCacheInterceptor.java
@@ -1,10 +1,11 @@
 package org.wikipedia.dataclient.okhttp;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.settings.Prefs;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
 import okhttp3.CacheDelegate;
 import okhttp3.Interceptor;
 import okhttp3.Request;

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.java
@@ -8,6 +8,8 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import androidx.annotation.NonNull;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.page.PageViewModel;
@@ -22,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
 import okhttp3.Headers;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/StatusResponseInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/StatusResponseInterceptor.kt
@@ -1,14 +1,12 @@
 package org.wikipedia.dataclient.okhttp
 
 import androidx.annotation.NonNull
-import org.wikipedia.dataclient.okhttp.util.HttpUrlUtil
-import org.wikipedia.settings.RbSwitch
-
-import java.io.IOException
-
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
+import org.wikipedia.dataclient.okhttp.util.HttpUrlUtil
+import org.wikipedia.settings.RbSwitch
+import java.io.IOException
 
 class StatusResponseInterceptor(private val cb: RbSwitch) : Interceptor {
 

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/UnsuccessfulResponseInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/UnsuccessfulResponseInterceptor.kt
@@ -1,9 +1,8 @@
 package org.wikipedia.dataclient.okhttp
 
-import java.io.IOException
-
 import okhttp3.Interceptor
 import okhttp3.Response
+import java.io.IOException
 
 class UnsuccessfulResponseInterceptor : Interceptor {
     @Throws(IOException::class)

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/util/HttpUrlUtil.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/util/HttpUrlUtil.java
@@ -1,10 +1,11 @@
 package org.wikipedia.dataclient.okhttp.util;
 
+import androidx.annotation.NonNull;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import okhttp3.HttpUrl;
 
 public final class HttpUrlUtil {

--- a/app/src/main/java/org/wikipedia/dataclient/page/PageClient.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageClient.java
@@ -1,9 +1,10 @@
 package org.wikipedia.dataclient.page;
 
-import org.wikipedia.dataclient.WikiSite;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.dataclient.WikiSite;
+
 import io.reactivex.Observable;
 import okhttp3.CacheControl;
 import okhttp3.Request;

--- a/app/src/main/java/org/wikipedia/dataclient/page/PageClientFactory.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageClientFactory.java
@@ -1,12 +1,12 @@
 package org.wikipedia.dataclient.page;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.mwapi.page.MwPageClient;
 import org.wikipedia.dataclient.restbase.page.RbPageClient;
 import org.wikipedia.page.Namespace;
 import org.wikipedia.settings.RbSwitch;
-
-import androidx.annotation.NonNull;
 
 /**
  * This redirection exists because we want to be able to switch between the traditional

--- a/app/src/main/java/org/wikipedia/dataclient/page/PageLead.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageLead.java
@@ -2,11 +2,11 @@ package org.wikipedia.dataclient.page;
 
 import android.location.Location;
 
-import org.wikipedia.page.Page;
-import org.wikipedia.page.PageTitle;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.page.Page;
+import org.wikipedia.page.PageTitle;
 
 /**
  * Gson POJI for loading the first stage of page content.

--- a/app/src/main/java/org/wikipedia/dataclient/page/PageLeadProperties.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageLeadProperties.java
@@ -2,13 +2,13 @@ package org.wikipedia.dataclient.page;
 
 import android.location.Location;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.page.Namespace;
 import org.wikipedia.page.Section;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * The main properties of a page

--- a/app/src/main/java/org/wikipedia/dataclient/page/PageRemaining.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageRemaining.java
@@ -1,10 +1,10 @@
 package org.wikipedia.dataclient.page;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.page.Section;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 /**
  * Gson POJI for loading remaining page content.

--- a/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.java
@@ -1,9 +1,9 @@
 package org.wikipedia.dataclient.page;
 
-import org.wikipedia.page.Namespace;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.page.Namespace;
 
 /**
  * Represents a summary of a page, useful for page previews.

--- a/app/src/main/java/org/wikipedia/dataclient/page/Protection.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/Protection.java
@@ -1,10 +1,10 @@
 package org.wikipedia.dataclient.page;
 
-import java.util.Collections;
-import java.util.Set;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.Set;
 
 /** Protection settings for a page */
 public class Protection {

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/RbDefinition.java
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/RbDefinition.java
@@ -1,11 +1,11 @@
 package org.wikipedia.dataclient.restbase;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.json.annotations.Required;
 
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class RbDefinition {
     @Required @NonNull private Map<String, Usage[]> usagesByLang;

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/RbRelatedPages.java
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/RbRelatedPages.java
@@ -1,12 +1,12 @@
 package org.wikipedia.dataclient.restbase;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class RbRelatedPages {
     @SuppressWarnings("unused") @Nullable private List<RbPageSummary> pages;

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/RbServiceError.java
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/RbServiceError.java
@@ -1,11 +1,11 @@
 package org.wikipedia.dataclient.restbase;
 
+import androidx.annotation.NonNull;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.dataclient.ServiceError;
 import org.wikipedia.json.GsonUnmarshaller;
 import org.wikipedia.model.BaseModel;
-
-import androidx.annotation.NonNull;
 
 /**
  * Gson POJO for a RESTBase API error.

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageClient.java
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageClient.java
@@ -1,12 +1,13 @@
 package org.wikipedia.dataclient.restbase.page;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.page.PageClient;
 import org.wikipedia.dataclient.page.PageSummary;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.Observable;
 import okhttp3.CacheControl;
 import okhttp3.Request;

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageLead.java
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageLead.java
@@ -2,6 +2,9 @@ package org.wikipedia.dataclient.restbase.page;
 
 import android.location.Location;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 
@@ -19,9 +22,6 @@ import org.wikipedia.util.UriUtil;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.dataclient.Service.PREFERRED_THUMB_SIZE;
 

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageRemaining.java
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageRemaining.java
@@ -1,13 +1,13 @@
 package org.wikipedia.dataclient.restbase.page;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.page.PageRemaining;
 import org.wikipedia.page.Section;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * Gson POJO for loading remaining page content.

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageSummary.java
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageSummary.java
@@ -2,6 +2,9 @@ package org.wikipedia.dataclient.restbase.page;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.dataclient.WikiSite;
@@ -9,9 +12,6 @@ import org.wikipedia.dataclient.page.PageSummary;
 import org.wikipedia.json.annotations.Required;
 import org.wikipedia.page.Namespace;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * A standardized page summary object constructed by RESTBase, used for link previews and as the

--- a/app/src/main/java/org/wikipedia/dataclient/retrofit/RetrofitException.java
+++ b/app/src/main/java/org/wikipedia/dataclient/retrofit/RetrofitException.java
@@ -1,9 +1,10 @@
 package org.wikipedia.dataclient.retrofit;
 
-import java.io.IOException;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.io.IOException;
+
 import retrofit2.Response;
 
 /**

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.java
@@ -3,6 +3,9 @@ package org.wikipedia.descriptions;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.analytics.SuggestedEditsFunnel;
@@ -18,9 +21,6 @@ import org.wikipedia.readinglist.AddToReadingListDialog;
 import org.wikipedia.util.ClipboardUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.ShareUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE;
 import static org.wikipedia.Constants.InvokeSource;

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
@@ -7,6 +7,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.FragmentUtil;
@@ -34,9 +38,6 @@ import org.wikipedia.util.log.L;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditRevertHelpView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditRevertHelpView.java
@@ -10,13 +10,14 @@ import android.text.style.BulletSpan;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.StringUtil;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditSuccessActivity.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditSuccessActivity.java
@@ -3,9 +3,9 @@ package org.wikipedia.descriptions;
 import android.content.Context;
 import android.content.Intent;
 
-import org.wikipedia.activity.SingleFragmentActivityTransparent;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.activity.SingleFragmentActivityTransparent;
 
 public class DescriptionEditSuccessActivity
         extends SingleFragmentActivityTransparent<DescriptionEditSuccessFragment>

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditSuccessFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditSuccessFragment.java
@@ -5,11 +5,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
 import org.wikipedia.R;
 import org.wikipedia.activity.FragmentUtil;
 
-import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditSuccessView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditSuccessView.java
@@ -4,10 +4,11 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.views.AppTextViewWithImages;
 
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditTutorialActivity.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditTutorialActivity.java
@@ -4,13 +4,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.onboarding.OnboardingFragment;
 import org.wikipedia.util.ResourceUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class DescriptionEditTutorialActivity
         extends SingleFragmentActivity<DescriptionEditTutorialFragment>

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditTutorialFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditTutorialFragment.java
@@ -1,10 +1,10 @@
 package org.wikipedia.descriptions;
 
-import org.wikipedia.R;
-import org.wikipedia.onboarding.OnboardingFragment;
-
 import androidx.annotation.NonNull;
 import androidx.viewpager.widget.PagerAdapter;
+
+import org.wikipedia.R;
+import org.wikipedia.onboarding.OnboardingFragment;
 
 public class DescriptionEditTutorialFragment extends OnboardingFragment {
 

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditTutorialPage.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditTutorialPage.java
@@ -1,11 +1,11 @@
 package org.wikipedia.descriptions;
 
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.model.EnumCode;
 import org.wikipedia.model.EnumCodeMap;
-
-import androidx.annotation.LayoutRes;
-import androidx.annotation.NonNull;
 
 enum DescriptionEditTutorialPage implements EnumCode {
     PAGE_ONE(R.layout.inflate_description_edit_tutorial_page_one),

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditTutorialPagerAdapter.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditTutorialPagerAdapter.java
@@ -4,10 +4,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.wikipedia.onboarding.OnboardingPageView;
-
 import androidx.annotation.NonNull;
 import androidx.viewpager.widget.PagerAdapter;
+
+import org.wikipedia.onboarding.OnboardingPageView;
 
 class DescriptionEditTutorialPagerAdapter extends PagerAdapter {
     @NonNull private final OnboardingPageView.DefaultCallback viewCallback

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditUtil.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditUtil.java
@@ -2,6 +2,8 @@ package org.wikipedia.descriptions;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONArray;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.page.Page;
@@ -9,8 +11,6 @@ import org.wikipedia.page.PageProperties;
 import org.wikipedia.util.ReleaseUtil;
 
 import java.util.Arrays;
-
-import androidx.annotation.NonNull;
 
 public final class DescriptionEditUtil {
     static final String ABUSEFILTER_DISALLOWED = "abusefilter-disallowed";

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
@@ -11,6 +11,10 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import com.google.android.material.textfield.TextInputLayout;
 
 import org.apache.commons.lang3.StringUtils;
@@ -23,9 +27,6 @@ import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.views.PlainPasteEditText;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/edit/Edit.java
+++ b/app/src/main/java/org/wikipedia/edit/Edit.java
@@ -1,8 +1,8 @@
 package org.wikipedia.edit;
 
-import org.wikipedia.dataclient.mwapi.MwPostResponse;
-
 import androidx.annotation.Nullable;
+
+import org.wikipedia.dataclient.mwapi.MwPostResponse;
 
 public class Edit extends MwPostResponse {
     @SuppressWarnings("unused,") @Nullable private Result edit;

--- a/app/src/main/java/org/wikipedia/edit/EditClient.java
+++ b/app/src/main/java/org/wikipedia/edit/EditClient.java
@@ -1,5 +1,9 @@
 package org.wikipedia.edit;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import org.wikipedia.captcha.CaptchaResult;
 import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.ServiceFactory;
@@ -8,9 +12,6 @@ import org.wikipedia.page.PageTitle;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import retrofit2.Call;
 import retrofit2.Response;
 

--- a/app/src/main/java/org/wikipedia/edit/EditHandler.java
+++ b/app/src/main/java/org/wikipedia/edit/EditHandler.java
@@ -5,6 +5,10 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.PopupMenu;
+
 import org.json.JSONObject;
 import org.wikipedia.Constants;
 import org.wikipedia.R;
@@ -18,10 +22,6 @@ import org.wikipedia.page.PageFragment;
 import org.wikipedia.page.Section;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.log.L;
-
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.PopupMenu;
 
 public class EditHandler implements CommunicationBridge.JSEventListener {
     public static final int RESULT_REFRESH_PAGE = 1;

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
@@ -17,6 +17,12 @@ import android.widget.ImageView;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
+
 import org.wikipedia.Constants;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -54,11 +60,6 @@ import org.wikipedia.views.WikiTextKeyboardView;
 
 import java.util.concurrent.TimeUnit;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AlertDialog;
-import androidx.core.content.ContextCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;

--- a/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.java
+++ b/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.java
@@ -5,12 +5,12 @@ import android.view.ActionMode;
 import android.view.View;
 import android.widget.ScrollView;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.edit.richtext.SyntaxHighlighter;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.views.FindInPageActionProvider;
 import org.wikipedia.views.PlainPasteEditText;
-
-import androidx.annotation.NonNull;
 
 
 public class FindInEditorActionProvider extends FindInPageActionProvider

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreview.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreview.java
@@ -1,11 +1,11 @@
 package org.wikipedia.edit.preview;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.dataclient.mwapi.MwPostResponse;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class EditPreview extends MwPostResponse {
     @SuppressWarnings("unused") @Nullable private Parse parse;

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -12,6 +12,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ScrollView;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.Fragment;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wikipedia.R;
@@ -39,9 +43,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-import androidx.fragment.app.Fragment;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/edit/richtext/ColorSpanEx.java
+++ b/app/src/main/java/org/wikipedia/edit/richtext/ColorSpanEx.java
@@ -5,14 +5,14 @@ import android.os.Parcelable;
 import android.text.TextPaint;
 import android.text.style.ForegroundColorSpan;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.wikipedia.json.GsonMarshaller;
 import org.wikipedia.json.GsonUnmarshaller;
-
-import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
 
 public class ColorSpanEx extends ForegroundColorSpan implements SpanExtents {
     public static final Parcelable.Creator<ColorSpanEx> CREATOR = new Parcelable.Creator<ColorSpanEx>() {

--- a/app/src/main/java/org/wikipedia/edit/richtext/StyleSpanEx.java
+++ b/app/src/main/java/org/wikipedia/edit/richtext/StyleSpanEx.java
@@ -4,13 +4,13 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.style.StyleSpan;
 
+import androidx.annotation.NonNull;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.wikipedia.json.GsonMarshaller;
 import org.wikipedia.json.GsonUnmarshaller;
-
-import androidx.annotation.NonNull;
 
 public class StyleSpanEx extends StyleSpan implements SpanExtents {
     public static final Parcelable.Creator<StyleSpanEx> CREATOR = new Parcelable.Creator<StyleSpanEx>() {

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.java
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.java
@@ -10,6 +10,9 @@ import android.text.TextWatcher;
 import android.text.format.DateUtils;
 import android.widget.EditText;
 
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.util.log.L;
 
@@ -18,8 +21,6 @@ import java.util.List;
 import java.util.Stack;
 import java.util.concurrent.Callable;
 
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxRuleStyle.java
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxRuleStyle.java
@@ -4,11 +4,11 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Typeface;
 
-import org.wikipedia.R;
-import org.wikipedia.util.ResourceUtil;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+
+import org.wikipedia.R;
+import org.wikipedia.util.ResourceUtil;
 
 import static org.wikipedia.util.ResourceUtil.getThemedColor;
 

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryDatabaseTable.java
@@ -3,14 +3,14 @@ package org.wikipedia.edit.summaries;
 import android.content.ContentValues;
 import android.database.Cursor;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.database.DatabaseTable;
 import org.wikipedia.database.column.Column;
 import org.wikipedia.database.contract.EditHistoryContract;
 import org.wikipedia.database.contract.EditHistoryContract.Col;
 
 import java.util.Date;
-
-import androidx.annotation.NonNull;
 
 public class EditSummaryDatabaseTable extends DatabaseTable<EditSummary> {
     private static final int DB_VER_INTRODUCED = 2;

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryFragment.java
@@ -8,13 +8,13 @@ import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.widget.AutoCompleteTextView;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
 import org.wikipedia.R;
 import org.wikipedia.edit.EditSectionActivity;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.views.ViewAnimations;
-
-import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 
 import static org.wikipedia.util.DeviceUtil.hideSoftKeyboard;
 import static org.wikipedia.util.DeviceUtil.showSoftKeyboard;

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryHandler.java
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryHandler.java
@@ -11,15 +11,15 @@ import android.view.ViewGroup;
 import android.widget.AutoCompleteTextView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.cursoradapter.widget.CursorAdapter;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.database.contract.EditHistoryContract;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.ContentProviderClientCompat;
 
 import java.util.Date;
-
-import androidx.annotation.NonNull;
-import androidx.cursoradapter.widget.CursorAdapter;
 
 import static org.wikipedia.util.L10nUtil.setConditionalTextDirection;
 

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryTag.java
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryTag.java
@@ -5,14 +5,14 @@ import android.content.res.Resources;
 import android.util.AttributeSet;
 import android.widget.LinearLayout.LayoutParams;
 
-import org.wikipedia.R;
-import org.wikipedia.util.DimenUtil;
-import org.wikipedia.util.ResourceUtil;
-
 import androidx.annotation.AttrRes;
 import androidx.annotation.ColorInt;
 import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.content.res.ResourcesCompat;
+
+import org.wikipedia.R;
+import org.wikipedia.util.DimenUtil;
+import org.wikipedia.util.ResourceUtil;
 
 public class EditSummaryTag extends AppCompatTextView {
     public static final int MARGIN = 4;

--- a/app/src/main/java/org/wikipedia/feed/FeedContentType.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedContentType.java
@@ -1,5 +1,9 @@
 package org.wikipedia.feed;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
@@ -18,10 +22,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 
 public enum FeedContentType implements EnumCode {
     NEWS(0, R.string.view_card_news_title, R.string.feed_item_type_news, true) {

--- a/app/src/main/java/org/wikipedia/feed/FeedCoordinator.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedCoordinator.java
@@ -3,6 +3,8 @@ package org.wikipedia.feed;
 import android.annotation.SuppressLint;
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.aggregated.AggregatedFeedContentClient;
 import org.wikipedia.feed.announcement.AnnouncementClient;
@@ -17,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import io.reactivex.Completable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/feed/FeedCoordinatorBase.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedCoordinatorBase.java
@@ -2,6 +2,9 @@ package org.wikipedia.feed;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.dataclient.FeedClient;
 import org.wikipedia.feed.dayheader.DayHeaderCard;
@@ -24,9 +27,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public abstract class FeedCoordinatorBase {
     private static final int MAX_HIDDEN_CARDS = 100;

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.java
@@ -10,6 +10,16 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.view.ViewCompat;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 import com.google.android.material.snackbar.Snackbar;
 
 import org.wikipedia.BackPressedHandler;
@@ -52,15 +62,6 @@ import org.wikipedia.util.UriUtil;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.IntRange;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.view.ViewCompat;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/aggregated/AggregatedFeedContent.java
+++ b/app/src/main/java/org/wikipedia/feed/aggregated/AggregatedFeedContent.java
@@ -1,5 +1,7 @@
 package org.wikipedia.feed.aggregated;
 
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
@@ -9,8 +11,6 @@ import org.wikipedia.feed.news.NewsItem;
 import org.wikipedia.feed.onthisday.OnThisDay;
 
 import java.util.List;
-
-import androidx.annotation.Nullable;
 
 public class AggregatedFeedContent {
     @SuppressWarnings("unused") @Nullable private RbPageSummary tfa;

--- a/app/src/main/java/org/wikipedia/feed/aggregated/AggregatedFeedContentClient.java
+++ b/app/src/main/java/org/wikipedia/feed/aggregated/AggregatedFeedContentClient.java
@@ -2,6 +2,10 @@ package org.wikipedia.feed.aggregated;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
@@ -23,9 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.util.Pair;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;

--- a/app/src/main/java/org/wikipedia/feed/announcement/Announcement.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/Announcement.java
@@ -2,6 +2,9 @@ package org.wikipedia.feed.announcement;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.json.annotations.Required;
@@ -12,9 +15,6 @@ import java.text.ParseException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 

--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCard.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCard.java
@@ -2,11 +2,11 @@ package org.wikipedia.feed.announcement;
 
 import android.net.Uri;
 
-import org.wikipedia.feed.model.Card;
-import org.wikipedia.feed.model.CardType;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.feed.model.Card;
+import org.wikipedia.feed.model.CardType;
 
 public class AnnouncementCard extends Card {
     @NonNull private final Announcement announcement;

--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.java
@@ -8,6 +8,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.view.DefaultFeedCardView;
@@ -16,7 +18,6 @@ import org.wikipedia.util.StringUtil;
 import org.wikipedia.views.FaceAndColorDetectImageView;
 import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
 
-import androidx.annotation.NonNull;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementClient.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementClient.java
@@ -3,6 +3,10 @@ package org.wikipedia.feed.announcement;
 import android.content.Context;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.dataclient.RestService;
@@ -20,9 +24,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import retrofit2.Call;
 import retrofit2.Response;
 

--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementList.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementList.java
@@ -1,13 +1,13 @@
 package org.wikipedia.feed.announcement;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.model.BaseModel;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public class AnnouncementList extends BaseModel {
 

--- a/app/src/main/java/org/wikipedia/feed/announcement/FundraisingCard.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/FundraisingCard.java
@@ -1,8 +1,8 @@
 package org.wikipedia.feed.announcement;
 
-import org.wikipedia.feed.model.CardType;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.feed.model.CardType;
 
 public class FundraisingCard extends AnnouncementCard {
 

--- a/app/src/main/java/org/wikipedia/feed/announcement/GeoIPCookieUnmarshaller.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/GeoIPCookieUnmarshaller.java
@@ -3,11 +3,11 @@ package org.wikipedia.feed.announcement;
 import android.location.Location;
 import android.text.TextUtils;
 
-import org.wikipedia.dataclient.SharedPreferenceCookieManager;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+
+import org.wikipedia.dataclient.SharedPreferenceCookieManager;
 
 /*
 This currently supports the "v4" version of the GeoIP cookie.

--- a/app/src/main/java/org/wikipedia/feed/announcement/SurveyCard.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/SurveyCard.java
@@ -1,8 +1,8 @@
 package org.wikipedia.feed.announcement;
 
-import org.wikipedia.feed.model.CardType;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.feed.model.CardType;
 
 public class SurveyCard extends AnnouncementCard {
 

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadCard.java
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadCard.java
@@ -3,6 +3,9 @@ package org.wikipedia.feed.becauseyouread;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.model.CardType;
@@ -12,9 +15,6 @@ import org.wikipedia.page.PageTitle;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class BecauseYouReadCard extends ListCard<BecauseYouReadItemCard> {
     @NonNull private HistoryEntry entry;

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadCardView.java
@@ -3,6 +3,9 @@ package org.wikipedia.feed.becauseyouread;
 import android.content.Context;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.view.ListCardItemView;
@@ -14,9 +17,6 @@ import org.wikipedia.views.DefaultViewHolder;
 import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class BecauseYouReadCardView extends ListCardView<BecauseYouReadCard>
         implements ItemTouchHelperSwipeAdapter.SwipeableView {

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadClient.java
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadClient.java
@@ -2,6 +2,8 @@ package org.wikipedia.feed.becauseyouread;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.Constants;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
@@ -15,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadItemCard.java
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadItemCard.java
@@ -3,13 +3,13 @@ package org.wikipedia.feed.becauseyouread;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class BecauseYouReadItemCard extends Card {
     @NonNull private final PageTitle title;

--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureActivity.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureActivity.java
@@ -3,9 +3,9 @@ package org.wikipedia.feed.configure;
 import android.content.Context;
 import android.content.Intent;
 
-import org.wikipedia.activity.SingleFragmentActivity;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.activity.SingleFragmentActivity;
 
 public class ConfigureActivity extends SingleFragmentActivity<ConfigureFragment> {
     public static final int CONFIGURATION_CHANGED_RESULT = 1;

--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureFragment.java
@@ -9,6 +9,13 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.analytics.FeedConfigureFunnel;
@@ -26,12 +33,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.ItemTouchHelper;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureItemLanguageDialogView.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureItemLanguageDialogView.java
@@ -8,15 +8,15 @@ import android.widget.CheckBox;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.views.DefaultViewHolder;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
 public class ConfigureItemLanguageDialogView extends FrameLayout {
     private List<String> langList;

--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureItemView.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureItemView.java
@@ -7,6 +7,13 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.FeedContentType;
@@ -14,12 +21,6 @@ import org.wikipedia.feed.FeedContentType;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.SwitchCompat;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnCheckedChanged;

--- a/app/src/main/java/org/wikipedia/feed/configure/FeedAvailability.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/FeedAvailability.java
@@ -1,11 +1,11 @@
 package org.wikipedia.feed.configure;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 @SuppressWarnings("unused")
 public class FeedAvailability {

--- a/app/src/main/java/org/wikipedia/feed/configure/LanguageItemAdapter.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/LanguageItemAdapter.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.FeedContentType;
@@ -11,9 +14,6 @@ import org.wikipedia.util.DimenUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 
 import static android.view.View.inflate;
 

--- a/app/src/main/java/org/wikipedia/feed/configure/LanguageItemHolder.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/LanguageItemHolder.java
@@ -5,12 +5,12 @@ import android.graphics.PorterDuff;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.views.DefaultViewHolder;
-
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 
 public class LanguageItemHolder extends DefaultViewHolder<View> {
     private Context context;

--- a/app/src/main/java/org/wikipedia/feed/dataclient/DummyClient.java
+++ b/app/src/main/java/org/wikipedia/feed/dataclient/DummyClient.java
@@ -2,14 +2,14 @@ package org.wikipedia.feed.dataclient;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.FeedCoordinator;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.searchbar.SearchCard;
 
 import java.util.Collections;
-
-import androidx.annotation.NonNull;
 
 /** A dummy client for providing static cards (main page, random) on tap to the FeedCoordinator. */
 public abstract class DummyClient implements FeedClient {

--- a/app/src/main/java/org/wikipedia/feed/dataclient/FeedClient.java
+++ b/app/src/main/java/org/wikipedia/feed/dataclient/FeedClient.java
@@ -2,12 +2,12 @@ package org.wikipedia.feed.dataclient;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.model.Card;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public interface FeedClient {
     void request(@NonNull Context context, @NonNull WikiSite wiki, int age, @NonNull final Callback cb);

--- a/app/src/main/java/org/wikipedia/feed/dayheader/DayHeaderCard.java
+++ b/app/src/main/java/org/wikipedia/feed/dayheader/DayHeaderCard.java
@@ -1,10 +1,10 @@
 package org.wikipedia.feed.dayheader;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
 import org.wikipedia.util.DateUtil;
-
-import androidx.annotation.NonNull;
 
 public class DayHeaderCard extends Card {
     private int age;

--- a/app/src/main/java/org/wikipedia/feed/dayheader/DayHeaderCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/dayheader/DayHeaderCardView.java
@@ -4,13 +4,13 @@ import android.content.Context;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.view.FeedAdapter;
 import org.wikipedia.feed.view.FeedCardView;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class DayHeaderCardView extends FrameLayout implements FeedCardView<Card> {
     private Card card;

--- a/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCard.java
+++ b/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCard.java
@@ -2,6 +2,9 @@ package org.wikipedia.feed.featured;
 
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -12,9 +15,6 @@ import org.wikipedia.feed.model.WikiSiteCard;
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.DateUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class FeaturedArticleCard extends WikiSiteCard {
     @NonNull private RbPageSummary page;

--- a/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCardView.java
@@ -6,6 +6,9 @@ import android.net.Uri;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.events.ArticleSavedOrDeletedEvent;
@@ -25,8 +28,6 @@ import org.wikipedia.views.FaceAndColorDetectImageView;
 import org.wikipedia.views.GoneIfEmptyTextView;
 import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/image/FeaturedImage.java
+++ b/app/src/main/java/org/wikipedia/feed/image/FeaturedImage.java
@@ -1,11 +1,11 @@
 package org.wikipedia.feed.image;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.gallery.GalleryItem;
 import org.wikipedia.gallery.ImageInfo;
 import org.wikipedia.json.PostProcessingTypeAdapter;
 import org.wikipedia.json.annotations.Required;
-
-import androidx.annotation.NonNull;
 
 public final class FeaturedImage extends GalleryItem implements PostProcessingTypeAdapter.PostProcessable {
     @SuppressWarnings("unused,NullableProblems") @Required @NonNull private String title;

--- a/app/src/main/java/org/wikipedia/feed/image/FeaturedImageCard.java
+++ b/app/src/main/java/org/wikipedia/feed/image/FeaturedImageCard.java
@@ -2,15 +2,15 @@ package org.wikipedia.feed.image;
 
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
 import org.wikipedia.util.DateUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class FeaturedImageCard extends Card {
     @NonNull private FeaturedImage featuredImage;

--- a/app/src/main/java/org/wikipedia/feed/image/FeaturedImageCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/image/FeaturedImageCardView.java
@@ -5,6 +5,9 @@ import android.net.Uri;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.view.ActionFooterView;
 import org.wikipedia.feed.view.CardHeaderView;
@@ -14,8 +17,6 @@ import org.wikipedia.richtext.RichTextUtil;
 import org.wikipedia.views.FaceAndColorDetectImageView;
 import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/feed/mainpage/MainPageCard.java
+++ b/app/src/main/java/org/wikipedia/feed/mainpage/MainPageCard.java
@@ -1,9 +1,9 @@
 package org.wikipedia.feed.mainpage;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
-
-import androidx.annotation.NonNull;
 
 public class MainPageCard extends Card {
     @NonNull @Override public CardType type() {

--- a/app/src/main/java/org/wikipedia/feed/mainpage/MainPageCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/mainpage/MainPageCardView.java
@@ -3,6 +3,9 @@ package org.wikipedia.feed.mainpage;
 import android.content.Context;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.view.FeedAdapter;
 import org.wikipedia.feed.view.StaticCardView;
@@ -10,9 +13,6 @@ import org.wikipedia.history.HistoryEntry;
 
 import java.text.DateFormat;
 import java.util.Date;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class MainPageCardView extends StaticCardView<MainPageCard> {
     public MainPageCardView(@NonNull Context context) {

--- a/app/src/main/java/org/wikipedia/feed/mainpage/MainPageClient.java
+++ b/app/src/main/java/org/wikipedia/feed/mainpage/MainPageClient.java
@@ -1,13 +1,13 @@
 package org.wikipedia.feed.mainpage;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.dataclient.DummyClient;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.settings.SiteInfoClient;
-
-import androidx.annotation.NonNull;
 
 public class MainPageClient extends DummyClient {
     @Override public Card getNewCard(WikiSite wiki) {

--- a/app/src/main/java/org/wikipedia/feed/model/Card.java
+++ b/app/src/main/java/org/wikipedia/feed/model/Card.java
@@ -2,10 +2,10 @@ package org.wikipedia.feed.model;
 
 import android.net.Uri;
 
-import org.wikipedia.model.BaseModel;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.model.BaseModel;
 
 public abstract class Card extends BaseModel {
     @NonNull public String title() {

--- a/app/src/main/java/org/wikipedia/feed/model/CardType.java
+++ b/app/src/main/java/org/wikipedia/feed/model/CardType.java
@@ -2,6 +2,8 @@ package org.wikipedia.feed.model;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.feed.FeedContentType;
 import org.wikipedia.feed.announcement.AnnouncementCardView;
 import org.wikipedia.feed.becauseyouread.BecauseYouReadCardView;
@@ -20,8 +22,6 @@ import org.wikipedia.feed.suggestededits.SuggestedEditsCardView;
 import org.wikipedia.feed.view.FeedCardView;
 import org.wikipedia.model.EnumCode;
 import org.wikipedia.model.EnumCodeMap;
-
-import androidx.annotation.NonNull;
 
 public enum CardType implements EnumCode {
     SEARCH_BAR(0) {

--- a/app/src/main/java/org/wikipedia/feed/model/ListCard.java
+++ b/app/src/main/java/org/wikipedia/feed/model/ListCard.java
@@ -1,11 +1,11 @@
 package org.wikipedia.feed.model;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.dataclient.WikiSite;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public abstract class ListCard<T extends Card> extends WikiSiteCard {
     @NonNull private final List<T> items;

--- a/app/src/main/java/org/wikipedia/feed/model/UtcDate.java
+++ b/app/src/main/java/org/wikipedia/feed/model/UtcDate.java
@@ -1,8 +1,8 @@
 package org.wikipedia.feed.model;
 
-import java.util.Calendar;
-
 import androidx.annotation.NonNull;
+
+import java.util.Calendar;
 
 import static java.util.TimeZone.getTimeZone;
 

--- a/app/src/main/java/org/wikipedia/feed/model/WikiSiteCard.java
+++ b/app/src/main/java/org/wikipedia/feed/model/WikiSiteCard.java
@@ -1,8 +1,8 @@
 package org.wikipedia.feed.model;
 
-import org.wikipedia.dataclient.WikiSite;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.dataclient.WikiSite;
 
 public abstract class WikiSiteCard extends Card {
     @NonNull private WikiSite wiki;

--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadArticles.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadArticles.java
@@ -1,12 +1,12 @@
 package org.wikipedia.feed.mostread;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 import org.wikipedia.json.annotations.Required;
 
 import java.util.Date;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public final class MostReadArticles {
     @SuppressWarnings("unused,NullableProblems") @Required @NonNull private Date date;

--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadArticlesActivity.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadArticlesActivity.java
@@ -3,11 +3,11 @@ package org.wikipedia.feed.mostread;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.json.GsonMarshaller;
 import org.wikipedia.json.GsonUnmarshaller;
-
-import androidx.annotation.NonNull;
 
 public class MostReadArticlesActivity extends SingleFragmentActivity<MostReadFragment> {
     protected static final String MOST_READ_CARD = "item";

--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadCardView.java
@@ -2,6 +2,9 @@ package org.wikipedia.feed.mostread;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.view.ListCardItemView;
 import org.wikipedia.feed.view.ListCardRecyclerAdapter;
@@ -12,9 +15,6 @@ import org.wikipedia.views.DefaultViewHolder;
 import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class MostReadCardView extends ListCardView<MostReadListCard>
         implements ItemTouchHelperSwipeAdapter.SwipeableView {

--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadFragment.java
@@ -5,6 +5,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.view.ListCardItemView;
@@ -22,12 +29,6 @@ import org.wikipedia.views.DrawableItemDecoration;
 
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadItemCard.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadItemCard.java
@@ -3,14 +3,14 @@ package org.wikipedia.feed.mostread;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class MostReadItemCard extends Card {
     @NonNull private final RbPageSummary page;

--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadListCard.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadListCard.java
@@ -2,6 +2,11 @@ package org.wikipedia.feed.mostread;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.annotation.VisibleForTesting;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
@@ -13,11 +18,6 @@ import org.wikipedia.util.DateUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
-import androidx.annotation.VisibleForTesting;
 
 public class MostReadListCard extends ListCard<MostReadItemCard> {
     @NonNull private final MostReadArticles articles;

--- a/app/src/main/java/org/wikipedia/feed/news/NewsActivity.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsActivity.java
@@ -6,14 +6,14 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.view.WindowManager;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.json.GsonMarshaller;
 import org.wikipedia.json.GsonUnmarshaller;
 import org.wikipedia.util.AnimationUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class NewsActivity extends SingleFragmentActivity<NewsFragment> {
     protected static final String EXTRA_NEWS_ITEM = "item";

--- a/app/src/main/java/org/wikipedia/feed/news/NewsFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsFragment.java
@@ -9,6 +9,14 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 
@@ -34,13 +42,6 @@ import org.wikipedia.views.FaceAndColorDetectImageView;
 
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/feed/news/NewsItem.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsItem.java
@@ -2,6 +2,9 @@ package org.wikipedia.feed.news;
 
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 import org.wikipedia.json.annotations.Required;
@@ -9,9 +12,6 @@ import org.wikipedia.json.annotations.Required;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.dataclient.Service.PREFERRED_THUMB_SIZE;
 import static org.wikipedia.util.ImageUrlUtil.getUrlForSize;

--- a/app/src/main/java/org/wikipedia/feed/news/NewsItemCard.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsItemCard.java
@@ -5,6 +5,9 @@ import android.net.Uri;
 import android.text.Spanned;
 import android.text.style.StyleSpan;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 import org.wikipedia.feed.model.Card;
@@ -14,9 +17,6 @@ import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class NewsItemCard extends Card {
     @NonNull private NewsItem newsItem;

--- a/app/src/main/java/org/wikipedia/feed/news/NewsLinkCard.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsLinkCard.java
@@ -3,14 +3,14 @@ package org.wikipedia.feed.news;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.dataclient.Service.PREFERRED_THUMB_SIZE;
 import static org.wikipedia.util.ImageUrlUtil.getUrlForSize;

--- a/app/src/main/java/org/wikipedia/feed/news/NewsListCard.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsListCard.java
@@ -1,5 +1,8 @@
 package org.wikipedia.feed.news;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.model.CardType;
 import org.wikipedia.feed.model.ListCard;
@@ -8,9 +11,6 @@ import org.wikipedia.feed.model.UtcDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
 
 public class NewsListCard extends ListCard<NewsItemCard> {
     @NonNull private UtcDate date;

--- a/app/src/main/java/org/wikipedia/feed/news/NewsListCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsListCardView.java
@@ -2,6 +2,9 @@ package org.wikipedia.feed.news;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.view.FeedAdapter;
 import org.wikipedia.feed.view.HorizontalScrollingListCardItemView;
@@ -11,9 +14,6 @@ import org.wikipedia.views.DefaultViewHolder;
 import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class NewsListCardView extends HorizontalScrollingListCardView<NewsListCard>
         implements ItemTouchHelperSwipeAdapter.SwipeableView {

--- a/app/src/main/java/org/wikipedia/feed/offline/OfflineCard.java
+++ b/app/src/main/java/org/wikipedia/feed/offline/OfflineCard.java
@@ -1,9 +1,9 @@
 package org.wikipedia.feed.offline;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
-
-import androidx.annotation.NonNull;
 
 public class OfflineCard extends Card {
     @NonNull @Override public CardType type() {

--- a/app/src/main/java/org/wikipedia/feed/offline/OfflineCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/offline/OfflineCardView.java
@@ -4,13 +4,14 @@ import android.content.Context;
 import android.widget.LinearLayout;
 import android.widget.Space;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.view.FeedAdapter;
 import org.wikipedia.feed.view.FeedCardView;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/onboarding/CustomizeOnboardingCard.java
+++ b/app/src/main/java/org/wikipedia/feed/onboarding/CustomizeOnboardingCard.java
@@ -1,11 +1,11 @@
 package org.wikipedia.feed.onboarding;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.announcement.Announcement;
 import org.wikipedia.feed.model.CardType;
-
-import androidx.annotation.NonNull;
 
 public class CustomizeOnboardingCard extends OnboardingCard {
     public CustomizeOnboardingCard(@NonNull Announcement announcement) {

--- a/app/src/main/java/org/wikipedia/feed/onboarding/OnboardingCard.java
+++ b/app/src/main/java/org/wikipedia/feed/onboarding/OnboardingCard.java
@@ -1,11 +1,11 @@
 package org.wikipedia.feed.onboarding;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
 import org.wikipedia.feed.announcement.Announcement;
 import org.wikipedia.feed.announcement.AnnouncementCard;
 import org.wikipedia.settings.PrefsIoUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 
 public abstract class OnboardingCard extends AnnouncementCard {
     public OnboardingCard(@NonNull Announcement announcement) {

--- a/app/src/main/java/org/wikipedia/feed/onboarding/OnboardingClient.java
+++ b/app/src/main/java/org/wikipedia/feed/onboarding/OnboardingClient.java
@@ -2,6 +2,8 @@ package org.wikipedia.feed.onboarding;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.FeedCoordinator;
@@ -13,8 +15,6 @@ import org.wikipedia.util.UriUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public class OnboardingClient implements FeedClient {
     @Override public void request(@NonNull Context context, @NonNull WikiSite wiki, int age,

--- a/app/src/main/java/org/wikipedia/feed/onboarding/ReadingListsSyncOnboardingCard.java
+++ b/app/src/main/java/org/wikipedia/feed/onboarding/ReadingListsSyncOnboardingCard.java
@@ -1,12 +1,12 @@
 package org.wikipedia.feed.onboarding;
 
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.feed.announcement.Announcement;
 import org.wikipedia.feed.model.CardType;
-
-import androidx.annotation.NonNull;
 
 public class ReadingListsSyncOnboardingCard extends OnboardingCard {
     public ReadingListsSyncOnboardingCard(@NonNull Announcement announcement) {

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDay.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDay.java
@@ -1,5 +1,8 @@
 package org.wikipedia.feed.onthisday;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 import org.wikipedia.json.annotations.Required;
@@ -9,9 +12,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class OnThisDay {
 

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayActionsDialog.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayActionsDialog.java
@@ -5,14 +5,14 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.activity.FragmentUtil;
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment;
 import org.wikipedia.util.ResourceUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class OnThisDayActionsDialog extends ExtendedBottomSheetDialogFragment {
     public interface Callback {

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayActionsView.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayActionsView.java
@@ -6,10 +6,11 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.R;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayActivity.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayActivity.java
@@ -3,10 +3,10 @@ package org.wikipedia.feed.onthisday;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.dataclient.WikiSite;
-
-import androidx.annotation.NonNull;
 
 public class OnThisDayActivity extends SingleFragmentActivity<OnThisDayFragment> {
     public static final String AGE = "age";

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCard.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCard.java
@@ -1,5 +1,8 @@
 package org.wikipedia.feed.onthisday;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
@@ -13,9 +16,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class OnThisDayCard extends WikiSiteCard {
     private int nextYear;

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.java
@@ -10,6 +10,15 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.cardview.widget.CardView;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.analytics.FeedFunnel;
@@ -32,14 +41,6 @@ import org.wikipedia.views.MarginItemDecoration;
 
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.cardview.widget.CardView;
-import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayFragment.java
@@ -11,6 +11,14 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 
@@ -38,13 +46,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.java
@@ -9,6 +9,13 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.view.ViewCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -22,12 +29,6 @@ import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.views.FaceAndColorDetectImageView;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.cardview.widget.CardView;
-import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.view.ViewCompat;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/progress/ProgressCard.java
+++ b/app/src/main/java/org/wikipedia/feed/progress/ProgressCard.java
@@ -1,9 +1,9 @@
 package org.wikipedia.feed.progress;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
-
-import androidx.annotation.NonNull;
 
 public class ProgressCard extends Card {
     @NonNull @Override public CardType type() {

--- a/app/src/main/java/org/wikipedia/feed/progress/ProgressCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/progress/ProgressCardView.java
@@ -3,13 +3,13 @@ package org.wikipedia.feed.progress;
 import android.content.Context;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.view.FeedAdapter;
 import org.wikipedia.feed.view.FeedCardView;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class ProgressCardView extends FrameLayout implements FeedCardView<Card> {
     public ProgressCardView(Context context) {

--- a/app/src/main/java/org/wikipedia/feed/random/RandomCard.java
+++ b/app/src/main/java/org/wikipedia/feed/random/RandomCard.java
@@ -1,10 +1,10 @@
 package org.wikipedia.feed.random;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
-
-import androidx.annotation.NonNull;
 
 public class RandomCard extends Card {
     @NonNull private WikiSite wiki;

--- a/app/src/main/java/org/wikipedia/feed/random/RandomCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/random/RandomCardView.java
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.ServiceFactory;
@@ -13,7 +15,6 @@ import org.wikipedia.page.PageTitle;
 import org.wikipedia.readinglist.database.ReadingListDbHelper;
 import org.wikipedia.readinglist.database.ReadingListPage;
 
-import androidx.annotation.NonNull;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/feed/searchbar/SearchCard.java
+++ b/app/src/main/java/org/wikipedia/feed/searchbar/SearchCard.java
@@ -1,9 +1,9 @@
 package org.wikipedia.feed.searchbar;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.feed.model.CardType;
-
-import androidx.annotation.NonNull;
 
 public class SearchCard extends Card {
     @NonNull @Override public CardType type() {

--- a/app/src/main/java/org/wikipedia/feed/view/ActionFooterView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/ActionFooterView.java
@@ -6,14 +6,15 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-
 import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.ContextCompat;
+
+import org.wikipedia.R;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/feed/view/CardHeaderView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/CardHeaderView.java
@@ -9,10 +9,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-import org.wikipedia.WikipediaApp;
-import org.wikipedia.feed.model.Card;
-
 import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
@@ -24,6 +20,11 @@ import androidx.appcompat.widget.PopupMenu;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
+
+import org.wikipedia.R;
+import org.wikipedia.WikipediaApp;
+import org.wikipedia.feed.model.Card;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.java
@@ -9,14 +9,15 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-import org.wikipedia.views.FaceAndColorDetectImageView;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.ContextCompat;
+
+import org.wikipedia.R;
+import org.wikipedia.views.FaceAndColorDetectImageView;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/feed/view/DefaultFeedCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/DefaultFeedCardView.java
@@ -3,14 +3,14 @@ package org.wikipedia.feed.view;
 import android.content.Context;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+
 import org.wikipedia.R;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.util.ResourceUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.cardview.widget.CardView;
 
 import static org.wikipedia.util.L10nUtil.isLangRTL;
 

--- a/app/src/main/java/org/wikipedia/feed/view/FeedAdapter.java
+++ b/app/src/main/java/org/wikipedia/feed/view/FeedAdapter.java
@@ -4,6 +4,11 @@ import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.StaggeredGridLayoutManager;
+
 import org.wikipedia.feed.FeedCoordinatorBase;
 import org.wikipedia.feed.announcement.AnnouncementCardView;
 import org.wikipedia.feed.becauseyouread.BecauseYouReadCardView;
@@ -21,11 +26,6 @@ import org.wikipedia.util.DimenUtil;
 import org.wikipedia.views.DefaultRecyclerAdapter;
 import org.wikipedia.views.DefaultViewHolder;
 import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
 public class FeedAdapter<T extends View & FeedCardView<?>> extends DefaultRecyclerAdapter<Card, T> {
     public interface Callback extends ItemTouchHelperSwipeAdapter.Callback,

--- a/app/src/main/java/org/wikipedia/feed/view/FeedCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/FeedCardView.java
@@ -1,9 +1,9 @@
 package org.wikipedia.feed.view;
 
-import org.wikipedia.feed.model.Card;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.feed.model.Card;
 
 public interface FeedCardView<T extends Card> {
     void setCard(@NonNull T card);

--- a/app/src/main/java/org/wikipedia/feed/view/FeedView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/FeedView.java
@@ -4,6 +4,12 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
 
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.DefaultItemAnimator;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.StaggeredGridLayoutManager;
+
 import org.wikipedia.R;
 import org.wikipedia.crash.RemoteLogException;
 import org.wikipedia.util.log.L;
@@ -11,12 +17,6 @@ import org.wikipedia.views.AutoFitRecyclerView;
 import org.wikipedia.views.HeaderMarginItemDecoration;
 import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
 import org.wikipedia.views.MarginItemDecoration;
-
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.DefaultItemAnimator;
-import androidx.recyclerview.widget.ItemTouchHelper;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
 import static org.wikipedia.util.DimenUtil.getDimension;
 import static org.wikipedia.util.DimenUtil.roundedDpToPx;

--- a/app/src/main/java/org/wikipedia/feed/view/HorizontalScrollingListCardItemView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/HorizontalScrollingListCardItemView.java
@@ -5,14 +5,15 @@ import android.net.Uri;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+
 import org.wikipedia.R;
 import org.wikipedia.richtext.RichTextUtil;
 import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.views.FaceAndColorDetectImageView;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.cardview.widget.CardView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/feed/view/HorizontalScrollingListCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/HorizontalScrollingListCardView.java
@@ -3,6 +3,11 @@ package org.wikipedia.feed.view;
 import android.content.Context;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.model.Card;
 import org.wikipedia.util.DimenUtil;
@@ -12,11 +17,6 @@ import org.wikipedia.views.DontInterceptTouchListener;
 import org.wikipedia.views.MarginItemDecoration;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
 public abstract class HorizontalScrollingListCardView<T extends Card> extends ListCardView<T> {
     public HorizontalScrollingListCardView(@NonNull Context context) {

--- a/app/src/main/java/org/wikipedia/feed/view/ListCardItemView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/ListCardItemView.java
@@ -6,6 +6,12 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
+
 import com.facebook.drawee.view.SimpleDraweeView;
 
 import org.apache.commons.lang3.StringUtils;
@@ -20,11 +26,6 @@ import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.views.GoneIfEmptyTextView;
 import org.wikipedia.views.ViewUtil;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.content.ContextCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/view/ListCardRecyclerAdapter.java
+++ b/app/src/main/java/org/wikipedia/feed/view/ListCardRecyclerAdapter.java
@@ -2,13 +2,13 @@ package org.wikipedia.feed.view;
 
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.views.DefaultRecyclerAdapter;
 import org.wikipedia.views.DefaultViewHolder;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public abstract class ListCardRecyclerAdapter<T>
         extends DefaultRecyclerAdapter<T, ListCardItemView> {

--- a/app/src/main/java/org/wikipedia/feed/view/ListCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/ListCardView.java
@@ -5,14 +5,15 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-import org.wikipedia.feed.model.Card;
-import org.wikipedia.views.DrawableItemDecoration;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.wikipedia.R;
+import org.wikipedia.feed.model.Card;
+import org.wikipedia.views.DrawableItemDecoration;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/feed/view/StaticCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/StaticCardView.java
@@ -7,15 +7,16 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-import org.wikipedia.feed.model.Card;
-import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
-
 import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.core.content.ContextCompat;
+
+import org.wikipedia.R;
+import org.wikipedia.feed.model.Card;
+import org.wikipedia.views.ItemTouchHelperSwipeAdapter;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/gallery/ArtistInfo.java
+++ b/app/src/main/java/org/wikipedia/gallery/ArtistInfo.java
@@ -1,8 +1,8 @@
 package org.wikipedia.gallery;
 
-import com.google.gson.annotations.SerializedName;
-
 import androidx.annotation.Nullable;
+
+import com.google.gson.annotations.SerializedName;
 
 public class ArtistInfo extends TextInfo {
 

--- a/app/src/main/java/org/wikipedia/gallery/ExtMetadata.java
+++ b/app/src/main/java/org/wikipedia/gallery/ExtMetadata.java
@@ -1,9 +1,9 @@
 package org.wikipedia.gallery;
 
-import com.google.gson.annotations.SerializedName;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.google.gson.annotations.SerializedName;
 
 public class ExtMetadata {
     @SuppressWarnings("unused") @SerializedName("DateTime") @Nullable private Values dateTime;

--- a/app/src/main/java/org/wikipedia/gallery/Gallery.java
+++ b/app/src/main/java/org/wikipedia/gallery/Gallery.java
@@ -1,10 +1,10 @@
 package org.wikipedia.gallery;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class Gallery {
     @SuppressWarnings("unused,NullableProblems") @Nullable private String revision;

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -18,6 +18,19 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.fragment.app.FragmentTransaction;
+import androidx.viewpager.widget.ViewPager;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.BaseActivity;
@@ -48,18 +61,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.ColorInt;
-import androidx.annotation.ColorRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentPagerAdapter;
-import androidx.fragment.app.FragmentTransaction;
-import androidx.viewpager.widget.ViewPager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItem.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItem.java
@@ -1,5 +1,8 @@
 package org.wikipedia.gallery;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
@@ -9,9 +12,6 @@ import org.wikipedia.util.StringUtil;
 
 import java.io.Serializable;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.Constants.PREFERRED_GALLERY_IMAGE_SIZE;
 

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
@@ -15,6 +15,10 @@ import android.widget.MediaController;
 import android.widget.ProgressBar;
 import android.widget.VideoView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.controller.BaseControllerListener;
 import com.facebook.drawee.drawable.ScalingUtils;
@@ -40,9 +44,6 @@ import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 import org.wikipedia.views.ZoomableDraweeViewWithBackground;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/gallery/GalleryThumbnailScrollView.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryThumbnailScrollView.java
@@ -9,17 +9,17 @@ import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.facebook.drawee.view.SimpleDraweeView;
 
 import org.wikipedia.R;
 import org.wikipedia.views.ViewUtil;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
 public class GalleryThumbnailScrollView extends RecyclerView {
     @NonNull private final Animation mPressAnimation;

--- a/app/src/main/java/org/wikipedia/gallery/ImageInfo.java
+++ b/app/src/main/java/org/wikipedia/gallery/ImageInfo.java
@@ -1,13 +1,13 @@
 package org.wikipedia.gallery;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * Gson POJO for a standard image info object as returned by the API ImageInfo module

--- a/app/src/main/java/org/wikipedia/gallery/ImageLicense.java
+++ b/app/src/main/java/org/wikipedia/gallery/ImageLicense.java
@@ -1,14 +1,14 @@
 package org.wikipedia.gallery;
 
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.R;
 
 import java.io.Serializable;
 import java.util.Locale;
-
-import androidx.annotation.DrawableRes;
-import androidx.annotation.NonNull;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 

--- a/app/src/main/java/org/wikipedia/gallery/ImagePipelineBitmapGetter.java
+++ b/app/src/main/java/org/wikipedia/gallery/ImagePipelineBitmapGetter.java
@@ -6,6 +6,8 @@ import android.graphics.Paint;
 import android.net.Uri;
 import android.widget.Toast;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.common.executors.UiThreadImmediateExecutorService;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.DataSource;
@@ -17,8 +19,6 @@ import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.imagepipeline.request.ImageRequestBuilder;
 
 import org.wikipedia.WikipediaApp;
-
-import androidx.annotation.Nullable;
 
 public abstract class ImagePipelineBitmapGetter {
     private String imageUrl;

--- a/app/src/main/java/org/wikipedia/gallery/MediaDownloadReceiver.java
+++ b/app/src/main/java/org/wikipedia/gallery/MediaDownloadReceiver.java
@@ -10,15 +10,15 @@ import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.image.FeaturedImage;
 import org.wikipedia.util.FileUtil;
 
 import java.io.File;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class MediaDownloadReceiver extends BroadcastReceiver {
     private static final String FILE_NAMESPACE = "File:";

--- a/app/src/main/java/org/wikipedia/gallery/TextInfo.java
+++ b/app/src/main/java/org/wikipedia/gallery/TextInfo.java
@@ -1,11 +1,11 @@
 package org.wikipedia.gallery;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class TextInfo implements Serializable {
     @SuppressWarnings("unused,NullableProblems") @Nullable private String html;

--- a/app/src/main/java/org/wikipedia/gallery/VideoInfo.java
+++ b/app/src/main/java/org/wikipedia/gallery/VideoInfo.java
@@ -1,10 +1,10 @@
 package org.wikipedia.gallery;
 
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
-
-import androidx.annotation.Nullable;
 
 /**
  * Gson POJO for a standard video info object as returned by the API VideoInfo module

--- a/app/src/main/java/org/wikipedia/history/HistoryEntry.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryEntry.java
@@ -3,13 +3,13 @@ package org.wikipedia.history;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.page.PageTitle;
 
 import java.util.Date;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class HistoryEntry implements Parcelable {
     public static final HistoryEntryDatabaseTable DATABASE_TABLE = new HistoryEntryDatabaseTable();

--- a/app/src/main/java/org/wikipedia/history/HistoryEntryDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryEntryDatabaseTable.java
@@ -3,6 +3,8 @@ package org.wikipedia.history;
 import android.content.ContentValues;
 import android.database.Cursor;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.database.DatabaseTable;
 import org.wikipedia.database.column.Column;
 import org.wikipedia.database.contract.PageHistoryContract;
@@ -11,8 +13,6 @@ import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.PageTitle;
 
 import java.util.Date;
-
-import androidx.annotation.NonNull;
 
 public class HistoryEntryDatabaseTable extends DatabaseTable<HistoryEntry> {
     private static final int DB_VER_NAMESPACE_ADDED = 6;

--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.java
@@ -15,6 +15,19 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.ActionMode;
+import androidx.fragment.app.Fragment;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.google.android.material.snackbar.Snackbar;
 
 import org.wikipedia.BackPressedHandler;
@@ -45,18 +58,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.view.ActionMode;
-import androidx.fragment.app.Fragment;
-import androidx.loader.app.LoaderManager;
-import androidx.loader.content.CursorLoader;
-import androidx.loader.content.Loader;
-import androidx.recyclerview.widget.ItemTouchHelper;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/history/SearchActionModeCallback.java
+++ b/app/src/main/java/org/wikipedia/history/SearchActionModeCallback.java
@@ -4,11 +4,11 @@ import android.content.Context;
 import android.view.Menu;
 import android.view.MenuItem;
 
-import org.wikipedia.views.SearchActionProvider;
-
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ActionMode;
 import androidx.core.view.MenuItemCompat;
+
+import org.wikipedia.views.SearchActionProvider;
 
 public abstract class SearchActionModeCallback implements ActionMode.Callback {
     public static final String ACTION_MODE_TAG = "searchActionMode";

--- a/app/src/main/java/org/wikipedia/history/UpdateHistoryTask.java
+++ b/app/src/main/java/org/wikipedia/history/UpdateHistoryTask.java
@@ -2,11 +2,12 @@ package org.wikipedia.history;
 
 import android.database.Cursor;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.database.DatabaseClient;
 import org.wikipedia.database.contract.PageHistoryContract;
 
-import androidx.annotation.NonNull;
 import io.reactivex.functions.Action;
 
 /**

--- a/app/src/main/java/org/wikipedia/html/ImageElement.java
+++ b/app/src/main/java/org/wikipedia/html/ImageElement.java
@@ -1,13 +1,13 @@
 package org.wikipedia.html;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class ImageElement {
     private static final PixelDensityDescriptor DESCRIPTOR_DEFAULT = null;

--- a/app/src/main/java/org/wikipedia/html/ImageTagParser.java
+++ b/app/src/main/java/org/wikipedia/html/ImageTagParser.java
@@ -1,5 +1,8 @@
 package org.wikipedia.html;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -8,9 +11,6 @@ import org.jsoup.nodes.Element;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class ImageTagParser {
     @NonNull private static final String TAG_NAME = "img";

--- a/app/src/main/java/org/wikipedia/html/PixelDensityDescriptor.java
+++ b/app/src/main/java/org/wikipedia/html/PixelDensityDescriptor.java
@@ -1,8 +1,8 @@
 package org.wikipedia.html;
 
-import org.wikipedia.model.BaseModel;
-
 import androidx.annotation.FloatRange;
+
+import org.wikipedia.model.BaseModel;
 
 public class PixelDensityDescriptor extends BaseModel {
     @FloatRange(from = 0, fromInclusive = false) private final float density;

--- a/app/src/main/java/org/wikipedia/html/PixelDensityDescriptorParser.java
+++ b/app/src/main/java/org/wikipedia/html/PixelDensityDescriptorParser.java
@@ -1,9 +1,9 @@
 package org.wikipedia.html;
 
-import java.util.Locale;
-
 import androidx.annotation.FloatRange;
 import androidx.annotation.NonNull;
+
+import java.util.Locale;
 
 public class PixelDensityDescriptorParser {
     /** @throws ParseException */

--- a/app/src/main/java/org/wikipedia/json/GsonMarshaller.java
+++ b/app/src/main/java/org/wikipedia/json/GsonMarshaller.java
@@ -1,9 +1,9 @@
 package org.wikipedia.json;
 
-import com.google.gson.Gson;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.google.gson.Gson;
 
 public final class GsonMarshaller {
     public static String marshal(@Nullable Object object) {

--- a/app/src/main/java/org/wikipedia/json/GsonUnmarshaller.java
+++ b/app/src/main/java/org/wikipedia/json/GsonUnmarshaller.java
@@ -1,10 +1,10 @@
 package org.wikipedia.json;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 public final class GsonUnmarshaller {
     /** @return Unmarshalled object. */

--- a/app/src/main/java/org/wikipedia/json/GsonUtil.java
+++ b/app/src/main/java/org/wikipedia/json/GsonUtil.java
@@ -2,14 +2,14 @@ package org.wikipedia.json;
 
 import android.net.Uri;
 
+import androidx.annotation.VisibleForTesting;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import org.wikipedia.dataclient.SharedPreferenceCookieManager;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.Namespace;
-
-import androidx.annotation.VisibleForTesting;
 
 public final class GsonUtil {
     private static final String DATE_FORMAT = "MMM dd, yyyy HH:mm:ss";

--- a/app/src/main/java/org/wikipedia/json/RequiredFieldsCheckOnReadTypeAdapterFactory.java
+++ b/app/src/main/java/org/wikipedia/json/RequiredFieldsCheckOnReadTypeAdapterFactory.java
@@ -1,5 +1,9 @@
 package org.wikipedia.json;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.collection.ArraySet;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
@@ -14,10 +18,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.collection.ArraySet;
 
 /**
  * TypeAdapterFactory that provides TypeAdapters that return null values for objects that are

--- a/app/src/main/java/org/wikipedia/json/SessionUnmarshaller.java
+++ b/app/src/main/java/org/wikipedia/json/SessionUnmarshaller.java
@@ -1,11 +1,11 @@
 package org.wikipedia.json;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.analytics.SessionData;
 import org.wikipedia.crash.RemoteLogException;
 import org.wikipedia.util.log.L;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public final class SessionUnmarshaller {
     @NonNull public static SessionData unmarshal(@Nullable String json) {

--- a/app/src/main/java/org/wikipedia/json/TabUnmarshaller.java
+++ b/app/src/main/java/org/wikipedia/json/TabUnmarshaller.java
@@ -1,5 +1,8 @@
 package org.wikipedia.json;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.reflect.TypeToken;
 
 import org.wikipedia.crash.RemoteLogException;
@@ -8,9 +11,6 @@ import org.wikipedia.util.log.L;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public final class TabUnmarshaller {
     private static final TypeToken<List<Tab>> TYPE_TOKEN = new TypeToken<List<Tab>>() { };

--- a/app/src/main/java/org/wikipedia/language/AcceptLanguageUtil.java
+++ b/app/src/main/java/org/wikipedia/language/AcceptLanguageUtil.java
@@ -1,8 +1,8 @@
 package org.wikipedia.language;
 
-import java.util.Locale;
-
 import androidx.annotation.NonNull;
+
+import java.util.Locale;
 
 public final class AcceptLanguageUtil {
     private static final float APP_LANGUAGE_QUALITY = .9f;

--- a/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.java
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.java
@@ -4,16 +4,16 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.text.TextUtils;
 
+import androidx.annotation.ArrayRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 
 import java.lang.ref.SoftReference;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-
-import androidx.annotation.ArrayRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /** Immutable look up table for all app supported languages. All article languages may not be
   * present in this table as it is statically bundled with the app. */

--- a/app/src/main/java/org/wikipedia/language/AppLanguageState.java
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageState.java
@@ -3,6 +3,9 @@ package org.wikipedia.language;
 import android.content.Context;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.settings.Prefs;
@@ -11,9 +14,6 @@ import org.wikipedia.util.StringUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.wikipedia.language.AppLanguageLookUpTable.TEST_LANGUAGE_CODE;

--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
@@ -11,6 +11,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.appcompat.view.ActionMode;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -35,12 +42,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.appcompat.view.ActionMode;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;

--- a/app/src/main/java/org/wikipedia/language/LanguageUtil.java
+++ b/app/src/main/java/org/wikipedia/language/LanguageUtil.java
@@ -7,6 +7,10 @@ import android.view.inputmethod.InputMethodInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.os.LocaleListCompat;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.StringUtil;
 
@@ -15,10 +19,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.os.LocaleListCompat;
 
 public final class LanguageUtil {
     private static final String HONG_KONG_COUNTRY_CODE = "HK";

--- a/app/src/main/java/org/wikipedia/language/LanguagesListActivity.java
+++ b/app/src/main/java/org/wikipedia/language/LanguagesListActivity.java
@@ -11,6 +11,12 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.view.ActionMode;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -27,11 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.view.ActionMode;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;

--- a/app/src/main/java/org/wikipedia/login/LoginActivity.java
+++ b/app/src/main/java/org/wikipedia/login/LoginActivity.java
@@ -11,6 +11,9 @@ import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.android.material.textfield.TextInputLayout;
 
 import org.wikipedia.Constants;
@@ -31,8 +34,6 @@ import org.wikipedia.views.WikiErrorView;
 
 import java.util.Collections;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/login/LoginClient.java
+++ b/app/src/main/java/org/wikipedia/login/LoginClient.java
@@ -4,6 +4,9 @@ import android.annotation.SuppressLint;
 import android.text.TextUtils;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
@@ -21,8 +24,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 import retrofit2.Call;

--- a/app/src/main/java/org/wikipedia/login/LoginOAuthResult.java
+++ b/app/src/main/java/org/wikipedia/login/LoginOAuthResult.java
@@ -1,9 +1,9 @@
 package org.wikipedia.login;
 
-import org.wikipedia.dataclient.WikiSite;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.dataclient.WikiSite;
 
 class LoginOAuthResult extends LoginResult {
 

--- a/app/src/main/java/org/wikipedia/login/LoginResetPasswordResult.java
+++ b/app/src/main/java/org/wikipedia/login/LoginResetPasswordResult.java
@@ -1,9 +1,9 @@
 package org.wikipedia.login;
 
-import org.wikipedia.dataclient.WikiSite;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.dataclient.WikiSite;
 
 class LoginResetPasswordResult extends LoginResult {
     LoginResetPasswordResult(@NonNull WikiSite site, @NonNull String status, @Nullable String userName,

--- a/app/src/main/java/org/wikipedia/login/LoginResult.java
+++ b/app/src/main/java/org/wikipedia/login/LoginResult.java
@@ -1,12 +1,12 @@
 package org.wikipedia.login;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.WikiSite;
 
 import java.util.Collections;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class LoginResult {
     @NonNull private final WikiSite site;

--- a/app/src/main/java/org/wikipedia/login/ResetPasswordActivity.java
+++ b/app/src/main/java/org/wikipedia/login/ResetPasswordActivity.java
@@ -10,6 +10,9 @@ import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.android.material.textfield.TextInputLayout;
 
 import org.wikipedia.R;
@@ -22,8 +25,6 @@ import org.wikipedia.util.log.L;
 import org.wikipedia.views.NonEmptyValidator;
 import org.wikipedia.views.WikiErrorView;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/main/MainActivity.java
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.java
@@ -5,6 +5,16 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBarDrawerToggle;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.view.ActionMode;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
+
 import org.wikipedia.Constants;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -28,15 +38,6 @@ import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.views.WikiDrawerLayout;
 
-import androidx.annotation.LayoutRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBarDrawerToggle;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.view.ActionMode;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.view.GravityCompat;
-import androidx.drawerlayout.widget.DrawerLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/main/MainDrawerView.java
+++ b/app/src/main/java/org/wikipedia/main/MainDrawerView.java
@@ -9,6 +9,8 @@ import android.widget.ImageView;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
+
 import org.wikipedia.BuildConfig;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -17,7 +19,6 @@ import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.util.UriUtil;
 
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -13,6 +13,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.view.ViewCompat;
+import androidx.fragment.app.Fragment;
+import androidx.viewpager.widget.ViewPager;
+
 import org.wikipedia.BackPressedHandler;
 import org.wikipedia.Constants;
 import org.wikipedia.R;
@@ -58,12 +65,6 @@ import org.wikipedia.util.log.L;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.view.ViewCompat;
-import androidx.fragment.app.Fragment;
-import androidx.viewpager.widget.ViewPager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnPageChange;

--- a/app/src/main/java/org/wikipedia/main/floatingqueue/FloatingQueueBottomViewBehavior.java
+++ b/app/src/main/java/org/wikipedia/main/floatingqueue/FloatingQueueBottomViewBehavior.java
@@ -5,10 +5,10 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
 import org.wikipedia.R;
 import org.wikipedia.random.BottomViewBehavior;
-
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 public class FloatingQueueBottomViewBehavior extends BottomViewBehavior {
     public FloatingQueueBottomViewBehavior(Context context, AttributeSet attrs) {

--- a/app/src/main/java/org/wikipedia/media/MediaPlayerImplementation.java
+++ b/app/src/main/java/org/wikipedia/media/MediaPlayerImplementation.java
@@ -2,12 +2,12 @@ package org.wikipedia.media;
 
 import android.media.MediaPlayer;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 
 import java.io.IOException;
-
-import androidx.annotation.NonNull;
 
 public class MediaPlayerImplementation {
     private static final boolean VERBOSE = false;

--- a/app/src/main/java/org/wikipedia/media/State.java
+++ b/app/src/main/java/org/wikipedia/media/State.java
@@ -1,9 +1,9 @@
 package org.wikipedia.media;
 
-import org.apache.commons.lang3.StringUtils;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
 
 class State {
     private enum LoadState {

--- a/app/src/main/java/org/wikipedia/navtab/NavTab.java
+++ b/app/src/main/java/org/wikipedia/navtab/NavTab.java
@@ -1,5 +1,10 @@
 package org.wikipedia.navtab;
 
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.fragment.app.Fragment;
+
 import org.wikipedia.R;
 import org.wikipedia.feed.FeedFragment;
 import org.wikipedia.history.HistoryFragment;
@@ -7,11 +12,6 @@ import org.wikipedia.model.EnumCode;
 import org.wikipedia.model.EnumCodeMap;
 import org.wikipedia.nearby.NearbyLazyLoadFragment;
 import org.wikipedia.readinglist.ReadingListsFragment;
-
-import androidx.annotation.DrawableRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
-import androidx.fragment.app.Fragment;
 
 public enum NavTab implements EnumCode {
     EXPLORE(R.string.nav_item_feed, R.drawable.ic_globe) {

--- a/app/src/main/java/org/wikipedia/nearby/NearbyFragment.java
+++ b/app/src/main/java/org/wikipedia/nearby/NearbyFragment.java
@@ -14,6 +14,12 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.core.util.Pair;
+import androidx.fragment.app.Fragment;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -57,11 +63,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
-import androidx.core.util.Pair;
-import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/nearby/NearbyLazyLoadFragment.java
+++ b/app/src/main/java/org/wikipedia/nearby/NearbyLazyLoadFragment.java
@@ -6,11 +6,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
-import org.wikipedia.WikipediaApp;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
+import org.wikipedia.WikipediaApp;
 
 public class NearbyLazyLoadFragment extends Fragment {
     private static final int CONTAINER_VIEW_ID = 0x8675309;

--- a/app/src/main/java/org/wikipedia/nearby/NearbyResult.java
+++ b/app/src/main/java/org/wikipedia/nearby/NearbyResult.java
@@ -1,13 +1,13 @@
 package org.wikipedia.nearby;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.mwapi.NearbyPage;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 class NearbyResult {
     @NonNull private final List<NearbyPage> pages = new ArrayList<>();

--- a/app/src/main/java/org/wikipedia/notifications/Notification.java
+++ b/app/src/main/java/org/wikipedia/notifications/Notification.java
@@ -1,5 +1,8 @@
 package org.wikipedia.notifications;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
@@ -14,9 +17,6 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class Notification {
     public static final String TYPE_EDIT_USER_TALK = "edit-user-talk";

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
@@ -10,6 +10,17 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.view.ActionMode;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 import com.google.android.material.snackbar.Snackbar;
 
 import org.wikipedia.R;
@@ -44,16 +55,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.view.ActionMode;
-import androidx.appcompat.widget.AppCompatImageView;
-import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.recyclerview.widget.ItemTouchHelper;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
@@ -4,6 +4,9 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.analytics.SuggestedEditsFunnel;
@@ -11,9 +14,6 @@ import org.wikipedia.dataclient.mwapi.EditorTaskCounts;
 import org.wikipedia.events.EditorTaskUnlockEvent;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.suggestededits.SuggestedEditsTasksActivity;
-
-import androidx.annotation.NonNull;
-import androidx.core.app.NotificationCompat;
 
 import static org.wikipedia.Constants.InvokeSource.EDIT_FEED_TITLE_DESC;
 import static org.wikipedia.Constants.InvokeSource.EDIT_FEED_TRANSLATE_TITLE_DESC;

--- a/app/src/main/java/org/wikipedia/notifications/NotificationItemActionsDialog.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationItemActionsDialog.java
@@ -11,6 +11,10 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatImageView;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.FragmentUtil;
@@ -23,9 +27,6 @@ import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.AppCompatImageView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.java
@@ -9,6 +9,8 @@ import android.content.Intent;
 import android.os.SystemClock;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
@@ -25,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import androidx.annotation.NonNull;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.java
@@ -12,17 +12,17 @@ import android.graphics.Rect;
 import android.net.Uri;
 import android.text.TextUtils;
 
-import org.wikipedia.Constants;
-import org.wikipedia.R;
-import org.wikipedia.util.DimenUtil;
-import org.wikipedia.util.ResourceUtil;
-import org.wikipedia.util.StringUtil;
-
 import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
+
+import org.wikipedia.Constants;
+import org.wikipedia.R;
+import org.wikipedia.util.DimenUtil;
+import org.wikipedia.util.ResourceUtil;
+import org.wikipedia.util.StringUtil;
 
 public final class NotificationPresenter {
     private static final int REQUEST_CODE_ACTIVITY = 0;

--- a/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingActivity.java
+++ b/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingActivity.java
@@ -4,12 +4,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.ResourceUtil;
-
-import androidx.annotation.NonNull;
 
 public class InitialOnboardingActivity
         extends SingleFragmentActivity<InitialOnboardingFragment>

--- a/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingFragment.java
+++ b/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingFragment.java
@@ -6,6 +6,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.viewpager.widget.PagerAdapter;
+
 import org.wikipedia.Constants;
 import org.wikipedia.R;
 import org.wikipedia.analytics.LoginFunnel;
@@ -16,11 +21,6 @@ import org.wikipedia.model.EnumCodeMap;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity;
 import org.wikipedia.util.FeedbackUtil;
-
-import androidx.annotation.LayoutRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.viewpager.widget.PagerAdapter;
 
 import static org.wikipedia.util.UriUtil.handleExternalLink;
 

--- a/app/src/main/java/org/wikipedia/onboarding/OnboardingFragment.java
+++ b/app/src/main/java/org/wikipedia/onboarding/OnboardingFragment.java
@@ -6,15 +6,16 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import org.wikipedia.BackPressedHandler;
-import org.wikipedia.R;
-import org.wikipedia.activity.FragmentUtil;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
+
+import org.wikipedia.BackPressedHandler;
+import org.wikipedia.R;
+import org.wikipedia.activity.FragmentUtil;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/onboarding/OnboardingPageView.java
+++ b/app/src/main/java/org/wikipedia/onboarding/OnboardingPageView.java
@@ -13,15 +13,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.apache.commons.lang3.StringUtils;
-import org.wikipedia.R;
-import org.wikipedia.WikipediaApp;
-import org.wikipedia.page.LinkMovementMethodExt;
-import org.wikipedia.util.StringUtil;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -31,6 +22,16 @@ import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.apache.commons.lang3.StringUtils;
+import org.wikipedia.R;
+import org.wikipedia.WikipediaApp;
+import org.wikipedia.page.LinkMovementMethodExt;
+import org.wikipedia.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnCheckedChanged;

--- a/app/src/main/java/org/wikipedia/onboarding/OnboardingView.java
+++ b/app/src/main/java/org/wikipedia/onboarding/OnboardingView.java
@@ -4,12 +4,13 @@ import android.content.Context;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-import org.wikipedia.page.LinkMovementMethodExt;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+
+import org.wikipedia.R;
+import org.wikipedia.page.LinkMovementMethodExt;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.java
+++ b/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.java
@@ -3,13 +3,13 @@ package org.wikipedia.page;
 import android.app.Dialog;
 import android.content.DialogInterface;
 
-import org.wikipedia.Constants.InvokeSource;
-import org.wikipedia.readinglist.AddToReadingListDialog;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
+
+import org.wikipedia.Constants.InvokeSource;
+import org.wikipedia.readinglist.AddToReadingListDialog;
 
 public class ExclusiveBottomSheetPresenter {
     private static final String BOTTOM_SHEET_FRAGMENT_TAG = "bottom_sheet_fragment";

--- a/app/src/main/java/org/wikipedia/page/FindInWebPageActionProvider.java
+++ b/app/src/main/java/org/wikipedia/page/FindInWebPageActionProvider.java
@@ -1,9 +1,9 @@
 package org.wikipedia.page;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.analytics.FindInPageFunnel;
 import org.wikipedia.views.FindInPageActionProvider;
-
-import androidx.annotation.NonNull;
 
 public class FindInWebPageActionProvider extends FindInPageActionProvider
         implements FindInPageActionProvider.FindInPageListener {

--- a/app/src/main/java/org/wikipedia/page/GeoMarshaller.java
+++ b/app/src/main/java/org/wikipedia/page/GeoMarshaller.java
@@ -2,10 +2,10 @@ package org.wikipedia.page;
 
 import android.location.Location;
 
+import androidx.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import androidx.annotation.Nullable;
 
 public final class GeoMarshaller {
     @Nullable

--- a/app/src/main/java/org/wikipedia/page/GeoUnmarshaller.java
+++ b/app/src/main/java/org/wikipedia/page/GeoUnmarshaller.java
@@ -2,11 +2,11 @@ package org.wikipedia.page;
 
 import android.location.Location;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public final class GeoUnmarshaller {
     static final String LATITUDE = "latitude";

--- a/app/src/main/java/org/wikipedia/page/IssuesListAdapter.java
+++ b/app/src/main/java/org/wikipedia/page/IssuesListAdapter.java
@@ -8,10 +8,10 @@ import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.util.StringUtil;
-
-import androidx.annotation.NonNull;
 
 /**
  *

--- a/app/src/main/java/org/wikipedia/page/LinkHandler.java
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wikipedia.bridge.CommunicationBridge;
@@ -13,9 +16,6 @@ import org.wikipedia.util.log.L;
 
 import java.util.Arrays;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.util.UriUtil.decodeURL;
 import static org.wikipedia.util.UriUtil.handleExternalLink;

--- a/app/src/main/java/org/wikipedia/page/LinkMovementMethodExt.java
+++ b/app/src/main/java/org/wikipedia/page/LinkMovementMethodExt.java
@@ -7,11 +7,11 @@ import android.text.style.URLSpan;
 import android.view.MotionEvent;
 import android.widget.TextView;
 
-import org.wikipedia.util.UriUtil;
-import org.wikipedia.util.log.L;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.util.UriUtil;
+import org.wikipedia.util.log.L;
 
 import static org.wikipedia.util.UriUtil.decodeURL;
 

--- a/app/src/main/java/org/wikipedia/page/Namespace.java
+++ b/app/src/main/java/org/wikipedia/page/Namespace.java
@@ -1,5 +1,8 @@
 package org.wikipedia.page;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.language.AppLanguageLookUpTable;
@@ -10,9 +13,6 @@ import org.wikipedia.staticdata.FileAliasData;
 import org.wikipedia.staticdata.SpecialAliasData;
 
 import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /** An enumeration describing the different possible namespace codes. Do not attempt to use this
  *  class to preserve URL path information such as Talk: or User: or localization.

--- a/app/src/main/java/org/wikipedia/page/NoDimBottomSheetDialog.java
+++ b/app/src/main/java/org/wikipedia/page/NoDimBottomSheetDialog.java
@@ -4,12 +4,12 @@ import android.content.Context;
 import android.os.Bundle;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
+
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 
 import org.wikipedia.WikipediaApp;
-
-import androidx.annotation.NonNull;
 
 /**
  * Descendant of BottomSheetDialog that prevents the background from being dimmed.

--- a/app/src/main/java/org/wikipedia/page/Page.java
+++ b/app/src/main/java/org/wikipedia/page/Page.java
@@ -1,12 +1,12 @@
 package org.wikipedia.page;
 
-import org.wikipedia.settings.RbSwitch;
-
-import java.util.List;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+
+import org.wikipedia.settings.RbSwitch;
+
+import java.util.List;
 
 /**
  * Represents a particular page along with its full contents.

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -24,6 +24,14 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.view.ViewCompat;
+import androidx.preference.PreferenceManager;
+
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
@@ -70,13 +78,6 @@ import org.wikipedia.wiktionary.WiktionaryDialog;
 import java.util.HashSet;
 import java.util.Set;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.view.ViewCompat;
-import androidx.preference.PreferenceManager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/page/PageBackStackItem.java
+++ b/app/src/main/java/org/wikipedia/page/PageBackStackItem.java
@@ -1,9 +1,9 @@
 package org.wikipedia.page;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.model.BaseModel;
-
-import androidx.annotation.NonNull;
 
 public class PageBackStackItem extends BaseModel {
     @NonNull private PageTitle title;

--- a/app/src/main/java/org/wikipedia/page/PageCacher.java
+++ b/app/src/main/java/org/wikipedia/page/PageCacher.java
@@ -2,6 +2,8 @@ package org.wikipedia.page;
 
 import android.annotation.SuppressLint;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.page.PageClient;
 import org.wikipedia.dataclient.page.PageClientFactory;
@@ -9,7 +11,6 @@ import org.wikipedia.dataclient.page.PageLead;
 import org.wikipedia.dataclient.page.PageRemaining;
 import org.wikipedia.util.log.L;
 
-import androidx.annotation.NonNull;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/page/PageContainerLongPressHandler.java
+++ b/app/src/main/java/org/wikipedia/page/PageContainerLongPressHandler.java
@@ -1,5 +1,7 @@
 package org.wikipedia.page;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.Constants.InvokeSource;
 import org.wikipedia.LongPressHandler;
 import org.wikipedia.R;
@@ -8,8 +10,6 @@ import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.util.ClipboardUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.ShareUtil;
-
-import androidx.annotation.NonNull;
 
 public class PageContainerLongPressHandler implements LongPressHandler.ContextMenuListener,
         LongPressHandler.WebViewContextMenuListener{

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -19,6 +19,14 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
@@ -78,13 +86,6 @@ import org.wikipedia.views.WikiPageErrorView;
 import java.util.Date;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -8,6 +8,10 @@ import android.util.SparseArray;
 import android.view.View;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -44,9 +48,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;

--- a/app/src/main/java/org/wikipedia/page/PageProperties.java
+++ b/app/src/main/java/org/wikipedia/page/PageProperties.java
@@ -5,15 +5,15 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.page.PageLeadProperties;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.log.L;
 
 import java.text.ParseException;
 import java.util.Date;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.wikipedia.util.DateUtil.iso8601DateParse;

--- a/app/src/main/java/org/wikipedia/page/PageTitle.java
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.java
@@ -4,6 +4,9 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.dataclient.WikiSite;
@@ -14,9 +17,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.util.UriUtil.decodeURL;
 

--- a/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
+++ b/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
@@ -10,14 +10,14 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.Toolbar;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.views.TabCountsView;
-
-import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.Toolbar;
 
 import static org.wikipedia.util.ResourceUtil.getThemedColor;
 

--- a/app/src/main/java/org/wikipedia/page/PageViewModel.java
+++ b/app/src/main/java/org/wikipedia/page/PageViewModel.java
@@ -1,9 +1,10 @@
 package org.wikipedia.page;
 
+import androidx.annotation.Nullable;
+
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.readinglist.database.ReadingListPage;
 
-import androidx.annotation.Nullable;
 import okhttp3.CacheControl;
 
 /**

--- a/app/src/main/java/org/wikipedia/page/ReferenceDialog.java
+++ b/app/src/main/java/org/wikipedia/page/ReferenceDialog.java
@@ -6,6 +6,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.viewpager.widget.PagerAdapter;
+
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.rd.PageIndicatorView;
@@ -18,8 +21,6 @@ import org.wikipedia.views.WrapContentViewPager;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.viewpager.widget.PagerAdapter;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/page/ReferenceHandler.java
+++ b/app/src/main/java/org/wikipedia/page/ReferenceHandler.java
@@ -1,5 +1,7 @@
 package org.wikipedia.page;
 
+import androidx.annotation.NonNull;
+
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -8,8 +10,6 @@ import org.wikipedia.bridge.CommunicationBridge;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 /**
  * Handles any reference links coming from a {@link PageFragment}

--- a/app/src/main/java/org/wikipedia/page/Section.java
+++ b/app/src/main/java/org/wikipedia/page/Section.java
@@ -1,11 +1,11 @@
 package org.wikipedia.page;
 
+import androidx.annotation.NonNull;
+
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wikipedia.json.GsonUtil;
-
-import androidx.annotation.NonNull;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 

--- a/app/src/main/java/org/wikipedia/page/ToCHandler.java
+++ b/app/src/main/java/org/wikipedia/page/ToCHandler.java
@@ -14,6 +14,8 @@ import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import com.getkeepsafe.taptargetview.TapTargetView;
 
 import org.json.JSONArray;
@@ -35,8 +37,6 @@ import org.wikipedia.views.PageScrollerView;
 import org.wikipedia.views.SwipeableListView;
 
 import java.util.ArrayList;
-
-import androidx.annotation.NonNull;
 
 import static org.wikipedia.util.L10nUtil.getStringForArticleLanguage;
 import static org.wikipedia.util.L10nUtil.setConditionalLayoutDirection;

--- a/app/src/main/java/org/wikipedia/page/ViewHideHandler.java
+++ b/app/src/main/java/org/wikipedia/page/ViewHideHandler.java
@@ -3,11 +3,11 @@ package org.wikipedia.page;
 import android.view.Gravity;
 import android.view.View;
 
-import org.wikipedia.views.ObservableWebView;
-import org.wikipedia.views.ViewAnimations;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.views.ObservableWebView;
+import org.wikipedia.views.ViewAnimations;
 
 public abstract class ViewHideHandler
         implements ObservableWebView.OnScrollChangeListener,

--- a/app/src/main/java/org/wikipedia/page/action/PageActionTab.java
+++ b/app/src/main/java/org/wikipedia/page/action/PageActionTab.java
@@ -1,9 +1,9 @@
 package org.wikipedia.page.action;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.model.EnumCode;
 import org.wikipedia.model.EnumCodeMap;
-
-import androidx.annotation.NonNull;
 
 public enum PageActionTab implements EnumCode {
     ADD_TO_READING_LIST() {

--- a/app/src/main/java/org/wikipedia/page/action/PageActionToolbarHideHandler.java
+++ b/app/src/main/java/org/wikipedia/page/action/PageActionToolbarHideHandler.java
@@ -3,10 +3,10 @@ package org.wikipedia.page.action;
 import android.view.Gravity;
 import android.view.View;
 
-import org.wikipedia.page.ViewHideHandler;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.page.ViewHideHandler;
 
 public class PageActionToolbarHideHandler extends ViewHideHandler {
     public PageActionToolbarHideHandler(@NonNull View hideableView, @Nullable View anchoredView) {

--- a/app/src/main/java/org/wikipedia/page/bottomcontent/BottomContentView.java
+++ b/app/src/main/java/org/wikipedia/page/bottomcontent/BottomContentView.java
@@ -15,6 +15,9 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -49,8 +52,6 @@ import org.wikipedia.views.PageItemView;
 
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -5,6 +5,10 @@ import android.net.Uri;
 import android.text.TextUtils;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wikipedia.Constants;
@@ -18,10 +22,6 @@ import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.UriUtil;
 import org.wikipedia.views.ObservableWebView;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.FragmentActivity;
 
 import static org.wikipedia.settings.Prefs.isImageDownloadEnabled;
 import static org.wikipedia.util.DimenUtil.getContentTopOffsetPx;

--- a/app/src/main/java/org/wikipedia/page/leadimages/PageHeaderView.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/PageHeaderView.java
@@ -10,6 +10,11 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.views.FaceAndColorDetectImageView;
@@ -17,10 +22,6 @@ import org.wikipedia.views.LinearLayoutOverWebView;
 import org.wikipedia.views.ObservableWebView;
 import org.wikipedia.views.ViewUtil;
 
-import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.view.ViewCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewContents.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewContents.java
@@ -2,6 +2,9 @@ package org.wikipedia.page.linkpreview;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
@@ -14,9 +17,6 @@ import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class LinkPreviewContents {
     private static final int EXTRACT_MAX_SENTENCES = 2;

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
@@ -12,6 +12,10 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.PopupMenu;
+
 import com.facebook.drawee.view.SimpleDraweeView;
 
 import org.wikipedia.Constants;
@@ -32,9 +36,6 @@ import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 import org.wikipedia.views.ViewUtil;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.PopupMenu;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewErrorType.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewErrorType.java
@@ -1,12 +1,12 @@
 package org.wikipedia.page.linkpreview;
 
-import org.wikipedia.R;
-import org.wikipedia.util.ThrowableUtil;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+
+import org.wikipedia.R;
+import org.wikipedia.util.ThrowableUtil;
 
 enum LinkPreviewErrorType {
     // Note: The string resource corresponding to the 'text' field will be updated programmatically

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewErrorView.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewErrorView.java
@@ -6,11 +6,12 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+
+import org.wikipedia.R;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewOverlayView.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewOverlayView.java
@@ -6,9 +6,10 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/page/shareafact/ShareHandler.java
+++ b/app/src/main/java/org/wikipedia/page/shareafact/ShareHandler.java
@@ -9,6 +9,9 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,8 +40,6 @@ import org.wikipedia.wiktionary.WiktionaryDialog;
 import java.util.Arrays;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/page/shareafact/SnippetImage.java
+++ b/app/src/main/java/org/wikipedia/page/shareafact/SnippetImage.java
@@ -16,15 +16,15 @@ import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.text.TextUtils;
 
-import org.wikipedia.R;
-import org.wikipedia.gallery.ImageLicense;
-import org.wikipedia.util.L10nUtil;
-import org.wikipedia.util.StringUtil;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
+
+import org.wikipedia.R;
+import org.wikipedia.gallery.ImageLicense;
+import org.wikipedia.util.L10nUtil;
+import org.wikipedia.util.StringUtil;
 
 import static android.text.Layout.Alignment.ALIGN_NORMAL;
 import static android.text.Layout.Alignment.ALIGN_OPPOSITE;

--- a/app/src/main/java/org/wikipedia/page/tabs/Tab.java
+++ b/app/src/main/java/org/wikipedia/page/tabs/Tab.java
@@ -1,14 +1,14 @@
 package org.wikipedia.page.tabs;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.model.BaseModel;
 import org.wikipedia.page.PageBackStackItem;
 import org.wikipedia.page.PageTitle;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class Tab extends BaseModel {
     @NonNull private final List<PageBackStackItem> backStack = new ArrayList<>();

--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
@@ -13,6 +13,12 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.appcompat.widget.Toolbar;
+
 import com.google.android.material.snackbar.Snackbar;
 
 import org.wikipedia.Constants;
@@ -31,11 +37,6 @@ import org.wikipedia.views.TabCountsView;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.AppCompatImageView;
-import androidx.appcompat.widget.Toolbar;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/pageimages/PageImage.java
+++ b/app/src/main/java/org/wikipedia/pageimages/PageImage.java
@@ -4,15 +4,15 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.collection.ArrayMap;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.mwapi.MwQueryPage;
 import org.wikipedia.page.PageTitle;
 
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.collection.ArrayMap;
 
 public class PageImage implements Parcelable {
     public static final PageImageDatabaseTable DATABASE_TABLE = new PageImageDatabaseTable();

--- a/app/src/main/java/org/wikipedia/pageimages/PageImageDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/pageimages/PageImageDatabaseTable.java
@@ -3,14 +3,14 @@ package org.wikipedia.pageimages;
 import android.content.ContentValues;
 import android.database.Cursor;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.database.DatabaseTable;
 import org.wikipedia.database.column.Column;
 import org.wikipedia.database.contract.PageImageHistoryContract;
 import org.wikipedia.database.contract.PageImageHistoryContract.Col;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
 
 
 // todo: network caching preserves images. Remove this class and drop table?

--- a/app/src/main/java/org/wikipedia/random/BottomViewBehavior.java
+++ b/app/src/main/java/org/wikipedia/random/BottomViewBehavior.java
@@ -5,9 +5,9 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.google.android.material.snackbar.Snackbar;
-
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+import com.google.android.material.snackbar.Snackbar;
 
 public class BottomViewBehavior extends CoordinatorLayout.Behavior<ViewGroup> {
     public BottomViewBehavior(Context context, AttributeSet attrs) {

--- a/app/src/main/java/org/wikipedia/random/RandomActivity.java
+++ b/app/src/main/java/org/wikipedia/random/RandomActivity.java
@@ -4,9 +4,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
-import org.wikipedia.activity.SingleFragmentActivity;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.activity.SingleFragmentActivity;
 
 public class RandomActivity extends SingleFragmentActivity<RandomFragment> {
     public static final int INVOKE_SOURCE_FEED = 0;

--- a/app/src/main/java/org/wikipedia/random/RandomFragment.java
+++ b/app/src/main/java/org/wikipedia/random/RandomFragment.java
@@ -8,6 +8,14 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.viewpager.widget.ViewPager;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import org.wikipedia.R;
@@ -25,13 +33,6 @@ import org.wikipedia.util.AnimationUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.log.L;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentPagerAdapter;
-import androidx.viewpager.widget.ViewPager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/random/RandomItemFragment.java
+++ b/app/src/main/java/org/wikipedia/random/RandomItemFragment.java
@@ -9,6 +9,10 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.ServiceFactory;
@@ -20,9 +24,6 @@ import org.wikipedia.views.FaceAndColorDetectImageView;
 import org.wikipedia.views.GoneIfEmptyTextView;
 import org.wikipedia.views.WikiErrorView;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/readinglist/AddToReadingListDialog.java
+++ b/app/src/main/java/org/wikipedia/readinglist/AddToReadingListDialog.java
@@ -7,6 +7,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import org.wikipedia.Constants;
@@ -27,10 +32,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListActivity.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListActivity.java
@@ -3,10 +3,10 @@ package org.wikipedia.readinglist;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.readinglist.database.ReadingList;
-
-import androidx.annotation.NonNull;
 
 public class ReadingListActivity extends SingleFragmentActivity<ReadingListFragment> {
     protected static final String EXTRA_READING_LIST_ID = "readingListId";

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBookmarkMenu.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBookmarkMenu.java
@@ -6,6 +6,12 @@ import android.view.Gravity;
 import android.view.MenuItem;
 import android.view.View;
 
+import androidx.annotation.MenuRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.PopupMenu;
+import androidx.core.view.ViewCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.readinglist.database.ReadingList;
@@ -14,11 +20,6 @@ import org.wikipedia.readinglist.database.ReadingListPage;
 
 import java.util.List;
 
-import androidx.annotation.MenuRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.PopupMenu;
-import androidx.core.view.ViewCompat;
 import io.reactivex.Completable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
@@ -17,6 +17,20 @@ import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.ActionMode;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.view.ViewCompat;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.SimpleItemAnimator;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 
@@ -59,19 +73,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.view.ActionMode;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.view.ViewCompat;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.ItemTouchHelper;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.recyclerview.widget.SimpleItemAnimator;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListHeaderView.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListHeaderView.java
@@ -8,6 +8,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.facebook.drawee.drawable.ScalingUtils;
 
 import org.wikipedia.R;
@@ -20,8 +23,6 @@ import org.wikipedia.views.ViewUtil;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.BindViews;
 import butterknife.ButterKnife;

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListItemActionsDialog.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListItemActionsDialog.java
@@ -5,6 +5,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.activity.FragmentUtil;
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment;
@@ -13,9 +16,6 @@ import org.wikipedia.readinglist.database.ReadingListPage;
 import org.wikipedia.util.ResourceUtil;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class ReadingListItemActionsDialog extends ExtendedBottomSheetDialogFragment {
     public interface Callback {

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListItemActionsView.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListItemActionsView.java
@@ -6,11 +6,12 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SwitchCompat;
+
+import org.wikipedia.R;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListItemView.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListItemView.java
@@ -11,6 +11,15 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.annotation.StyleRes;
+import androidx.appcompat.widget.PopupMenu;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
+import androidx.core.widget.TextViewCompat;
+
 import com.facebook.drawee.drawable.ScalingUtils;
 import com.facebook.drawee.view.SimpleDraweeView;
 
@@ -25,14 +34,6 @@ import org.wikipedia.views.ViewUtil;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
-import androidx.annotation.StyleRes;
-import androidx.appcompat.widget.PopupMenu;
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.content.ContextCompat;
-import androidx.core.widget.TextViewCompat;
 import butterknife.BindView;
 import butterknife.BindViews;
 import butterknife.ButterKnife;

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListSyncBehaviorDialogs.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListSyncBehaviorDialogs.java
@@ -6,6 +6,9 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.analytics.LoginFunnel;
@@ -19,9 +22,6 @@ import org.wikipedia.settings.Prefs;
 import org.wikipedia.settings.SettingsActivity;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.StringUtil;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 public final class ReadingListSyncBehaviorDialogs {
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListTitleDialog.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListTitleDialog.java
@@ -2,14 +2,14 @@ package org.wikipedia.readinglist;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 import org.wikipedia.views.TextInputDialog;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public final class ReadingListTitleDialog {
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
@@ -15,6 +15,17 @@ import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.ActionMode;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.Constants;
 import org.wikipedia.R;
@@ -55,16 +66,6 @@ import org.wikipedia.views.ViewUtil;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.view.ActionMode;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.DiffUtil;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/readinglist/RemoveFromReadingListsDialog.java
+++ b/app/src/main/java/org/wikipedia/readinglist/RemoveFromReadingListsDialog.java
@@ -2,6 +2,10 @@ package org.wikipedia.readinglist;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+
 import org.wikipedia.R;
 import org.wikipedia.readinglist.database.ReadingList;
 import org.wikipedia.readinglist.database.ReadingListDbHelper;
@@ -10,10 +14,6 @@ import org.wikipedia.readinglist.database.ReadingListPage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 
 public class RemoveFromReadingListsDialog {
     public interface Callback {

--- a/app/src/main/java/org/wikipedia/readinglist/SortReadingListsDialog.java
+++ b/app/src/main/java/org/wikipedia/readinglist/SortReadingListsDialog.java
@@ -8,6 +8,11 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.activity.FragmentUtil;
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment;
@@ -15,11 +20,6 @@ import org.wikipedia.page.ExtendedBottomSheetDialogFragment;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
 
 public class SortReadingListsDialog extends ExtendedBottomSheetDialogFragment {

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingList.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingList.java
@@ -2,6 +2,9 @@ package org.wikipedia.readinglist.database;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -10,9 +13,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class ReadingList implements Serializable {
     public static final int SORT_BY_NAME_ASC = 0;

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
@@ -5,6 +5,9 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.database.contract.ReadingListContract;
@@ -19,9 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class ReadingListDbHelper {
     private static ReadingListDbHelper INSTANCE;

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPage.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPage.java
@@ -1,5 +1,8 @@
 package org.wikipedia.readinglist.database;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.Namespace;
@@ -7,9 +10,6 @@ import org.wikipedia.page.PageTitle;
 import org.wikipedia.settings.Prefs;
 
 import java.io.Serializable;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class ReadingListPage implements Serializable {
     public static final int STATUS_QUEUE_FOR_SAVE = 0;

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPageTable.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPageTable.java
@@ -5,6 +5,8 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Base64;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.database.DatabaseTable;
@@ -21,8 +23,6 @@ import org.wikipedia.util.log.L;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
 
 public class ReadingListPageTable extends DatabaseTable<ReadingListPage> {
     private static final int DB_VER_INTRODUCED = 18;

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListTable.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListTable.java
@@ -3,14 +3,14 @@ package org.wikipedia.readinglist.database;
 import android.content.ContentValues;
 import android.database.Cursor;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.database.DatabaseTable;
 import org.wikipedia.database.column.Column;
 import org.wikipedia.database.contract.ReadingListContract;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 public class ReadingListTable extends DatabaseTable<ReadingList> {
     private static final int DB_VER_INTRODUCED = 18;

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListClient.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListClient.java
@@ -2,6 +2,9 @@ package org.wikipedia.readinglist.sync;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.okhttp.HttpStatusException;
@@ -10,8 +13,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import retrofit2.Response;
 
 import static org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingList;

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
@@ -10,6 +10,8 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.BuildConfig;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -37,8 +39,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
 
 import static org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingList;
 import static org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingListEntry;

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncNotification.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncNotification.java
@@ -2,10 +2,10 @@ package org.wikipedia.readinglist.sync;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.views.NotificationWithProgressBar;
-
-import androidx.annotation.NonNull;
 
 public final class ReadingListSyncNotification {
 

--- a/app/src/main/java/org/wikipedia/readinglist/sync/SyncedReadingLists.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/SyncedReadingLists.java
@@ -1,5 +1,8 @@
 package org.wikipedia.readinglist.sync;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
@@ -8,9 +11,6 @@ import org.wikipedia.json.annotations.Required;
 
 import java.text.Normalizer;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class SyncedReadingLists {
 

--- a/app/src/main/java/org/wikipedia/recurring/DailyEventTask.java
+++ b/app/src/main/java/org/wikipedia/recurring/DailyEventTask.java
@@ -2,14 +2,14 @@ package org.wikipedia.recurring;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.analytics.DailyStatsFunnel;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
 
 public class DailyEventTask extends RecurringTask {
     @NonNull private final String name;

--- a/app/src/main/java/org/wikipedia/richtext/AnimatedImageSpan.java
+++ b/app/src/main/java/org/wikipedia/richtext/AnimatedImageSpan.java
@@ -6,11 +6,11 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.view.View;
 
-import org.wikipedia.views.AlienDrawableCallback;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.views.AlienDrawableCallback;
 
 public class AnimatedImageSpan extends DrawableSpan {
     private Drawable.Callback animateCallback;

--- a/app/src/main/java/org/wikipedia/richtext/RichTextUtil.java
+++ b/app/src/main/java/org/wikipedia/richtext/RichTextUtil.java
@@ -8,14 +8,14 @@ import android.text.TextUtils;
 import android.text.style.URLSpan;
 import android.widget.TextView;
 
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+
 import org.wikipedia.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import androidx.annotation.IntRange;
-import androidx.annotation.NonNull;
 
 public final class RichTextUtil {
     @NonNull public static Spannable setSpans(@NonNull Spannable spannable,

--- a/app/src/main/java/org/wikipedia/savedpages/PageImageUrlParser.java
+++ b/app/src/main/java/org/wikipedia/savedpages/PageImageUrlParser.java
@@ -1,5 +1,8 @@
 package org.wikipedia.savedpages;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -17,9 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
 
 public class PageImageUrlParser {
     @NonNull private final ImageTagParser imageParser;

--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncNotification.java
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncNotification.java
@@ -4,11 +4,11 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.Constants;
 import org.wikipedia.R;
 import org.wikipedia.views.NotificationWithProgressBar;
-
-import androidx.annotation.NonNull;
 
 public final class SavedPageSyncNotification extends BroadcastReceiver {
 

--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.java
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.java
@@ -4,6 +4,10 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.JobIntentService;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.database.contract.PageImageHistoryContract;
 import org.wikipedia.dataclient.WikiSite;
@@ -35,9 +39,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.app.JobIntentService;
 import io.reactivex.Observable;
 import io.reactivex.schedulers.Schedulers;
 import okhttp3.CacheControl;

--- a/app/src/main/java/org/wikipedia/search/PrefixSearchResponse.java
+++ b/app/src/main/java/org/wikipedia/search/PrefixSearchResponse.java
@@ -1,10 +1,10 @@
 package org.wikipedia.search;
 
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.dataclient.mwapi.MwQueryResponse;
-
-import androidx.annotation.Nullable;
 
 public class PrefixSearchResponse extends MwQueryResponse {
     @SuppressWarnings("unused") @SerializedName("searchinfo") private SearchInfo searchInfo;

--- a/app/src/main/java/org/wikipedia/search/RecentSearchDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/search/RecentSearchDatabaseTable.java
@@ -3,14 +3,14 @@ package org.wikipedia.search;
 import android.content.ContentValues;
 import android.database.Cursor;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.database.DatabaseTable;
 import org.wikipedia.database.column.Column;
 import org.wikipedia.database.contract.SearchHistoryContract;
 import org.wikipedia.database.contract.SearchHistoryContract.Col;
 
 import java.util.Date;
-
-import androidx.annotation.NonNull;
 
 public class RecentSearchDatabaseTable extends DatabaseTable<RecentSearch> {
     private static final int DB_VER_INTRODUCED = 5;

--- a/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.java
+++ b/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.java
@@ -11,11 +11,6 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-import org.wikipedia.WikipediaApp;
-import org.wikipedia.database.contract.SearchHistoryContract;
-import org.wikipedia.util.FeedbackUtil;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.cursoradapter.widget.CursorAdapter;
@@ -23,6 +18,12 @@ import androidx.fragment.app.Fragment;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
+
+import org.wikipedia.R;
+import org.wikipedia.WikipediaApp;
+import org.wikipedia.database.contract.SearchHistoryContract;
+import org.wikipedia.util.FeedbackUtil;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/search/SearchActivity.java
+++ b/app/src/main/java/org/wikipedia/search/SearchActivity.java
@@ -3,12 +3,12 @@ package org.wikipedia.search;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.analytics.IntentFunnel;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class SearchActivity extends SingleFragmentActivity<SearchFragment> {
     static final String INVOKE_SOURCE_EXTRA = "invokeSource";

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.java
@@ -11,6 +11,13 @@ import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
 import org.wikipedia.Constants;
 import org.wikipedia.Constants.InvokeSource;
 import org.wikipedia.R;
@@ -37,12 +44,6 @@ import org.wikipedia.views.ViewUtil;
 
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.SearchView;
-import androidx.appcompat.widget.Toolbar;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/search/SearchResult.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResult.java
@@ -4,13 +4,13 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.mwapi.MwQueryPage;
 import org.wikipedia.model.BaseModel;
 import org.wikipedia.page.PageTitle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class SearchResult extends BaseModel implements Parcelable {
     private PageTitle pageTitle;

--- a/app/src/main/java/org/wikipedia/search/SearchResults.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResults.java
@@ -1,5 +1,8 @@
 package org.wikipedia.search;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.mwapi.MwQueryPage;
 
@@ -7,9 +10,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * Simple Data Object to hold search result data for both prefix search and full text search.

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -11,6 +11,11 @@ import android.widget.BaseAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.collection.LruCache;
+import androidx.fragment.app.Fragment;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.Constants.InvokeSource;
 import org.wikipedia.LongPressHandler;
@@ -31,10 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.collection.LruCache;
-import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/settings/AboutActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/AboutActivity.java
@@ -9,6 +9,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.BuildConfig;
 import org.wikipedia.R;
 import org.wikipedia.activity.BaseActivity;
@@ -16,7 +18,6 @@ import org.wikipedia.richtext.RichTextUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.StringUtil;
 
-import androidx.annotation.NonNull;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.java
+++ b/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.java
@@ -3,6 +3,12 @@ package org.wikipedia.settings;
 import android.content.Context;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.TwoStatePreference;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.crash.RemoteLogException;
@@ -23,11 +29,6 @@ import org.wikipedia.views.DialogTitleWithImage;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
-import androidx.preference.TwoStatePreference;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 

--- a/app/src/main/java/org/wikipedia/settings/EditTextAutoSummarizePreference.java
+++ b/app/src/main/java/org/wikipedia/settings/EditTextAutoSummarizePreference.java
@@ -4,9 +4,9 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
 
-import org.wikipedia.R;
-
 import androidx.preference.EditTextPreference;
+
+import org.wikipedia.R;
 
 public class EditTextAutoSummarizePreference extends EditTextPreference {
     protected static final int DEFAULT_STYLE_ATTR = R.attr.editTextAutoSummarizePreferenceStyle;

--- a/app/src/main/java/org/wikipedia/settings/NotificationSettingsActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/NotificationSettingsActivity.java
@@ -7,13 +7,13 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.analytics.NotificationPreferencesFunnel;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 public class NotificationSettingsActivity extends SingleFragmentActivity<NotificationSettingsFragment> {
     public static Intent newIntent(@NonNull Context ctx) {

--- a/app/src/main/java/org/wikipedia/settings/NotificationSettingsPreferenceLoader.java
+++ b/app/src/main/java/org/wikipedia/settings/NotificationSettingsPreferenceLoader.java
@@ -2,17 +2,17 @@ package org.wikipedia.settings;
 
 import android.graphics.drawable.Drawable;
 
-import org.wikipedia.R;
-import org.wikipedia.WikipediaApp;
-import org.wikipedia.notifications.NotificationPollBroadcastReceiver;
-import org.wikipedia.util.ResourceUtil;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+
+import org.wikipedia.R;
+import org.wikipedia.WikipediaApp;
+import org.wikipedia.notifications.NotificationPollBroadcastReceiver;
+import org.wikipedia.util.ResourceUtil;
 
 class NotificationSettingsPreferenceLoader extends BasePreferenceLoader {
 

--- a/app/src/main/java/org/wikipedia/settings/PreferenceLoaderFragment.java
+++ b/app/src/main/java/org/wikipedia/settings/PreferenceLoaderFragment.java
@@ -4,11 +4,11 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
-import org.wikipedia.R;
-import org.wikipedia.util.ResourceUtil;
-
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.wikipedia.R;
+import org.wikipedia.util.ResourceUtil;
 
 abstract class PreferenceLoaderFragment extends PreferenceFragmentCompat
         implements PreferenceLoader {

--- a/app/src/main/java/org/wikipedia/settings/PreferenceMultiLine.java
+++ b/app/src/main/java/org/wikipedia/settings/PreferenceMultiLine.java
@@ -6,11 +6,11 @@ import android.util.AttributeSet;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.wikipedia.R;
-
 import androidx.annotation.NonNull;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
+
+import org.wikipedia.R;
 
 public class PreferenceMultiLine extends Preference {
 

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -2,6 +2,10 @@ package org.wikipedia.settings;
 
 import android.text.TextUtils;
 
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.reflect.TypeToken;
 
 import org.wikipedia.R;
@@ -26,9 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import androidx.annotation.IntRange;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;

--- a/app/src/main/java/org/wikipedia/settings/PrefsIoUtil.java
+++ b/app/src/main/java/org/wikipedia/settings/PrefsIoUtil.java
@@ -5,14 +5,14 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.preference.PreferenceManager;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+
 import org.wikipedia.WikipediaApp;
 
 import java.util.Collections;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 
 /** Shared preferences input / output utility providing set* functionality that writes to SP on the
  * client's behalf, IO without client supplied {@link Context}, and wrappers for using string

--- a/app/src/main/java/org/wikipedia/settings/RbSwitch.java
+++ b/app/src/main/java/org/wikipedia/settings/RbSwitch.java
@@ -1,5 +1,8 @@
 package org.wikipedia.settings;
 
+import androidx.annotation.IntRange;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.okhttp.HttpStatusException;
@@ -7,9 +10,6 @@ import org.wikipedia.dataclient.retrofit.RetrofitException;
 import org.wikipedia.util.ReleaseUtil;
 
 import java.util.Random;
-
-import androidx.annotation.IntRange;
-import androidx.annotation.Nullable;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 

--- a/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
@@ -3,9 +3,9 @@ package org.wikipedia.settings;
 import android.content.Context;
 import android.content.Intent;
 
-import org.wikipedia.activity.SingleFragmentActivity;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.activity.SingleFragmentActivity;
 
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_ADD_A_LANGUAGE;
 

--- a/app/src/main/java/org/wikipedia/settings/SettingsFragment.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsFragment.java
@@ -5,6 +5,8 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
+import androidx.preference.SwitchPreferenceCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.events.ReadingListsEnableSyncStatusEvent;
@@ -12,7 +14,6 @@ import org.wikipedia.events.ReadingListsEnabledStatusEvent;
 import org.wikipedia.events.ReadingListsMergeLocalDialogEvent;
 import org.wikipedia.events.ReadingListsNoLongerSyncedEvent;
 
-import androidx.preference.SwitchPreferenceCompat;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.functions.Consumer;
 

--- a/app/src/main/java/org/wikipedia/settings/SettingsPreferenceLoader.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsPreferenceLoader.java
@@ -3,6 +3,12 @@ package org.wikipedia.settings;
 import android.content.DialogInterface;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.SwitchPreferenceCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.analytics.LoginFunnel;
@@ -12,12 +18,6 @@ import org.wikipedia.login.LoginActivity;
 import org.wikipedia.readinglist.sync.ReadingListSyncAdapter;
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity;
 import org.wikipedia.theme.ThemeFittingRoomActivity;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
-import androidx.preference.SwitchPreferenceCompat;
 
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_ADD_A_LANGUAGE;
 

--- a/app/src/main/java/org/wikipedia/settings/SiteInfo.java
+++ b/app/src/main/java/org/wikipedia/settings/SiteInfo.java
@@ -1,10 +1,10 @@
 package org.wikipedia.settings;
 
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
-
-import androidx.annotation.Nullable;
 
 public class SiteInfo {
     @SuppressWarnings("unused") @Nullable private String mainpage;

--- a/app/src/main/java/org/wikipedia/settings/SiteInfoClient.java
+++ b/app/src/main/java/org/wikipedia/settings/SiteInfoClient.java
@@ -3,6 +3,9 @@ package org.wikipedia.settings;
 import android.annotation.SuppressLint;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.Constants;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.ServiceFactory;
@@ -13,8 +16,6 @@ import org.wikipedia.util.log.L;
 import java.util.HashMap;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 

--- a/app/src/main/java/org/wikipedia/settings/SwitchPreferenceWithLinks.java
+++ b/app/src/main/java/org/wikipedia/settings/SwitchPreferenceWithLinks.java
@@ -6,13 +6,13 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-import org.wikipedia.page.LinkMovementMethodExt;
-import org.wikipedia.util.ResourceUtil;
-
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceViewHolder;
+
+import org.wikipedia.R;
+import org.wikipedia.page.LinkMovementMethodExt;
+import org.wikipedia.util.ResourceUtil;
 
 import static org.wikipedia.util.UriUtil.handleExternalLink;
 

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesActivity.java
@@ -3,10 +3,10 @@ package org.wikipedia.settings.languages;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.widgets.WidgetProviderFeaturedPage;
-
-import androidx.annotation.NonNull;
 
 public class WikipediaLanguagesActivity extends SingleFragmentActivity<WikipediaLanguagesFragment> {
     static final String INVOKE_SOURCE_EXTRA = "invokeSource";

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.java
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.java
@@ -12,6 +12,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.ActionMode;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.analytics.AppLanguageSettingsFunnel;
@@ -25,14 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.view.ActionMode;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.ItemTouchHelper;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesItemView.java
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesItemView.java
@@ -10,14 +10,15 @@ import android.widget.CheckBox;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.views.ViewUtil;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnCheckedChanged;

--- a/app/src/main/java/org/wikipedia/staticdata/FileAliasData.java
+++ b/app/src/main/java/org/wikipedia/staticdata/FileAliasData.java
@@ -3,11 +3,11 @@
    TO HAVE YOUR CHANGES OVERWRITTEN */
 package org.wikipedia.staticdata;
 
+import androidx.annotation.NonNull;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
 
 public final class FileAliasData {
     @NonNull private static final Map<String, String> DATA_MAP = Collections.unmodifiableMap(newMap());

--- a/app/src/main/java/org/wikipedia/staticdata/MainPageNameData.java
+++ b/app/src/main/java/org/wikipedia/staticdata/MainPageNameData.java
@@ -3,11 +3,11 @@
    TO HAVE YOUR CHANGES OVERWRITTEN */
 package org.wikipedia.staticdata;
 
+import androidx.annotation.NonNull;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
 
 public final class MainPageNameData {
     @NonNull private static final Map<String, String> DATA_MAP = Collections.unmodifiableMap(newMap());

--- a/app/src/main/java/org/wikipedia/staticdata/SpecialAliasData.java
+++ b/app/src/main/java/org/wikipedia/staticdata/SpecialAliasData.java
@@ -3,11 +3,11 @@
    TO HAVE YOUR CHANGES OVERWRITTEN */
 package org.wikipedia.staticdata;
 
+import androidx.annotation.NonNull;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
 
 public final class SpecialAliasData {
     @NonNull private static final Map<String, String> DATA_MAP = Collections.unmodifiableMap(newMap());

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTaskView.java
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTaskView.java
@@ -7,9 +7,10 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 
-import androidx.annotation.NonNull;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksActivity.java
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksActivity.java
@@ -4,11 +4,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.Constants.InvokeSource;
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.analytics.SuggestedEditsFunnel;
-
-import androidx.annotation.NonNull;
 
 import static org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE;
 import static org.wikipedia.Constants.InvokeSource.EDIT_FEED_TITLE_DESC;

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.java
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.java
@@ -9,6 +9,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
@@ -30,14 +39,6 @@ import org.wikipedia.views.HeaderMarginItemDecoration;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/theme/Theme.java
+++ b/app/src/main/java/org/wikipedia/theme/Theme.java
@@ -1,12 +1,12 @@
 package org.wikipedia.theme;
 
-import org.wikipedia.R;
-import org.wikipedia.model.EnumCode;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
+
+import org.wikipedia.R;
+import org.wikipedia.model.EnumCode;
 
 public enum Theme implements EnumCode {
     LIGHT(0, "light", R.style.ThemeLight, R.string.color_theme_light, "pagelib_theme_light"),

--- a/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.java
+++ b/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.java
@@ -9,6 +9,11 @@ import android.widget.ProgressBar;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.core.content.ContextCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.FragmentUtil;
@@ -21,10 +26,6 @@ import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.views.DiscreteSeekBar;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.SwitchCompat;
-import androidx.core.content.ContextCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnCheckedChanged;

--- a/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomActivity.java
+++ b/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomActivity.java
@@ -4,10 +4,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.page.ExclusiveBottomSheetPresenter;
-
-import androidx.annotation.NonNull;
 
 public class ThemeFittingRoomActivity extends SingleFragmentActivity<ThemeFittingRoomFragment>
         implements ThemeChooserDialog.Callback {

--- a/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomFragment.java
+++ b/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomFragment.java
@@ -6,14 +6,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.events.ChangeTextSizeEvent;
 import org.wikipedia.events.WebViewInvalidateEvent;
 import org.wikipedia.views.FaceAndColorDetectImageView;
 
-import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;

--- a/app/src/main/java/org/wikipedia/useroption/dataclient/UserOptionDataClient.java
+++ b/app/src/main/java/org/wikipedia/useroption/dataclient/UserOptionDataClient.java
@@ -2,6 +2,9 @@ package org.wikipedia.useroption.dataclient;
 
 import android.annotation.SuppressLint;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.csrf.CsrfTokenClient;
 import org.wikipedia.dataclient.ServiceFactory;
@@ -9,8 +12,6 @@ import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.mwapi.UserInfo;
 import org.wikipedia.util.log.L;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 

--- a/app/src/main/java/org/wikipedia/util/AnimationUtil.java
+++ b/app/src/main/java/org/wikipedia/util/AnimationUtil.java
@@ -3,11 +3,11 @@ package org.wikipedia.util;
 import android.app.Activity;
 import android.view.View;
 
-import com.facebook.drawee.drawable.ScalingUtils;
-import com.facebook.drawee.view.DraweeTransition;
-
 import androidx.annotation.NonNull;
 import androidx.viewpager.widget.ViewPager;
+
+import com.facebook.drawee.drawable.ScalingUtils;
+import com.facebook.drawee.view.DraweeTransition;
 
 public final class AnimationUtil {
 

--- a/app/src/main/java/org/wikipedia/util/BatchUtil.java
+++ b/app/src/main/java/org/wikipedia/util/BatchUtil.java
@@ -1,10 +1,10 @@
 package org.wikipedia.util;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.page.PageTitle;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 import static org.wikipedia.Constants.API_QUERY_MAX_TITLES;
 

--- a/app/src/main/java/org/wikipedia/util/ConfigurationCompat.java
+++ b/app/src/main/java/org/wikipedia/util/ConfigurationCompat.java
@@ -3,9 +3,9 @@ package org.wikipedia.util;
 import android.content.res.Configuration;
 import android.os.Build;
 
-import java.util.Locale;
-
 import androidx.annotation.NonNull;
+
+import java.util.Locale;
 
 public final class ConfigurationCompat {
 

--- a/app/src/main/java/org/wikipedia/util/DateUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.icu.text.RelativeDateTimeFormatter;
 import android.os.Build;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.model.UtcDate;
@@ -18,8 +20,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-
-import androidx.annotation.NonNull;
 
 public final class DateUtil {
     private static Map<String, SimpleDateFormat> DATE_FORMATS = new HashMap<>();

--- a/app/src/main/java/org/wikipedia/util/DeviceUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DeviceUtil.java
@@ -14,14 +14,14 @@ import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.Toolbar;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.log.L;
 
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.Toolbar;
 
 public final class DeviceUtil {
 

--- a/app/src/main/java/org/wikipedia/util/DimenUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DimenUtil.java
@@ -9,10 +9,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 
+import androidx.annotation.DimenRes;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
-
-import androidx.annotation.DimenRes;
 
 public final class DimenUtil {
     public static float dpToPx(float dp) {

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
@@ -9,6 +9,13 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+
 import com.getkeepsafe.taptargetview.TapTarget;
 import com.getkeepsafe.taptargetview.TapTargetView;
 import com.google.android.material.snackbar.Snackbar;
@@ -22,13 +29,6 @@ import org.wikipedia.readinglist.ReadingListActivity;
 import org.wikipedia.suggestededits.SuggestedEditsAddDescriptionsActivity;
 
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
 
 import static org.wikipedia.util.UriUtil.visitInExternalBrowser;
 

--- a/app/src/main/java/org/wikipedia/util/FileUtil.java
+++ b/app/src/main/java/org/wikipedia/util/FileUtil.java
@@ -3,6 +3,8 @@ package org.wikipedia.util;
 import android.content.Context;
 import android.graphics.Bitmap;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.R;
 
 import java.io.BufferedReader;
@@ -12,8 +14,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
-import androidx.annotation.NonNull;
 
 public final class FileUtil {
     public static final int JPEG_QUALITY = 85;

--- a/app/src/main/java/org/wikipedia/util/GeoUtil.java
+++ b/app/src/main/java/org/wikipedia/util/GeoUtil.java
@@ -7,11 +7,11 @@ import android.location.Location;
 import android.net.Uri;
 import android.text.TextUtils;
 
-import org.wikipedia.R;
-import org.wikipedia.feed.announcement.GeoIPCookieUnmarshaller;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.R;
+import org.wikipedia.feed.announcement.GeoIPCookieUnmarshaller;
 
 public final class GeoUtil {
 

--- a/app/src/main/java/org/wikipedia/util/GradientUtil.java
+++ b/app/src/main/java/org/wikipedia/util/GradientUtil.java
@@ -9,12 +9,12 @@ import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.RectShape;
 import android.view.Gravity;
 
-import org.wikipedia.WikipediaApp;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
+
+import org.wikipedia.WikipediaApp;
 
 public final class GradientUtil {
     private static final int GRADIENT_NUM_STOPS = 8;

--- a/app/src/main/java/org/wikipedia/util/ImageUrlUtil.java
+++ b/app/src/main/java/org/wikipedia/util/ImageUrlUtil.java
@@ -2,10 +2,10 @@ package org.wikipedia.util;
 
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import androidx.annotation.NonNull;
 
 public final class ImageUrlUtil {
     private static Pattern WIDTH_IN_IMAGE_URL_REGEX = Pattern.compile("/(\\d+)px-");

--- a/app/src/main/java/org/wikipedia/util/L10nUtil.java
+++ b/app/src/main/java/org/wikipedia/util/L10nUtil.java
@@ -6,6 +6,9 @@ import android.content.res.Resources;
 import android.util.SparseArray;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wikipedia.R;
@@ -17,9 +20,6 @@ import org.wikipedia.page.PageTitle;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 
 import static android.text.format.DateUtils.SECOND_IN_MILLIS;
 import static android.text.format.DateUtils.getRelativeTimeSpanString;

--- a/app/src/main/java/org/wikipedia/util/PermissionUtil.java
+++ b/app/src/main/java/org/wikipedia/util/PermissionUtil.java
@@ -6,13 +6,13 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 
-import org.wikipedia.settings.Prefs;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
+
+import org.wikipedia.settings.Prefs;
 
 /**
  * Common methods for dealing with runtime permissions.

--- a/app/src/main/java/org/wikipedia/util/ReleaseUtil.java
+++ b/app/src/main/java/org/wikipedia/util/ReleaseUtil.java
@@ -4,10 +4,10 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.BuildConfig;
 import org.wikipedia.settings.Prefs;
-
-import androidx.annotation.NonNull;
 
 public final class ReleaseUtil {
     private static final int RELEASE_PROD = 0;

--- a/app/src/main/java/org/wikipedia/util/ShareUtil.java
+++ b/app/src/main/java/org/wikipedia/util/ShareUtil.java
@@ -11,6 +11,10 @@ import android.os.Build;
 import android.os.Parcelable;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
+
 import org.wikipedia.BuildConfig;
 import org.wikipedia.R;
 import org.wikipedia.page.PageTitle;
@@ -22,9 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.content.FileProvider;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/main/java/org/wikipedia/util/StringUtil.java
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.java
@@ -11,6 +11,10 @@ import android.text.style.TypefaceSpan;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.Gson;
 
 import org.json.JSONArray;
@@ -23,10 +27,6 @@ import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.IntRange;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public final class StringUtil {
     private static final String CSV_DELIMITER = ",";

--- a/app/src/main/java/org/wikipedia/util/ThrowableUtil.java
+++ b/app/src/main/java/org/wikipedia/util/ThrowableUtil.java
@@ -2,6 +2,9 @@ package org.wikipedia.util;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.json.JSONException;
 import org.wikipedia.R;
 import org.wikipedia.createaccount.CreateAccountException;
@@ -15,9 +18,6 @@ import java.net.UnknownHostException;
 import java.util.concurrent.TimeoutException;
 
 import javax.net.ssl.SSLException;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public final class ThrowableUtil {
 

--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -5,6 +5,10 @@ import android.content.Intent;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.annotation.VisibleForTesting;
+
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
@@ -14,10 +18,6 @@ import org.wikipedia.util.log.L;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
-import androidx.annotation.VisibleForTesting;
 
 public final class UriUtil {
     public static final String LOCAL_URL_SETTINGS = "#settings";

--- a/app/src/main/java/org/wikipedia/util/log/L.java
+++ b/app/src/main/java/org/wikipedia/util/log/L.java
@@ -2,10 +2,10 @@ package org.wikipedia.util.log;
 
 import android.util.Log;
 
-import org.wikipedia.util.ReleaseUtil;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.util.ReleaseUtil;
 
 /** Logging utility like {@link Log} but with implied tags. */
 public final class L {

--- a/app/src/main/java/org/wikipedia/views/AppTextViewWithImages.java
+++ b/app/src/main/java/org/wikipedia/views/AppTextViewWithImages.java
@@ -11,15 +11,15 @@ import android.text.TextUtils;
 import android.text.style.ImageSpan;
 import android.util.AttributeSet;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
+
+import java.util.ArrayList;
+import java.util.List;
 
 // Credit: https://stackoverflow.com/a/38977396
 public class AppTextViewWithImages extends AppTextView {

--- a/app/src/main/java/org/wikipedia/views/AutoFitRecyclerView.java
+++ b/app/src/main/java/org/wikipedia/views/AutoFitRecyclerView.java
@@ -4,14 +4,14 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
 
-import org.wikipedia.R;
-import org.wikipedia.util.log.L;
-
 import androidx.annotation.AttrRes;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.wikipedia.R;
+import org.wikipedia.util.log.L;
 
 /** {@link RecyclerView} that invokes a callback when the number of columns should be updated. */
 public class AutoFitRecyclerView extends RecyclerView {

--- a/app/src/main/java/org/wikipedia/views/CabSearchView.java
+++ b/app/src/main/java/org/wikipedia/views/CabSearchView.java
@@ -9,14 +9,14 @@ import android.util.TypedValue;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.appcompat.widget.SearchView;
+import androidx.core.content.ContextCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.richtext.RichTextUtil;
 import org.wikipedia.util.FeedbackUtil;
 
 import java.util.Arrays;
-
-import androidx.appcompat.widget.SearchView;
-import androidx.core.content.ContextCompat;
 
 import static org.wikipedia.util.ResourceUtil.getThemedColor;
 

--- a/app/src/main/java/org/wikipedia/views/CircularProgressBar.java
+++ b/app/src/main/java/org/wikipedia/views/CircularProgressBar.java
@@ -8,13 +8,13 @@ import android.graphics.RectF;
 import android.util.AttributeSet;
 import android.view.View;
 
-import org.wikipedia.R;
-import org.wikipedia.util.DimenUtil;
-import org.wikipedia.util.ResourceUtil;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.R;
+import org.wikipedia.util.DimenUtil;
+import org.wikipedia.util.ResourceUtil;
 
 public class CircularProgressBar extends View {
 

--- a/app/src/main/java/org/wikipedia/views/ConfigurableTabLayout.java
+++ b/app/src/main/java/org/wikipedia/views/ConfigurableTabLayout.java
@@ -5,11 +5,11 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageView;
 
-import org.wikipedia.R;
-
 import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.constraintlayout.widget.ConstraintLayout;
+
+import org.wikipedia.R;
 
 import static androidx.core.content.ContextCompat.getColor;
 import static androidx.core.graphics.drawable.DrawableCompat.setTint;

--- a/app/src/main/java/org/wikipedia/views/CustomDatePicker.java
+++ b/app/src/main/java/org/wikipedia/views/CustomDatePicker.java
@@ -9,6 +9,12 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.wikipedia.R;
 import org.wikipedia.util.DateUtil;
 import org.wikipedia.util.ResourceUtil;
@@ -16,11 +22,6 @@ import org.wikipedia.util.ResourceUtil;
 import java.util.Calendar;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-import androidx.fragment.app.DialogFragment;
-import androidx.recyclerview.widget.GridLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/views/DefaultRecyclerAdapter.java
+++ b/app/src/main/java/org/wikipedia/views/DefaultRecyclerAdapter.java
@@ -2,10 +2,10 @@ package org.wikipedia.views;
 
 import android.view.View;
 
-import java.util.List;
-
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.List;
 
 public abstract class DefaultRecyclerAdapter<T, V extends View>
         extends RecyclerView.Adapter<DefaultViewHolder<V>> {

--- a/app/src/main/java/org/wikipedia/views/DialogTitleWithImage.java
+++ b/app/src/main/java/org/wikipedia/views/DialogTitleWithImage.java
@@ -5,12 +5,13 @@ import android.content.Context;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.AppCompatImageView;
+
+import org.wikipedia.R;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/views/DiscreteSeekBar.java
+++ b/app/src/main/java/org/wikipedia/views/DiscreteSeekBar.java
@@ -8,12 +8,12 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.widget.SeekBar;
 
-import org.wikipedia.R;
-
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+
+import org.wikipedia.R;
 
 @SuppressLint("AppCompatCustomView")
 public class DiscreteSeekBar extends SeekBar {

--- a/app/src/main/java/org/wikipedia/views/DrawableItemDecoration.java
+++ b/app/src/main/java/org/wikipedia/views/DrawableItemDecoration.java
@@ -6,12 +6,12 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 
-import org.wikipedia.util.ResourceUtil;
-
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.wikipedia.util.ResourceUtil;
 
 // todo: replace with DividerItemDecoration once it supports headers and footers
 public class DrawableItemDecoration extends RecyclerView.ItemDecoration {

--- a/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.java
+++ b/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.java
@@ -5,17 +5,17 @@ import android.graphics.PointF;
 import android.net.Uri;
 import android.util.AttributeSet;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.interfaces.DraweeController;
 import com.facebook.drawee.view.SimpleDraweeView;
 import com.facebook.imagepipeline.request.ImageRequestBuilder;
 
 import org.wikipedia.R;
-
-import androidx.annotation.ColorInt;
-import androidx.annotation.DrawableRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.wikipedia.settings.Prefs.isImageDownloadEnabled;
 

--- a/app/src/main/java/org/wikipedia/views/FacePostprocessor.java
+++ b/app/src/main/java/org/wikipedia/views/FacePostprocessor.java
@@ -8,6 +8,12 @@ import android.graphics.PointF;
 import android.graphics.Rect;
 import android.media.FaceDetector;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.palette.graphics.Palette;
+
 import com.facebook.imagepipeline.request.BasePostprocessor;
 
 import org.wikipedia.R;
@@ -17,12 +23,6 @@ import org.wikipedia.util.MathUtil;
 import org.wikipedia.util.log.L;
 
 import java.lang.ref.WeakReference;
-
-import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
-import androidx.palette.graphics.Palette;
 
 public class FacePostprocessor extends BasePostprocessor {
     private static final int BITMAP_COPY_WIDTH = 200;

--- a/app/src/main/java/org/wikipedia/views/FindInPageActionProvider.java
+++ b/app/src/main/java/org/wikipedia/views/FindInPageActionProvider.java
@@ -9,12 +9,13 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.SearchView;
+
 import org.wikipedia.R;
 import org.wikipedia.util.DeviceUtil;
 import org.wikipedia.util.ResourceUtil;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.SearchView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/views/FlowLayout.java
+++ b/app/src/main/java/org/wikipedia/views/FlowLayout.java
@@ -6,13 +6,13 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.core.view.ViewCompat;
+
 import org.wikipedia.BuildConfig;
 import org.wikipedia.util.DimenUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.core.view.ViewCompat;
 
 /**
  * Implements a "Flow" layout, where child Views are arranged horizontally, and allowed

--- a/app/src/main/java/org/wikipedia/views/FooterMarginItemDecoration.java
+++ b/app/src/main/java/org/wikipedia/views/FooterMarginItemDecoration.java
@@ -4,11 +4,11 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.view.View;
 
-import org.wikipedia.util.DimenUtil;
-
 import androidx.annotation.DimenRes;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.wikipedia.util.DimenUtil;
 
 public class FooterMarginItemDecoration extends MarginItemDecoration {
     public FooterMarginItemDecoration(int topDp, int bottomDp) {

--- a/app/src/main/java/org/wikipedia/views/HeaderMarginItemDecoration.java
+++ b/app/src/main/java/org/wikipedia/views/HeaderMarginItemDecoration.java
@@ -4,11 +4,11 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.view.View;
 
-import org.wikipedia.util.DimenUtil;
-
 import androidx.annotation.DimenRes;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.wikipedia.util.DimenUtil;
 
 public class HeaderMarginItemDecoration extends MarginItemDecoration {
 

--- a/app/src/main/java/org/wikipedia/views/LanguageScrollView.java
+++ b/app/src/main/java/org/wikipedia/views/LanguageScrollView.java
@@ -12,6 +12,13 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
+import androidx.core.view.ViewCompat;
+
 import com.google.android.material.tabs.TabLayout;
 
 import org.wikipedia.R;
@@ -20,12 +27,6 @@ import org.wikipedia.util.ResourceUtil;
 
 import java.util.List;
 
-import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.content.ContextCompat;
-import androidx.core.view.ViewCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/views/LinearLayoutOverWebView.java
+++ b/app/src/main/java/org/wikipedia/views/LinearLayoutOverWebView.java
@@ -6,9 +6,9 @@ import android.view.MotionEvent;
 import android.view.ViewConfiguration;
 import android.widget.LinearLayout;
 
-import org.wikipedia.util.DimenUtil;
-
 import androidx.annotation.NonNull;
+
+import org.wikipedia.util.DimenUtil;
 
 public class LinearLayoutOverWebView extends LinearLayout {
     private ObservableWebView webView;

--- a/app/src/main/java/org/wikipedia/views/MultiSelectActionModeCallback.java
+++ b/app/src/main/java/org/wikipedia/views/MultiSelectActionModeCallback.java
@@ -3,10 +3,10 @@ package org.wikipedia.views;
 import android.view.Menu;
 import android.view.MenuItem;
 
-import org.wikipedia.R;
-
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ActionMode;
+
+import org.wikipedia.R;
 
 public abstract class MultiSelectActionModeCallback implements ActionMode.Callback {
     private static final String ACTION_MODE_TAG = "multiSelectActionMode";

--- a/app/src/main/java/org/wikipedia/views/NotificationWithProgressBar.java
+++ b/app/src/main/java/org/wikipedia/views/NotificationWithProgressBar.java
@@ -8,14 +8,14 @@ import android.content.Intent;
 import android.graphics.BitmapFactory;
 import android.os.Build;
 
-import org.wikipedia.Constants;
-import org.wikipedia.R;
-import org.wikipedia.util.MathUtil;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.core.app.NotificationCompat;
+
+import org.wikipedia.Constants;
+import org.wikipedia.R;
+import org.wikipedia.util.MathUtil;
 
 public class NotificationWithProgressBar {
     private boolean canceled;

--- a/app/src/main/java/org/wikipedia/views/PageActionOverflowView.java
+++ b/app/src/main/java/org/wikipedia/views/PageActionOverflowView.java
@@ -9,14 +9,15 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.PopupWindow;
 
-import org.wikipedia.R;
-import org.wikipedia.page.tabs.Tab;
-import org.wikipedia.util.FeedbackUtil;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatImageView;
 import androidx.core.widget.PopupWindowCompat;
+
+import org.wikipedia.R;
+import org.wikipedia.page.tabs.Tab;
+import org.wikipedia.util.FeedbackUtil;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/views/PageItemView.java
+++ b/app/src/main/java/org/wikipedia/views/PageItemView.java
@@ -8,6 +8,16 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.AttrRes;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.core.widget.TextViewCompat;
+
 import com.facebook.drawee.view.SimpleDraweeView;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
@@ -21,15 +31,6 @@ import org.wikipedia.util.StringUtil;
 
 import java.util.List;
 
-import androidx.annotation.AttrRes;
-import androidx.annotation.DrawableRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.core.widget.TextViewCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/views/PageScrollerView.java
+++ b/app/src/main/java/org/wikipedia/views/PageScrollerView.java
@@ -4,10 +4,10 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
-import org.wikipedia.util.DimenUtil;
-
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatImageView;
+
+import org.wikipedia.util.DimenUtil;
 
 public class PageScrollerView extends AppCompatImageView {
     public interface Callback {

--- a/app/src/main/java/org/wikipedia/views/PlainPasteEditText.java
+++ b/app/src/main/java/org/wikipedia/views/PlainPasteEditText.java
@@ -9,6 +9,9 @@ import android.view.KeyEvent;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.android.material.textfield.TextInputEditText;
 
 import org.wikipedia.edit.richtext.SpanExtents;
@@ -17,9 +20,6 @@ import org.wikipedia.util.ClipboardUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static android.text.InputType.TYPE_TEXT_FLAG_MULTI_LINE;
 

--- a/app/src/main/java/org/wikipedia/views/ReadingListsOverflowView.java
+++ b/app/src/main/java/org/wikipedia/views/ReadingListsOverflowView.java
@@ -11,15 +11,16 @@ import android.widget.FrameLayout;
 import android.widget.PopupWindow;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.widget.PopupWindowCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.DateUtil;
 
 import java.text.ParseException;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.widget.PopupWindowCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/views/SearchActionProvider.java
+++ b/app/src/main/java/org/wikipedia/views/SearchActionProvider.java
@@ -5,12 +5,13 @@ import android.graphics.Color;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 
-import org.wikipedia.R;
-import org.wikipedia.util.DeviceUtil;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.ActionProvider;
+
+import org.wikipedia.R;
+import org.wikipedia.util.DeviceUtil;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/views/SearchEmptyView.java
+++ b/app/src/main/java/org/wikipedia/views/SearchEmptyView.java
@@ -5,10 +5,11 @@ import android.util.AttributeSet;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+
+import org.wikipedia.R;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/views/SwipeableItemTouchHelperCallback.java
+++ b/app/src/main/java/org/wikipedia/views/SwipeableItemTouchHelperCallback.java
@@ -5,16 +5,16 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 
-import org.wikipedia.R;
-import org.wikipedia.util.DimenUtil;
-import org.wikipedia.util.ResourceUtil;
-
 import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.wikipedia.R;
+import org.wikipedia.util.DimenUtil;
+import org.wikipedia.util.ResourceUtil;
 
 public class SwipeableItemTouchHelperCallback extends ItemTouchHelper.Callback {
     private static final float SWIPE_ICON_PADDING_DP = 16f;

--- a/app/src/main/java/org/wikipedia/views/TextInputDialog.java
+++ b/app/src/main/java/org/wikipedia/views/TextInputDialog.java
@@ -8,16 +8,16 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 
-import com.google.android.material.textfield.TextInputLayout;
-
-import org.wikipedia.R;
-import org.wikipedia.util.DeviceUtil;
-
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.textfield.TextInputLayout;
+
+import org.wikipedia.R;
+import org.wikipedia.util.DeviceUtil;
 
 public final class TextInputDialog extends AlertDialog {
 

--- a/app/src/main/java/org/wikipedia/views/ViewUtil.java
+++ b/app/src/main/java/org/wikipedia/views/ViewUtil.java
@@ -15,6 +15,10 @@ import android.view.animation.Animation;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.view.ActionMode;
+
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.view.SimpleDraweeView;
 
@@ -22,10 +26,6 @@ import org.wikipedia.R;
 import org.wikipedia.util.DimenUtil;
 
 import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.view.ActionMode;
 
 import static org.wikipedia.settings.Prefs.isImageDownloadEnabled;
 

--- a/app/src/main/java/org/wikipedia/views/WikiDrawerLayout.java
+++ b/app/src/main/java/org/wikipedia/views/WikiDrawerLayout.java
@@ -6,15 +6,15 @@ import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.View;
 
-import org.wikipedia.util.log.L;
-
-import java.lang.reflect.Field;
-
 import androidx.core.view.GravityCompat;
 import androidx.core.view.ViewCompat;
 import androidx.customview.widget.ViewDragHelper;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.drawerlayout.widget.FixedDrawerLayout;
+
+import org.wikipedia.util.log.L;
+
+import java.lang.reflect.Field;
 
 /**
  * A thin wrapper around {@link FixedDrawerLayout} with additional functionality:

--- a/app/src/main/java/org/wikipedia/views/WikiErrorView.java
+++ b/app/src/main/java/org/wikipedia/views/WikiErrorView.java
@@ -9,14 +9,15 @@ import android.widget.LinearLayout;
 import android.widget.Space;
 import android.widget.TextView;
 
-import org.wikipedia.R;
-import org.wikipedia.dataclient.mwapi.MwException;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
+
+import org.wikipedia.R;
+import org.wikipedia.dataclient.mwapi.MwException;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.java
+++ b/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.java
@@ -8,10 +8,11 @@ import android.view.View;
 import android.view.inputmethod.InputConnection;
 import android.widget.FrameLayout;
 
-import org.wikipedia.R;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.wikipedia.R;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;

--- a/app/src/main/java/org/wikipedia/views/WikitextKeyboardButtonView.java
+++ b/app/src/main/java/org/wikipedia/views/WikitextKeyboardButtonView.java
@@ -9,13 +9,14 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.AttrRes;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+
 import org.wikipedia.R;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.ResourceUtil;
 
-import androidx.annotation.AttrRes;
-import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 

--- a/app/src/main/java/org/wikipedia/widgets/WidgetProviderFeaturedPage.java
+++ b/app/src/main/java/org/wikipedia/widgets/WidgetProviderFeaturedPage.java
@@ -12,6 +12,8 @@ import android.text.TextUtils;
 import android.text.style.URLSpan;
 import android.widget.RemoteViews;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.Constants;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -29,7 +31,6 @@ import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 
-import androidx.annotation.NonNull;
 import io.reactivex.Observable;
 import io.reactivex.schedulers.Schedulers;
 

--- a/app/src/main/java/org/wikipedia/wikidata/Entities.java
+++ b/app/src/main/java/org/wikipedia/wikidata/Entities.java
@@ -1,11 +1,11 @@
 package org.wikipedia.wikidata;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.dataclient.mwapi.MwResponse;
 
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public class Entities extends MwResponse {
     @SuppressWarnings("unused") @Nullable private Map<String, Entity> entities;

--- a/app/src/main/java/org/wikipedia/wikidata/EntityClient.java
+++ b/app/src/main/java/org/wikipedia/wikidata/EntityClient.java
@@ -1,13 +1,14 @@
 package org.wikipedia.wikidata;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
 import com.google.gson.JsonParseException;
 
 import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
 import retrofit2.Call;
 import retrofit2.Response;
 

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.java
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.java
@@ -9,6 +9,9 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.FragmentUtil;
@@ -23,8 +26,6 @@ import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 import org.wikipedia.views.AppTextView;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;

--- a/app/src/test/java/org/wikipedia/csrf/CsrfTokenClientTest.java
+++ b/app/src/test/java/org/wikipedia/csrf/CsrfTokenClientTest.java
@@ -1,5 +1,7 @@
 package org.wikipedia.csrf;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.stream.MalformedJsonException;
 
 import org.junit.Test;
@@ -11,7 +13,6 @@ import org.wikipedia.dataclient.mwapi.MwQueryResponse;
 import org.wikipedia.dataclient.okhttp.HttpStatusException;
 import org.wikipedia.test.MockWebServerTest;
 
-import androidx.annotation.NonNull;
 import retrofit2.Call;
 
 import static org.mockito.Matchers.any;

--- a/app/src/test/java/org/wikipedia/dataclient/mwapi/page/MwMobileViewPageLeadTest.java
+++ b/app/src/test/java/org/wikipedia/dataclient/mwapi/page/MwMobileViewPageLeadTest.java
@@ -1,12 +1,13 @@
 package org.wikipedia.dataclient.mwapi.page;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.wikipedia.dataclient.mwapi.MwException;
 import org.wikipedia.dataclient.page.BasePageLeadTest;
 import org.wikipedia.dataclient.page.PageClient;
 
-import androidx.annotation.NonNull;
 import io.reactivex.observers.TestObserver;
 import okhttp3.CacheControl;
 import retrofit2.Response;

--- a/app/src/test/java/org/wikipedia/dataclient/mwapi/page/MwPageClientTest.java
+++ b/app/src/test/java/org/wikipedia/dataclient/mwapi/page/MwPageClientTest.java
@@ -1,12 +1,13 @@
 package org.wikipedia.dataclient.mwapi.page;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.wikipedia.dataclient.page.BasePageClientTest;
 import org.wikipedia.dataclient.page.PageClient;
 import org.wikipedia.dataclient.page.PageLead;
 
-import androidx.annotation.NonNull;
 import io.reactivex.observers.TestObserver;
 import retrofit2.Response;
 

--- a/app/src/test/java/org/wikipedia/dataclient/page/BasePageClientTest.java
+++ b/app/src/test/java/org/wikipedia/dataclient/page/BasePageClientTest.java
@@ -1,10 +1,11 @@
 package org.wikipedia.dataclient.page;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Test;
 import org.wikipedia.dataclient.okhttp.OfflineCacheInterceptor;
 import org.wikipedia.test.MockRetrofitTest;
 
-import androidx.annotation.NonNull;
 import io.reactivex.observers.TestObserver;
 import okhttp3.CacheControl;
 import retrofit2.Response;

--- a/app/src/test/java/org/wikipedia/dataclient/page/BasePageLeadTest.java
+++ b/app/src/test/java/org/wikipedia/dataclient/page/BasePageLeadTest.java
@@ -1,9 +1,9 @@
 package org.wikipedia.dataclient.page;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.dataclient.mwapi.MwException;
 import org.wikipedia.dataclient.mwapi.MwServiceError;
-
-import androidx.annotation.NonNull;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;

--- a/app/src/test/java/org/wikipedia/dataclient/restbase/page/RbPageLeadTest.java
+++ b/app/src/test/java/org/wikipedia/dataclient/restbase/page/RbPageLeadTest.java
@@ -1,11 +1,12 @@
 package org.wikipedia.dataclient.restbase.page;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.wikipedia.dataclient.page.BasePageLeadTest;
 import org.wikipedia.dataclient.page.PageClient;
 
-import androidx.annotation.NonNull;
 import io.reactivex.observers.TestObserver;
 import okhttp3.CacheControl;
 import retrofit2.Response;

--- a/app/src/test/java/org/wikipedia/descriptions/DescriptionEditClientTest.java
+++ b/app/src/test/java/org/wikipedia/descriptions/DescriptionEditClientTest.java
@@ -1,5 +1,7 @@
 package org.wikipedia.descriptions;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.stream.MalformedJsonException;
 
 import org.junit.Test;
@@ -15,7 +17,6 @@ import org.wikipedia.test.MockRetrofitTest;
 
 import java.util.Collections;
 
-import androidx.annotation.NonNull;
 import io.reactivex.observers.TestObserver;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/app/src/test/java/org/wikipedia/edit/EditClientTest.java
+++ b/app/src/test/java/org/wikipedia/edit/EditClientTest.java
@@ -1,5 +1,7 @@
 package org.wikipedia.edit;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.stream.MalformedJsonException;
 
 import org.junit.Test;
@@ -11,7 +13,6 @@ import org.wikipedia.dataclient.okhttp.HttpStatusException;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.test.MockWebServerTest;
 
-import androidx.annotation.NonNull;
 import retrofit2.Call;
 
 import static org.mockito.Matchers.any;

--- a/app/src/test/java/org/wikipedia/edit/EditUnitTest.java
+++ b/app/src/test/java/org/wikipedia/edit/EditUnitTest.java
@@ -1,6 +1,8 @@
 package org.wikipedia.edit;
 
 
+import androidx.annotation.NonNull;
+
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.wikipedia.dataclient.Service;
@@ -9,7 +11,6 @@ import org.wikipedia.edit.EditClient.Callback;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.test.MockWebServerTest;
 
-import androidx.annotation.NonNull;
 import retrofit2.Call;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.java
+++ b/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.java
@@ -1,5 +1,7 @@
 package org.wikipedia.feed.announcement;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.wikipedia.dataclient.RestService;
@@ -13,7 +15,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
 import retrofit2.Call;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/app/src/test/java/org/wikipedia/feed/mostread/MostReadArticlesTest.java
+++ b/app/src/test/java/org/wikipedia/feed/mostread/MostReadArticlesTest.java
@@ -1,5 +1,7 @@
 package org.wikipedia.feed.mostread;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -10,8 +12,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-
-import androidx.annotation.NonNull;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/app/src/test/java/org/wikipedia/html/ImageTagParserTest.java
+++ b/app/src/test/java/org/wikipedia/html/ImageTagParserTest.java
@@ -1,10 +1,10 @@
 package org.wikipedia.html;
 
+import androidx.annotation.NonNull;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.junit.Test;
-
-import androidx.annotation.NonNull;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/app/src/test/java/org/wikipedia/html/PixelDensityDescriptorParserTest.java
+++ b/app/src/test/java/org/wikipedia/html/PixelDensityDescriptorParserTest.java
@@ -1,8 +1,8 @@
 package org.wikipedia.html;
 
-import org.junit.Test;
-
 import androidx.annotation.NonNull;
+
+import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/app/src/test/java/org/wikipedia/json/NamespaceTypeAdapterTest.java
+++ b/app/src/test/java/org/wikipedia/json/NamespaceTypeAdapterTest.java
@@ -1,5 +1,8 @@
 package org.wikipedia.json;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
@@ -7,9 +10,6 @@ import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
 import org.wikipedia.page.Namespace;
 
 import java.util.Arrays;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/app/src/test/java/org/wikipedia/json/RequiredFieldsCheckOnReadTypeAdapterFactoryTest.java
+++ b/app/src/test/java/org/wikipedia/json/RequiredFieldsCheckOnReadTypeAdapterFactoryTest.java
@@ -2,6 +2,9 @@ package org.wikipedia.json;
 
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
@@ -11,9 +14,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.wikipedia.dataclient.Service;
 import org.wikipedia.json.annotations.Required;
 import org.wikipedia.model.BaseModel;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;

--- a/app/src/test/java/org/wikipedia/json/UriTypeAdapterTest.java
+++ b/app/src/test/java/org/wikipedia/json/UriTypeAdapterTest.java
@@ -2,6 +2,9 @@ package org.wikipedia.json;
 
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
@@ -9,9 +12,6 @@ import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
 import org.wikipedia.dataclient.Service;
 
 import java.util.Arrays;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/app/src/test/java/org/wikipedia/language/LanguageUtilTest.java
+++ b/app/src/test/java/org/wikipedia/language/LanguageUtilTest.java
@@ -1,5 +1,8 @@
 package org.wikipedia.language;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -9,9 +12,6 @@ import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
 
 import java.util.Arrays;
 import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/app/src/test/java/org/wikipedia/language/TranslationTests.java
+++ b/app/src/test/java/org/wikipedia/language/TranslationTests.java
@@ -1,5 +1,7 @@
 package org.wikipedia.language;
 
+import androidx.annotation.NonNull;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -16,8 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/app/src/test/java/org/wikipedia/nearby/NearbyUnitTest.java
+++ b/app/src/test/java/org/wikipedia/nearby/NearbyUnitTest.java
@@ -2,6 +2,9 @@ package org.wikipedia.nearby;
 
 import android.location.Location;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,9 +16,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/app/src/test/java/org/wikipedia/savedpages/PageImageUrlParserTest.java
+++ b/app/src/test/java/org/wikipedia/savedpages/PageImageUrlParserTest.java
@@ -1,5 +1,7 @@
 package org.wikipedia.savedpages;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Test;
 import org.wikipedia.dataclient.page.PageLead;
 import org.wikipedia.html.ImageTagParser;
@@ -8,8 +10,6 @@ import org.wikipedia.page.Section;
 
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;

--- a/app/src/test/java/org/wikipedia/test/ImmediateExecutor.java
+++ b/app/src/test/java/org/wikipedia/test/ImmediateExecutor.java
@@ -1,8 +1,8 @@
 package org.wikipedia.test;
 
-import java.util.concurrent.Executor;
-
 import androidx.annotation.NonNull;
+
+import java.util.concurrent.Executor;
 
 public class ImmediateExecutor implements Executor {
     @Override

--- a/app/src/test/java/org/wikipedia/test/ImmediateExecutorService.java
+++ b/app/src/test/java/org/wikipedia/test/ImmediateExecutorService.java
@@ -1,10 +1,10 @@
 package org.wikipedia.test;
 
+import androidx.annotation.NonNull;
+
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.NonNull;
 
 public final class ImmediateExecutorService extends AbstractExecutorService {
     @Override public void shutdown() {

--- a/app/src/test/java/org/wikipedia/test/MockWebServerTest.java
+++ b/app/src/test/java/org/wikipedia/test/MockWebServerTest.java
@@ -1,5 +1,7 @@
 package org.wikipedia.test;
 
+import androidx.annotation.NonNull;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -7,7 +9,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory;
 import org.wikipedia.json.GsonUtil;
 
-import androidx.annotation.NonNull;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;

--- a/app/src/test/java/org/wikipedia/test/TestFileUtil.java
+++ b/app/src/test/java/org/wikipedia/test/TestFileUtil.java
@@ -1,12 +1,12 @@
 package org.wikipedia.test;
 
+import androidx.annotation.NonNull;
+
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-
-import androidx.annotation.NonNull;
 
 public final class TestFileUtil {
     private static final String RAW_DIR = "src/test/res/raw/";

--- a/app/src/test/java/org/wikipedia/test/TestWebServer.java
+++ b/app/src/test/java/org/wikipedia/test/TestWebServer.java
@@ -1,10 +1,11 @@
 package org.wikipedia.test;
 
+import androidx.annotation.NonNull;
+
 import org.wikipedia.testlib.TestConstants;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;

--- a/app/src/test/java/org/wikipedia/util/BatchUtilTest.java
+++ b/app/src/test/java/org/wikipedia/util/BatchUtilTest.java
@@ -1,5 +1,7 @@
 package org.wikipedia.util;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,8 +12,6 @@ import org.wikipedia.testlib.TestLatch;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/app/src/test/java/org/wikipedia/wikidata/EntityClientTest.java
+++ b/app/src/test/java/org/wikipedia/wikidata/EntityClientTest.java
@@ -1,12 +1,13 @@
 package org.wikipedia.wikidata;
 
+import androidx.annotation.NonNull;
+
 import org.junit.Test;
 import org.wikipedia.dataclient.Service;
 import org.wikipedia.json.GsonUnmarshaller;
 import org.wikipedia.test.MockWebServerTest;
 import org.wikipedia.test.TestFileUtil;
 
-import androidx.annotation.NonNull;
 import retrofit2.Call;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/gradle/src/checkstyle.xml
+++ b/gradle/src/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <!--
 

--- a/gradle/src/checkstyle.xml
+++ b/gradle/src/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
 
@@ -84,7 +84,7 @@
         <module name="AvoidStarImport" />
         <module name="ImportOrder">
             <property name="option" value="bottom" />
-            <property name="groups" value="android,com,junit,net,org,java,javax,*" />
+            <property name="groups" value="android,androidx,com,junit,net,org,java,javax,*" />
             <property name="separated" value="true" />
             <property name="sortStaticImportsAlphabetically" value="true" />
         </module>


### PR DESCRIPTION
After we migrated to AndroidX, the **CheckStyle** rules of import order should be updated, too.

The main change in this PR is to update the `ImportOrder` rules in `gradle/src/checkstyle.xml`, and the rest of the job is to re-run the `Optimize imports` in Android Studio.