### PR TITLE
Show the correct title when editing and reviewing article description and image caption

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
@@ -111,26 +111,32 @@ public class DescriptionEditView extends LinearLayout {
     }
 
     private int getHeaderTextRes(boolean inReview) {
-        if (TextUtils.isEmpty(originalDescription)) {
-            if (inReview) {
-                if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
-                    return R.string.suggested_edits_review_image_caption;
-                } else {
-                    return R.string.suggested_edits_review_description;
-                }
+        if (inReview) {
+            if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION
+                    || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION
+                    || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION
+                    || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+                return R.string.suggested_edits_review_image_caption;
             } else {
-                if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
-                    return R.string.description_edit_translate_description;
-                } else if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
-                    return R.string.description_edit_add_image_caption;
-                } else if (invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
-                    return R.string.description_edit_translate_image_caption;
-                } else {
-                    return R.string.description_edit_add_description;
-                }
+                return R.string.suggested_edits_review_description;
+            }
+        }
+
+        if (TextUtils.isEmpty(originalDescription)) {
+            if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+                return R.string.description_edit_translate_description;
+            } else if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+                return R.string.description_edit_add_image_caption;
+            } else if (invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+                return R.string.description_edit_translate_image_caption;
+            } else {
+                return R.string.description_edit_add_description;
             }
         } else {
-            if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION) {
+            if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION
+                    || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION
+                    || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION
+                    || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
                 return R.string.description_edit_edit_image_caption;
             } else {
                 return R.string.description_edit_edit_description;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -626,7 +626,7 @@
     <string name="description_edit_read">Read</string>
     <string name="description_edit_add_description">Add article description</string>
     <string name="description_edit_translate_description">Translate article description</string>
-    <string name="description_edit_edit_description">Edit description</string>
+    <string name="description_edit_edit_description">Edit article description</string>
     <string name="description_edit_add_image_caption">Add image caption</string>
     <string name="description_edit_edit_image_caption">Edit image caption</string>
     <string name="description_edit_translate_image_caption">Translate image caption</string>


### PR DESCRIPTION
The toolbar should show the correct title based on the current action