### PR TITLE
Remove unused parameter from SuggestedEditsSummary

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
@@ -68,7 +68,6 @@ class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource)
                             pageSummary.displayTitle,
                             pageSummary.description,
                             pageSummary.thumbnailUrl,
-                            pageSummary.originalImageUrl,
                             pageSummary.extractHtml,
                             null, null, null
                     )
@@ -101,7 +100,6 @@ class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource)
                             source.displayTitle,
                             source.description,
                             source.thumbnailUrl,
-                            source.originalImageUrl,
                             source.extractHtml,
                             null, null, null
                     )
@@ -114,7 +112,6 @@ class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource)
                             target.displayTitle,
                             target.description,
                             target.thumbnailUrl,
-                            target.originalImageUrl,
                             target.extractHtml,
                             null, null, null
                     )
@@ -159,7 +156,6 @@ class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource)
                                 StringUtil.removeHTMLTags(title),
                                 imageInfo.metadata!!.imageDescription(),
                                 imageInfo.thumbUrl,
-                                imageInfo.originalUrl,
                                 null,
                                 imageInfo.timestamp,
                                 imageInfo.user,
@@ -207,7 +203,6 @@ class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource)
                                 StringUtil.removeHTMLTags(title),
                                 fileCaption,
                                 imageInfo.thumbUrl,
-                                imageInfo.originalUrl,
                                 null,
                                 imageInfo.timestamp,
                                 imageInfo.user,

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -313,7 +313,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
 
         SuggestedEditsSummary summary = new SuggestedEditsSummary(title.getPrefixedText(), app.getAppOrSystemLanguageCode(), title,
                 title.getDisplayText(), title.getDisplayText(), StringUtils.defaultIfBlank(StringUtil.fromHtml(item.getDescription().getHtml()).toString(), null),
-                item.getThumbnailUrl(), item.getPreferredSizedImageUrl(), null, null, null, null);
+                item.getThumbnailUrl(), null, null, null, null);
 
         startActivityForResult(DescriptionEditActivity.newIntent(this, title, null, summary, null, SUGGESTED_EDITS_ADD_CAPTION),
                 ACTIVITY_REQUEST_DESCRIPTION_EDIT);
