### PR TITLE
Fix: update unlock suggested edits preferences correctly.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
@@ -36,11 +36,12 @@ public final class NotificationEditorTasksHandler {
                 maybeShowEditDescriptionUnlockNotification(context, false);
                 eventToDispatch = new DescriptionEditUnlockEvent(1);
             }
-            if (!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked()
-                    && WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
+            if (!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked()) {
                 Prefs.setSuggestedEditsTranslateDescriptionsUnlocked(true);
-                maybeShowTranslateDescriptionUnlockNotification(context, false);
-                eventToDispatch = new DescriptionEditUnlockEvent(descriptionTargetsPassed);
+                if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION){
+                    maybeShowTranslateDescriptionUnlockNotification(context, false);
+                    eventToDispatch = new DescriptionEditUnlockEvent(descriptionTargetsPassed);
+                }
             }
         } else if (descriptionTargetsPassed > 0) {
             if (!Prefs.isSuggestedEditsAddDescriptionsUnlocked()) {
@@ -71,11 +72,12 @@ public final class NotificationEditorTasksHandler {
                 maybeShowEditCaptionUnlockNotification(context, false);
                 eventToDispatch = new CaptionEditUnlockEvent(1);
             }
-            if (!Prefs.isSuggestedEditsTranslateCaptionsUnlocked()
-                    && WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
+            if (!Prefs.isSuggestedEditsTranslateCaptionsUnlocked()) {
                 Prefs.setSuggestedEditsTranslateCaptionsUnlocked(true);
-                maybeShowTranslateCaptionUnlockNotification(context, false);
-                eventToDispatch = new CaptionEditUnlockEvent(captionTargetsPassed);
+                if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
+                    maybeShowTranslateCaptionUnlockNotification(context, false);
+                    eventToDispatch = new CaptionEditUnlockEvent(captionTargetsPassed);
+                }
             }
         } else if (captionTargetsPassed > 0) {
             if (!Prefs.isSuggestedEditsAddCaptionsUnlocked()) {

--- a/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationEditorTasksHandler.java
@@ -38,7 +38,7 @@ public final class NotificationEditorTasksHandler {
             }
             if (!Prefs.isSuggestedEditsTranslateDescriptionsUnlocked()) {
                 Prefs.setSuggestedEditsTranslateDescriptionsUnlocked(true);
-                if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION){
+                if (WikipediaApp.getInstance().language().getAppLanguageCodes().size() >= MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
                     maybeShowTranslateDescriptionUnlockNotification(context, false);
                     eventToDispatch = new DescriptionEditUnlockEvent(descriptionTargetsPassed);
                 }


### PR DESCRIPTION
To reproduce:
1. Have an account that has 50+ verified description edits.
2. Keep only "English" app language and log out.
3. Log in the same account and go to the Suggested edits
4. You will see the "Multilingual task" card with incorrect messages. It should be the one with "add languages" button