### PR TITLE
Open articles from other sources in current tab, not new tab.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.java
@@ -76,7 +76,7 @@ public class DescriptionEditActivity extends SingleFragmentActivity<DescriptionE
     }
 
     public void onLinkPreviewLoadPage(@NonNull PageTitle title, @NonNull HistoryEntry entry, boolean inNewTab) {
-        startActivity(PageActivity.newIntentForNewTab(this, entry, entry.getTitle()));
+        startActivity(PageActivity.newIntentForCurrentTab(this, entry, entry.getTitle()));
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -202,7 +202,7 @@ public class EditPreviewFragment extends Fragment {
 
                 @Override
                 public void onInternalLinkClicked(@NonNull final PageTitle title) {
-                    showLeavingEditDialogue(() -> startActivity(PageActivity.newIntentForNewTab(getContext(),
+                    showLeavingEditDialogue(() -> startActivity(PageActivity.newIntentForCurrentTab(getContext(),
                             new HistoryEntry(title, HistoryEntry.SOURCE_INTERNAL_LINK), title)));
                 }
 

--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadFragment.java
@@ -113,7 +113,7 @@ public class MostReadFragment extends Fragment {
     private class Callback implements ListCardItemView.Callback {
         @Override
         public void onSelectPage(@NonNull Card card, @NonNull HistoryEntry entry) {
-            startActivity(PageActivity.newIntentForNewTab(requireContext(), entry, entry.getTitle()));
+            startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()));
         }
 
         @Override

--- a/app/src/main/java/org/wikipedia/feed/news/NewsFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsFragment.java
@@ -155,7 +155,7 @@ public class NewsFragment extends Fragment {
     private class Callback implements ListCardItemView.Callback {
         @Override
         public void onSelectPage(@NonNull Card card, @NonNull HistoryEntry entry) {
-            startActivity(PageActivity.newIntentForNewTab(requireContext(), entry, entry.getTitle()));
+            startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()));
         }
 
         @Override

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.java
@@ -76,7 +76,7 @@ public class OnThisDayPagesViewHolder extends RecyclerView.ViewHolder {
         HistoryEntry entry = new HistoryEntry(pageTitle,
                 isSingleCard ? HistoryEntry.SOURCE_ON_THIS_DAY_CARD : HistoryEntry.SOURCE_ON_THIS_DAY_ACTIVITY);
 
-        activity.startActivity(PageActivity.newIntentForNewTab(activity, entry, pageTitle));
+        activity.startActivity(PageActivity.newIntentForCurrentTab(activity, entry, pageTitle));
     }
 
     @OnLongClick(R.id.parent) boolean showOverflowMenu(View anchorView) {

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -234,7 +234,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
     }
 
     @Override public void onFeedSelectPage(HistoryEntry entry) {
-        startActivity(PageActivity.newIntentForNewTab(requireContext(), entry, entry.getTitle()), getTransitionAnimationBundle(entry.getTitle()));
+        startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()), getTransitionAnimationBundle(entry.getTitle()));
     }
 
     @Override public void onFeedSelectPageFromExistingTab(HistoryEntry entry) {
@@ -333,7 +333,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
     }
 
     @Override public void onLoadPage(@NonNull HistoryEntry entry) {
-        startActivity(PageActivity.newIntentForNewTab(requireContext(), entry, entry.getTitle()), getTransitionAnimationBundle(entry.getTitle()));
+        startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()), getTransitionAnimationBundle(entry.getTitle()));
     }
 
     @Override public void onClearHistory() {
@@ -341,7 +341,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
     }
 
     public void onLinkPreviewLoadPage(@NonNull PageTitle title, @NonNull HistoryEntry entry, boolean inNewTab) {
-        startActivity(PageActivity.newIntentForNewTab(requireContext(), entry, entry.getTitle()), getTransitionAnimationBundle(entry.getTitle()));
+        startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()), getTransitionAnimationBundle(entry.getTitle()));
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
@@ -400,7 +400,7 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
 
     @Override
     public void onActionPageTitle(@NonNull PageTitle pageTitle) {
-        startActivity(PageActivity.newIntentForNewTab(this,
+        startActivity(PageActivity.newIntentForCurrentTab(this,
                 new HistoryEntry(pageTitle, HistoryEntry.SOURCE_NOTIFICATION), pageTitle));
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -269,12 +269,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     }
 
     @NonNull
-    public static Intent newIntent(@NonNull Context context, @NonNull String title) {
-        PageTitle pageTitle = new PageTitle(title, WikipediaApp.getInstance().getWikiSite());
-        return newIntentForNewTab(context, new HistoryEntry(pageTitle, HistoryEntry.SOURCE_INTERNAL_LINK), pageTitle);
-    }
-
-    @NonNull
     public static Intent newIntentForNewTab(@NonNull Context context) {
         return new Intent(ACTION_CREATE_NEW_TAB)
                 .setClass(context, PageActivity.class);

--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
@@ -252,14 +252,24 @@ public class TabActivity extends BaseActivity {
             case R.id.menu_open_a_new_tab:
                 openNewTab();
                 return true;
+            case R.id.menu_explore:
+                startActivity(MainActivity.newIntent(TabActivity.this)
+                        .putExtra(Constants.INTENT_EXTRA_GO_TO_MAIN_TAB, NavTab.EXPLORE.code()));
+                finish();
+                return true;
             case R.id.menu_reading_lists:
                 startActivity(MainActivity.newIntent(TabActivity.this)
                         .putExtra(Constants.INTENT_EXTRA_GO_TO_MAIN_TAB, NavTab.READING_LISTS.code()));
                 finish();
                 return true;
-            case R.id.menu_recently_viewed:
+            case R.id.menu_history:
                 startActivity(MainActivity.newIntent(TabActivity.this)
                         .putExtra(Constants.INTENT_EXTRA_GO_TO_MAIN_TAB, NavTab.HISTORY.code()));
+                finish();
+                return true;
+            case R.id.menu_nearby:
+                startActivity(MainActivity.newIntent(TabActivity.this)
+                        .putExtra(Constants.INTENT_EXTRA_GO_TO_MAIN_TAB, NavTab.NEARBY.code()));
                 finish();
                 return true;
             default:

--- a/app/src/main/java/org/wikipedia/random/RandomFragment.java
+++ b/app/src/main/java/org/wikipedia/random/RandomFragment.java
@@ -151,7 +151,7 @@ public class RandomFragment extends Fragment {
     }
 
     public void onSelectPage(@NonNull PageTitle title) {
-        startActivity(PageActivity.newIntentForNewTab(requireActivity(),
+        startActivity(PageActivity.newIntentForCurrentTab(requireActivity(),
                 new HistoryEntry(title, HistoryEntry.SOURCE_RANDOM), title));
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
@@ -762,7 +762,7 @@ public class ReadingListFragment extends Fragment implements ReadingListItemActi
                     ReadingListDbHelper.instance().updatePage(page);
                 }).subscribeOn(Schedulers.io()).subscribe();
 
-                startActivity(PageActivity.newIntentForNewTab(requireContext(), entry, entry.getTitle()), getTransitionAnimationBundle(entry.getTitle()));
+                startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()), getTransitionAnimationBundle(entry.getTitle()));
             }
         }
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
@@ -581,7 +581,7 @@ public class ReadingListsFragment extends Fragment implements
                     ReadingListDbHelper.instance().updatePage(page);
                 }).subscribeOn(Schedulers.io()).subscribe();
 
