### PR TITLE
Fix: check "redirected" filename correctly in GalleryActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -547,8 +547,10 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         if (initialFilename != null) {
             for (GalleryItem item : list) {
                 // sometimes the namespace of a file would be in different languages rather than English.
-                if (StringUtil.removeNamespace(item.getTitles().getCanonical())
-                        .equals(StringUtil.removeNamespace(addUnderscores(initialFilename)))) {
+                String title = StringUtil.removeNamespace(item.getTitles().getCanonical());
+                String titleFromFilePageUrl = StringUtil.removeNamespace(addUnderscores(UriUtil.getTitleFromUrl(item.getFilePage())));
+                String titleFromPage = StringUtil.removeNamespace(addUnderscores(initialFilename));
+                if (title.equals(titleFromPage) || titleFromFilePageUrl.equals(titleFromPage)) {
                     initialImagePos = list.indexOf(item);
                     break;
                 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T224728#5374588

The core of this issue is:
https://en.wikipedia.org/api/rest_v1/page/media/Badminton_at_the_1992_Summer_Olympics

If looks closely, you will notice that the `Titles` is `File:Olympic_rings.svg`, but the `file_page` is `https://commons.wikimedia.org/wiki/File:Olympic_rings_without_rims.svg`.

`File:Olympic_rings.svg` will be redirected to the `File:Olympic_rings_without_rims.svg`, and we should make a double check the `filename` from both `Titles` and `file_page` url.