### PR TITLE
Fix the "edit" icon in Suggested edits has incorrect color

### DIFF
--- a/app/src/main/res/layout-land/fragment_suggested_edits_add_descriptions.xml
+++ b/app/src/main/res/layout-land/fragment_suggested_edits_add_descriptions.xml
@@ -130,6 +130,7 @@
                     android:layout_height="match_parent"
                     android:padding="12dp"
                     android:contentDescription="@null"
+                    android:tint="@color/base100"
                     app:srcCompat="@drawable/ic_add_gray_white_24dp" />
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_suggested_edits_add_descriptions.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_add_descriptions.xml
@@ -129,6 +129,7 @@
                         android:layout_height="24dp"
                         android:layout_marginEnd="8dp"
                         android:contentDescription="@null"
+                        android:tint="@color/base100"
                         app:srcCompat="@drawable/ic_add_gray_white_24dp" />
 
                     <TextView


### PR DESCRIPTION
The "ADD" button actually needs the `android:tint="@color/base100"` since the "edit" icon is not in white.