### PR TITLE
Tweak: update suggested edits lock message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -710,7 +710,7 @@
     <string name="suggested_edits_task_multilingual_title">More tasks for multilingual editors</string>
     <string name="suggested_edits_task_multilingual_description">Translation tasks are available if you read and write in more than one Wikipedia language.</string>
     <string name="suggested_edits_task_image_caption_edit_disable_text">Locked until you’ve edited %d image captions</string>
-    <string name="suggested_edits_task_translate_description_edit_disable_text">Locked until you’ve made %d verified contributions</string>
+    <string name="suggested_edits_task_translate_description_edit_disable_text">Locked until you’ve edited %d article descriptions (verified)</string>
     <string name="suggested_edits_task_multilingual_negative">Not for me</string>
     <string name="suggested_edits_task_multilingual_positive">Add languages</string>
     <string name="suggested_edits_image_caption_summary_title_artist">Artist</string>


### PR DESCRIPTION
`#7` in https://phabricator.wikimedia.org/T225635#5299612
https://phabricator.wikimedia.org/T225635#5304437

Update the string base on the `copy master` document: https://docs.google.com/spreadsheets/d/1t0IWXoSz7EYBS6LrQM5fV_qZ6paK_sFRjnCp9H7rEPo/edit#gid=0

