### PR TITLE
Fix ability to build app while offline.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,9 +3,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 import com.android.build.gradle.internal.dsl.ProductFlavor
-import com.android.ddmlib.DdmPreferences
-
-import java.util.concurrent.TimeUnit
 
 // Copy the signing.properties.sample file to ~/.sign/signing.properties and adjust the values.
 final File PROD_PROPS_FILE = new File(System.getProperty('user.home'), '.sign/signing.properties')
@@ -13,19 +10,6 @@ final File REPO_PROPS_FILE = new File('repo.properties')
 final Properties PROD_PROPS = loadProperties(PROD_PROPS_FILE)
 final Properties REPO_PROPS = loadProperties(REPO_PROPS_FILE)
 
-final int ADB_TIMEOUT = TimeUnit.MINUTES.toMillis(15)
-final boolean continuousIntegrationBuild = System.getenv('JENKINS_HOME') != null
-final boolean preDexEnabled = hasProperty('pre.dex') ?
-        Boolean.valueOf(getProperty('pre.dex').toString()) :
-        !continuousIntegrationBuild
-if (!preDexEnabled) {
-    println 'Pre-dexing disabled.'
-}
-
-if (continuousIntegrationBuild) {
-    DdmPreferences.setTimeOut(ADB_TIMEOUT)
-    println "Device timeout is ${DdmPreferences.getTimeOut()}ms"
-}
 
 def static getDate() {
     def date = new Date()
@@ -39,7 +23,6 @@ def computeVersionName(label) {
 
 final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_8
 android {
-    // Keep version in sync with /project.properties
     compileSdkVersion 28
 
     compileOptions {
@@ -48,7 +31,7 @@ android {
     }
 
     dexOptions {
-        preDexLibraries = preDexEnabled
+        preDexLibraries = true
         jumboMode = true
     }
 
@@ -177,7 +160,7 @@ dependencies {
     String mockitoCore = 'org.mockito:mockito-core:1.9.5'
     String leakCanaryVersion = '1.6.2'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation "com.google.android.material:material:1.0.0"
     implementation "androidx.core:core:1.0.1"
@@ -188,7 +171,10 @@ dependencies {
     implementation "androidx.preference:preference:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
 
-    implementation 'com.github.michael-rapp:chrome-like-tab-switcher:0.4.4'
+    implementation ('com.github.michael-rapp:chrome-like-tab-switcher:0.4.4') {
+        exclude group: 'org.jetbrains'
+    }
+
     implementation 'com.duolingo.open:rtl-viewpager:1.0.3'
     implementation "com.facebook.fresco:animated-gif:$frescoVersion"
     implementation "com.facebook.fresco:fresco:$frescoVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
     repositories {
         jcenter()
         google()
+        mavenLocal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.0'
@@ -14,5 +15,6 @@ allprojects {
     repositories {
         jcenter()
         google()
+        mavenLocal()
     }
 }

--- a/project.properties
+++ b/project.properties
@@ -1,8 +1,0 @@
-# Used by the Jenkins Android Emulator plugin to install the proper SDK
-# automatically. The plugin does not recognize apps/build.gradle
-#
-# Should be kept in sync with android.compileSdkVersion
-#
-# https://phabricator.wikimedia.org/T138506#2404266
-#
-target=28


### PR DESCRIPTION
If your workstation is offline, it is currently not possible to build and install the app onto a device or emulator, making it difficult to work while traveling.

The issue was because the `chrome-like-tab-switcher` library was depending on an old version of the `jetbrains:annotations` library that we don't provide.

This fixes the issue of building offline, and also cleans up some additional items in our Gradle file.