### PR TITLE
Fix possible crash when rendering News cards.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/news/NewsItem.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsItem.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.restbase.page.RbPageSummary;
 import org.wikipedia.json.annotations.Required;
@@ -17,33 +18,36 @@ import static org.wikipedia.dataclient.Service.PREFERRED_THUMB_SIZE;
 import static org.wikipedia.util.ImageUrlUtil.getUrlForSize;
 
 public final class NewsItem {
-    @SuppressWarnings("unused,NullableProblems") @Required @NonNull private String story;
-    @SuppressWarnings("unused,NullableProblems") @NonNull private List<RbPageSummary> links
+    @SuppressWarnings("unused") @Required @Nullable private String story;
+    @SuppressWarnings("unused") @Nullable private List<RbPageSummary> links
             = Collections.emptyList();
 
     @NonNull String story() {
-        return story;
+        return StringUtils.defaultString(story);
     }
 
     @NonNull public List<RbPageSummary> links() {
-        return links;
+        return links != null ? links : Collections.emptyList();
     }
 
     @NonNull List<NewsLinkCard> linkCards(WikiSite wiki) {
         List<NewsLinkCard> linkCards = new ArrayList<>();
-        for (RbPageSummary link : links) {
+        for (RbPageSummary link : links()) {
+            if (link == null) {
+                continue;
+            }
             linkCards.add(new NewsLinkCard(link, wiki));
         }
         return linkCards;
     }
 
     @Nullable public Uri thumb() {
-        Uri uri = getFirstImageUri(links);
+        Uri uri = getFirstImageUri(links());
         return uri != null ? getUrlForSize(uri, PREFERRED_THUMB_SIZE) : null;
     }
 
     @Nullable Uri featureImage() {
-        return getFirstImageUri(links);
+        return getFirstImageUri(links());
     }
 
     /**
@@ -52,6 +56,9 @@ public final class NewsItem {
      */
     @Nullable private Uri getFirstImageUri(List<RbPageSummary> links) {
         for (RbPageSummary link : links) {
+            if (link == null) {
+                continue;
+            }
             String thumbnail = link.getThumbnailUrl();
             if (thumbnail != null) {
                 return Uri.parse(thumbnail);


### PR DESCRIPTION
Caused indirectly by the same crash as #288, but this will catch even more possible issues.

https://rink.hockeyapp.net/manage/apps/226649/app_versions/669/crash_reasons/272569905