### PR TITLE
Fix possible crash on Tab screen

### DIFF
--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
@@ -284,7 +284,7 @@ public class TabActivity extends BaseActivity {
     private boolean topTabLeadImageEnabled() {
         if (app.getTabCount() > 0) {
             PageTitle pageTitle = app.getTabList().get(app.getTabCount() - 1).getBackStackPositionTitle();
-            return pageTitle != null && !TextUtils.isEmpty(pageTitle.getThumbUrl());
+            return pageTitle != null && (!pageTitle.isMainPage() && !TextUtils.isEmpty(pageTitle.getThumbUrl()));
         }
         return false;
     }

--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
@@ -283,7 +283,8 @@ public class TabActivity extends BaseActivity {
 
     private boolean topTabLeadImageEnabled() {
         if (app.getTabCount() > 0) {
-            return !TextUtils.isEmpty(app.getTabList().get(app.getTabCount() - 1).getBackStackPositionTitle().getThumbUrl());
+            PageTitle pageTitle = app.getTabList().get(app.getTabCount() - 1).getBackStackPositionTitle();
+            return pageTitle != null && !TextUtils.isEmpty(pageTitle.getThumbUrl());
         }
         return false;
     }


### PR DESCRIPTION
https://rink.hockeyapp.net/manage/apps/226649/app_versions/678/crash_reasons/275174097

Sometime it will crash when getting a `null` PageTitle object.

This PR also add an additional logic of the Main page since the `getThumbUrl()` from the Main page is not empty.