### PR TITLE
Fix date text clipping at On this day dialog

### DIFF
--- a/app/src/main/res/layout/date_picker_dialog.xml
+++ b/app/src/main/res/layout/date_picker_dialog.xml
@@ -11,9 +11,10 @@
         android:layout_width="320dp"
         android:layout_height="110dp"
         android:background="?attr/main_toolbar_color"
-        android:gravity="center_vertical"
         android:orientation="vertical"
-        android:padding="24dp">
+        android:paddingStart="24dp"
+        android:paddingTop="24dp"
+        android:paddingEnd="24dp">
 
         <TextView
             android:id="@+id/otd"


### PR DESCRIPTION
@dbrant 
I found a bug at `OnThisDayActivity` when I opened the date picker dialog. The bottom of the month's text was clipped. 
I was able to reproduce it on Samsung S8 and on emulators as well.

Solution:
As the `TextView` was in a `LinearLayout` with fix height, I removed the bottom padding as it clipped the bottom of the `TextView` and has no purpose.

See attached image about the issue:
![date_text_bottom_clipped](https://user-images.githubusercontent.com/22046406/58592767-7f464780-8269-11e9-8b88-4f19cccf50d3.png)
