### PR TITLE
Use setTextZoom() to change the WebView font size

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -646,6 +646,7 @@ public class PageFragment extends Fragment implements BackPressedHandler {
      * Update the WebView's font size, based on the specified font size multiplier from the app
      * preferences. The default text zoom starts from 100, which is by percentage.
      */
+    @SuppressWarnings("checkstyle:magicnumber")
     public void updateFontSize() {
         webView.getSettings().setTextZoom(100 + getTextSizeMultiplier() * 10);
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -99,6 +99,7 @@ import static org.wikipedia.Constants.InvokeSource.PAGE_ACTIVITY;
 import static org.wikipedia.descriptions.DescriptionEditTutorialActivity.DESCRIPTION_SELECTED_TEXT;
 import static org.wikipedia.page.PageActivity.ACTION_RESUME_READING;
 import static org.wikipedia.page.PageCacher.loadIntoCache;
+import static org.wikipedia.settings.Prefs.getTextSizeMultiplier;
 import static org.wikipedia.settings.Prefs.isDescriptionEditTutorialEnabled;
 import static org.wikipedia.settings.Prefs.isLinkPreviewEnabled;
 import static org.wikipedia.util.DimenUtil.getContentTopOffset;
@@ -642,11 +643,11 @@ public class PageFragment extends Fragment implements BackPressedHandler {
     }
 
     /**
-     * Update the WebView's base font size, based on the specified font size from the app
-     * preferences.
+     * Update the WebView's font size, based on the specified font size multiplier from the app
+     * preferences. The default text zoom starts from 100, which is by percentage.
      */
     public void updateFontSize() {
-        webView.getSettings().setDefaultFontSize((int) app.getFontSize(requireActivity().getWindow()));
+        webView.getSettings().setTextZoom(100 + getTextSizeMultiplier() * 10);
     }
 
     public void updateBookmarkAndMenuOptions() {


### PR DESCRIPTION
The issue can be found here: https://github.com/wikimedia/wikimedia-page-library/pull/217

To fix that, we can also use the `setTextZoom()` to update the percentage of the text size, which is more sense to me.