### PR TITLE
Replace Kotlin occurrences of TextUtils.isEmpty(String) with String#isNullOrEmpty()

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReadArticleBarView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReadArticleBarView.kt
@@ -2,7 +2,6 @@ package org.wikipedia.descriptions
 
 import android.content.Context
 import android.net.Uri
-import android.text.TextUtils
 import android.util.AttributeSet
 import androidx.constraintlayout.widget.ConstraintLayout
 import kotlinx.android.synthetic.main.view_description_edit_read_article_bar.view.*
@@ -31,7 +30,7 @@ class DescriptionEditReadArticleBarView @JvmOverloads constructor(
         setConditionalLayoutDirection(this, pageSummary.lang)
         viewArticleTitle!!.text = StringUtil.fromHtml(pageSummary.displayTitle)
 
-        if (TextUtils.isEmpty(pageSummary.thumbnailUrl)) {
+        if (pageSummary.thumbnailUrl.isNullOrEmpty()) {
             viewArticleImage!!.visibility = GONE
         } else {
             viewArticleImage!!.visibility = VISIBLE

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
@@ -39,7 +39,7 @@ class DescriptionEditReviewView @JvmOverloads constructor(
         articleSubtitle!!.text = StringUtils.capitalize(description)
         articleExtract!!.text = StringUtil.fromHtml(pageSummary.extractHtml)
 
-        if (pageSummary.thumbnailUrl.isNullOrEmpty()) {
+        if (pageSummary.thumbnailUrl.isNullOrBlank()) {
             articleImage.visibility = View.GONE
             articleExtract.maxLines = ARTICLE_EXTRACT_MAX_LINE_WITHOUT_IMAGE
         } else {

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
@@ -2,7 +2,6 @@ package org.wikipedia.descriptions
 
 import android.content.Context
 import android.net.Uri
-import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -40,7 +39,7 @@ class DescriptionEditReviewView @JvmOverloads constructor(
         articleSubtitle!!.text = StringUtils.capitalize(description)
         articleExtract!!.text = StringUtil.fromHtml(pageSummary.extractHtml)
 
-        if (TextUtils.isEmpty(pageSummary.thumbnailUrl)) {
+        if (pageSummary.thumbnailUrl.isNullOrEmpty()) {
             articleImage.visibility = View.GONE
             articleExtract.maxLines = ARTICLE_EXTRACT_MAX_LINE_WITHOUT_IMAGE
         } else {

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -3,7 +3,6 @@ package org.wikipedia.feed.suggestededits
 
 import android.content.Context
 import android.net.Uri
-import android.text.TextUtils
 import android.view.View
 import io.reactivex.annotations.NonNull
 import io.reactivex.disposables.CompositeDisposable
@@ -70,7 +69,7 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
     }
 
     private fun showImageOrExtract() {
-        if (TextUtils.isEmpty(sourceSummary!!.thumbnailUrl)) {
+        if (sourceSummary!!.thumbnailUrl.isNullOrEmpty()) {
             viewArticleImage.visibility = View.GONE
             viewArticleExtract.visibility = View.VISIBLE
             divider.visibility = View.VISIBLE

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -69,7 +69,7 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
     }
 
     private fun showImageOrExtract() {
-        if (sourceSummary!!.thumbnailUrl.isNullOrEmpty()) {
+        if (sourceSummary!!.thumbnailUrl.isNullOrBlank()) {
             viewArticleImage.visibility = View.GONE
             viewArticleExtract.visibility = View.VISIBLE
             divider.visibility = View.VISIBLE

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.DialogInterface
 import android.text.Spanned
-import android.text.TextUtils
 import androidx.appcompat.app.AlertDialog
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -319,7 +318,7 @@ object ReadingListBehaviorsUtil {
                 .map {
                     allReadingLists = it
                     val list = applySearchQuery(searchQuery, it)
-                    if (TextUtils.isEmpty(searchQuery)) {
+                    if (searchQuery.isNullOrEmpty()) {
                         ReadingList.sortGenericList(list, Prefs.getReadingListSortMode(ReadingList.SORT_BY_NAME_ASC))
                     }
                     list
@@ -332,7 +331,7 @@ object ReadingListBehaviorsUtil {
     private fun applySearchQuery(searchQuery: String?, lists: List<ReadingList>): MutableList<Any> {
         val result = mutableListOf<Any>()
 
-        if (TextUtils.isEmpty(searchQuery)) {
+        if (searchQuery.isNullOrEmpty()) {
             result.addAll(lists)
             return result
         }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsAddDescriptionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsAddDescriptionsFragment.kt
@@ -4,7 +4,6 @@ import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.graphics.drawable.Animatable
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.GONE
@@ -211,7 +210,7 @@ class SuggestedEditsAddDescriptionsFragment : Fragment() {
                 break
             }
         }
-        if (TextUtils.isEmpty(name)) {
+        if (name.isNullOrEmpty()) {
             name = app.language().getAppLanguageLocalizedName(code)
         }
         return name ?: code

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsAddDescriptionsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsAddDescriptionsItemFragment.kt
@@ -2,7 +2,6 @@ package org.wikipedia.suggestededits
 
 import android.net.Uri
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.GONE
@@ -100,7 +99,7 @@ class SuggestedEditsAddDescriptionsItemFragment : Fragment() {
     }
 
     fun showAddedDescriptionView(addedDescription: String?) {
-        if (!TextUtils.isEmpty(addedDescription)) {
+        if (!addedDescription.isNullOrEmpty()) {
             viewArticleSubtitleContainer.visibility = VISIBLE
             if (parent().source == EDIT_FEED_TRANSLATE_TITLE_DESC) {
                 viewArticleSubtitleAddedBy.visibility = VISIBLE
@@ -110,7 +109,7 @@ class SuggestedEditsAddDescriptionsItemFragment : Fragment() {
             viewAddDescriptionButton.visibility = GONE
             viewArticleSubtitle.text = addedDescription
             viewArticleExtract.maxLines = viewArticleExtract.maxLines - 1
-            this.addedDescription = addedDescription!!
+            this.addedDescription = addedDescription
         }
     }
 
@@ -140,7 +139,7 @@ class SuggestedEditsAddDescriptionsItemFragment : Fragment() {
         }
 
         viewArticleExtract.text = StringUtil.fromHtml(sourceSummary!!.extractHtml)
-        if (TextUtils.isEmpty(sourceSummary!!.thumbnailUrl)) {
+        if (sourceSummary!!.thumbnailUrl.isNullOrEmpty()) {
             viewArticleImage.visibility = GONE
             viewArticleExtract.maxLines = ARTICLE_EXTRACT_MAX_LINE_WITHOUT_IMAGE
         } else {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsAddDescriptionsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsAddDescriptionsItemFragment.kt
@@ -139,7 +139,7 @@ class SuggestedEditsAddDescriptionsItemFragment : Fragment() {
         }
 
         viewArticleExtract.text = StringUtil.fromHtml(sourceSummary!!.extractHtml)
-        if (sourceSummary!!.thumbnailUrl.isNullOrEmpty()) {
+        if (sourceSummary!!.thumbnailUrl.isNullOrBlank()) {
             viewArticleImage.visibility = GONE
             viewArticleExtract.maxLines = ARTICLE_EXTRACT_MAX_LINE_WITHOUT_IMAGE
         } else {

--- a/app/src/main/java/org/wikipedia/suggestededits/provider/MissingDescriptionProvider.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/MissingDescriptionProvider.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.suggestededits.provider
 
-import android.text.TextUtils
 import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
 import org.apache.commons.lang3.StringUtils
@@ -36,14 +35,14 @@ object MissingDescriptionProvider {
             }
         }
 
-        return (if (!TextUtils.isEmpty(cachedTitle)) Observable.just(cachedTitle) else
+        return (if (cachedTitle.isNotEmpty()) Observable.just(cachedTitle) else
             ServiceFactory.get(wiki).randomWithPageProps
                     .map<String> { response ->
                         var title : String? = null
                         synchronized(articlesWithMissingDescriptionCache) {
                             articlesWithMissingDescriptionCacheLang = wiki.languageCode()
                             for (page in response.query()!!.pages()!!) {
-                                if (page.pageProps() == null || page.pageProps()!!.isDisambiguation || !TextUtils.isEmpty(page.description())) {
+                                if (page.pageProps() == null || page.pageProps()!!.isDisambiguation || !page.description().isNullOrEmpty()) {
                                     continue
                                 }
                                 articlesWithMissingDescriptionCache.push(page.title())
@@ -91,7 +90,7 @@ object MissingDescriptionProvider {
                     .flatMap { response: MwQueryResponse ->
                         val qNumbers = ArrayList<String>()
                         for (page in response.query()!!.pages()!!) {
-                            if (page.pageProps() == null || page.pageProps()!!.isDisambiguation || TextUtils.isEmpty(page.pageProps()!!.wikiBaseItem)) {
+                            if (page.pageProps() == null || page.pageProps()!!.isDisambiguation || page.pageProps()!!.wikiBaseItem.isEmpty()) {
                                 continue
                             }
                             qNumbers.add(page.pageProps()!!.wikiBaseItem)


### PR DESCRIPTION
`String?#isNullOrEmpty()` uses contracts such that the string is implicitly non-nullable if the check passes. For example, [here](https://github.com/wikimedia/apps-android-wikipedia/compare/master...veyndan:kt-TextUtils?expand=1#diff-eb25cdd07ccca1c70f96371dd907b1b6R112) the not-null assertion operator is no longer required as the [surrounding conditional](https://github.com/wikimedia/apps-android-wikipedia/compare/master...veyndan:kt-TextUtils?expand=1#diff-eb25cdd07ccca1c70f96371dd907b1b6R102) states the use of the string in that instance is not-null.

As an additional bonus, the linter tells us that `String?#isNullOrEmpty()` can be replaced with `String#isEmpty()` when the string is non-null, removing a redundant non-null check, and more importantly, making the code more concise.