### PR TITLE
Utilize the displaytitle returned by /page/summary - SearchResult

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageSummary.java
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/page/RbPageSummary.java
@@ -92,7 +92,9 @@ public class RbPageSummary implements PageSummary {
 
     @NonNull
     public PageTitle getPageTitle(@NonNull WikiSite wiki) {
-        return new PageTitle(getTitle(), wiki, getThumbnailUrl(), getDescription());
+        PageTitle pageTitle = new PageTitle(getDisplayTitle(), wiki, getThumbnailUrl(), getDescription());
+        pageTitle.setConvertedText(getConvertedTitle());
+        return pageTitle;
     }
 
     public int getPageId() {

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -310,7 +310,7 @@ public class PageFragmentLoadState {
 
         disposables.add(PageClientFactory.create(model.getTitle().getWikiSite(), model.getTitle().namespace())
                 .lead(model.getTitle().getWikiSite(), model.getCacheControl(), model.shouldSaveOffline() ? OfflineCacheInterceptor.SAVE_HEADER_SAVE : null,
-                        model.getCurEntry().getReferrer(), model.getTitle().getPrefixedText(), calculateLeadImageWidth())
+                        model.getCurEntry().getReferrer(), model.getTitle().getConvertedText(), calculateLeadImageWidth())
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(rsp -> {
@@ -333,7 +333,7 @@ public class PageFragmentLoadState {
         Request remainingRequest = PageClientFactory.create(model.getTitle().getWikiSite(), model.getTitle().namespace())
                 .sectionsUrl(model.getTitle().getWikiSite(), model.shouldForceNetwork() ? CacheControl.FORCE_NETWORK : null,
                         model.shouldSaveOffline() ? OfflineCacheInterceptor.SAVE_HEADER_SAVE : null,
-                        model.getTitle().getPrefixedText());
+                        model.getTitle().getConvertedText());
 
         sendLeadSectionPayload(page, remainingRequest.url().toString());
 

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -338,7 +338,7 @@ public class SearchResultsFragment extends Fragment {
                                 .getSummary(null, searchResult.getPageTitle().getConvertedText())
                                 .subscribeOn(Schedulers.io()))
                 .observeOn(AndroidSchedulers.mainThread())
-                .map(summary -> {
+                .concatMapIterable(summary -> {
                     for (int i = 0; i < totalResults.size(); i++) {
                         if (totalResults.get(i).getPageTitle().getConvertedText().equals(summary.getConvertedTitle())) {
                             // replace with original one
@@ -349,10 +349,14 @@ public class SearchResultsFragment extends Fragment {
                     return totalResults;
                 })
                 .doAfterTerminate(() -> updateProgressBar(false))
-                .subscribe(results -> {
+                .toList()
+                .subscribe(result -> {
                     // TODO: use lambda when done
                     // TODO: have correct title for new page (e.g.: Search IoT in zh wiki)
                     // TODO: handle cache
+                    L.d("doFullTextSearch subscribe called");
+                    cache(result, searchTerm);
+                    log(result, startTime);
                     getAdapter().notifyDataSetChanged();
                 }, throwable -> {
                     // If there's an error, just log it and let the existing prefix search results be.

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -538,7 +538,7 @@ public class SearchResultsFragment extends Fragment {
             }
 
             // highlight search term within the text
-            StringUtil.boldenKeywordText(pageTitleText, result.getPageTitle().getDisplayText(), currentSearchTerm);
+            StringUtil.boldenKeywordText(pageTitleText, StringUtil.removeHTMLTags(result.getPageTitle().getDisplayText()), currentSearchTerm);
 
             searchResultItemImage.setVisibility((result.getPageTitle().getThumbUrl() == null) ? View.GONE : View.VISIBLE);
             ViewUtil.loadImageUrlInto(searchResultItemImage,

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -30,6 +30,7 @@ import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.StringUtil;
+import org.wikipedia.util.log.L;
 import org.wikipedia.views.GoneIfEmptyTextView;
 import org.wikipedia.views.ViewUtil;
 import org.wikipedia.views.WikiErrorView;
@@ -347,14 +348,15 @@ public class SearchResultsFragment extends Fragment {
                     }
                     return totalResults;
                 })
-                .toList()
                 .doAfterTerminate(() -> updateProgressBar(false))
                 .subscribe(results -> {
                     // TODO: use lambda when done
                     // TODO: have correct title for new page (e.g.: Search IoT in zh wiki)
+                    // TODO: handle cache
                     getAdapter().notifyDataSetChanged();
                 }, throwable -> {
                     // If there's an error, just log it and let the existing prefix search results be.
+                    L.d("doFullTextSearch error " + throwable );
                     logError(true, startTime);
                 }));
     }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T227092

This PR relates to #448  since it would be better if sends requests using the `converetedTitle()`

TODO: add `displaytitle` to a new table?