### PR TITLE
Fix padding around suggested edit card.

### DIFF
--- a/app/src/main/res/layout/fragment_suggested_edits_cards.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_cards.xml
@@ -72,8 +72,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:layout_constraintBottom_toTopOf="@id/bottomButtonContainer"
-            app:layout_constraintTop_toBottomOf="@id/wikiLanguageDropdownContainer"
-            app:layout_constraintVertical_weight="1" />
+            app:layout_constraintTop_toBottomOf="@id/wikiLanguageDropdownContainer" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/bottomButtonContainer"

--- a/app/src/main/res/layout/fragment_suggested_edits_cards_item.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_cards_item.xml
@@ -4,6 +4,7 @@
     android:id="@+id/suggestedEditsItemRootView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingTop="4dp"
     android:paddingBottom="20dp">
 
     <androidx.cardview.widget.CardView
@@ -13,7 +14,6 @@
         android:layout_gravity="center_vertical"
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"
-        android:layout_marginBottom="20dp"
         android:clickable="true"
         android:focusable="true"
         android:foreground="?attr/selectableItemBackground"


### PR DESCRIPTION
If you look closely, the top border of the suggested edit card is cut off (overlapped by the toolbar).