### PR TITLE
Set scale type for CAPTCHA image to avoid image being cut off

### DIFF
--- a/app/src/main/res/layout/group_captcha.xml
+++ b/app/src/main/res/layout/group_captcha.xml
@@ -43,6 +43,7 @@
             android:background="@null"
             android:layout_gravity="center_horizontal"
             android:contentDescription="@string/captcha_image"
+            app:actualImageScaleType="fitCenter"
             style="@style/SimpleDraweeViewPlaceholder"/>
         <ProgressBar
             android:id="@+id/captcha_image_progress"


### PR DESCRIPTION
The view should set a `ScaleType` for __CAPTCHA__ image since it is wider than the parent view's width. 

The following screenshot shows the difference between with and without setting up `scaleType="fitCenter"`

![Screenshot_1558116986](https://user-images.githubusercontent.com/2435576/57948018-64e99280-7895-11e9-950c-df0cb4d8b3c4.png)
