### PR TITLE
Force dependency on latest version of SoLoader.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -181,6 +181,14 @@ dependencies {
     implementation "com.facebook.fresco:animated-gif:$frescoVersion"
     implementation "com.facebook.fresco:fresco:$frescoVersion"
     implementation "com.facebook.fresco:imagepipeline-okhttp3:$frescoVersion"
+
+    // TODO: remove when Fresco updates its bundled version of soloader.
+    configurations.all {
+        resolutionStrategy {
+            force "com.facebook.soloader:soloader:0.8.0"
+        }
+    }
+
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.romandanylyk:pageindicatorview:1.0.2'
     implementation "com.squareup.okhttp3:logging-interceptor:$okHttpVersion"


### PR DESCRIPTION
Since Facebook is quite slow at releasing a new version of Fresco with the newest version of SoLoader (which fixes a significant crash), we might as well do it ourselves for now.