### PR TITLE
Fix: To stay in the theme fitting room after changing theme

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.java
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.java
@@ -38,7 +38,6 @@ import org.wikipedia.events.ReadingListsEnableDialogEvent;
 import org.wikipedia.events.ReadingListsMergeLocalDialogEvent;
 import org.wikipedia.events.ReadingListsNoLongerSyncedEvent;
 import org.wikipedia.events.SplitLargeListsEvent;
-import org.wikipedia.events.ThemeChangeEvent;
 import org.wikipedia.login.LoginActivity;
 import org.wikipedia.readinglist.ReadingListSyncBehaviorDialogs;
 import org.wikipedia.readinglist.sync.ReadingListSyncAdapter;
@@ -71,7 +70,6 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         exclusiveBusMethods = new ExclusiveBusConsumer();
-        disposables.add(WikipediaApp.getInstance().getBus().subscribe(new NonExclusiveBusConsumer()));
         setTheme();
         removeSplashBackground();
 
@@ -250,18 +248,6 @@ public abstract class BaseActivity extends AppCompatActivity {
                             -> startActivity(LoginActivity.newIntent(BaseActivity.this, LoginFunnel.SOURCE_LOGOUT_BACKGROUND)))
                     .setNegativeButton(R.string.logged_out_in_background_cancel, null)
                     .show();
-        }
-    }
-
-    /**
-     * Bus consumer that should be registered by all created activities.
-     */
-    private class NonExclusiveBusConsumer implements Consumer<Object> {
-        @Override
-        public void accept(Object event) throws Exception {
-            if (event instanceof ThemeChangeEvent) {
-                BaseActivity.this.recreate();
-            }
         }
     }
 

--- a/app/src/main/java/org/wikipedia/main/MainActivity.java
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.java
@@ -23,6 +23,7 @@ import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.appshortcuts.AppShortcuts;
 import org.wikipedia.auth.AccountUtil;
+import org.wikipedia.events.ThemeChangeEvent;
 import org.wikipedia.feed.FeedFragment;
 import org.wikipedia.history.HistoryFragment;
 import org.wikipedia.navtab.NavTab;
@@ -46,6 +47,8 @@ import org.wikipedia.views.WikiDrawerLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.functions.Consumer;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
@@ -60,6 +63,7 @@ public class MainActivity extends SingleFragmentActivity<MainFragment>
     @BindView(R.id.drawer_icon_layout) View drawerIconLayout;
     @BindView(R.id.drawer_icon_dot) View drawerIconDot;
     @BindView(R.id.hamburger_and_wordmark_layout) View hamburgerAndWordmarkLayout;
+    private CompositeDisposable disposables = new CompositeDisposable();
 
     private boolean controlNavTabInFragment;
 
@@ -74,6 +78,7 @@ public class MainActivity extends SingleFragmentActivity<MainFragment>
         ButterKnife.bind(this);
         AnimationUtil.setSharedElementTransitions(this);
         AppShortcuts.setShortcuts(this);
+        disposables.add(WikipediaApp.getInstance().getBus().subscribe(new EventBusConsumer()));
 
         if (Prefs.isInitialOnboardingEnabled() && savedInstanceState == null) {
             // Updating preference so the search multilingual tooltip
@@ -319,5 +324,20 @@ public class MainActivity extends SingleFragmentActivity<MainFragment>
             startActivity(new Intent(MainActivity.this, AboutActivity.class));
             closeMainDrawer();
         }
+    }
+
+    private class EventBusConsumer implements Consumer<Object> {
+        @Override
+        public void accept(Object event) {
+            if (event instanceof ThemeChangeEvent) {
+                MainActivity.this.recreate();
+            }
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        disposables.dispose();
     }
 }

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -45,6 +45,7 @@ import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.descriptions.DescriptionEditRevertHelpView;
 import org.wikipedia.events.ArticleSavedOrDeletedEvent;
 import org.wikipedia.events.ChangeTextSizeEvent;
