### PR TITLE
Minor tweaks to ImagePreviewDialog.

### DIFF
--- a/app/src/main/res/layout/view_image_detail.xml
+++ b/app/src/main/res/layout/view_image_detail.xml
@@ -16,7 +16,6 @@
         android:layout_height="48dp"
         android:fontFamily="sans-serif"
         android:gravity="center_vertical"
-        android:letterSpacing="0.04"
         android:lineSpacingExtra="6sp"
         android:textAllCaps="true"
         android:textColor="?attr/primary_text_color"
@@ -43,21 +42,23 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif"
-            android:gravity="center_vertical"
+            android:layout_gravity="center_vertical"
             android:lineSpacingExtra="8sp"
             android:textColor="?attr/primary_text_color"
             android:textSize="16sp"
-            android:textStyle="normal"
             tools:text="Watercolor portrait of Ada King, Countess of Lovelace (Ada Lovelace)" />
 
         <ImageView
             android:id="@+id/externalLinkView"
-            android:layout_width="@dimen/app_shortcut_icon_size"
-            android:layout_height="@dimen/app_shortcut_icon_size"
-            android:layout_marginStart="12dp"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="1dp"
+            android:layout_gravity="center_vertical"
             android:contentDescription="@null"
             android:tint="?attr/colorAccent"
             android:visibility="gone"
-            app:srcCompat="@drawable/ic_open_in_new_black_24px" />
+            app:srcCompat="@drawable/ic_open_in_new_black_24px"
+            tools:visibility="visible"/>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -732,7 +732,7 @@
     <string name="suggested_edits_image_preview_dialog_date">Date</string>
     <string name="suggested_edits_image_preview_dialog_source">Source/Photographer</string>
     <string name="suggested_edits_image_preview_dialog_licensing">Licensing</string>
-    <string name="suggested_edits_image_preview_dialog_more_info">More Infos</string>
+    <string name="suggested_edits_image_preview_dialog_more_info">More Info</string>
     <string name="suggested_edits_image_preview_dialog_file_page_link_text">File page on Wikimedia Commons</string>
     <string name="suggested_edits_article_cta_add_image_caption">Add caption</string>
     <string name="suggested_edits_article_cta_translate_image_caption">Add caption (%s)</string>


### PR DESCRIPTION
- "infos" is not a word.
- the external link arrow icon should be 16x16, according to Zeplin.