### PR TITLE
Use view click listener to solve the conflict of actions in SearchResultsFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import butterknife.OnItemClick;
 import butterknife.Unbinder;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
@@ -120,14 +119,6 @@ public class SearchResultsFragment extends Fragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
-    }
-
-    @OnItemClick(R.id.search_results_list) void onItemClick(ListView view, int position) {
-        Callback callback = callback();
-        if (callback != null) {
-            PageTitle item = ((SearchResult) getAdapter().getItem(position)).getPageTitle();
-            callback.navigateToTitle(item, false, position);
-        }
     }
 
     @OnClick(R.id.search_suggestion) void onSuggestionClick(View view) {
@@ -524,6 +515,16 @@ public class SearchResultsFragment extends Fragment {
                     doFullTextSearch(currentSearchTerm, lastFullTextResults.getContinuation(), false);
                 }
             }
+
+            convertView.setOnClickListener((view) -> {
+                Callback callback = callback();
+                if (callback != null) {
+                    PageTitle item = ((SearchResult) getAdapter().getItem(position)).getPageTitle();
+                    callback.navigateToTitle(item, false, position);
+                }
+            });
+
+            convertView.setOnLongClickListener(view -> false);
 
             return convertView;
         }


### PR DESCRIPTION
Since we've fixed the `ContextMenu` issue, I found that the long press action in `SearchResultsFragment` will show a `PopupMenu` and then also go to the article page, which is incorrect.

The way of doing this correctly is to implement the `OnClickListener` to each list item, like how `BottomContentView` does. 