### PR TITLE
Fix: crash happens when tapping on ImagePreviewDialog if no metadata in SuggestedEditsSummary

### DIFF
--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -5,13 +5,19 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.view.ViewGroup
-import androidx.annotation.NonNull
 import androidx.annotation.Nullable
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.dialog_image_preview.*
 import kotlinx.android.synthetic.main.view_image_detail.view.*
 import org.wikipedia.Constants
 import org.wikipedia.R
+import org.wikipedia.dataclient.ServiceFactory
+import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.json.GsonMarshaller
 import org.wikipedia.json.GsonUnmarshaller
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
@@ -23,10 +29,10 @@ import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
 import org.wikipedia.util.log.L
 
-
 class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.OnDismissListener {
 
     private lateinit var suggestedEditsSummary: SuggestedEditsSummary
+    private val disposables = CompositeDisposable()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val rootView = inflater.inflate(R.layout.dialog_image_preview, container)
@@ -37,52 +43,85 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        progressBar!!.visibility = View.VISIBLE
+        progressBar!!.visibility = VISIBLE
         toolbarView.setOnClickListener { dismiss() }
         imagePageCommonsLinkContainer.setOnClickListener {
             dismiss()
             UriUtil.visitInExternalBrowser(context,
                     Uri.parse(String.format(getString(R.string.suggested_edits_image_file_page_commons_link), suggestedEditsSummary.title)))
         }
-        setImageDetails()
+
+        titleText!!.text = StringUtil.fromHtml(StringUtil.removeNamespace(suggestedEditsSummary.title))
+        loadImage(ImageUrlUtil.getUrlForPreferredSize(suggestedEditsSummary.originalUrl!!, Constants.PREFERRED_GALLERY_IMAGE_SIZE))
+        loadImageInfoIfNeeded()
     }
 
     override fun onDestroyView() {
         toolbarView!!.setOnClickListener(null)
+        disposables.clear()
         super.onDestroyView()
     }
 
+    private fun showError(caught: Throwable?) {
+        dialogDetailContainer.layoutTransition = null
+        dialogDetailContainer.minimumHeight = 0
+        progressBar.visibility = GONE
+        detailsHolder.visibility = GONE
+        galleryImage.visibility = GONE
+        moreInfoContainer.visibility = GONE
+        errorView.visibility = VISIBLE
+        errorView.setError(caught)
+    }
+
+    private fun loadImageInfoIfNeeded() {
+        if (suggestedEditsSummary.metadata == null) {
+            disposables.add(ServiceFactory.get(WikiSite.forLanguageCode(suggestedEditsSummary.lang)).getImageExtMetadata(suggestedEditsSummary.title)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .doFinally{ setImageDetails() }
+                    .subscribe({ response ->
+                        val page = response.query()!!.pages()!![0]
+                        if (page.imageInfo() != null) {
+                            val imageInfo = page.imageInfo()!!
+                            suggestedEditsSummary.timestamp = imageInfo.timestamp
+                            suggestedEditsSummary.user = imageInfo.user
+                            suggestedEditsSummary.metadata = imageInfo.metadata
+                        }
+                    }, { caught ->
+                        L.e(caught)
+                        showError(caught)
+                    }))
+        } else {
+            setImageDetails()
+        }
+    }
+
     private fun setImageDetails() {
-        loadImage(ImageUrlUtil.getUrlForPreferredSize(suggestedEditsSummary.originalUrl!!, Constants.PREFERRED_GALLERY_IMAGE_SIZE))
-        titleText!!.text = StringUtil.fromHtml(StringUtil.removeNamespace(suggestedEditsSummary.title))
-        addDetailPortion(getString(R.string.suggested_edits_image_preview_dialog_caption_title), StringUtil.fromHtml(suggestedEditsSummary.description).toString(), false)
-        addDetailPortion(getString(R.string.suggested_edits_image_preview_dialog_artist), StringUtil.fromHtml(suggestedEditsSummary.metadata!!.artist()!!.value()).toString(), false)
-        addDetailPortion(getString(R.string.suggested_edits_image_preview_dialog_date), suggestedEditsSummary.metadata!!.dateTime()!!.value(), false)
-        addDetailPortion(getString(R.string.suggested_edits_image_preview_dialog_source), suggestedEditsSummary.metadata!!.imageDescription()!!.source(), true)
-        addDetailPortion(getString(R.string.suggested_edits_image_preview_dialog_licensing), suggestedEditsSummary.metadata!!.licenseShortName()!!.value(), true)
+        addDetailPortion(R.string.suggested_edits_image_preview_dialog_caption_title, suggestedEditsSummary.description, false)
+        addDetailPortion(R.string.suggested_edits_image_preview_dialog_artist, suggestedEditsSummary.metadata!!.artist()!!.value(), false)
+        addDetailPortion(R.string.suggested_edits_image_preview_dialog_date, suggestedEditsSummary.metadata!!.dateTime()!!.value(), false)
+        addDetailPortion(R.string.suggested_edits_image_preview_dialog_source, suggestedEditsSummary.metadata!!.imageDescription()!!.source(), true)
+        addDetailPortion(R.string.suggested_edits_image_preview_dialog_licensing, suggestedEditsSummary.metadata!!.licenseShortName()!!.value(), true)
         detailsHolder.requestLayout()
     }
 
