### PR TITLE
Gallery activity editing fix

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/RestService.java
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.java
@@ -114,7 +114,7 @@ public interface RestService {
     @GET("page/related/{title}")
     @NonNull Observable<RbRelatedPages> getRelatedPages(@Path("title") String title);
 
-    @GET("page/media/{title}")
+    @GET("page/media/{title}?action=purge")
     @NonNull Observable<Gallery> getMedia(@Path("title") String title);
 
     @GET("feed/onthisday/events/{mm}/{dd}")

--- a/app/src/main/java/org/wikipedia/dataclient/RestService.java
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.java
@@ -114,7 +114,7 @@ public interface RestService {
     @GET("page/related/{title}")
     @NonNull Observable<RbRelatedPages> getRelatedPages(@Path("title") String title);
 
-    @GET("page/media/{title}?action=purge")
+    @GET("page/media/{title}")
     @NonNull Observable<Gallery> getMedia(@Path("title") String title);
 
     @GET("feed/onthisday/events/{mm}/{dd}")

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -122,6 +122,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     @Nullable private Unbinder unbinder;
     private CompositeDisposable disposables = new CompositeDisposable();
     private Disposable imageCaptionDisposable;
+    private WikiSite sourceWiki;
 
     private boolean controlsShowing = true;
     @Nullable private ViewPager.OnPageChangeListener pageChangeListener;
@@ -205,6 +206,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         }
         initialFilename = getIntent().getStringExtra(EXTRA_FILENAME);
         initialImageUrl = getIntent().getStringExtra(EXTRA_IMAGEURL);
+        sourceWiki = getIntent().getParcelableExtra(EXTRA_WIKI);
 
         galleryAdapter = new GalleryItemAdapter(GalleryActivity.this);
         galleryPager.setAdapter(galleryAdapter);
@@ -307,11 +309,11 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
 
     @OnClick(R.id.gallery_caption_edit_button) void onEditClick(View v) {
         GalleryItem item = getCurrentItem();
-        PageTitle title = new PageTitle(item.getFilePage().equals(Service.COMMONS_URL) ? item.getTitles().getCanonical() : UriUtil.getTitleFromUrl(item.getFilePage()), new WikiSite(Service.COMMONS_URL, app.getAppOrSystemLanguageCode()));
-        String currentCaption = item.getStructuredCaptions().get(app.getAppOrSystemLanguageCode());
+        PageTitle title = new PageTitle(item.getFilePage().equals(Service.COMMONS_URL) ? item.getTitles().getCanonical() : UriUtil.getTitleFromUrl(item.getFilePage()), new WikiSite(Service.COMMONS_URL, sourceWiki.languageCode()));
+        String currentCaption = item.getStructuredCaptions().get(sourceWiki.languageCode());
         title.setDescription(currentCaption);
 
-        SuggestedEditsSummary summary = new SuggestedEditsSummary(title.getPrefixedText(), app.getAppOrSystemLanguageCode(), title,
+        SuggestedEditsSummary summary = new SuggestedEditsSummary(title.getPrefixedText(), sourceWiki.languageCode(), title,
                 title.getDisplayText(), title.getDisplayText(), StringUtils.defaultIfBlank(StringUtil.fromHtml(item.getDescription().getHtml()).toString(), null),
                 item.getThumbnailUrl(), null, null, null, null);
 
@@ -325,7 +327,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         }
         GalleryItem item = getCurrentItem();
         String title = item.getFilePage().equals(Service.COMMONS_URL) ? item.getTitles().getCanonical() : UriUtil.getTitleFromUrl(item.getFilePage());
-        PageTitle sourceTitle = new PageTitle(title, new WikiSite(Service.COMMONS_URL, app.language().getAppLanguageCodes().get(0)));
+        PageTitle sourceTitle = new PageTitle(title, new WikiSite(Service.COMMONS_URL, sourceWiki.languageCode()));
         PageTitle targetTitle = new PageTitle(title, new WikiSite(Service.COMMONS_URL, StringUtils.defaultString(targetLanguageCode, app.language().getAppLanguageCodes().get(1))));
         String currentCaption = item.getStructuredCaptions().get(app.getAppOrSystemLanguageCode());
         if (TextUtils.isEmpty(currentCaption)) {
@@ -651,8 +653,9 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
 
         // If we have a structured caption in our current language, then display that instead
         // of the unstructured description, and make it editable.
-        if (item.getStructuredCaptions().containsKey(app.getAppOrSystemLanguageCode())) {
-            descriptionStr = item.getStructuredCaptions().get(app.getAppOrSystemLanguageCode());
+
+        if (item.getStructuredCaptions().containsKey(sourceWiki.languageCode())) {
+            descriptionStr = item.getStructuredCaptions().get(sourceWiki.languageCode());
         } else {
             descriptionStr = StringUtil.fromHtml(item.getDescription().getHtml());
         }


### PR DESCRIPTION
Changes the assumption that the source language will be the 0th language of the app languages and the target language is the 1st. This PR keeps track of the source language in which the galleryActivity is launched and the target language as the one that doesn't have structured caption.