### PR TITLE
Fix the issue of a crash when loading article offline

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -793,9 +793,6 @@ public class PageFragment extends Fragment implements BackPressedHandler {
         refreshView.setEnabled(true);
         refreshView.setRefreshing(false);
         requireActivity().invalidateOptionsMenu();
-
-        setupToC(model, pageFragmentLoadState.isFirstPage());
-        editHandler.setPage(model.getPage());
         initPageScrollFunnel();
 
         if (model.getReadingListPage() != null) {
@@ -809,6 +806,8 @@ public class PageFragment extends Fragment implements BackPressedHandler {
                     ReadingListDbHelper.instance().updatePage(page);
                 }
             }).subscribeOn(Schedulers.io()).subscribe());
+            setupToC(model, pageFragmentLoadState.isFirstPage());
+            editHandler.setPage(model.getPage());
         }
 
         checkAndShowBookmarkOnboarding();


### PR DESCRIPTION
If the article is not available for offline reading, it will cause a crash because of the `null` object.