### PR TITLE
Handle HTML tags in SnackBar

### DIFF
--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
@@ -121,7 +121,7 @@ public final class FeedbackUtil {
 
     public static Snackbar makeSnackbar(Activity activity, CharSequence text, int duration) {
         View view = findBestView(activity);
-        Snackbar snackbar = Snackbar.make(view, text, duration);
+        Snackbar snackbar = Snackbar.make(view, StringUtil.fromHtml(text.toString()), duration);
         TextView textView = snackbar.getView().findViewById(R.id.snackbar_text);
         textView.setMaxLines(SNACKBAR_MAX_LINES);
         textView.setMovementMethod(LinkMovementMethod.getInstance());


### PR DESCRIPTION
When logging with globally locked username, for example, "test", the message from the API response will contain `<strong>` HTML tag.

We should handle the HTML tags. 