### PR TITLE
Remove unused CompositeDisposable

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import android.text.TextUtils
 import android.view.View
 import io.reactivex.annotations.NonNull
-import io.reactivex.disposables.CompositeDisposable
 import kotlinx.android.synthetic.main.view_suggested_edit_card.view.*
 import org.apache.commons.lang3.StringUtils
 import org.wikipedia.R
@@ -23,7 +22,6 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
         fun onSuggestedEditsCardClick(view: SuggestedEditsCardView)
     }
 
-    private val disposables = CompositeDisposable()
     private var sourceDescription: String = ""
     private val app = WikipediaApp.getInstance()
     var isTranslation: Boolean = false
@@ -82,11 +80,6 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
             divider.visibility = View.GONE
             viewArticleImage.loadImage(Uri.parse(sourceSummary!!.thumbnailUrl))
         }
-    }
-
-    override fun onDetachedFromWindow() {
-        disposables.clear()
-        super.onDetachedFromWindow()
     }
 
     private fun header(card: SuggestedEditsCard) {


### PR DESCRIPTION
`disposable` is never added to, so only every clearing an empty `CompositeDisposable` is rather pointless.