### PR TITLE
Fix analytics of the first impression of suggested edit card.

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
@@ -74,6 +74,7 @@ class SuggestedEditsCardsFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         retainInstance = true
+        source = arguments?.getSerializable(EXTRA_SOURCE) as InvokeSource
 
         // Record the first impression, since the ViewPager doesn't send an event for the first topmost item.
         SuggestedEditsFunnel.get().impression(source)
@@ -81,7 +82,6 @@ class SuggestedEditsCardsFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
-        source = arguments?.getSerializable(EXTRA_SOURCE) as InvokeSource
         return inflater.inflate(R.layout.fragment_suggested_edits_cards, container, false)
     }
 


### PR DESCRIPTION
The `source` field gets deserialized in `onCreateView()`, whereas the funnel for the initial impression gets called in `onCreate()` which happens earlier, and uses the default value for `source`.

https://phabricator.wikimedia.org/T225439