### PR TITLE
Whoops: bring back the WebView's scroll bar!

### DIFF
--- a/app/src/main/res/layout/fragment_page.xml
+++ b/app/src/main/res/layout/fragment_page.xml
@@ -14,8 +14,7 @@
             <org.wikipedia.views.ObservableWebView
                 android:id="@+id/page_web_view"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:scrollbars="none" />
+                android:layout_height="match_parent" />
 
             <org.wikipedia.page.leadimages.PageHeaderView
                 android:id="@+id/page_header_view"


### PR DESCRIPTION
After we removed the circular thumb-scroller, we forgot to re-enable the default scroll bar on the WebView.