### PR TITLE
Use correct SuggestedEditsSummary for ImagePreviewDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.java
@@ -76,8 +76,8 @@ public class DescriptionEditActivity extends SingleFragmentActivity<DescriptionE
     @Override
     public void onBottomBarContainerClicked(@NonNull InvokeSource invokeSource) {
         SuggestedEditsSummary summary;
-        if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION
-                || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+
+        if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
             summary = GsonUnmarshaller.unmarshal(SuggestedEditsSummary.class, getIntent().getStringExtra(EXTRA_TARGET_SUMMARY));
         } else {
             summary = GsonUnmarshaller.unmarshal(SuggestedEditsSummary.class, getIntent().getStringExtra(EXTRA_SOURCE_SUMMARY));

--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -95,8 +95,7 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
     }
 
     private fun setImageDetails() {
-        addDetailPortion(R.string.suggested_edits_image_preview_dialog_caption_title,
-                if (suggestedEditsSummary.description.isNullOrEmpty()) suggestedEditsSummary.extractHtml else suggestedEditsSummary.description, false)
+        addDetailPortion(R.string.suggested_edits_image_preview_dialog_caption_title, suggestedEditsSummary.description, false)
         addDetailPortion(R.string.suggested_edits_image_preview_dialog_artist, suggestedEditsSummary.metadata!!.artist(), false)
         addDetailPortion(R.string.suggested_edits_image_preview_dialog_date, suggestedEditsSummary.metadata!!.dateTime(), false)
         addDetailPortion(R.string.suggested_edits_image_preview_dialog_source, suggestedEditsSummary.metadata!!.imageDescriptionSource(), true)

--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -95,7 +95,8 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
     }
 
     private fun setImageDetails() {
-        addDetailPortion(R.string.suggested_edits_image_preview_dialog_caption_title, suggestedEditsSummary.description, false)
+        addDetailPortion(R.string.suggested_edits_image_preview_dialog_caption_title,
+                if (suggestedEditsSummary.description.isNullOrEmpty()) suggestedEditsSummary.extractHtml else suggestedEditsSummary.description, false)
         addDetailPortion(R.string.suggested_edits_image_preview_dialog_artist, suggestedEditsSummary.metadata!!.artist(), false)
         addDetailPortion(R.string.suggested_edits_image_preview_dialog_date, suggestedEditsSummary.metadata!!.dateTime(), false)
         addDetailPortion(R.string.suggested_edits_image_preview_dialog_source, suggestedEditsSummary.metadata!!.imageDescriptionSource(), true)


### PR DESCRIPTION
`#8` in https://phabricator.wikimedia.org/T225635

The source and target `SuggestedEditsSummary` for image caption are basically the same, and only the source contains the description (or caption).