### PR TITLE
Fix: don't create a default list every time when upgrading the database

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPageTable.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPageTable.java
@@ -71,7 +71,7 @@ public class ReadingListPageTable extends DatabaseTable<ReadingListPage> {
     @Override
     public void onUpgradeSchema(@NonNull SQLiteDatabase db, int fromVersion, int toVersion) {
         if (toVersion == DB_VER_INTRODUCED) {
-            List<ReadingList> currentLists = new ArrayList<>();
+            List<ReadingList> currentLists = ReadingListDbHelper.instance().getAllLists();
             createDefaultList(db, currentLists);
             renameListsWithIdenticalNameAsDefault(db, currentLists);
             // TODO: add other one-time conversions here.


### PR DESCRIPTION
The `currentLists` is empty, so it will let the `createDefaultList()` create a default list every time when upgrading the database.