### PR TITLE
Exclude languages while creating app bundles

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,12 @@ android {
             returnDefaultValues = true
         }
     }
+
+    bundle {
+        language {
+            enableSplit false
+        }
+    }
 }
 
 apply from: '../gradle/src/test.gradle'


### PR DESCRIPTION
The app bundle splitting process splits apk according different screen densities, cpu architectures and languages. While this has not been a problem in the past,Playstore threw an error while trying to split the apk according to languages as it doesn't recognize th 'qq' flavor. This patch requests languages to be excluded during splitting, hence avoiding the problem. 