### PR TITLE
Use correct themed "add icon" in TabActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsAddDescriptionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsAddDescriptionsFragment.kt
@@ -141,7 +141,7 @@ class SuggestedEditsAddDescriptionsFragment : Fragment() {
     private fun updateActionButton() {
         val isAddedDescriptionEmpty = topChild?.addedDescription.isNullOrEmpty()
         if (!isAddedDescriptionEmpty) topChild?.showAddedDescriptionView(topChild?.addedDescription)
-        addDescriptionImage!!.setImageDrawable(requireContext().getDrawable(if (isAddedDescriptionEmpty) R.drawable.ic_add_gray_themed_24dp else R.drawable.ic_mode_edit_white_24dp))
+        addDescriptionImage!!.setImageDrawable(requireContext().getDrawable(if (isAddedDescriptionEmpty) R.drawable.ic_add_gray_white_24dp else R.drawable.ic_mode_edit_white_24dp))
         if (source == EDIT_FEED_TRANSLATE_TITLE_DESC) {
             addDescriptionText?.text = getString(if (isAddedDescriptionEmpty) R.string.suggested_edits_add_translation_button_label else R.string.suggested_edits_edit_translation_button_label)
         } else if (addDescriptionText != null) {

--- a/app/src/main/res/drawable/ic_add_gray_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_gray_white_24dp.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="?attr/main_toolbar_icon_color"
+        android:fillColor="@color/base100"
         android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
 </vector>

--- a/app/src/main/res/layout-land/fragment_suggested_edits_add_descriptions.xml
+++ b/app/src/main/res/layout-land/fragment_suggested_edits_add_descriptions.xml
@@ -130,7 +130,7 @@
                     android:layout_height="match_parent"
                     android:padding="12dp"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_add_gray_themed_24dp"
+                    app:srcCompat="@drawable/ic_add_gray_white_24dp"
                     android:tint="@color/base100" />
             </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_add_to_reading_list.xml
+++ b/app/src/main/res/layout/dialog_add_to_reading_list.xml
@@ -56,7 +56,7 @@
                     android:padding="10dp"
                     android:layout_gravity="center_vertical"
                     android:background="@drawable/button_shape_add_reading_list"
-                    app:srcCompat="@drawable/ic_add_gray_themed_24dp"
+                    app:srcCompat="@drawable/ic_add_gray_white_24dp"
                     app:tint="@color/base30"
                     android:contentDescription="@null"/>
 

--- a/app/src/main/res/layout/fragment_suggested_edits_add_descriptions.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_add_descriptions.xml
@@ -127,7 +127,7 @@
                         android:layout_height="24dp"
                         android:layout_marginEnd="8dp"
                         android:contentDescription="@null"
-                        app:srcCompat="@drawable/ic_add_gray_themed_24dp"
+                        app:srcCompat="@drawable/ic_add_gray_white_24dp"
                         app:tint="@color/base100" />
 
                     <TextView

--- a/app/src/main/res/layout/view_onboarding_language_list.xml
+++ b/app/src/main/res/layout/view_onboarding_language_list.xml
@@ -39,7 +39,7 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:tint="?attr/colorAccent"
-            app:srcCompat="@drawable/ic_add_gray_themed_24dp"
+            app:srcCompat="@drawable/ic_add_gray_white_24dp"
             app:tint="@color/base30"
             android:contentDescription="@null"/>
 

--- a/app/src/main/res/layout/view_wikipedia_language_footer.xml
+++ b/app/src/main/res/layout/view_wikipedia_language_footer.xml
@@ -14,7 +14,7 @@
         android:layout_marginStart="18dp"
         android:layout_marginEnd="12dp"
         android:tint="?colorPrimary"
-        app:srcCompat="@drawable/ic_add_gray_themed_24dp"
+        app:srcCompat="@drawable/ic_add_gray_white_24dp"
         app:tint="@color/base30"
         android:contentDescription="@null"/>
     <TextView


### PR DESCRIPTION
The "add" icon in `TabActivity` was replaced to a non-themed icon, which should be fixed.