### PR TITLE
Suggested edits: Removed date from feed card

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCard.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCard.kt
@@ -7,7 +7,6 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.feed.model.CardType
 import org.wikipedia.feed.model.WikiSiteCard
 import org.wikipedia.suggestededits.SuggestedEditsSummary
-import org.wikipedia.util.DateUtil
 
 class SuggestedEditsCard(wiki: WikiSite,
                          val invokeSource: InvokeSource,
@@ -21,9 +20,5 @@ class SuggestedEditsCard(wiki: WikiSite,
 
     override fun title(): String {
         return WikipediaApp.getInstance().getString(R.string.suggested_edits_feed_card_title)
-    }
-
-    override fun subtitle(): String {
-        return DateUtil.getFeedCardDateString(DateUtil.getDefaultDateFor(age))
     }
 }

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -108,7 +108,6 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
 
     private fun header(card: SuggestedEditsCard) {
         headerView!!.setTitle(card.title())
-                .setSubtitle(card.subtitle())
                 .setImage(R.drawable.ic_mode_edit_white_24dp)
                 .setImageCircleColor(R.color.base30)
                 .setLangCode(if (card.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION || card.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) card.wikiSite().languageCode() else "")


### PR DESCRIPTION
Remove date completely from all Suggested edit cards, since it’s not really relevant for it.
Phab: https://phabricator.wikimedia.org/T224600