### PR TITLE
Fix: make sure the "go back" button work properly on WikiErrorView

### DIFF
--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
@@ -95,6 +95,7 @@ public class LangLinksActivity extends BaseActivity {
 
         fetchLangLinks();
 
+        langLinksError.setBackClickListener((v) -> onBackPressed());
         langLinksError.setRetryClickListener((v) -> {
             ViewAnimations.crossFade(langLinksError, langLinksProgress);
             fetchLangLinks();

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
@@ -99,6 +99,7 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
         ButterKnife.bind(this);
 
         errorView.setRetryClickListener((v) -> beginUpdateList());
+        errorView.setBackClickListener((v) -> onBackPressed());
 
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         recyclerView.addItemDecoration(new DrawableItemDecoration(this, R.attr.list_separator_drawable));

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -92,6 +92,7 @@ public class SearchResultsFragment extends Fragment {
         SearchResultAdapter adapter = new SearchResultAdapter(inflater);
         searchResultsList.setAdapter(adapter);
 
+        searchErrorView.setBackClickListener((v) -> requireActivity().finish());
         searchErrorView.setRetryClickListener((v) -> {
             searchErrorView.setVisibility(View.GONE);
             startSearch(currentSearchTerm, true);


### PR DESCRIPTION
**Steps to reproduce:**

 - Go to "NotificationActivity"
 - Log out the account somewhere else (e.g. Desktop Wikipedia)
 - Try to refresh the page
