### PR TITLE
Fix: Invisible app bar on article page with image

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
+++ b/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
@@ -26,7 +26,6 @@ public class PageToolbarHideHandler extends ViewHideHandler {
 
     private ArgbEvaluator argbEvaluator = new ArgbEvaluator();
     private boolean fadeEnabled;
-    private boolean forceNoFade;
     @NonNull private PageFragment pageFragment;
     @NonNull private Toolbar toolbar;
     @NonNull private Drawable toolbarBackground;
@@ -36,6 +35,8 @@ public class PageToolbarHideHandler extends ViewHideHandler {
     @ColorInt private int baseStatusBarColor;
     @ColorInt private int themedStatusBarColor;
 
+    private int toolbarHeight;
+
     public PageToolbarHideHandler(@NonNull PageFragment pageFragment, @NonNull View hideableView,
                                   @NonNull Toolbar toolbar, @NonNull TabCountsView tabsButton) {
         super(hideableView, null, Gravity.TOP);
@@ -43,29 +44,18 @@ public class PageToolbarHideHandler extends ViewHideHandler {
         this.toolbar = toolbar;
         this.toolbarBackground = hideableView.getBackground().mutate();
         this.tabsButton = tabsButton;
-
         themedIconColor = getThemedColor(toolbar.getContext(), R.attr.page_toolbar_icon_color);
         baseStatusBarColor = getThemedColor(toolbar.getContext(), R.attr.page_expanded_status_bar_color);
         themedStatusBarColor = getThemedColor(toolbar.getContext(), R.attr.page_status_bar_color);
+        toolbarHeight = DimenUtil.getToolbarHeightPx(pageFragment.requireContext());
     }
 
     /**
      * Whether to enable fading in/out of the search bar when near the top of the article.
      * @param enabled True to enable fading, false otherwise.
      */
-    public void setFadeEnabled(boolean enabled) {
+    void setFadeEnabled(boolean enabled) {
         fadeEnabled = enabled;
-        update();
-    }
-
-    /**
-     * Whether to temporarily disable fading of the search bar, even if fading is enabled otherwise.
-     * May be used when displaying a temporary UI element that requires the search bar to be shown
-     * fully, e.g. when the ToC is pulled out.
-     * @param force True to temporarily disable fading, false otherwise.
-     */
-    public void setForceNoFade(boolean force) {
-        forceNoFade = force;
         update();
     }
 
@@ -73,25 +63,14 @@ public class PageToolbarHideHandler extends ViewHideHandler {
     protected void onScrolled(int oldScrollY, int scrollY) {
         tabsButton.setTabCount(WikipediaApp.getInstance().getTabCount());
 
-        int opacity = calculateScrollOpacity(scrollY);
+        int opacity = fadeEnabled && scrollY < (pageFragment.getHeaderView().getHeight() - toolbarHeight) ? 0 : FULL_OPACITY;
+
         toolbarBackground.setAlpha(opacity);
         updateChildIconTint(toolbar, opacity);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             pageFragment.requireActivity().getWindow()
                     .setStatusBarColor(calculateStatusBarTintForOpacity(opacity));
         }
-    }
-
-    /** @return Alpha value between 0 and 0xff. */
-    private int calculateScrollOpacity(int scrollY) {
-        final int fadeHeight = 200;
-        int opacity = FULL_OPACITY;
-        if (fadeEnabled && !forceNoFade) {
-            opacity = scrollY * FULL_OPACITY / (int) (fadeHeight * DimenUtil.getDensityScalar());
-        }
-        opacity = Math.max(0, opacity);
-        opacity = Math.min(FULL_OPACITY, opacity);
-        return opacity;
     }
 
     private void updateChildIconTint(@NonNull ViewGroup viewGroup, float opacity) {

--- a/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
+++ b/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
@@ -37,7 +37,7 @@ public class PageToolbarHideHandler extends ViewHideHandler {
 
     private int toolbarHeight;
 
-    public PageToolbarHideHandler(@NonNull PageFragment pageFragment, @NonNull View hideableView,
+    PageToolbarHideHandler(@NonNull PageFragment pageFragment, @NonNull View hideableView,
                                   @NonNull Toolbar toolbar, @NonNull TabCountsView tabsButton) {
         super(hideableView, null, Gravity.TOP);
         this.pageFragment = pageFragment;


### PR DESCRIPTION
Instead of continuously updating the opacity of toolbar and its icons, we can use the height of the header view and update opacity when `ScrollY` reaches/over the height.

Also, update methods and constructor to the `package-private` level.

https://phabricator.wikimedia.org/T223121