### PR TITLE
Fix the issue of media playback overlaps the navigation bar.

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
@@ -36,6 +36,8 @@ import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.image.FeaturedImage;
 import org.wikipedia.page.Namespace;
 import org.wikipedia.page.PageTitle;
+import org.wikipedia.util.DeviceUtil;
+import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.FileUtil;
 import org.wikipedia.util.PermissionUtil;
@@ -264,6 +266,9 @@ public class GalleryItemFragment extends Fragment {
             L.d("Loading video from url: " + galleryItem.getOriginalVideoSource().getOriginalUrl());
             videoView.setVisibility(View.VISIBLE);
             mediaController = new MediaController(parentActivity);
+            if (!DeviceUtil.isNavigationBarShowing()) {
+                mediaController.setPadding(0, 0, 0, (int) DimenUtil.dpToPx(DimenUtil.getNavigationBarHeight(requireContext())));
+            }
             updateProgressBar(true, true, 0);
             videoView.setMediaController(mediaController);
             videoView.setOnPreparedListener((mp) -> {

--- a/app/src/main/java/org/wikipedia/util/DeviceUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DeviceUtil.java
@@ -10,6 +10,8 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
@@ -112,6 +114,11 @@ public final class DeviceUtil {
             L.d("Location service setting not found.", e);
         }
         return locationMode != Settings.Secure.LOCATION_MODE_OFF;
+    }
+
+    public static boolean isNavigationBarShowing() {
+        // TODO: revisit this if there's no more navigation bar by default.
+        return KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK) && KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_HOME);
     }
 
     private static ConnectivityManager getConnectivityManager() {

--- a/app/src/main/java/org/wikipedia/util/DimenUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DimenUtil.java
@@ -98,6 +98,11 @@ public final class DimenUtil {
         return id > 0 ? DimenUtil.getDimension(id) : 0;
     }
 
+    public static float getNavigationBarHeight(Context context) {
+        int id = getNavigationBarId(context);
+        return id > 0 ? DimenUtil.getDimension(id) : 0;
+    }
+
     private static float getToolbarHeight(Context context) {
         return DimenUtil.roundedPxToDp(getToolbarHeightPx(context));
     }
@@ -120,6 +125,10 @@ public final class DimenUtil {
 
     @DimenRes private static int getStatusBarId(Context context) {
         return context.getResources().getIdentifier("status_bar_height", "dimen", "android");
+    }
+
+    @DimenRes private static int getNavigationBarId(Context context) {
+        return context.getResources().getIdentifier("navigation_bar_height", "dimen", "android");
     }
 
     public static void setViewHeight(View view, int height) {


### PR DESCRIPTION
It is reproducible on my Pixel 3 XL running Android 9.0.

The full-screen mode in the `GalleryActivity` will also hide the navigation bar.

https://phabricator.wikimedia.org/T223948