### PR TITLE
Fix support for switching to be-tarask language.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.java
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.java
@@ -290,6 +290,8 @@ public class WikiSite implements Parcelable {
                 return AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE;
             case AppLanguageLookUpTable.NORWEGIAN_BOKMAL_LANGUAGE_CODE:
                 return AppLanguageLookUpTable.NORWEGIAN_LEGACY_LANGUAGE_CODE; // T114042
+            case AppLanguageLookUpTable.BELARUSIAN_LEGACY_LANGUAGE_CODE:
+                return AppLanguageLookUpTable.BELARUSIAN_TARASK_LANGUAGE_CODE; // T111853
             default:
                 return languageCode;
         }

--- a/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.java
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.java
@@ -29,6 +29,8 @@ public class AppLanguageLookUpTable {
     public static final String CHINESE_LANGUAGE_CODE = "zh";
     public static final String NORWEGIAN_LEGACY_LANGUAGE_CODE = "no";
     public static final String NORWEGIAN_BOKMAL_LANGUAGE_CODE = "nb";
+    public static final String BELARUSIAN_LEGACY_LANGUAGE_CODE = "be-x-old";
+    public static final String BELARUSIAN_TARASK_LANGUAGE_CODE = "be-tarask";
     public static final String TEST_LANGUAGE_CODE = "test";
     public static final String FALLBACK_LANGUAGE_CODE = "en"; // Must exist in preference_language_keys.
 


### PR DESCRIPTION
There is still some confusion and inconsistency within MediaWiki itself regarding the deprecation of the old `be-x-old` domain and the newer `be-tarask`: https://phabricator.wikimedia.org/T111853

This provides some logic to work around the issue.