### PR TITLE
Adjusting bottom sheet peekHeight

### DIFF
--- a/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.java
+++ b/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.java
@@ -1,9 +1,14 @@
 package org.wikipedia.page;
 
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Bundle;
+import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import org.wikipedia.R;
@@ -26,6 +31,23 @@ public class ExtendedBottomSheetDialogFragment extends BottomSheetDialogFragment
     public void onStart() {
         super.onStart();
         setWindowLayout();
+        setPeekHeightPerDevice();
+    }
+
+    private void setPeekHeightPerDevice() {
+        View view = getView();
+        if (view != null) {
+            view.post(() -> {
+                View parent = (View) view.getParent();
+                CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) (parent).getLayoutParams();
+                CoordinatorLayout.Behavior behavior = params.getBehavior();
+                BottomSheetBehavior bottomSheetBehavior = (BottomSheetBehavior) behavior;
+                int screenHeight = Resources.getSystem().getDisplayMetrics().heightPixels;
+                if (bottomSheetBehavior != null) {
+                    bottomSheetBehavior.setPeekHeight(screenHeight / 2);
+                }
+            });
+        }
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.java
+++ b/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.java
@@ -1,14 +1,9 @@
 package org.wikipedia.page;
 
 import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.Bundle;
-import android.view.View;
 import android.view.ViewGroup;
 
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-
-import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import org.wikipedia.R;
@@ -31,23 +26,6 @@ public class ExtendedBottomSheetDialogFragment extends BottomSheetDialogFragment
     public void onStart() {
         super.onStart();
         setWindowLayout();
-        setPeekHeightPerDevice();
-    }
-
-    private void setPeekHeightPerDevice() {
-        View view = getView();
-        if (view != null) {
-            view.post(() -> {
-                View parent = (View) view.getParent();
-                CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) (parent).getLayoutParams();
-                CoordinatorLayout.Behavior behavior = params.getBehavior();
-                BottomSheetBehavior bottomSheetBehavior = (BottomSheetBehavior) behavior;
-                int screenHeight = Resources.getSystem().getDisplayMetrics().heightPixels;
-                if (bottomSheetBehavior != null) {
-                    bottomSheetBehavior.setPeekHeight(screenHeight / 2);
-                }
-            });
-        }
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -23,6 +24,7 @@ import org.wikipedia.json.GsonUnmarshaller
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.suggestededits.SuggestedEditsSummary
+import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
@@ -44,6 +46,12 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
         setConditionalLayoutDirection(rootView, suggestedEditsSummary.lang)
         enableFullWidthDialog()
         return rootView
+    }
+
+    override fun onStart() {
+        super.onStart()
+        BottomSheetBehavior.from(view!!.parent as View).peekHeight = DimenUtil
+                .roundedDpToPx(DimenUtil.getDimension(R.dimen.imagePreviewSheetPeekHeight))
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -5,5 +5,6 @@
          screen margins) for sw600dp devices (e.g. 7" tablets) in landscape here.
     -->
     <dimen name="activity_horizontal_margin">32dp</dimen>
+    <dimen name="imagePreviewSheetPeekHeight">400dp</dimen>
 
 </resources>

--- a/app/src/main/res/values-sw720dp-port/dimens.xml
+++ b/app/src/main/res/values-sw720dp-port/dimens.xml
@@ -5,5 +5,6 @@
          screen margins) for sw720dp devices (e.g. 10" tablets) in landscape here.
     -->
     <dimen name="activity_horizontal_margin">64dp</dimen>
+    <dimen name="imagePreviewSheetPeekHeight">600dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -44,6 +44,7 @@
     <!-- Default height with which bottom sheets peek out from the bottom -->
     <dimen name="bottomSheetPeekHeight">320dp</dimen>
     <dimen name="readingListSheetPeekHeight">360dp</dimen>
+    <dimen name="imagePreviewSheetPeekHeight">320dp</dimen>
     <!-- Default size of images in Link Preview thumbnail gallery -->
     <dimen name="linkPreviewImageSize">112dp</dimen>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -44,7 +44,7 @@
     <!-- Default height with which bottom sheets peek out from the bottom -->
     <dimen name="bottomSheetPeekHeight">320dp</dimen>
     <dimen name="readingListSheetPeekHeight">360dp</dimen>
-    <dimen name="imagePreviewSheetPeekHeight">320dp</dimen>
+    <dimen name="imagePreviewSheetPeekHeight">280dp</dimen>
     <!-- Default size of images in Link Preview thumbnail gallery -->
     <dimen name="linkPreviewImageSize">112dp</dimen>
 


### PR DESCRIPTION
On tablets, the default peekheight of bottomsheets is very small. so, we need to set it dynamically to a fraction of the screen height.
**Phab**: https://phabricator.wikimedia.org/T223130