### PR TITLE
Fix: show HTML style for article title in Suggested edits

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditBottomBarView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditBottomBarView.kt
@@ -29,7 +29,7 @@ class DescriptionEditBottomBarView @JvmOverloads constructor(
 
     fun setSummary(summary: SuggestedEditsSummary) {
         setConditionalLayoutDirection(this, summary.lang)
-        viewArticleTitle!!.text = StringUtil.removeNamespace(summary.displayTitle!!)
+        viewArticleTitle!!.text = StringUtil.fromHtml(StringUtil.removeNamespace(summary.displayTitle!!))
         if (summary.thumbnailUrl.isNullOrEmpty()) {
             viewImageThumbnail.visibility = GONE
         } else {

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -63,7 +63,7 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
     }
 
     private fun showAddDescriptionUI() {
-        viewArticleTitle.text = card!!.sourceSummary!!.normalizedTitle
+        viewArticleTitle.text = StringUtil.fromHtml(card!!.sourceSummary!!.displayTitle!!)
         callToActionText.text = if (card!!.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) context.getString(R.string.suggested_edits_feed_card_add_translation_in_language_button, app.language().getAppLanguageCanonicalName(card!!.targetSummary!!.lang)) else context.getString(R.string.suggested_edits_add_description_button)
         showImageOrExtract()
     }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -261,7 +261,7 @@ class SuggestedEditsCardsItemFragment : Fragment() {
     }
 
     private fun updateDescriptionContents() {
-        viewArticleTitle.text = sourceSummary!!.displayTitle
+        viewArticleTitle.text = StringUtil.fromHtml(sourceSummary!!.displayTitle)
 
         if (parent().source == SUGGESTED_EDITS_TRANSLATE_DESC) {
             viewArticleSubtitleContainer.visibility = VISIBLE


### PR DESCRIPTION
For "Add article descriptions" or "Translate article descriptions" in Suggested edits, the article title will contain HTML tag such as `<i></i>`, and we should show it properly. 