### PR TITLE
Tweaking code logic, naming, and default values in SuggestedEditsTask

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -841,12 +841,12 @@ public final class Prefs {
         setBoolean(R.string.preference_key_suggested_edits_translate_descriptions_unlocked, enabled);
     }
 
-    public static boolean showTranslateDescriptionsTeaserTask() {
-        return getBoolean(R.string.preference_key_show_multilingual_task, true);
+    public static boolean showSuggestedEditsMultilingualTeaserTask() {
+        return getBoolean(R.string.preference_key_show_suggested_edits_multilingual_teaser_task, true);
     }
 
-    public static void setShowTranslateDescriptionsTeaserTask(boolean showTask) {
-        setBoolean(R.string.preference_key_show_multilingual_task, showTask);
+    public static void setShowSuggestedEditsMultilingualTeaserTask(boolean showTask) {
+        setBoolean(R.string.preference_key_show_suggested_edits_multilingual_teaser_task, showTask);
     }
 
     public static boolean shouldShowSuggestedEditsCardsForTesting() {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTask.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTask.kt
@@ -7,10 +7,10 @@ class SuggestedEditsTask {
     var title: String? = null
     var description: String? = null
     var disabled: Boolean = false
-    var imagePlaceHolderShown: Boolean = false
-    var noActionLayout: Boolean = false
-    var enabledPositiveActionString: String? = null
-    var enabledNegativeActionString: String? = null
-    var disabledDescriptionText: String? = null
+    var showImagePlaceholder: Boolean = true
+    var showActionLayout: Boolean = false
+    var unlockActionPositiveButtonString: String? = null
+    var unlockActionNegativeButtonString: String? = null
+    var unlockMessageText: String? = null
     var imageDrawable: Drawable? = null
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTaskView.java
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTaskView.java
@@ -26,11 +26,11 @@ class SuggestedEditsTaskView extends FrameLayout {
     @BindView(R.id.description) TextView description;
     @BindView(R.id.image) ImageView image;
     @BindView(R.id.action_layout) View actionLayout;
-    @BindView(R.id.disabled_action_layout) View disabledActionLayout;
-    @BindView(R.id.enabled_action_layout) View enabledActionLayout;
-    @BindView(R.id.disabled_text) TextView disabledTextView;
-    @BindView(R.id.positive_button) TextView enabledPositiveActionButton;
-    @BindView(R.id.negative_button) TextView enabledNegativeActionButton;
+    @BindView(R.id.unlock_message_container) View unlockMessageContainer;
+    @BindView(R.id.unlock_message_text) TextView unlockMessageText;
+    @BindView(R.id.unlock_actions_container) View unlockActionContainer;
+    @BindView(R.id.unlock_action_positive_button) TextView unlockActionPositiveButton;
+    @BindView(R.id.unlock_action_negative_button) TextView unlockActionNegativeButton;
     private SuggestedEditsTask task;
     private Callback callback;
 
@@ -51,25 +51,25 @@ class SuggestedEditsTaskView extends FrameLayout {
         this.callback = callback;
         title.setText(suggestedEditsTask.getTitle());
         description.setText(suggestedEditsTask.getDescription());
-        image.setVisibility(suggestedEditsTask.getImagePlaceHolderShown() ? VISIBLE : GONE);
+        image.setVisibility(suggestedEditsTask.getShowImagePlaceholder() ? VISIBLE : GONE);
         image.setImageDrawable(suggestedEditsTask.getImageDrawable());
         taskInfoLayout.setAlpha(suggestedEditsTask.getDisabled() ? 0.56f : 1.0f);
-        enabledActionLayout.setVisibility(suggestedEditsTask.getDisabled() ? GONE : VISIBLE);
-        disabledActionLayout.setVisibility(suggestedEditsTask.getDisabled() ? VISIBLE : GONE);
-        disabledTextView.setText(suggestedEditsTask.getDisabledDescriptionText());
-        enabledPositiveActionButton.setText(suggestedEditsTask.getEnabledPositiveActionString());
-        enabledNegativeActionButton.setText(suggestedEditsTask.getEnabledNegativeActionString());
-        actionLayout.setVisibility(suggestedEditsTask.getNoActionLayout() ? GONE : VISIBLE);
+        unlockMessageContainer.setVisibility(suggestedEditsTask.getDisabled() ? VISIBLE : GONE);
+        unlockMessageText.setText(suggestedEditsTask.getUnlockMessageText());
+        unlockActionContainer.setVisibility(suggestedEditsTask.getDisabled() ? GONE : VISIBLE);
+        unlockActionPositiveButton.setText(suggestedEditsTask.getUnlockActionPositiveButtonString());
+        unlockActionNegativeButton.setText(suggestedEditsTask.getUnlockActionNegativeButtonString());
+        actionLayout.setVisibility(suggestedEditsTask.getShowActionLayout() ? VISIBLE : GONE);
     }
 
-    @OnClick(R.id.positive_button)
+    @OnClick(R.id.unlock_action_positive_button)
     void onPositiveClick(View v) {
         if (callback != null) {
             callback.onPositiveActionClick(task);
         }
     }
 
-    @OnClick(R.id.negative_button)
+    @OnClick(R.id.unlock_action_negative_button)
     void onNegativeClick(View v) {
         if (callback != null) {
             callback.onNegativeActionClick(task);

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.java
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.java
@@ -62,10 +62,10 @@ public class SuggestedEditsTasksFragment extends Fragment {
     @BindView(R.id.progress_bar) View progressBar;
 
     private SuggestedEditsTask addDescriptionsTask;
-    private SuggestedEditsTask translateDescriptionsTeaserTask;
     private SuggestedEditsTask translateDescriptionsTask;
     private SuggestedEditsTask addImageCaptionsTask;
     private SuggestedEditsTask translateImageCaptionsTask;
+    private SuggestedEditsTask multilingualTeaserTask;
 
     private List<SuggestedEditsTask> displayedTasks = new ArrayList<>();
     private TaskViewCallback callback = new TaskViewCallback();
@@ -158,41 +158,33 @@ public class SuggestedEditsTasksFragment extends Fragment {
         addDescriptionsTask = new SuggestedEditsTask();
         addDescriptionsTask.setTitle(getString(R.string.suggested_edits_task_add_description_title));
         addDescriptionsTask.setDescription(getString(R.string.suggested_edits_task_add_description_description));
-        addDescriptionsTask.setImagePlaceHolderShown(true);
         addDescriptionsTask.setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.ic_short_text_white_24dp));
-        addDescriptionsTask.setNoActionLayout(true);
-
-        translateDescriptionsTeaserTask = new SuggestedEditsTask();
-        translateDescriptionsTeaserTask.setTitle(getString(R.string.suggested_edits_task_multilingual_title));
-        translateDescriptionsTeaserTask.setDescription(getString(R.string.suggested_edits_task_multilingual_description));
-        translateDescriptionsTeaserTask.setImagePlaceHolderShown(false);
-        translateDescriptionsTeaserTask.setNoActionLayout(false);
-        translateDescriptionsTeaserTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
-        translateDescriptionsTeaserTask.setEnabledPositiveActionString(getString(R.string.suggested_edits_task_multilingual_positive));
-        translateDescriptionsTeaserTask.setEnabledNegativeActionString(getString(R.string.suggested_edits_task_multilingual_negative));
 
         translateDescriptionsTask = new SuggestedEditsTask();
         translateDescriptionsTask.setTitle(getString(R.string.suggested_edits_task_translation_title));
         translateDescriptionsTask.setDescription(getString(R.string.suggested_edits_task_translation_description));
-        translateDescriptionsTask.setImagePlaceHolderShown(true);
-        translateDescriptionsTask.setNoActionLayout(true);
         translateDescriptionsTask.setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.ic_icon_translate_title_descriptions));
-        translateDescriptionsTask.setNoActionLayout(Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
-        translateDescriptionsTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
 
         addImageCaptionsTask = new SuggestedEditsTask();
         addImageCaptionsTask.setTitle(getString(R.string.suggested_edits_task_image_caption_title));
         addImageCaptionsTask.setDescription(getString(R.string.suggested_edits_task_image_caption_description));
-        addImageCaptionsTask.setImagePlaceHolderShown(true);
         addImageCaptionsTask.setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.ic_icon_caption_images));
         addImageCaptionsTask.setDisabled(true);
 
         translateImageCaptionsTask = new SuggestedEditsTask();
         translateImageCaptionsTask.setTitle(getString(R.string.suggested_edits_task_translate_caption_title));
         translateImageCaptionsTask.setDescription(getString(R.string.suggested_edits_task_translate_caption_description));
-        translateImageCaptionsTask.setImagePlaceHolderShown(true);
         translateImageCaptionsTask.setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.ic_icon_translate_title_descriptions));
         translateImageCaptionsTask.setDisabled(true);
+
+        multilingualTeaserTask = new SuggestedEditsTask();
+        multilingualTeaserTask.setTitle(getString(R.string.suggested_edits_task_multilingual_title));
+        multilingualTeaserTask.setDescription(getString(R.string.suggested_edits_task_multilingual_description));
+        multilingualTeaserTask.setShowImagePlaceholder(false);
+        multilingualTeaserTask.setShowActionLayout(true);
+        multilingualTeaserTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
+        multilingualTeaserTask.setUnlockActionPositiveButtonString(getString(R.string.suggested_edits_task_multilingual_positive));
+        multilingualTeaserTask.setUnlockActionNegativeButtonString(getString(R.string.suggested_edits_task_multilingual_negative));
     }
 
     private void updateDisplayedTasks(@Nullable EditorTaskCounts editorTaskCounts) {
@@ -208,15 +200,17 @@ public class SuggestedEditsTasksFragment extends Fragment {
             addDescriptionsTask.setDisabled(!Prefs.isSuggestedEditsAddDescriptionsUnlocked());
 
             if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() < MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
-                if (Prefs.showTranslateDescriptionsTeaserTask()) {
-                    displayedTasks.add(translateDescriptionsTeaserTask);
-                    translateDescriptionsTeaserTask.setDisabledDescriptionText(String.format(getString(R.string.suggested_edits_task_translate_description_edit_disable_text), targetForTranslateDescriptions));
-                    translateDescriptionsTeaserTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
+                if (Prefs.showSuggestedEditsMultilingualTeaserTask()) {
+                    displayedTasks.add(multilingualTeaserTask);
+                    multilingualTeaserTask.setUnlockMessageText(String.format(getString(R.string.suggested_edits_task_translate_description_edit_disable_text), targetForTranslateDescriptions));
+                    multilingualTeaserTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
                 }
             } else {
                 displayedTasks.add(translateDescriptionsTask);
-                translateDescriptionsTask.setDisabledDescriptionText(String.format(getString(R.string.suggested_edits_task_translate_description_edit_disable_text), targetForTranslateDescriptions));
-                translateDescriptionsTask.setDisabled(!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked());
+                translateDescriptionsTask.setUnlockMessageText(String.format(getString(R.string.suggested_edits_task_translate_description_edit_disable_text), targetForTranslateDescriptions));
+                boolean t = true;
+                translateDescriptionsTask.setShowActionLayout(t);
+                translateDescriptionsTask.setDisabled(t);
             }
 
             // TODO: enable image caption tasks.
@@ -268,7 +262,7 @@ public class SuggestedEditsTasksFragment extends Fragment {
     private class TaskViewCallback implements SuggestedEditsTaskView.Callback {
         @Override
         public void onPositiveActionClick(SuggestedEditsTask task) {
-            if (task.equals(translateDescriptionsTeaserTask)) {
+            if (task.equals(multilingualTeaserTask)) {
                 requireActivity().startActivityForResult(WikipediaLanguagesActivity.newIntent(requireActivity(),
                         LanguageSettingsInvokeSource.DESCRIPTION_EDITING.text()), ACTIVITY_REQUEST_ADD_A_LANGUAGE);
             }
@@ -276,11 +270,11 @@ public class SuggestedEditsTasksFragment extends Fragment {
 
         @Override
         public void onNegativeActionClick(SuggestedEditsTask task) {
-            if (task.equals(translateDescriptionsTeaserTask)) {
-                int multilingualTaskPosition = displayedTasks.indexOf(translateDescriptionsTeaserTask);
-                displayedTasks.remove(translateDescriptionsTeaserTask);
+            if (task.equals(multilingualTeaserTask)) {
+                int multilingualTaskPosition = displayedTasks.indexOf(multilingualTeaserTask);
+                displayedTasks.remove(multilingualTeaserTask);
                 tasksRecyclerView.getAdapter().notifyItemChanged(multilingualTaskPosition);
-                Prefs.setShowTranslateDescriptionsTeaserTask(false);
+                Prefs.setShowSuggestedEditsMultilingualTeaserTask(false);
             }
         }
 

--- a/app/src/main/res/layout/view_suggested_edits_task.xml
+++ b/app/src/main/res/layout/view_suggested_edits_task.xml
@@ -10,55 +10,63 @@
     app:cardBackgroundColor="?attr/paper_color"
     app:cardUseCompatPadding="true">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/task_info_layout"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
         android:background="?android:attr/selectableItemBackground">
 
-        <TextView
-            android:id="@+id/title"
-            android:layout_width="0dp"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/task_info_layout"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:fontFamily="sans-serif-medium"
-            android:lineSpacingExtra="10sp"
-            android:textColor="?attr/material_theme_primary_color"
-            android:textSize="14sp"
-            app:layout_constraintEnd_toStartOf="@id/image"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="Add title descriptions" />
+            android:background="?android:attr/selectableItemBackground">
 
-        <TextView
-            android:id="@+id/description"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="16dp"
-            android:lineSpacingExtra="4sp"
-            android:textColor="?attr/material_theme_secondary_color"
-            android:textSize="12sp"
-            app:layout_constraintBottom_toTopOf="@id/action_layout"
-            app:layout_constraintEnd_toStartOf="@id/image"
-            app:layout_constraintStart_toStartOf="@id/title"
-            app:layout_constraintTop_toBottomOf="@id/title"
-            tools:text="Contribute to articles without title descriptions" />
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:fontFamily="sans-serif-medium"
+                android:lineSpacingExtra="10sp"
+                android:textColor="?attr/material_theme_primary_color"
+                android:textSize="14sp"
+                app:layout_constraintEnd_toStartOf="@id/image"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Add title descriptions" />
 
-        <ImageView
-            android:id="@+id/image"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_marginEnd="16dp"
-            android:contentDescription="@null"
-            android:tint="?attr/material_theme_secondary_color"
-            app:layout_constraintBottom_toTopOf="@id/action_layout"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_image_gray_24dp" />
+            <TextView
+                android:id="@+id/description"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:lineSpacingExtra="4sp"
+                android:textColor="?attr/material_theme_secondary_color"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toStartOf="@id/image"
+                app:layout_constraintStart_toStartOf="@id/title"
+                app:layout_constraintTop_toBottomOf="@id/title"
+                app:layout_constraintBottom_toBottomOf="parent"
+                tools:text="Contribute to articles without title descriptions" />
+
+            <ImageView
+                android:id="@+id/image"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_marginEnd="16dp"
+                android:contentDescription="@null"
+                android:tint="?attr/material_theme_secondary_color"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:srcCompat="@drawable/ic_image_gray_24dp" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <FrameLayout
             android:id="@+id/action_layout"
@@ -68,7 +76,7 @@
             app:layout_constraintTop_toBottomOf="@id/description">
 
             <LinearLayout
-                android:id="@+id/disabled_action_layout"
+                android:id="@+id/unlock_message_container"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="?android:attr/colorBackground"
@@ -84,19 +92,18 @@
                     app:srcCompat="@drawable/ic_lock_white_24dp" />
 
                 <TextView
-                    android:id="@+id/disabled_text"
+                    android:id="@+id/unlock_message_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="12dp"
                     android:lineSpacingExtra="4sp"
-                    android:textColor="?attr/material_theme_secondary_color"
+                    android:textColor="?attr/material_theme_primary_color"
                     android:textSize="12sp"
-                    android:textStyle="italic"
                     tools:text="Locked until you’ve made 50 verified in-app edits" />
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/enabled_action_layout"
+                android:id="@+id/unlock_actions_container"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:gravity="end"
@@ -105,7 +112,7 @@
                 android:paddingEnd="16dp">
 
                 <TextView
-                    android:id="@+id/negative_button"
+                    android:id="@+id/unlock_action_negative_button"
                     style="@style/TransparentButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -113,7 +120,7 @@
                     tools:text="Not for me" />
 
                 <TextView
-                    android:id="@+id/positive_button"
+                    android:id="@+id/unlock_action_positive_button"
                     style="@style/TransparentButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -123,6 +130,6 @@
 
         </FrameLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -106,7 +106,7 @@
     <string name="preference_key_show_edit_menu_option_indicator">showEditMenuOptionIndicator</string>
     <string name="preference_key_show_action_feed_indicator">showActionFeedIndicator</string>
     <string name="preference_key_show_edit_tasks_onboarding">showEditTasksOnboarding</string>
-    <string name="preference_key_show_multilingual_task">showMultilingualTask</string>
+    <string name="preference_key_show_suggested_edits_multilingual_teaser_task">showSuggestedEditsMultilingualTeaserTask</string>
     <string name="preference_key_show_suggested_edits_cards_testing">showSuggestedEditsCardsTesting</string>
     <string name="preference_key_logged_out_in_background">loggedOutInBackground</string>
 </resources>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -292,6 +292,10 @@
             android:title="@string/preference_key_show_edit_tasks_onboarding" />
 
         <SwitchPreferenceCompat
+            android:key="@string/preference_key_show_suggested_edits_multilingual_teaser_task"
+            android:title="@string/preference_key_show_suggested_edits_multilingual_teaser_task" />
+
+        <SwitchPreferenceCompat
             android:key="@string/preference_key_suggested_edits_add_descriptions_unlocked"
             android:title="@string/preference_key_suggested_edits_add_descriptions_unlocked" />
 


### PR DESCRIPTION
While doing the task of adding __Translate image caption__ into the `SuggestedEditsTask`, I got confused about the naming and logic.

In this PR:

1. Updated the name of `TranslateDescriptionsTeaserTask` to `SuggestedEditsMultilingualTeaserTask`
2. Updated some default values in `SuggestedEditsTask` so there's no need to set up the value again.
3. Updated the name `disabled_action_layout` to `unlock_message_container`
4. Updated the name `enabled_action_layout` to `unlock_actions_container`
5. Added `preference_key_show_suggested_edits_multilingual_teaser_task` to Dev preference
6. Updated the __unlock message__ to match the design in https://app.zeplin.io/project/57a120b91998d8977642a238/screen/5c77cfa2b062a1bc6644cc93