### PR TITLE
Don't squash current tab backstack when opening Gallery file page or LangLinks

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -478,7 +478,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     }
 
     public void finishWithPageResult(@NonNull PageTitle resultTitle, @NonNull HistoryEntry historyEntry) {
-        Intent intent = PageActivity.newIntentForCurrentTab(GalleryActivity.this, historyEntry, resultTitle);
+        Intent intent = PageActivity.newIntentForCurrentTab(GalleryActivity.this, historyEntry, resultTitle, false);
         setResult(ACTIVITY_RESULT_PAGE_SELECTED, intent);
         finish();
     }

--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
@@ -458,7 +458,7 @@ public class LangLinksActivity extends BaseActivity {
             PageTitle langLink = languageEntries.get(pos);
             app.language().addMruLanguageCode(langLink.getWikiSite().languageCode());
             HistoryEntry historyEntry = new HistoryEntry(langLink, HistoryEntry.SOURCE_LANGUAGE_LINK);
-            Intent intent = PageActivity.newIntentForCurrentTab(LangLinksActivity.this, historyEntry, langLink);
+            Intent intent = PageActivity.newIntentForCurrentTab(LangLinksActivity.this, historyEntry, langLink, false);
             setResult(ACTIVITY_RESULT_LANGLINK_SELECT, intent);
             hideSoftKeyboard(LangLinksActivity.this);
             finish();

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -94,6 +94,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
     public static final String ACTION_LOAD_IN_NEW_TAB = "org.wikipedia.load_in_new_tab";
     public static final String ACTION_LOAD_IN_CURRENT_TAB = "org.wikipedia.load_in_current_tab";
+    public static final String ACTION_LOAD_IN_CURRENT_TAB_SQUASH = "org.wikipedia.load_in_current_tab_squash";
     public static final String ACTION_LOAD_FROM_EXISTING_TAB = "org.wikipedia.load_from_existing_tab";
     public static final String ACTION_CREATE_NEW_TAB = "org.wikipedia.create_new_tab";
     public static final String ACTION_RESUME_READING = "org.wikipedia.resume_reading";
@@ -298,7 +299,14 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     public static Intent newIntentForCurrentTab(@NonNull Context context,
                                                 @NonNull HistoryEntry entry,
                                                 @NonNull PageTitle title) {
-        return new Intent(ACTION_LOAD_IN_CURRENT_TAB)
+        return newIntentForCurrentTab(context, entry, title, true);
+    }
+
+    public static Intent newIntentForCurrentTab(@NonNull Context context,
+                                                @NonNull HistoryEntry entry,
+                                                @NonNull PageTitle title,
+                                                boolean squashBackstack) {
+        return new Intent(squashBackstack ? ACTION_LOAD_IN_CURRENT_TAB_SQUASH : ACTION_LOAD_IN_CURRENT_TAB)
                 .setClass(context, PageActivity.class)
                 .putExtra(EXTRA_HISTORYENTRY, entry)
                 .putExtra(EXTRA_PAGETITLE, title);
@@ -339,12 +347,15 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
             }
             loadPage(title, historyEntry, TabPosition.NEW_TAB_FOREGROUND);
         } else if (ACTION_LOAD_IN_NEW_TAB.equals(intent.getAction())
-                || ACTION_LOAD_IN_CURRENT_TAB.equals(intent.getAction())) {
+                || ACTION_LOAD_IN_CURRENT_TAB.equals(intent.getAction())
+                || ACTION_LOAD_IN_CURRENT_TAB_SQUASH.equals(intent.getAction())) {
             PageTitle title = intent.getParcelableExtra(EXTRA_PAGETITLE);
             HistoryEntry historyEntry = intent.getParcelableExtra(EXTRA_HISTORYENTRY);
             if (ACTION_LOAD_IN_NEW_TAB.equals(intent.getAction())) {
                 loadPage(title, historyEntry, TabPosition.NEW_TAB_FOREGROUND);
             } else if (ACTION_LOAD_IN_CURRENT_TAB.equals(intent.getAction())) {
+                loadPage(title, historyEntry, TabPosition.CURRENT_TAB);
+            } else if (ACTION_LOAD_IN_CURRENT_TAB_SQUASH.equals(intent.getAction())) {
                 loadPage(title, historyEntry, TabPosition.CURRENT_TAB_SQUASH);
             }
             if (intent.hasExtra(Constants.INTENT_EXTRA_REVERT_QNUMBER)) {
@@ -671,7 +682,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         if (settingsActivityRequested(requestCode)) {
             handleSettingsActivityResult(resultCode);
         } else if (newArticleLanguageSelected(requestCode, resultCode) || galleryPageSelected(requestCode, resultCode)) {
-            handleLangLinkOrPageResult(data);
+            toolbarContainerView.post(() -> handleIntent(data));
         } else if (galleryImageCaptionAdded(requestCode, resultCode)) {
             pageFragment.refreshPage();
         } else if (requestCode == Constants.ACTIVITY_REQUEST_BROWSE_TABS) {
@@ -696,10 +707,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }
-    }
-
-    private void handleLangLinkOrPageResult(final Intent data) {
-        toolbarContainerView.post(() -> handleIntent(data));
     }
 
     @Override


### PR DESCRIPTION
When opening pages from the Gallery or LangLinks, let's push them onto the current backstack instead of squashing the backstack, kthx.

https://phabricator.wikimedia.org/T230203
