### PR TITLE
Fix: show ErrorView if click on an SVG file with no other available images in Gallery

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -546,6 +546,11 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     }
 
     private void applyGalleryList(@NonNull List<MediaListItem> list) {
+        if (list.isEmpty()) {
+            showError(new Throwable());
+            FeedbackUtil.showMessage(this, R.string.gallery_error_draw_failed);
+            return;
+        }
         // remove the page transformer while we operate on the pager...
         galleryPager.setPageTransformer(false, null);
         // first, verify that the collection contains the item that the user


### PR DESCRIPTION
Steps to reproduce:
1. https://en.wikipedia.org/wiki/Playoffs
2. Click on the book SVG icon
3. Open Gallery and see an empty view