### PR TITLE
Developer setting for testing suggested edits cards

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedContentType.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedContentType.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
+import org.wikipedia.Constants;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
@@ -85,6 +86,9 @@ public enum FeedContentType implements EnumCode {
         @Override
         public FeedClient newClient(AggregatedFeedContentClient aggregatedClient, int age) {
             if (ReleaseUtil.isPreBetaRelease() && isEnabled() && AccountUtil.isLoggedIn() && WikipediaApp.getInstance().isOnline()) {
+                if (Prefs.shouldShowSuggestedEditsCardsForTesting()) {
+                    return new SuggestedEditsFeedClient(!(age % 2 == 0) && WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= Constants.MIN_LANGUAGES_TO_UNLOCK_TRANSLATION);
+                }
                 return Prefs.isSuggestedEditsAddDescriptionsUnlocked() ? new SuggestedEditsFeedClient(!(age % 2 == 0) && Prefs.isSuggestedEditsTranslateDescriptionsUnlocked()) : null;
             }
             return null;

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -849,5 +849,9 @@ public final class Prefs {
         setBoolean(R.string.preference_key_show_multilingual_task, showTask);
     }
 
+    public static boolean shouldShowSuggestedEditsCardsForTesting() {
+        return getBoolean(R.string.preference_key_show_suggested_edits_cards_testing, false);
+    }
+
     private Prefs() { }
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -107,4 +107,5 @@
     <string name="preference_key_show_action_feed_indicator">showActionFeedIndicator</string>
     <string name="preference_key_show_edit_tasks_onboarding">showEditTasksOnboarding</string>
     <string name="preference_key_show_multilingual_task">showMultilingualTask</string>
+    <string name="preference_key_show_suggested_edits_cards_testing">showSuggestedEditsCardsTesting</string>
 </resources>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -299,6 +299,10 @@
             android:key="@string/preference_key_suggested_edits_translate_descriptions_unlocked"
             android:title="@string/preference_key_suggested_edits_translate_descriptions_unlocked" />
 
+        <SwitchPreferenceCompat
+            android:key="@string/preference_key_show_suggested_edits_cards_testing"
+            android:title="@string/preference_key_show_suggested_edits_cards_testing" />
+
         <Preference
             android:key="@string/preferences_developer_suggested_edits_add_description_dialog"
             android:title="@string/preferences_developer_suggested_edits_add_description_dialog"/>


### PR DESCRIPTION
-Turning on the developer setting for descriptions/translations dialog will not help load cards as it gets unset with the next poll, so created an exclusive switch for suggested edits feed cards.

User still needs to be logged in, the cards should be enabled and still under the preBeta flag.
**Phab**: https://phabricator.wikimedia.org/T217373