### PR TITLE
Make SuggestedEditsFunnel work when entering from Feed.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
@@ -12,6 +12,11 @@ import org.wikipedia.json.GsonUtil;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.wikipedia.Constants.InvokeSource.FEED;
+import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_ADD_DESC;
+import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION;
+import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC;
+import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION;
 import static org.wikipedia.Constants.InvokeSource.NAV_MENU;
 import static org.wikipedia.Constants.InvokeSource.NOTIFICATION;
 import static org.wikipedia.Constants.InvokeSource.ONBOARDING_DIALOG;
@@ -48,11 +53,17 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
     public static SuggestedEditsFunnel get(InvokeSource invokeSource) {
         if (INSTANCE == null) {
             INSTANCE = new SuggestedEditsFunnel(WikipediaApp.getInstance(), invokeSource);
+        } else if (INSTANCE.invokeSource != invokeSource) {
+            INSTANCE.log();
+            INSTANCE = new SuggestedEditsFunnel(WikipediaApp.getInstance(), invokeSource);
         }
         return INSTANCE;
     }
 
     public static SuggestedEditsFunnel get() {
+        if (INSTANCE != null && INSTANCE.invokeSource != NAV_MENU) {
+            return INSTANCE;
+        }
         return get(NAV_MENU);
     }
 
@@ -65,13 +76,13 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
     }
 
     public void impression(InvokeSource source) {
-        if (source == SUGGESTED_EDITS_ADD_DESC) {
+        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
             statsCollection.addDescriptionStats.impressions++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
             statsCollection.translateDescriptionStats.impressions++;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
             statsCollection.addCaptionStats.impressions++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
             statsCollection.translateCaptionStats.impressions++;
         }
     }
@@ -79,13 +90,13 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
 
     public void click(String title, InvokeSource source) {
         SuggestedEditStats stats;
-        if (source == SUGGESTED_EDITS_ADD_DESC) {
+        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
             stats = statsCollection.addDescriptionStats;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
             stats = statsCollection.translateDescriptionStats;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
             stats = statsCollection.addCaptionStats;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
             stats = statsCollection.translateCaptionStats;
         } else {
             return;
@@ -102,37 +113,37 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
     }
 
     public void cancel(InvokeSource source) {
-        if (source == SUGGESTED_EDITS_ADD_DESC) {
+        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
             statsCollection.addDescriptionStats.cancels++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
             statsCollection.translateDescriptionStats.cancels++;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
             statsCollection.addCaptionStats.cancels++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
             statsCollection.translateCaptionStats.cancels++;
         }
     }
 
     public void success(InvokeSource source) {
-        if (source == SUGGESTED_EDITS_ADD_DESC) {
+        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
             statsCollection.addDescriptionStats.successes++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
             statsCollection.translateDescriptionStats.successes++;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
             statsCollection.addCaptionStats.successes++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
             statsCollection.translateCaptionStats.successes++;
         }
     }
 
     public void failure(InvokeSource source) {
-        if (source == SUGGESTED_EDITS_ADD_DESC) {
+        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
             statsCollection.addDescriptionStats.failures++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
             statsCollection.translateDescriptionStats.failures++;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
             statsCollection.addCaptionStats.failures++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION) {
+        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
             statsCollection.translateCaptionStats.failures++;
         }
     }
@@ -151,7 +162,9 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
                 "help_opened", helpOpenedCount,
                 "scorecard_opened", contributionsOpenedCount,
                 "source", (invokeSource == ONBOARDING_DIALOG ? "dialog"
-                        : invokeSource == NOTIFICATION ? "notification" : "menu")
+                        : invokeSource == NOTIFICATION ? "notification"
+                        : invokeSource == FEED ? "feed"
+                        : "menu")
         );
     }
 

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.java
@@ -28,6 +28,7 @@ import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.FragmentUtil;
 import org.wikipedia.analytics.FeedFunnel;
+import org.wikipedia.analytics.SuggestedEditsFunnel;
 import org.wikipedia.descriptions.DescriptionEditActivity;
 import org.wikipedia.feed.configure.ConfigureActivity;
 import org.wikipedia.feed.configure.ConfigureItemLanguageDialogView;
@@ -40,6 +41,7 @@ import org.wikipedia.feed.mostread.MostReadArticlesActivity;
 import org.wikipedia.feed.mostread.MostReadListCard;
 import org.wikipedia.feed.news.NewsItemCard;
 import org.wikipedia.feed.random.RandomCardView;
