### PR TITLE
Fix obscure login issue.

### DIFF
--- a/app/src/main/java/org/wikipedia/login/LoginActivity.java
+++ b/app/src/main/java/org/wikipedia/login/LoginActivity.java
@@ -6,10 +6,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.ProgressBar;
 
 import androidx.annotation.NonNull;
@@ -52,7 +52,7 @@ public class LoginActivity extends BaseActivity {
 
     @BindView(R.id.login_username_text) TextInputLayout usernameInput;
     @BindView(R.id.login_password_input) TextInputLayout passwordInput;
-    @BindView(R.id.login_2fa_text) EditText twoFactorText;
+    @BindView(R.id.login_2fa_text) TextInputLayout twoFactorText;
     @BindView(R.id.view_login_error) WikiErrorView errorView;
     @BindView(R.id.login_button) Button loginButton;
     @BindView(R.id.view_progress_bar) ProgressBar progressBar;
@@ -211,11 +211,11 @@ public class LoginActivity extends BaseActivity {
     private void doLogin() {
         final String username = getText(usernameInput).toString();
         final String password = getText(passwordInput).toString();
-        final String twoFactorCode = twoFactorText.getText().toString();
+        final String twoFactorCode = getText(twoFactorText).toString();
 
         showProgressBar(true);
 
-        if (!twoFactorCode.isEmpty()) {
+        if (!TextUtils.isEmpty(twoFactorCode) && !TextUtils.isEmpty(firstStepToken)) {
             loginClient.login(WikipediaApp.getInstance().getWikiSite(), username, password,
                     null, twoFactorCode, firstStepToken, loginCallback);
         } else {

--- a/app/src/main/java/org/wikipedia/login/LoginClient.java
+++ b/app/src/main/java/org/wikipedia/login/LoginClient.java
@@ -85,7 +85,7 @@ public class LoginClient {
 
     void login(@NonNull final WikiSite wiki, @NonNull final String userName, @NonNull final String password,
                @Nullable final String retypedPassword, @Nullable final String twoFactorCode,
-               @Nullable final String loginToken, @NonNull final LoginCallback cb) {
+               @NonNull final String loginToken, @NonNull final LoginCallback cb) {
         loginCall = TextUtils.isEmpty(twoFactorCode) && TextUtils.isEmpty(retypedPassword)
                 ? ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, Service.WIKIPEDIA_URL)
                 : ServiceFactory.get(wiki).postLogIn(userName, password, retypedPassword, twoFactorCode, loginToken, true);

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -80,12 +80,12 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/login_2fa_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/login_2fa_hint">
 
                     <org.wikipedia.views.PlainPasteEditText
-                        android:id="@+id/login_2fa_text"
                         style="?android:textAppearanceMedium"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
If we add up all the evidence that we have gathered so far, there is only one code path that could lead to the `logintoken` being null in the login API call:

The issue is not related to 2FA _per se_, but rather has to do with how we display and bind to the entry field for the 2FA token.  For some reason, the text field for entering the 2FA code was being bound as an `EditText`, instead of a `TextInputLayout` as it's supposed to be.  This may be producing unexpected behavior (on some devices / platforms) when we try to read the string value from the field.

NOTE: We still need to test whether actual 2FA is still working after this patch.