### PR TITLE
Fix the issue that the add caption button in PageActivity does not work properly

### DIFF
--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -217,7 +217,7 @@ public class LeadImagesHandler {
                 .flatMap(gallery -> {
                     List<GalleryItem> list = gallery.getItems("image");
                     for (GalleryItem item : list) {
-                        if (getPage() != null && item.getFilePage().contains(getPage().getPageProperties().getLeadImageName())) {
+                        if (getPage() != null && item.getFilePage().contains(StringUtil.addUnderscores(getPage().getPageProperties().getLeadImageName()))) {
                             galleryItem[0] = item;
                             title[0] = item.getFilePage().equals(Service.COMMONS_URL) ? item.getTitles().getCanonical() : UriUtil.getTitleFromUrl(item.getFilePage());
                             return MediaHelper.INSTANCE.getImageCaptions(title[0]);
@@ -231,11 +231,11 @@ public class LeadImagesHandler {
                             PageTitle captionSourcePageTitle, captionTargetPageTitle;
                             if (galleryItem[0] != null) {
                                 WikipediaApp app = WikipediaApp.getInstance();
-                                captionSourcePageTitle = new PageTitle(title[0], new WikiSite(Service.COMMONS_URL, app.getAppOrSystemLanguageCode()));
+                                captionSourcePageTitle = new PageTitle(title[0], new WikiSite(Service.COMMONS_URL, getTitle().getWikiSite().languageCode()));
 
-                                if (!captions.containsKey(app.getAppOrSystemLanguageCode())) {
+                                if (!captions.containsKey(getTitle().getWikiSite().languageCode())) {
                                     pageHeaderView.setUpCallToAction(app.getResources().getString(R.string.suggested_edits_article_cta_add_image_caption));
-                                    callToActionSourceSummary = new SuggestedEditsSummary(captionSourcePageTitle.getPrefixedText(), app.getAppOrSystemLanguageCode(), captionSourcePageTitle,
+                                    callToActionSourceSummary = new SuggestedEditsSummary(captionSourcePageTitle.getPrefixedText(), getTitle().getWikiSite().languageCode(), captionSourcePageTitle,
                                             captionSourcePageTitle.getDisplayText(), captionSourcePageTitle.getDisplayText(), StringUtils.defaultIfBlank(StringUtil.fromHtml(galleryItem[0].getDescription().getHtml()).toString(), getActivity().getString(R.string.suggested_edits_no_description)),
                                             galleryItem[0].getThumbnailUrl(), galleryItem[0].getPreferredSizedImageUrl(), null, null, null, null);
 
@@ -246,7 +246,7 @@ public class LeadImagesHandler {
                                         if (!captions.containsKey(lang)) {
                                             callToActionIsTranslation = true;
                                             captionTargetPageTitle = new PageTitle(title[0], new WikiSite(Service.COMMONS_URL, lang));
-                                            String currentCaption = captions.get(app.getAppOrSystemLanguageCode());
+                                            String currentCaption = captions.get(getTitle().getWikiSite().languageCode());
                                             captionSourcePageTitle.setDescription(currentCaption);
                                             callToActionSourceSummary = new SuggestedEditsSummary(captionSourcePageTitle.getPrefixedText(), captionSourcePageTitle.getWikiSite().languageCode(), captionSourcePageTitle,
                                                     captionSourcePageTitle.getDisplayText(), captionSourcePageTitle.getDisplayText(), currentCaption, getLeadImageUrl(), getLeadImageUrl(),
@@ -345,6 +345,9 @@ public class LeadImagesHandler {
 
     public void dispose() {
         disposables.clear();
+        callToActionSourceSummary = null;
+        callToActionTargetSummary = null;
+        callToActionIsTranslation = false;
     }
 
     @Nullable public String getCallToActionEditLang() {


### PR DESCRIPTION
1. The `getPage().getPageProperties().getLeadImageName()` should add underscores when matching the file page name.
2. The "add caption" button should refer to the current article's language.
3. If the current article has assigned value to `callToActionTargetSummary`, and it should be cleared when setting up the CTA on the next article.