### PR TITLE
Fix incorrect button backgrounds in Lollipop.

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -283,6 +283,7 @@
     <style name="TransparentButton" parent="@style/Widget.MaterialComponents.Button.UnelevatedButton">
         <item name="android:textAlignment">center</item>
         <item name="android:backgroundTint">@android:color/transparent</item>
+        <item name="backgroundTint">@android:color/transparent</item>
         <item name="android:foreground">?android:selectableItemBackground</item>
     </style>
 


### PR DESCRIPTION
Here's what the buttons were looking like:

![device-2019-09-27-084906](https://user-images.githubusercontent.com/1682214/65770255-b50a1880-e103-11e9-829a-426a15ed4c6b.png)
