### PR TITLE
Update travis config to avoid a license error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 jdk:
-- oraclejdk8
+- oraclejdk9
 android:
   components:
   - platform-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: android
 jdk:
 - oraclejdk8
+- openjdk11
+dist: trusty
 android:
   components:
   - platform-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: android
 jdk:
 - oraclejdk8
-- openjdk11
 dist: trusty
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 jdk:
-- oraclejdk8
+- openjdk8
 android:
   components:
   - platform-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: android
 jdk:
 - oraclejdk8
-- openjdk8
 android:
   components:
   - platform-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 jdk:
-- oraclejdk9
+- oraclejdk8
 android:
   components:
   - platform-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: android
 jdk:
+- oraclejdk8
 - openjdk8
 android:
   components:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ def computeVersionName(label) {
     return "2.7.${android.defaultConfig.versionCode}-${label}-${date}"
 }
 
-final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_9
+final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_8
 android {
     compileSdkVersion 28
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ def computeVersionName(label) {
     return "2.7.${android.defaultConfig.versionCode}-${label}-${date}"
 }
 
-final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_8
+final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_9
 android {
     compileSdkVersion 28
 


### PR DESCRIPTION
Somehow the Travis CI changed their `install-jdk.sh` recently, and also something wrong with the license when installing `oraclejdk8`. 

```
Installing oraclejdk8
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2019-07-17
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
Your build has been stopped.
```

To solve that, we can simply change the virtual environment to `Trusty`. For more information about the different virtual environments, please see the links below:
https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
https://docs.travis-ci.com/user/reference/trusty/