### PR TITLE
Fix the /zh/ deep link always shows error page

### DIFF
--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -130,7 +130,7 @@ public final class UriUtil {
         return removeFragment(removeLinkPrefix(url)).replace("_", " ");
     }
 
-    /** Get language variant code from a Uri, e.g. "zh-*", otherwise returns empty string. */
+    /** Get language variant code from a Uri, e.g. "zh*", otherwise returns empty string. */
     @NonNull
     public static String getLanguageVariantFromUri(@NonNull Uri uri) {
         if (TextUtils.isEmpty(uri.getPath())) {
@@ -143,7 +143,7 @@ public final class UriUtil {
     /** For internal links only */
     @NonNull
     public static String removeInternalLinkPrefix(@NonNull String link) {
-        return link.replaceFirst("/wiki/|/zh-.*/", "");
+        return link.replaceFirst("/wiki/|/zh.*/", "");
     }
 
     /** For links that could be internal or external links */

--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -130,7 +130,7 @@ public final class UriUtil {
         return removeFragment(removeLinkPrefix(url)).replace("_", " ");
     }
 
-    /** Get language variant code from a Uri, e.g. "zh*", otherwise returns empty string. */
+    /** Get language variant code from a Uri, e.g. "zh.*", otherwise returns empty string. */
     @NonNull
     public static String getLanguageVariantFromUri(@NonNull Uri uri) {
         if (TextUtils.isEmpty(uri.getPath())) {


### PR DESCRIPTION
We've changed the deep link logic in #331 but forgot to update the method of removing the link prefix. This will cause the `/zh/` link always shows an error page.

https://phabricator.wikimedia.org/T224788