### PR TITLE
Fix tallying of suggested edit milestones.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
@@ -48,7 +48,7 @@ public class EditorTaskCounts {
         }
         int count = 0;
         for (int target : targetList) {
-            if (maxPassed > target) {
+            if (maxPassed >= target) {
                 count++;
             }
         }
@@ -93,7 +93,7 @@ public class EditorTaskCounts {
         }
         int count = 0;
         for (int target : targetList) {
-            if (maxPassed > target) {
+            if (maxPassed >= target) {
                 count++;
             }
         }

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
@@ -40,12 +40,16 @@ public class EditorTaskCounts {
     public int getDescriptionEditTargetsPassedCount() {
         List<Integer> targetList = getDescriptionEditTargets();
         List<Integer> passedList = getDescriptionEditTargetsPassed();
+        int maxPassed = 0;
+        for (int passed : passedList) {
+            if (passed > maxPassed) {
+                maxPassed = passed;
+            }
+        }
         int count = 0;
-        if (!targetList.isEmpty() && !passedList.isEmpty()) {
-            for (int target : targetList) {
-                if (passedList.contains(target)) {
-                    count++;
-                }
+        for (int target : targetList) {
+            if (maxPassed > target) {
+                count++;
             }
         }
         return count;
@@ -81,12 +85,16 @@ public class EditorTaskCounts {
     public int getCaptionEditTargetsPassedCount() {
         List<Integer> targetList = getCaptionEditTargets();
         List<Integer> passedList = getCaptionEditTargetsPassed();
+        int maxPassed = 0;
+        for (int passed : passedList) {
+            if (passed > maxPassed) {
+                maxPassed = passed;
+            }
+        }
         int count = 0;
-        if (!targetList.isEmpty() && !passedList.isEmpty()) {
-            for (int target : targetList) {
-                if (passedList.contains(target)) {
-                    count++;
-                }
+        for (int target : targetList) {
+            if (maxPassed > target) {
+                count++;
             }
         }
         return count;


### PR DESCRIPTION
Due to a quirk of the server-side logic, the "actual" milestones reported by the API might not exactly match the "theoretical" milestones. This PR updates the counting logic to properly determine the number of milestones passed by the user, in all cases.
