### PR TITLE
Encode the page title to prevent showing page with error codes

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -15,6 +15,7 @@ import androidx.annotation.NonNull;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wikipedia.dataclient.RestService;
+import org.wikipedia.util.UriUtil;
 import org.wikipedia.util.log.L;
 
 import java.util.ArrayList;
@@ -62,7 +63,7 @@ public class CommunicationBridge {
     public void resetHtml(@NonNull String wikiUrl, String title) {
         isDOMReady = false;
         pendingJSMessages.clear();
-        webView.loadUrl(wikiUrl + RestService.REST_API_PREFIX + RestService.PAGE_HTML_ENDPOINT + title);
+        webView.loadUrl(wikiUrl + RestService.REST_API_PREFIX + RestService.PAGE_HTML_ENDPOINT + UriUtil.encodeURL(title));
         execute(JavaScriptActionHandler.setHandler());
     }
 


### PR DESCRIPTION
**Steps to reproduce**
1. Open article [South Korea]
2. Go to [Climate] 
3. Open the "Quick facts" and click on the "explanation" for the climate chart
4. Open the article

The title is `Template:Climate_char/How_to_read_a_climate_chart`, and the `/` should be encoded to `%2F`, which will be `Template:Climate_chart%2FHow_to_read_a_climate_chart`