### PR TITLE
Use correct text color for Suggested edits "ADD" button

### DIFF
--- a/app/src/main/res/layout-land/fragment_suggested_edits_add_descriptions.xml
+++ b/app/src/main/res/layout-land/fragment_suggested_edits_add_descriptions.xml
@@ -130,8 +130,7 @@
                     android:layout_height="match_parent"
                     android:padding="12dp"
                     android:contentDescription="@null"
-                    app:srcCompat="@drawable/ic_add_gray_white_24dp"
-                    android:tint="@color/base100" />
+                    app:srcCompat="@drawable/ic_add_gray_white_24dp" />
             </LinearLayout>
 
             <androidx.appcompat.widget.AppCompatImageView

--- a/app/src/main/res/layout/fragment_suggested_edits_add_descriptions.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_add_descriptions.xml
@@ -129,8 +129,7 @@
                         android:layout_height="24dp"
                         android:layout_marginEnd="8dp"
                         android:contentDescription="@null"
-                        app:srcCompat="@drawable/ic_add_gray_white_24dp"
-                        app:tint="@color/base100" />
+                        app:srcCompat="@drawable/ic_add_gray_white_24dp" />
 
                     <TextView
                         android:id="@+id/addDescriptionText"
@@ -138,7 +137,7 @@
                         android:layout_height="wrap_content"
                         android:text="@string/suggested_edits_add_description_button"
                         android:textAllCaps="true"
-                        android:textColor="?attr/paper_color" />
+                        android:textColor="@color/base100" />
                 </LinearLayout>
             </FrameLayout>
 


### PR DESCRIPTION
- The "add" icon does not need to tint since it contains the correct color itself.
- The color of the button text should be `@color/base100` instead of themed colors.