### PR TITLE
Consider article CTA language during GalleryActivity launch from FeedbackUtil

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -687,9 +687,10 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         } else if (requestCode == Constants.ACTIVITY_REQUEST_IMAGE_CAPTION_EDIT
                 && resultCode == RESULT_OK) {
             pageFragment.refreshPage();
+            String editLanguage = StringUtils.defaultString(pageFragment.getLeadImageEditLang(), app.language().getAppLanguageCode());
             FeedbackUtil.makeSnackbar(this, TextUtils.isEmpty(pageFragment.getLeadImageEditLang()) ? getString(R.string.description_edit_success_saved_image_caption_snackbar)
-                    : getString(R.string.description_edit_success_saved_image_caption_in_lang_snackbar, app.language().getAppLanguageLocalizedName(StringUtils.defaultString(pageFragment.getLeadImageEditLang(), app.language().getAppLanguageCode()))), FeedbackUtil.LENGTH_DEFAULT)
-                    .setAction(R.string.suggested_edits_article_cta_snackbar_action, v -> pageFragment.openImageInGallery()).show();
+                    : getString(R.string.description_edit_success_saved_image_caption_in_lang_snackbar, app.language().getAppLanguageLocalizedName(editLanguage)), FeedbackUtil.LENGTH_DEFAULT)
+                    .setAction(R.string.suggested_edits_article_cta_snackbar_action, v -> pageFragment.openImageInGallery(editLanguage)).show();
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1245,8 +1245,8 @@ public class PageFragment extends Fragment implements BackPressedHandler {
         return leadImagesHandler.getCallToActionEditLang();
     }
 
-    void openImageInGallery() {
-        leadImagesHandler.openImageInGallery();
+    void openImageInGallery(@NonNull String language) {
+        leadImagesHandler.openImageInGallery(language);
     }
 
 }

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -293,7 +293,7 @@ public class LeadImagesHandler {
         pageHeaderView.setCallback(new PageHeaderView.Callback() {
             @Override
             public void onImageClicked() {
-                openImageInGallery();
+                openImageInGallery(null);
             }
 
             @Override
@@ -308,13 +308,13 @@ public class LeadImagesHandler {
         });
     }
 
-    public void openImageInGallery() {
+    public void openImageInGallery(@Nullable  String language) {
         if (getPage() != null && isLeadImageEnabled()) {
             String imageName = getPage().getPageProperties().getLeadImageName();
             String imageUrl = getPage().getPageProperties().getLeadImageUrl();
             if (imageName != null && imageUrl != null) {
                 String filename = "File:" + imageName;
-                WikiSite wiki = getTitle().getWikiSite();
+                WikiSite wiki = language == null ? getTitle().getWikiSite() : WikiSite.forLanguageCode(language);
                 getActivity().startActivityForResult(GalleryActivity.newIntent(getActivity(),
                         parentFragment.getTitleOriginal(), filename, UriUtil.resolveProtocolRelativeUrl(imageUrl), wiki,
                         GalleryFunnel.SOURCE_LEAD_IMAGE),


### PR DESCRIPTION
In every other case, GalleryActivity takes into account the pageTitle lanuguage that launches it, but only for launch from the feedbackUtil, we need to update it to the targetLanguage.