### PR TITLE
Fix: bottom content view list item does not have correct height

### DIFF
--- a/app/src/main/java/org/wikipedia/page/bottomcontent/BottomContentView.java
+++ b/app/src/main/java/org/wikipedia/page/bottomcontent/BottomContentView.java
@@ -403,8 +403,8 @@ public class BottomContentView extends LinearLayoutOverWebView
             PageItemView<RbPageSummary> itemView = (PageItemView<RbPageSummary>) convView;
             if (itemView == null) {
                 itemView = new PageItemView<>(getContext());
-                itemView.setLayoutParams(new ListView.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
             }
+            itemView.setLayoutParams(new ListView.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
             RbPageSummary result = getItem(position);
             PageTitle pageTitle = result.getPageTitle(page.getTitle().getWikiSite());
             itemView.setItem(result);


### PR DESCRIPTION
The issue can be reproduced by the following steps:

1. Open the article [Hackathon] in English
2. Scroll down to the "Read more" section
3. Change article language to Traditional Chinese
4. Scroll down to the "Read more" section, and you will see the issue.