### PR TITLE
Remove unnecessary (and destructive) ButterKnife parameters.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,13 +43,6 @@ android {
         testApplicationId 'org.wikipedia.test'
         testInstrumentationRunner "org.wikipedia.WikipediaTestRunner"
         vectorDrawables.useSupportLibrary = true
-
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments('butterknife.minSdk': minSdkVersion.apiString,
-                          'butterknife.debuggable': 'false')
-            }
-        }
     }
 
     sourceSets {


### PR DESCRIPTION
This should fix the weird-seeming issues with using standalone `OnClick` annotations.