### PR TITLE
Improve updating tab count button in PageActivity.

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainActivity.java
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.java
@@ -143,7 +143,7 @@ public class MainActivity extends SingleFragmentActivity<MainFragment>
                     startActivityForResult(TabActivity.newIntent(MainActivity.this), Constants.ACTIVITY_REQUEST_BROWSE_TABS);
                 }
             });
-            tabCountsView.setTabCount(WikipediaApp.getInstance().getTabCount());
+            tabCountsView.updateTabCount();
             tabsItem.setActionView(tabCountsView);
             tabsItem.expandActionView();
         }

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -219,7 +219,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     public void animateTabsButton() {
         Animation anim = AnimationUtils.loadAnimation(this, R.anim.tab_list_zoom_enter);
         tabsButton.startAnimation(anim);
-        tabsButton.setTabCount(WikipediaApp.getInstance().getTabCount());
+        tabsButton.updateTabCount();
     }
 
     private void finishActionMode() {
@@ -232,6 +232,12 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
     public void hideSoftKeyboard() {
         DeviceUtil.hideSoftKeyboard(this);
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        tabsButton.updateTabCount();
+        return false;
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
+++ b/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
@@ -15,7 +15,6 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 
 import org.wikipedia.R;
-import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.views.TabCountsView;
 
@@ -46,7 +45,7 @@ public class PageToolbarHideHandler extends ViewHideHandler {
         baseStatusBarColor = getThemedColor(toolbar.getContext(), R.attr.page_expanded_status_bar_color);
         themedStatusBarColor = getThemedColor(toolbar.getContext(), R.attr.page_status_bar_color);
         toolbarHeight = DimenUtil.getToolbarHeightPx(pageFragment.requireContext());
-        tabsButton.setTabCount(WikipediaApp.getInstance().getTabCount());
+        tabsButton.updateTabCount();
     }
 
     /**

--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
@@ -126,7 +126,7 @@ public class TabActivity extends BaseActivity {
         ButterKnife.bind(this);
         app = WikipediaApp.getInstance();
         funnel.logEnterList(app.getTabCount());
-        tabCountsView.setTabCount(app.getTabCount());
+        tabCountsView.updateTabCount();
         launchedFromPageActivity = getIntent().hasExtra(LAUNCHED_FROM_PAGE_ACTIVITY);
 
         FeedbackUtil.setToolbarButtonLongPressToast(tabCountsView);
@@ -322,7 +322,7 @@ public class TabActivity extends BaseActivity {
                 org.wikipedia.page.tabs.Tab tab = app.getTabList().remove(tabIndex);
                 app.getTabList().add(tab);
             }
-            tabCountsView.setTabCount(app.getTabCount());
+            tabCountsView.updateTabCount();
             cancelled = false;
 
             final int tabUpdateDebounceMillis = 250;
@@ -339,7 +339,7 @@ public class TabActivity extends BaseActivity {
 
         @Override
         public void onTabAdded(@NonNull TabSwitcher tabSwitcher, int index, @NonNull Tab tab, @NonNull Animation animation) {
-            tabCountsView.setTabCount(app.getTabCount());
+            tabCountsView.updateTabCount();
             tabUpdatedTimeMillis = System.currentTimeMillis();
         }
 
@@ -349,7 +349,7 @@ public class TabActivity extends BaseActivity {
             org.wikipedia.page.tabs.Tab appTab = app.getTabList().remove(tabIndex);
 
             funnel.logClose(app.getTabCount(), tabIndex);
-            tabCountsView.setTabCount(app.getTabCount());
+            tabCountsView.updateTabCount();
             setResult(RESULT_LOAD_FROM_BACKSTACK);
             showUndoSnackbar(tab, index, appTab, tabIndex);
             tabUpdatedTimeMillis = System.currentTimeMillis();
@@ -361,7 +361,7 @@ public class TabActivity extends BaseActivity {
             List<org.wikipedia.page.tabs.Tab> appTabs = new ArrayList<>(app.getTabList());
 
             app.getTabList().clear();
-            tabCountsView.setTabCount(0);
+            tabCountsView.updateTabCount();
             setResult(RESULT_LOAD_FROM_BACKSTACK);
             showUndoAllSnackbar(tabs, appTabs);
             tabUpdatedTimeMillis = System.currentTimeMillis();

--- a/app/src/main/java/org/wikipedia/views/TabCountsView.java
+++ b/app/src/main/java/org/wikipedia/views/TabCountsView.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import androidx.annotation.ColorInt;
 
 import org.wikipedia.R;
+import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.ResourceUtil;
 
@@ -51,7 +52,8 @@ public class TabCountsView extends FrameLayout {
         setBackgroundResource(ResourceUtil.getThemedAttributeId(getContext(), R.attr.selectableItemBackgroundBorderless));
     }
 
-    public void setTabCount(int count) {
+    public void updateTabCount() {
+        int count = WikipediaApp.getInstance().getTabCount();
         tabsCountText.setText(String.valueOf(count));
 
         float tabTextSize = TAB_COUNT_TEXT_SIZE_MEDIUM;


### PR DESCRIPTION
The tab count button was actually being updated incorrectly if you open a Search Result in a new tab. This improves the setting of the tab count by putting it in the `onPrepareOptionsMenu` function, where it logically belongs (even though we're not using a proper options menu).
