### PR TITLE
Fix: Use localized language names in DescriptionEditView

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
@@ -157,10 +157,10 @@ public class DescriptionEditView extends LinearLayout {
     private CharSequence getLabelText(@NonNull String lang) {
         if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
             return getContext().getString(R.string.description_edit_text_hint_per_language,
-                    WikipediaApp.getInstance().language().getAppLanguageCanonicalName(lang));
+                    WikipediaApp.getInstance().language().getAppLanguageLocalizedName(lang));
         } else if (invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
             return getContext().getString(R.string.description_edit_caption_hint_per_language,
-                    WikipediaApp.getInstance().language().getAppLanguageCanonicalName(lang));
+                    WikipediaApp.getInstance().language().getAppLanguageLocalizedName(lang));
         } else if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
             return getContext().getString(R.string.description_edit_description);
         } else {
@@ -171,12 +171,12 @@ public class DescriptionEditView extends LinearLayout {
     private CharSequence getHintText(@NonNull String lang) {
         if (invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
             return getContext().getString(R.string.description_edit_caption_hint_per_language,
-                    WikipediaApp.getInstance().language().getAppLanguageCanonicalName(lang));
+                    WikipediaApp.getInstance().language().getAppLanguageLocalizedName(lang));
         } else if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
             return getContext().getString(R.string.description_edit_caption_hint);
         } else {
             return getContext().getString(R.string.description_edit_text_hint_per_language,
-                    WikipediaApp.getInstance().language().getAppLanguageCanonicalName(lang));
+                    WikipediaApp.getInstance().language().getAppLanguageLocalizedName(lang));
         }
     }
 


### PR DESCRIPTION
Language names need to be according to the system language. so changing it to Localized names.
**Phab**: https://phabricator.wikimedia.org/T225874