### PR TITLE
Fix: prevent possible crash after left PageFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -415,6 +415,9 @@ public class PageFragment extends Fragment implements BackPressedHandler {
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
+                if (!isAdded()) {
+                    return;
+                }
                 bridge.onPageFinished();
                 updateProgressBar(false, true, 0);
                 bridge.execute(JavaScriptActionHandler.setMulti(requireContext(), app.getCurrentTheme().getFunnelName().toUpperCase(), app.getCurrentTheme().isDark() && Prefs.shouldDimDarkModeImages(), Prefs.isCollapseTablesEnabled()));


### PR DESCRIPTION
Steps to reproduce:

1. Read any article
2. Turn on airplane mode
3. Back to explore feed