### PR TITLE
Fix language variants issue on LinkHandler

### DIFF
--- a/app/src/main/java/org/wikipedia/page/LinkHandler.java
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.java
@@ -85,6 +85,13 @@ public abstract class LinkHandler implements CommunicationBridge.JSEventListener
                     .build();
         }
 
+        // TODO: remove this after the endpoint supporting language variants
+        String convertedText = UriUtil.getTitleFromUrl(href);
+        if (!convertedText.equals(titleString)) {
+            titleString = convertedText;
+        }
+
+
         L.d("Link clicked was " + uri.toString());
         if (!TextUtils.isEmpty(uri.getPath()) && WikiSite.supportedAuthority(uri.getAuthority())
                 && (uri.getPath().startsWith("/wiki/") || uri.getPath().startsWith("/zh-"))) {


### PR DESCRIPTION
Sometimes the `title` on the link does not match the `title` from the `JSONObject`, and we should check that.

https://zh.wikipedia.org/api/rest_v1/page/mobile-html/晚報
The link of `新民晚報` is `./新民晚报`, which the `報` is different with `报`