### PR TITLE
Fix copying of AAB bundle when building releases.

### DIFF
--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -100,7 +100,7 @@ def get_output_apk_file_name(flavor):
     return 'app/build/outputs/apk/' + flavor + '/release/app-' + flavor + '-release.apk'
 
 def get_output_bundle_file_name(flavor):
-    return 'app/build/outputs/bundle/' + flavor + 'Release/app.aab'
+    return 'app/build/outputs/bundle/' + flavor + 'Release/app-' + flavor + '-release.aab'
 
 
 def get_android_home():


### PR DESCRIPTION
The updated Gradle plugin puts the built Bundle in a slightly different folder than before.