@@ -333,11 +333,11 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         }
 
         SuggestedEditsSummary sourceSummary = new SuggestedEditsSummary(sourceTitle.getPrefixedText(), sourceTitle.getWikiSite().languageCode(), sourceTitle,
-                sourceTitle.getDisplayText(), sourceTitle.getDisplayText(), currentCaption, item.getThumbnailUrl(), item.getPreferredSizedImageUrl(),
+                sourceTitle.getDisplayText(), sourceTitle.getDisplayText(), currentCaption, item.getThumbnailUrl(),
                 null, null, null, null);
 
         SuggestedEditsSummary targetSummary = new SuggestedEditsSummary(targetTitle.getPrefixedText(), targetTitle.getWikiSite().languageCode(), targetTitle,
-                targetTitle.getDisplayText(), targetTitle.getDisplayText(), null, item.getThumbnailUrl(), item.getPreferredSizedImageUrl(),
+                targetTitle.getDisplayText(), targetTitle.getDisplayText(), null, item.getThumbnailUrl(),
                 null, null, null, null);
 
         startActivityForResult(DescriptionEditActivity.newIntent(this, targetTitle, null, sourceSummary, targetSummary,

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1011,7 +1011,7 @@ public class PageFragment extends Fragment implements BackPressedHandler {
                     Constants.ACTIVITY_REQUEST_DESCRIPTION_EDIT_TUTORIAL);
         } else {
             SuggestedEditsSummary sourceSummary = new SuggestedEditsSummary(getTitle().getPrefixedText(), getTitle().getWikiSite().languageCode(), getTitle(),
-                    getTitle().getDisplayText(), getTitle().getDisplayText(), getTitle().getDescription(), getTitle().getThumbUrl(), getTitle().getThumbUrl(),
+                    getTitle().getDisplayText(), getTitle().getDisplayText(), getTitle().getDescription(), getTitle().getThumbUrl(),
                     null, null, null, null);
             startActivityForResult(DescriptionEditActivity.newIntent(requireContext(), getTitle(), text, sourceSummary, null, PAGE_ACTIVITY),
                     Constants.ACTIVITY_REQUEST_DESCRIPTION_EDIT);

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -234,7 +234,7 @@ public class LeadImagesHandler {
                                     pageHeaderView.setUpCallToAction(app.getResources().getString(R.string.suggested_edits_article_cta_image_caption, app.language().getAppLanguageLocalizedName(getTitle().getWikiSite().languageCode())));
                                     callToActionSourceSummary = new SuggestedEditsSummary(captionSourcePageTitle.getPrefixedText(), getTitle().getWikiSite().languageCode(), captionSourcePageTitle,
                                             captionSourcePageTitle.getDisplayText(), captionSourcePageTitle.getDisplayText(), StringUtils.defaultIfBlank(StringUtil.fromHtml(galleryItem[0].getDescription().getHtml()).toString(), getActivity().getString(R.string.suggested_edits_no_description)),
-                                            galleryItem[0].getThumbnailUrl(), galleryItem[0].getPreferredSizedImageUrl(), null, null, null, null);
+                                            galleryItem[0].getThumbnailUrl(), null, null, null, null);
 
                                     return;
                                 }
@@ -246,11 +246,11 @@ public class LeadImagesHandler {
                                             String currentCaption = captions.get(getTitle().getWikiSite().languageCode());
                                             captionSourcePageTitle.setDescription(currentCaption);
                                             callToActionSourceSummary = new SuggestedEditsSummary(captionSourcePageTitle.getPrefixedText(), captionSourcePageTitle.getWikiSite().languageCode(), captionSourcePageTitle,
-                                                    captionSourcePageTitle.getDisplayText(), captionSourcePageTitle.getDisplayText(), currentCaption, getLeadImageUrl(), getLeadImageUrl(),
+                                                    captionSourcePageTitle.getDisplayText(), captionSourcePageTitle.getDisplayText(), currentCaption, getLeadImageUrl(),
                                                     null, null, null, null);
 
                                             callToActionTargetSummary = new SuggestedEditsSummary(captionTargetPageTitle.getPrefixedText(), captionTargetPageTitle.getWikiSite().languageCode(), captionTargetPageTitle,
-                                                    captionTargetPageTitle.getDisplayText(), captionTargetPageTitle.getDisplayText(), null, getLeadImageUrl(), getLeadImageUrl(),
+                                                    captionTargetPageTitle.getDisplayText(), captionTargetPageTitle.getDisplayText(), null, getLeadImageUrl(),
                                                     null, null, null, null);
                                             pageHeaderView.setUpCallToAction(app.getResources().getString(R.string.suggested_edits_article_cta_image_caption, app.language().getAppLanguageLocalizedName(lang)));
                                             break;

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -96,7 +96,6 @@ class SuggestedEditsCardsItemFragment : Fragment() {
                                     source.displayTitle,
                                     source.description,
                                     source.thumbnailUrl,
-                                    source.originalImageUrl,
                                     source.extractHtml,
                                     null, null, null
                             )
@@ -109,7 +108,6 @@ class SuggestedEditsCardsItemFragment : Fragment() {
                                     target.displayTitle,
                                     target.description,
                                     target.thumbnailUrl,
-                                    target.originalImageUrl,
                                     target.extractHtml,
                                     null, null, null
                             )
@@ -146,7 +144,6 @@ class SuggestedEditsCardsItemFragment : Fragment() {
                                         StringUtil.removeHTMLTags(title),
                                         imageInfo.metadata!!.imageDescription(),
                                         imageInfo.thumbUrl,
-                                        imageInfo.originalUrl,
                                         null,
                                         imageInfo.timestamp,
                                         imageInfo.user,
@@ -188,7 +185,6 @@ class SuggestedEditsCardsItemFragment : Fragment() {
                                         StringUtil.removeHTMLTags(title),
                                         fileCaption,
                                         imageInfo.thumbUrl,
-                                        imageInfo.originalUrl,
                                         null,
                                         imageInfo.timestamp,
                                         imageInfo.user,
@@ -224,7 +220,6 @@ class SuggestedEditsCardsItemFragment : Fragment() {
                                     pageSummary.displayTitle,
                                     pageSummary.description,
                                     pageSummary.thumbnailUrl,
-                                    pageSummary.originalImageUrl,
                                     pageSummary.extractHtml,
                                     null, null, null
                             )

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsSummary.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsSummary.kt
@@ -13,7 +13,6 @@ data class SuggestedEditsSummary(
         var displayTitle: String?,
         var description: String?,
         var thumbnailUrl: String?,
-        var originalUrl: String?,
         var extractHtml: String?,
         var timestamp: String?,
         var user: String?,


### PR DESCRIPTION
Since we are using `ImageUrlUtil.getUrlForPreferredSize()` for higher resolution images from `thumbnailUrl`, it would be better if we remove the unused `originalUrl` parameter.