### PR TITLE
New performance measure

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -10,6 +10,7 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -422,6 +423,7 @@ public class PageFragment extends Fragment implements BackPressedHandler {
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
+                L.d("ttfp: " + activeTimer.getElapsedMillis());
                 if (!isAdded()) {
                     return;
                 }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -10,7 +10,6 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.view.Menu;

--- a/app/src/main/java/org/wikipedia/util/ActiveTimer.java
+++ b/app/src/main/java/org/wikipedia/util/ActiveTimer.java
@@ -26,4 +26,8 @@ public class ActiveTimer {
     public int getElapsedSec() {
         return (int) TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - startMillis);
     }
+
+    public long getElapsedMillis() {
+        return System.currentTimeMillis() - startMillis;
+    }
 }


### PR DESCRIPTION
Comparison of load time

Old measurements taken from PR by @joewalsh : https://github.com/wikimedia/apps-android-wikipedia/commit/77861cf6f8148c906ec46b926c75387b8d3eee14

|Detail|Old Performance|mobile-html Performance|
|-------|-----------------|-------------|     
Page with image|~200ms|~600ms|
Page without image|~140ms|~400ms|
Re-open same page|~200ms|~150ms|
From existing tab|~160ms|~200ms|
 
**Note**: The page is painted a split second later during old measurements and mobile-html is fully painted