-                startActivity(PageActivity.newIntentForNewTab(requireContext(), entry, entry.getTitle()));
+                startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()));
             }
         }
 

--- a/app/src/main/res/menu/menu_tabs.xml
+++ b/app/src/main/res/menu/menu_tabs.xml
@@ -7,10 +7,16 @@
     <item android:id="@+id/menu_close_all_tabs"
         android:title="@string/menu_close_all_tabs"
         app:showAsAction="never" />
-    <item android:id="@+id/menu_reading_lists"
-        android:title="@string/menu_page_reading_lists"
+    <item android:id="@+id/menu_explore"
+        android:title="@string/feed"
         app:showAsAction="never" />
-    <item android:id="@+id/menu_recently_viewed"
-        android:title="@string/menu_page_recently_viewed"
+    <item android:id="@+id/menu_reading_lists"
+        android:title="@string/nav_item_reading_lists"
+        app:showAsAction="never" />
+    <item android:id="@+id/menu_history"
+        android:title="@string/nav_item_history"
+        app:showAsAction="never" />
+    <item android:id="@+id/menu_nearby"
+        android:title="@string/nav_item_nearby"
         app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
We want to change the general default behavior for opening articles (e.g. from the Feed, Reading Lists, History, etc) in the "current" tab, instead of opening a new tab every time.

https://phabricator.wikimedia.org/T222056
