### PR TITLE
Fix handling of TOTP login response.

### DIFF
--- a/app/src/main/java/org/wikipedia/login/LoginClient.java
+++ b/app/src/main/java/org/wikipedia/login/LoginClient.java
@@ -227,9 +227,9 @@ public class LoginClient {
                 if ("UI".equals(status)) {
                     if (requests != null) {
                         for (Request req : requests) {
-                            if ("TOTPAuthenticationRequest".equals(req.id())) {
+                            if (req.id().endsWith("TOTPAuthenticationRequest")) {
                                 return new LoginOAuthResult(site, status, userName, password, message);
-                            } else if ("MediaWiki\\Auth\\PasswordAuthenticationRequest".equals(req.id())) {
+                            } else if (req.id().endsWith("PasswordAuthenticationRequest")) {
                                 return new LoginResetPasswordResult(site, status, userName, password, message);
                             }
                         }
@@ -250,8 +250,8 @@ public class LoginClient {
             @SuppressWarnings("unused") @Nullable private String account;
             @SuppressWarnings("unused") @Nullable private Map<String, RequestField> fields;
 
-            @Nullable String id() {
-                return id;
+            @NonNull String id() {
+                return StringUtils.defaultString(id);
             }
         }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T227925

We were checking whether the response is exactly equal to `TOTPAuthenticationRequest`, when in fact the latest update to MediaWiki makes it `MediaWiki\Extension\OATHAuth\Auth\TOTPAuthenticationRequest`.

This PR loosens the check to whether the response _ends with_ this expected value.