### PR TITLE
Correctly preserve instanceState of Suggested Edit cards.

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -63,6 +63,14 @@ class SuggestedEditsCardsItemFragment : Fragment() {
             }
         }
         showAddedContributionView(addedContribution)
+        if (savedInstanceState != null) {
+            pagerPosition = savedInstanceState.getInt("pagerPosition", -1)
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt("pagerPosition", pagerPosition)
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
This fixes the issue of not being able to click the Suggested Edit card when returning from editing the caption. (with "don't keep activities" enabled)