### PR TITLE
Use Commons URL sas WikiSite to get all notifications

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
@@ -27,6 +27,7 @@ import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.BaseActivity;
 import org.wikipedia.analytics.NotificationFunnel;
+import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.history.HistoryEntry;
@@ -196,7 +197,7 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
             return;
         }
 
-        disposables.add(ServiceFactory.get(WikipediaApp.getInstance().getWikiSite()).getUnreadNotificationWikis()
+        disposables.add(ServiceFactory.get(new WikiSite(Service.COMMONS_URL)).getUnreadNotificationWikis()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> {
@@ -213,7 +214,7 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
 
     private void getOrContinueNotifications() {
         progressBarView.setVisibility(View.VISIBLE);
-        disposables.add(ServiceFactory.get(WikipediaApp.getInstance().getWikiSite()).getAllNotifications("*", displayArchived ? "read" : "!read", currentContinueStr)
+        disposables.add(ServiceFactory.get(new WikiSite(Service.COMMONS_URL)).getAllNotifications("*", displayArchived ? "read" : "!read", currentContinueStr)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> {

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.java
@@ -84,7 +84,7 @@ public class NotificationPollBroadcastReceiver extends BroadcastReceiver {
 
     @SuppressLint("CheckResult")
     private void pollNotifications(@NonNull final Context context) {
-        ServiceFactory.get(WikipediaApp.getInstance().getWikiSite()).getLastUnreadNotification()
+        ServiceFactory.get(new WikiSite(Service.COMMONS_URL)).getLastUnreadNotification()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> {
@@ -131,7 +131,7 @@ public class NotificationPollBroadcastReceiver extends BroadcastReceiver {
     private void retrieveNotifications(@NonNull final Context context) {
         dbNameWikiSiteMap.clear();
         dbNameWikiSiteMap.clear();
-        ServiceFactory.get(WikipediaApp.getInstance().getWikiSite()).getUnreadNotificationWikis()
+        ServiceFactory.get(new WikiSite(Service.COMMONS_URL)).getUnreadNotificationWikis()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> {
@@ -150,7 +150,7 @@ public class NotificationPollBroadcastReceiver extends BroadcastReceiver {
 
     @SuppressLint("CheckResult")
     private void getFullNotifications(@NonNull final Context context, @NonNull List<String> foreignWikis) {
-        ServiceFactory.get(WikipediaApp.getInstance().getWikiSite()).getAllNotifications(foreignWikis.isEmpty() ? "*" : TextUtils.join("|", foreignWikis), "!read", null)
+        ServiceFactory.get(new WikiSite(Service.COMMONS_URL)).getAllNotifications(foreignWikis.isEmpty() ? "*" : TextUtils.join("|", foreignWikis), "!read", null)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> onNotificationsComplete(context, response.query().notifications().list()),


### PR DESCRIPTION
Since we cannot get "read" Commons notifications from `en.wikipedia.org`, we can make the API calls from `https://commons.wikimedia.org/` to get notifications from Commons.