### PR TITLE
Fix appearance of text size SeekBar in RTL.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/DiscreteSeekBar.java
+++ b/app/src/main/java/org/wikipedia/views/DiscreteSeekBar.java
@@ -14,12 +14,14 @@ import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
 import org.wikipedia.R;
+import org.wikipedia.util.L10nUtil;
 
 @SuppressLint("AppCompatCustomView")
 public class DiscreteSeekBar extends SeekBar {
     private int min;
     @Nullable private Drawable tickDrawable;
     @Nullable private Drawable centerDrawable;
+    private boolean isRtl;
 
     public DiscreteSeekBar(Context context) {
         super(context);
@@ -60,6 +62,7 @@ public class DiscreteSeekBar extends SeekBar {
             }
             array.recycle();
         }
+        isRtl = L10nUtil.isDeviceRTL();
     }
 
     @Override
@@ -90,6 +93,9 @@ public class DiscreteSeekBar extends SeekBar {
         }
         float tickSpacing = (float) (getWidth() - getPaddingLeft() - getPaddingRight()) / (float) (max - min);
         canvas.save();
+        if (isRtl) {
+            canvas.scale(-1, 1, getWidth() / 2, getHeight() / 2);
+        }
         canvas.translate((float) getPaddingLeft(), (float) (getHeight() / 2));
         for (int i = min; i <= max; ++i) {
             if (drawOther && tickDrawable != null && i > value) {

--- a/app/src/main/java/org/wikipedia/views/DiscreteSeekBar.java
+++ b/app/src/main/java/org/wikipedia/views/DiscreteSeekBar.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
 import org.wikipedia.R;
-import org.wikipedia.util.L10nUtil;
 
 @SuppressLint("AppCompatCustomView")
 public class DiscreteSeekBar extends SeekBar {
@@ -62,7 +61,7 @@ public class DiscreteSeekBar extends SeekBar {
             }
             array.recycle();
         }
-        isRtl = L10nUtil.isDeviceRTL();
+        isRtl = getResources().getConfiguration().getLayoutDirection() == LAYOUT_DIRECTION_RTL;
     }
 
     @Override


### PR DESCRIPTION
When the system language is set to RTL, and you invoke the theme chooser, the text size SeekBar was looking weird, with incorrect placement of tick marks.