### PR TITLE
Consolidate Survey logic into its own utility class, and extend date.

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.java
+++ b/app/src/main/java/org/wikipedia/Constants.java
@@ -58,8 +58,6 @@ public final class Constants {
 
     public static final int MIN_LANGUAGES_TO_UNLOCK_TRANSLATION = 2;
 
-    public static final int VALID_SUGGESTED_EDITS_COUNT_FOR_SURVEY = 3;
-
     public enum InvokeSource {
         CONTEXT_MENU,
         LINK_PREVIEW_MENU,

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -48,16 +48,13 @@ import org.wikipedia.settings.Prefs;
 import org.wikipedia.settings.RemoteConfig;
 import org.wikipedia.settings.SiteInfoClient;
 import org.wikipedia.theme.Theme;
-import org.wikipedia.util.DateUtil;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.ReleaseUtil;
 import org.wikipedia.util.log.L;
 import org.wikipedia.views.ViewAnimations;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -69,7 +66,6 @@ import io.reactivex.internal.functions.Functions;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 
-import static java.util.Calendar.SEPTEMBER;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.wikipedia.settings.Prefs.getTextSizeMultiplier;
 import static org.wikipedia.util.DimenUtil.getFontSizeFromSp;
@@ -462,14 +458,5 @@ public class WikipediaApp extends Application {
 
     public boolean isAnyActivityResumed() {
         return activityLifecycleHandler.isAnyActivityResumed();
-    }
-
-    public boolean isSurveyLive() {
-        final int year = 2019;
-        final int startDay = 19;
-        final int endDay = 27; //Ends Sept 27 0:0:0
-        Date surveyStartDate = DateUtil.getDateObjectFor(year, SEPTEMBER, startDay);
-        Date surveyEndDate = DateUtil.getDateObjectFor(year, SEPTEMBER, endDay);
-        return DateUtil.isGivenDateBetweenDates(Calendar.getInstance().getTime(), surveyStartDate, surveyEndDate);
     }
 }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
@@ -38,6 +38,7 @@ import org.wikipedia.notifications.NotificationPollBroadcastReceiver;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.suggestededits.SuggestedEditsSummary;
+import org.wikipedia.suggestededits.SuggestedEditsSurvey;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
@@ -65,10 +66,8 @@ import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_CAPTION;
 import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_DESC;
 import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_CAPTION;
 import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_DESC;
-import static org.wikipedia.Constants.VALID_SUGGESTED_EDITS_COUNT_FOR_SURVEY;
 import static org.wikipedia.descriptions.DescriptionEditUtil.ABUSEFILTER_DISALLOWED;
 import static org.wikipedia.descriptions.DescriptionEditUtil.ABUSEFILTER_WARNING;
-import static org.wikipedia.settings.Prefs.setShouldShowSuggestedEditsSurvey;
 import static org.wikipedia.suggestededits.SuggestedEditsCardsActivity.EXTRA_SOURCE_ADDED_CONTRIBUTION;
 import static org.wikipedia.util.DeviceUtil.hideSoftKeyboard;
 
@@ -108,11 +107,8 @@ public class DescriptionEditFragment extends Fragment {
                 NotificationPollBroadcastReceiver.pollEditorTaskCounts(WikipediaApp.getInstance());
             }
 
-            if (WikipediaApp.getInstance().isSurveyLive() && isSuggestedEdits()) {
-                Prefs.setSuggestedEditsCountForSurvey(Prefs.getSuggestedEditsCountForSurvey() + 1);
-                if (Prefs.getSuggestedEditsCountForSurvey() == 1 || (Prefs.getSuggestedEditsCountForSurvey() == VALID_SUGGESTED_EDITS_COUNT_FOR_SURVEY && !Prefs.wasSuggestedEditsSurveyClicked())) {
-                    setShouldShowSuggestedEditsSurvey(true);
-                }
+            if (isSuggestedEdits()) {
+                SuggestedEditsSurvey.onEditSuccess();
             }
 
             Prefs.setLastDescriptionEditTime(new Date().getTime());

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -7,22 +7,17 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
 import android.location.Location;
-import android.net.Uri;
 import android.os.Bundle;
 import android.speech.RecognizerIntent;
-import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityOptionsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager.widget.ViewPager;
-
-import com.google.android.material.snackbar.Snackbar;
 
 import org.wikipedia.BackPressedHandler;
 import org.wikipedia.Constants;
@@ -58,11 +53,11 @@ import org.wikipedia.readinglist.AddToReadingListDialog;
 import org.wikipedia.search.SearchActivity;
 import org.wikipedia.search.SearchFragment;
 import org.wikipedia.settings.Prefs;
+import org.wikipedia.suggestededits.SuggestedEditsSurvey;
 import org.wikipedia.util.ClipboardUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.PermissionUtil;
 import org.wikipedia.util.ShareUtil;
-import org.wikipedia.util.UriUtil;
 import org.wikipedia.util.log.L;
 
 import java.io.File;
@@ -142,27 +137,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
         downloadReceiver.setCallback(downloadReceiverCallback);
         // reset the last-page-viewed timer
         Prefs.pageLastShown(0);
-        maybeRunSurvey();
-    }
-
-    private void maybeRunSurvey() {
-        final float extraLineSpacing = 5.0f;
-        if (Prefs.shouldShowSuggestedEditsSurvey() && WikipediaApp.getInstance().isSurveyLive()) {
-            Snackbar snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(R.string.suggested_edits_snackbar_survey_text), FeedbackUtil.LENGTH_LONG);
-            TextView textView = snackbar.getView().findViewById(R.id.snackbar_text);
-            textView.setLineSpacing(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, extraLineSpacing, getResources().getDisplayMetrics()), 1.0f);
-            TextView actionView = snackbar.getView().findViewById(R.id.snackbar_action);
-            actionView.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ic_open_in_new_accent_24, 0);
-            actionView.setCompoundDrawablePadding(getResources().getDimensionPixelOffset(R.dimen.margin));
-            snackbar.setAction(getString(R.string.suggested_edits_snackbar_survey_action_text), (v) -> openSurveyInBrowser());
-            snackbar.show();
-            Prefs.setShouldShowSuggestedEditsSurvey(false);
-        }
-    }
-
-    private void openSurveyInBrowser() {
-        Prefs.setSuggestedEditsSurveyClicked(true);
-        UriUtil.visitInExternalBrowser(getContext(), Uri.parse(getString(R.string.suggested_edits_survey_url)));
+        SuggestedEditsSurvey.maybeRunSurvey(requireActivity());
     }
 
     @Override public void onDestroyView() {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsSurvey.java
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsSurvey.java
@@ -1,0 +1,65 @@
+package org.wikipedia.suggestededits;
+
+import android.app.Activity;
+import android.net.Uri;
+import android.util.TypedValue;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.snackbar.Snackbar;
+
+import org.wikipedia.R;
+import org.wikipedia.WikipediaApp;
+import org.wikipedia.settings.Prefs;
+import org.wikipedia.util.DateUtil;
+import org.wikipedia.util.FeedbackUtil;
+import org.wikipedia.util.UriUtil;
+
+import java.util.Calendar;
+
+import static java.util.Calendar.SEPTEMBER;
+import static org.wikipedia.settings.Prefs.setShouldShowSuggestedEditsSurvey;
+
+public final class SuggestedEditsSurvey {
+    private static final int VALID_SUGGESTED_EDITS_COUNT_FOR_SURVEY = 3;
+
+    public static void maybeRunSurvey(@NonNull Activity activity) {
+        final float extraLineSpacing = 5.0f;
+        if (Prefs.shouldShowSuggestedEditsSurvey() && isSurveyLive()) {
+            Snackbar snackbar = FeedbackUtil.makeSnackbar(activity, activity.getString(R.string.suggested_edits_snackbar_survey_text), FeedbackUtil.LENGTH_LONG);
+            TextView textView = snackbar.getView().findViewById(R.id.snackbar_text);
+            textView.setLineSpacing(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, extraLineSpacing, activity.getResources().getDisplayMetrics()), 1.0f);
+            TextView actionView = snackbar.getView().findViewById(R.id.snackbar_action);
+            actionView.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ic_open_in_new_accent_24, 0);
+            actionView.setCompoundDrawablePadding(activity.getResources().getDimensionPixelOffset(R.dimen.margin));
+            snackbar.setAction(activity.getString(R.string.suggested_edits_snackbar_survey_action_text), (v) -> openSurveyInBrowser());
+            snackbar.show();
+            Prefs.setShouldShowSuggestedEditsSurvey(false);
+        }
+    }
+
+    public static void onEditSuccess() {
+        if (SuggestedEditsSurvey.isSurveyLive()) {
+            Prefs.setSuggestedEditsCountForSurvey(Prefs.getSuggestedEditsCountForSurvey() + 1);
+            if (Prefs.getSuggestedEditsCountForSurvey() == 1 || (Prefs.getSuggestedEditsCountForSurvey() == VALID_SUGGESTED_EDITS_COUNT_FOR_SURVEY && !Prefs.wasSuggestedEditsSurveyClicked())) {
+                setShouldShowSuggestedEditsSurvey(true);
+            }
+        }
+    }
+
+    private static void openSurveyInBrowser() {
+        Prefs.setSuggestedEditsSurveyClicked(true);
+        UriUtil.visitInExternalBrowser(WikipediaApp.getInstance(),
+                Uri.parse(WikipediaApp.getInstance().getString(R.string.suggested_edits_survey_url)));
+    }
+
+    @SuppressWarnings("checkstyle:magicnumber")
+    private static boolean isSurveyLive() {
+        return DateUtil.isGivenDateBetweenDates(Calendar.getInstance().getTime(),
+                DateUtil.getDateObjectFor(2019, SEPTEMBER, 19),
+                DateUtil.getDateObjectFor(2019, SEPTEMBER, 30));
+    }
+
+    private SuggestedEditsSurvey() { }
+}


### PR DESCRIPTION
Instead of having logic that is highly specific to a single survey spread throughout the app (including in the `WikipediaApp` class itself), this consolidates the logic into a self-contained helper class, which will be much easier to remove later.

This also extends the date of the survey until Sep 30, as requested in https://phabricator.wikimedia.org/T233745