### PR TITLE
Make bottom bar in Suggested edits consistent and update image view ratio in ImagePreviewDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditBottomBarView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditBottomBarView.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.constraintlayout.widget.ConstraintLayout
 import kotlinx.android.synthetic.main.view_description_edit_read_article_bar.view.*
-import org.wikipedia.Constants.InvokeSource
-import org.wikipedia.Constants.InvokeSource.*
 import org.wikipedia.R
 import org.wikipedia.suggestededits.SuggestedEditsSummary
 import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
@@ -29,41 +27,15 @@ class DescriptionEditBottomBarView @JvmOverloads constructor(
         visibility = GONE
     }
 
-    fun setSummary(summary: SuggestedEditsSummary, invokeSource: InvokeSource) {
+    fun setSummary(summary: SuggestedEditsSummary) {
         setConditionalLayoutDirection(this, summary.lang)
         viewArticleTitle!!.text = StringUtil.fromHtml(summary.displayTitle)
-        if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION ||
-                invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
-            setImageDetails(summary)
-        } else {
-            setArticleDetails(summary)
-        }
-        show()
-    }
-
-    private fun setArticleDetails(summary: SuggestedEditsSummary) {
         if (summary.thumbnailUrl.isNullOrEmpty()) {
-            viewArticleImage!!.visibility = GONE
-        } else {
-            viewArticleImage!!.visibility = VISIBLE
-            ViewUtil.loadImageUrlInto(viewArticleImage!!, summary.thumbnailUrl)
-        }
-
-        viewImageThumbnail.visibility = GONE
-        viewDownChevron.visibility = GONE
-        viewReadButton.visibility = VISIBLE
-    }
-
-    private fun setImageDetails(summary: SuggestedEditsSummary) {
-        if (summary.thumbnailUrl!!.isEmpty()) {
-            viewImageThumbnail!!.visibility = GONE
+            viewImageThumbnail.visibility = GONE
         } else {
             viewImageThumbnail.visibility = VISIBLE
-            ViewUtil.loadImageUrlInto(viewImageThumbnail!!, summary.thumbnailUrl)
+            ViewUtil.loadImageUrlInto(viewImageThumbnail, summary.thumbnailUrl)
         }
-
-        viewDownChevron.visibility = VISIBLE
-        viewArticleImage.visibility = GONE
-        viewReadButton.visibility = GONE
+        show()
     }
 }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
@@ -210,7 +210,7 @@ public class DescriptionEditView extends LinearLayout {
     }
 
     private void setUpBottomBar() {
-        bottomBarContainer.setSummary(suggestedEditsSummary, invokeSource);
+        bottomBarContainer.setSummary(suggestedEditsSummary);
         bottomBarContainer.setOnClickListener(view -> performReadArticleClick());
     }
 

--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -49,7 +49,7 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
                     Uri.parse(String.format(getString(R.string.suggested_edits_image_file_page_commons_link), suggestedEditsSummary.title)))
         }
 
-        titleText!!.text = StringUtil.fromHtml(StringUtil.removeNamespace(suggestedEditsSummary.title))
+        titleText!!.text = StringUtil.fromHtml(suggestedEditsSummary.displayTitle)
         loadImage(suggestedEditsSummary.thumbnailUrl)
         loadImageInfoIfNeeded()
     }

--- a/app/src/main/res/layout/dialog_image_preview.xml
+++ b/app/src/main/res/layout/dialog_image_preview.xml
@@ -51,6 +51,7 @@
                     android:paddingBottom="4dp"
                     android:textColor="?attr/primary_text_color"
                     android:textSize="14sp"
+                    android:layout_marginEnd="16dp"
                     tools:text="Lorem ipsum" />
             </LinearLayout>
 
@@ -58,8 +59,8 @@
                 android:id="@+id/galleryImage"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:adjustViewBounds="true"
                 android:contentDescription="@null"
