### PR TITLE
Follow up: simplify the logic of handling clickable links in ImagePreviewDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/util/StringUtil.java
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.java
@@ -261,5 +261,4 @@ public final class StringUtil {
 
     private StringUtil() {
     }
-
 }

--- a/app/src/main/res/layout/view_image_detail.xml
+++ b/app/src/main/res/layout/view_image_detail.xml
@@ -31,7 +31,7 @@
 
     <LinearLayout
         android:id="@+id/detailsContainer"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="?android:selectableItemBackground"
         android:orientation="horizontal"


### PR DESCRIPTION
Also fixed the issue that the `detailsContainer` is not clickable with the external icon if the `detailTextView` applies `movementMethod`