-    private fun addDetailPortion(@NonNull title: String, @Nullable detail: String?, shouldAddAccentTint: Boolean) {
+    private fun addDetailPortion(titleRes: Int, @Nullable detail: String?, shouldAddAccentTint: Boolean) {
         if (!detail.isNullOrEmpty()) {
             val view = ImageDetailView(requireContext())
-            view.titleTextView.text = title
+            view.titleTextView.text = getString(titleRes)
             if (shouldAddAccentTint) {
                 view.detailTextView.setTextColor(ResourceUtil.getThemedColor(context!!, R.attr.colorAccent))
             }
-            view.detailTextView.text = detail
+            view.detailTextView.text = StringUtil.fromHtml(detail)
             detailsHolder.addView(view)
         }
     }
 
     private fun loadImage(url: String?) {
-        progressBar!!.visibility = View.GONE
-
-        galleryImage.visibility = View.VISIBLE
+        progressBar!!.visibility = GONE
+        galleryImage.visibility = VISIBLE
         L.v("Loading image from url: $url")
-
         ViewUtil.loadImageUrlInto(galleryImage, url)
-
     }
 
     companion object {
@@ -95,6 +134,5 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
             dialog.arguments = args
             return dialog
         }
-
     }
 }

--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -14,7 +14,6 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.dialog_image_preview.*
 import kotlinx.android.synthetic.main.view_image_detail.view.*
-import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
@@ -22,7 +21,6 @@ import org.wikipedia.json.GsonMarshaller
 import org.wikipedia.json.GsonUnmarshaller
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.suggestededits.SuggestedEditsSummary
-import org.wikipedia.util.ImageUrlUtil
 import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
@@ -52,7 +50,7 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
         }
 
         titleText!!.text = StringUtil.fromHtml(StringUtil.removeNamespace(suggestedEditsSummary.title))
-        loadImage(ImageUrlUtil.getUrlForPreferredSize(suggestedEditsSummary.originalUrl!!, Constants.PREFERRED_GALLERY_IMAGE_SIZE))
+        loadImage(suggestedEditsSummary.thumbnailUrl)
         loadImageInfoIfNeeded()
     }
 

--- a/app/src/main/res/layout/dialog_image_preview.xml
+++ b/app/src/main/res/layout/dialog_image_preview.xml
@@ -125,12 +125,14 @@
             </LinearLayout>
 
             <org.wikipedia.page.linkpreview.LinkPreviewErrorView
-                android:id="@+id/imageLinkErrorContainer"
+                android:id="@+id/errorView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center_horizontal"
                 android:orientation="vertical"
-                android:visibility="gone" />
+                android:visibility="gone"
+                android:layout_marginTop="32dp"
+                android:layout_marginBottom="32dp"/>
         </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Steps to reproduce:
1. Go to any article page
2. Tap on the lead image and click the `Translate caption` button
3. Tap on the bottom bar to open the `ImagePreviewDialog`.

This PR also fixes the issue that the `errorView` does not work properly if an error happens. 