+import org.wikipedia.feed.suggestededits.SuggestedEditsCard;
 import org.wikipedia.feed.suggestededits.SuggestedEditsCardView;
 import org.wikipedia.feed.view.FeedAdapter;
 import org.wikipedia.feed.view.FeedView;
@@ -234,15 +236,19 @@ public class FeedFragment extends Fragment implements BackPressedHandler {
                 && resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED)
                 || requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE) {
             refresh();
-        } else if (requestCode == ACTIVITY_REQUEST_DESCRIPTION_EDIT && resultCode == RESULT_OK) {
-            boolean isTranslation;
-            if (suggestedEditsCardView != null) {
-                suggestedEditsCardView.refreshCardContent();
-                isTranslation = suggestedEditsCardView.isTranslation();
-                if (suggestedEditsCardView.getCard() != null) {
-                    FeedbackUtil.showMessage(this, isTranslation && app.language().getAppLanguageCodes().size() > 1
-                            ? getString(suggestedEditsCardView.getCard().getInvokeSource() == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC ? R.string.description_edit_success_saved_in_lang_snackbar : R.string.description_edit_success_saved_image_caption_in_lang_snackbar, app.language().getAppLanguageLocalizedName(app.language().getAppLanguageCodes().get(1)))
-                            : getString(suggestedEditsCardView.getCard().getInvokeSource() == FEED_CARD_SUGGESTED_EDITS_ADD_DESC ? R.string.description_edit_success_saved_snackbar : R.string.description_edit_success_saved_image_caption_snackbar));
+        } else if (requestCode == ACTIVITY_REQUEST_DESCRIPTION_EDIT) {
+            SuggestedEditsFunnel.get().log();
+            SuggestedEditsFunnel.reset();
+            if (resultCode == RESULT_OK) {
+                boolean isTranslation;
+                if (suggestedEditsCardView != null) {
+                    suggestedEditsCardView.refreshCardContent();
+                    isTranslation = suggestedEditsCardView.isTranslation();
+                    if (suggestedEditsCardView.getCard() != null) {
+                        FeedbackUtil.showMessage(this, isTranslation && app.language().getAppLanguageCodes().size() > 1
+                                ? getString(suggestedEditsCardView.getCard().getInvokeSource() == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC ? R.string.description_edit_success_saved_in_lang_snackbar : R.string.description_edit_success_saved_image_caption_in_lang_snackbar, app.language().getAppLanguageLocalizedName(app.language().getAppLanguageCodes().get(1)))
+                                : getString(suggestedEditsCardView.getCard().getInvokeSource() == FEED_CARD_SUGGESTED_EDITS_ADD_DESC ? R.string.description_edit_success_saved_snackbar : R.string.description_edit_success_saved_image_caption_snackbar));
+                    }
                 }
             }
         } else if (requestCode == ACTIVITY_REQUEST_SUGGESTED_EDITS_ONBOARDING && resultCode == RESULT_OK) {
@@ -362,6 +368,10 @@ public class FeedFragment extends Fragment implements BackPressedHandler {
         public void onShowCard(@Nullable Card card) {
             if (card != null) {
                 funnel.cardShown(card.type(), getCardLanguageCode(card));
+
+                if (card instanceof SuggestedEditsCard) {
+                    ((SuggestedEditsCard) card).logImpression();
+                }
             }
         }
 

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCard.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCard.kt
@@ -3,6 +3,7 @@ package org.wikipedia.feed.suggestededits
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
+import org.wikipedia.analytics.SuggestedEditsFunnel
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.feed.model.CardType
 import org.wikipedia.feed.model.WikiSiteCard
@@ -20,5 +21,9 @@ class SuggestedEditsCard(wiki: WikiSite,
 
     override fun title(): String {
         return WikipediaApp.getInstance().getString(R.string.suggested_edits_feed_card_title)
+    }
+
+    fun logImpression() {
+        SuggestedEditsFunnel.get(InvokeSource.FEED).impression(invokeSource)
     }
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksActivity.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksActivity.kt
@@ -26,7 +26,7 @@ class SuggestedEditsTasksActivity : SingleFragmentActivity<SuggestedEditsTasksFr
                 startActivity(SuggestedEditsCardsActivity.newIntent(this, source))
             }
         } else {
-            SuggestedEditsFunnel.get()
+            SuggestedEditsFunnel.get(NAV_MENU)
         }
     }
 


### PR DESCRIPTION
The `SuggestedEditsFunnel` wasn't really designed to work with how the user enters the workflow directly from the feed. This patch attempts to make it work as well as it can.