### PR TITLE
Fix unlocking of Left Nav menu upon adding captions.

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainDrawerView.java
+++ b/app/src/main/java/org/wikipedia/main/MainDrawerView.java
@@ -70,7 +70,8 @@ public class MainDrawerView extends ScrollView {
             accountAvatar.setVisibility(View.VISIBLE);
             accountWikiGlobe.setVisibility(View.GONE);
             notificationsContainer.setVisibility(View.VISIBLE);
-            if (Prefs.isSuggestedEditsAddDescriptionsUnlocked()) {
+            if (Prefs.isSuggestedEditsAddDescriptionsUnlocked()
+                    || Prefs.isSuggestedEditsAddCaptionsUnlocked()) {
                 editTasksContainer.setVisibility(VISIBLE);
             }
             maybeShowIndicatorDots();


### PR DESCRIPTION
The "Suggested edits" menu item wasn't being properly unlocked if the user makes only caption edits, and no description edits.