### PR TITLE
Tweak: use fadingEdge on LanguageScrollView and minor code clean up

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.java
@@ -74,8 +74,8 @@ public class SearchFragment extends Fragment implements SearchResultsFragment.Ca
     @BindView(R.id.search_progress_bar) ProgressBar progressBar;
     @BindView(R.id.search_lang_button_container) View langButtonContainer;
     @BindView(R.id.search_lang_button) TextView langButton;
-    @BindView(R.id.lang_scroll) LanguageScrollView languageScrollView;
-    @BindView(R.id.language_scroll_container) View languageScrollContainer;
+    @BindView(R.id.search_language_scroll_view) LanguageScrollView languageScrollView;
+    @BindView(R.id.search_language_scroll_view_container) View languageScrollContainer;
     private Unbinder unbinder;
     private CompositeDisposable disposables = new CompositeDisposable();
 

--- a/app/src/main/java/org/wikipedia/views/LanguageScrollView.java
+++ b/app/src/main/java/org/wikipedia/views/LanguageScrollView.java
@@ -1,11 +1,8 @@
 package org.wikipedia.views;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
-import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.GradientDrawable;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -18,13 +15,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.view.ViewCompat;
 
 import com.google.android.material.tabs.TabLayout;
 
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
-import org.wikipedia.util.ResourceUtil;
 
 import java.util.List;
 
@@ -43,7 +38,6 @@ public class LanguageScrollView extends ConstraintLayout {
     }
 
     @BindView(R.id.horizontal_scroll_languages) TabLayout horizontalLanguageScroll;
-    @BindView(R.id.horizontal_scroll_languages_gradient) View gradientView;
     private Callback callback;
     private List<String> languageCodes;
 
@@ -82,17 +76,6 @@ public class LanguageScrollView extends ConstraintLayout {
                 updateTabView(true, tab);
             }
         });
-    }
-
-    @SuppressLint("DrawAllocation")
-    @Override
-    protected void onLayout(boolean changed, int l, int t, int r, int b) {
-        super.onLayout(changed, l, t, r, b);
-        if (gradientView.getBackground() == null) {
-            gradientView.setBackground(new GradientDrawable(ViewCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_LTR
-                    ? GradientDrawable.Orientation.LEFT_RIGHT : GradientDrawable.Orientation.RIGHT_LEFT,
-                    new int[]{Color.TRANSPARENT, ResourceUtil.getThemedColor(getContext(), R.attr.page_toolbar_color)}));
-        }
     }
 
     private void updateTabView(boolean selected, TabLayout.Tab tab) {

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -84,7 +84,7 @@
     </FrameLayout>
 
     <LinearLayout
-        android:id="@+id/language_scroll_container"
+        android:id="@+id/search_language_scroll_view_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/page_toolbar_color"
@@ -98,9 +98,11 @@
             android:background="?attr/material_theme_border_color" />
 
         <org.wikipedia.views.LanguageScrollView
-            android:id="@+id/lang_scroll"
+            android:id="@+id/search_language_scroll_view"
             android:layout_width="match_parent"
-            android:layout_height="48dp" />
+            android:layout_height="48dp"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"/>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/view_language_scroll.xml
+++ b/app/src/main/res/layout/view_language_scroll.xml
@@ -13,8 +13,8 @@
         android:background="?attr/page_toolbar_color"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
+        android:requiresFadingEdge="horizontal"
+        android:fadingEdgeLength="24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/more_languages"
         app:layout_constraintStart_toStartOf="parent"
@@ -30,21 +30,11 @@
         app:tabPaddingTop="8dp"
         app:tabSelectedTextColor="?attr/colorAccent" />
 
-    <View
-        android:id="@+id/horizontal_scroll_languages_gradient"
-        android:layout_width="24dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/more_languages"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <Button
         android:id="@+id/more_languages"
         style="@style/TransparentButton"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
         android:minWidth="0dp"
         android:text="@string/more_language_options"
         android:textColor="?attr/colorAccent"


### PR DESCRIPTION
Since the `TabLayout` extends the `HorizontalScrollView`, which supports the `requiresFadingEdge` and `fadingEdgeLength`, we can use it instead of creating a custom gradient view. And, it supports RTL languages correctly.