### PR TITLE
Widen the edit icon clickable area in Gallery

### DIFF
--- a/app/src/main/res/layout/activity_gallery.xml
+++ b/app/src/main/res/layout/activity_gallery.xml
@@ -89,8 +89,10 @@
 
             <ImageView
                 android:id="@+id/gallery_caption_edit_button"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:padding="6dp"
+                android:layout_marginTop="-6dp"
                 app:srcCompat="@drawable/ic_mode_edit_white_24dp"
                 app:tint="@color/base90"
                 android:background="?attr/selectableItemBackgroundBorderless"
@@ -115,7 +117,7 @@
 
             <LinearLayout
                 android:id="@+id/gallery_caption_translate_button"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="16dp"
                 android:foreground="?attr/selectableItemBackgroundBorderless">


### PR DESCRIPTION
`#4` in https://phabricator.wikimedia.org/T225635

This PR also shorten the width of the translate button to `wrap_content`