### PR TITLE
Mobile-html: fix the logic of showing ToC

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -808,6 +808,9 @@ public class PageFragment extends Fragment implements BackPressedHandler {
                     ReadingListDbHelper.instance().updatePage(page);
                 }
             }).subscribeOn(Schedulers.io()).subscribe());
+        }
+
+        if (!errorState) {
             setupToC(model, pageFragmentLoadState.isFirstPage());
             editHandler.setPage(model.getPage());
         }


### PR DESCRIPTION
Shouldn't put the `setupToC()` and `editHandler.setPage()` into the logic of checking reading list.

The ToC will not display if the article has not being saved into the reading list.