### PR TITLE
Fix: the translation button visibility in GalleryActiviy

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -630,10 +630,12 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         boolean allowTranslate = false;
         // and if we have another language in which the caption doesn't exist, then offer
         // it to be translatable.
-        for (String lang : app.language().getAppLanguageCodes()) {
-            if (!item.getStructuredCaptions().containsKey(lang)) {
-                allowTranslate = true;
-                break;
+        if (app.language().getAppLanguageCodes().size() > 1) {
+            for (String lang : app.language().getAppLanguageCodes()) {
+                if (!item.getStructuredCaptions().containsKey(lang)) {
+                    allowTranslate = true;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
The translation button should not show if the user only has one language set.