+                app:viewAspectRatio="1.33"
                 app:actualImageScaleType="fitCenter" />
 
             <LinearLayout

--- a/app/src/main/res/layout/view_description_edit_read_article_bar.xml
+++ b/app/src/main/res/layout/view_description_edit_read_article_bar.xml
@@ -16,34 +16,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <FrameLayout
-        android:id="@+id/leftViewContainer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
+    <ImageView
+        android:id="@+id/viewDownChevron"
+        android:layout_width="@dimen/bottom_toolbar_icon_size"
+        android:layout_height="@dimen/bottom_toolbar_icon_size"
+        android:layout_gravity="center_vertical"
+        android:contentDescription="@null"
+        android:padding="@dimen/bottom_toolbar_item_padding"
+        android:tint="?attr/main_toolbar_icon_color"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-        <com.facebook.drawee.view.SimpleDraweeView
-            android:id="@+id/viewArticleImage"
-            style="@style/SimpleDraweeViewPlaceholder"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="8dp"
-            android:layout_marginEnd="16dp"
-            android:contentDescription="@null"/>
-
-        <ImageView
-            android:id="@+id/viewDownChevron"
-            android:layout_width="@dimen/bottom_toolbar_icon_size"
-            android:layout_height="@dimen/bottom_toolbar_icon_size"
-            android:layout_gravity="center_vertical"
-            android:contentDescription="@null"
-            android:padding="@dimen/bottom_toolbar_item_padding"
-            android:layout_marginStart="-16dp"
-            android:tint="?attr/main_toolbar_icon_color"
-            app:srcCompat="@drawable/ic_keyboard_arrow_up_black_24dp"/>
-    </FrameLayout>
+        app:layout_constraintStart_toStartOf="parent"
+        app:srcCompat="@drawable/ic_keyboard_arrow_up_black_24dp"/>
 
     <TextView
         android:id="@+id/viewArticleTitle"
@@ -56,42 +39,25 @@
         android:textSize="14sp"
         android:maxLines="2"
         android:ellipsize="end"
+        android:layout_marginEnd="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/leftViewContainer"
-        app:layout_constraintEnd_toStartOf="@+id/rightViewContainer"
+        app:layout_constraintStart_toEndOf="@+id/viewDownChevron"
+        app:layout_constraintEnd_toStartOf="@+id/viewImageThumbnail"
         app:layout_constraintTop_toBottomOf="@+id/viewDivider"
         app:layout_constraintHorizontal_weight="1" />
 
-    <FrameLayout
-        android:id="@+id/rightViewContainer"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:layout_marginStart="16dp"
+    <com.facebook.drawee.view.SimpleDraweeView
+        android:id="@+id/viewImageThumbnail"
+        style="@style/SimpleDraweeViewPlaceholder"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center"
+        android:visibility="gone"
         android:layout_marginEnd="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/viewArticleTitle"
         app:layout_constraintTop_toBottomOf="@+id/viewDivider"
-        app:layout_constraintVertical_weight="1">
-
-        <TextView
-            android:id="@+id/viewReadButton"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center_vertical"
-            android:text="@string/description_edit_read"
-            android:textAllCaps="true"
-            android:textColor="?attr/material_theme_secondary_color"
-            android:textSize="14sp" />
-
-        <com.facebook.drawee.view.SimpleDraweeView
-            android:id="@+id/viewImageThumbnail"
-            style="@style/SimpleDraweeViewPlaceholder"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_gravity="center"
-            android:visibility="gone" />
-    </FrameLayout>
+        app:layout_constraintVertical_weight="1" />
 
 </merge>


### PR DESCRIPTION
`#10` in https://phabricator.wikimedia.org/T225635
The `ViewGroup`s are not necessary anymore, and we can make it simpler.
And also update the title in `ImagePreviewDialog` to make it consistent with the title in bottom bar view.

`#25` in https://phabricator.wikimedia.org/T225635
Make the image has correct `wrap_content` to the height.