+import org.wikipedia.events.ThemeChangeEvent;
 import org.wikipedia.feed.mainpage.MainPageClient;
 import org.wikipedia.gallery.GalleryActivity;
 import org.wikipedia.history.HistoryEntry;
@@ -831,6 +832,8 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
                         pageFragment.updateBookmarkAndMenuOptionsFromDao();
                     }
                 }
+            } else if (event instanceof ThemeChangeEvent) {
+                PageActivity.this.recreate();
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/settings/SettingsFragment.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsFragment.java
@@ -13,6 +13,7 @@ import org.wikipedia.events.ReadingListsEnableSyncStatusEvent;
 import org.wikipedia.events.ReadingListsEnabledStatusEvent;
 import org.wikipedia.events.ReadingListsMergeLocalDialogEvent;
 import org.wikipedia.events.ReadingListsNoLongerSyncedEvent;
+import org.wikipedia.events.ThemeChangeEvent;
 
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.functions.Consumer;
@@ -24,6 +25,7 @@ public class SettingsFragment extends PreferenceLoaderFragment {
 
     private SettingsPreferenceLoader preferenceLoader;
     private CompositeDisposable disposables = new CompositeDisposable();
+    private boolean hasThemeChanged;
 
     @Override public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -66,6 +68,11 @@ public class SettingsFragment extends PreferenceLoaderFragment {
             preferenceLoader.updateLanguagePrefSummary();
         });
         getActivity().invalidateOptionsMenu();
+        if (hasThemeChanged) {
+            if (getActivity() instanceof SettingsActivity) {
+                getActivity().recreate();
+            }
+        }
     }
 
     @Override
@@ -117,6 +124,8 @@ public class SettingsFragment extends PreferenceLoaderFragment {
                 setReadingListSyncPref(false);
             } else if (event instanceof ReadingListsEnableSyncStatusEvent) {
                 setReadingListSyncPref(Prefs.isReadingListSyncEnabled());
+            } else if (event instanceof ThemeChangeEvent) {
+                hasThemeChanged = true;
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomActivity.java
+++ b/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomActivity.java
@@ -6,13 +6,19 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 
+import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.SingleFragmentActivity;
+import org.wikipedia.events.ThemeChangeEvent;
 import org.wikipedia.page.ExclusiveBottomSheetPresenter;
+
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.functions.Consumer;
 
 public class ThemeFittingRoomActivity extends SingleFragmentActivity<ThemeFittingRoomFragment>
         implements ThemeChooserDialog.Callback {
     private ThemeChooserDialog themeChooserDialog;
     private ExclusiveBottomSheetPresenter bottomSheetPresenter = new ExclusiveBottomSheetPresenter();
+    private CompositeDisposable disposables = new CompositeDisposable();
 
     public static Intent newIntent(@NonNull Context context) {
         return new Intent(context, ThemeFittingRoomActivity.class);
@@ -21,11 +27,18 @@ public class ThemeFittingRoomActivity extends SingleFragmentActivity<ThemeFittin
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        disposables.add(WikipediaApp.getInstance().getBus().subscribe(new EventBusConsumer()));
 
         if (savedInstanceState == null) {
             themeChooserDialog = new ThemeChooserDialog();
             bottomSheetPresenter.show(getSupportFragmentManager(), themeChooserDialog);
         }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        disposables.dispose();
     }
 
     @Override
@@ -41,5 +54,15 @@ public class ThemeFittingRoomActivity extends SingleFragmentActivity<ThemeFittin
     @Override
     public void onCancel() {
         finish();
+    }
+
+
+    private class EventBusConsumer implements Consumer<Object> {
+        @Override
+        public void accept(Object event) {
+            if (event instanceof ThemeChangeEvent) {
+                ThemeFittingRoomActivity.this.recreate();
+            }
+        }
     }
 }


### PR DESCRIPTION
Theme change bus method being handled by affected activities, instead of BaseActivity

**Phab:** https://phabricator.wikimedia.org/T231059 