### PR TITLE
Improve fix of WebView loading on Lollipop.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -6,7 +6,9 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -196,6 +198,17 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
             // then we must have been launched with an Intent, so... handle it!
             handleIntent(getIntent());
         }
+    }
+
+    @Override
+    public void applyOverrideConfiguration(Configuration configuration) {
+        // TODO: remove when this is fixed:
+        // https://issuetracker.google.com/issues/141132133
+        // On Lollipop the current version of AndroidX causes a crash when instantiating a WebView.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return;
+        }
+        super.applyOverrideConfiguration(configuration);
     }
 
 

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -205,7 +205,8 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         // TODO: remove when this is fixed:
         // https://issuetracker.google.com/issues/141132133
         // On Lollipop the current version of AndroidX causes a crash when instantiating a WebView.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+                && getResources().getConfiguration().uiMode == WikipediaApp.getInstance().getResources().getConfiguration().uiMode) {
             return;
         }
         super.applyOverrideConfiguration(configuration);

--- a/app/src/main/java/org/wikipedia/views/ObservableWebView.java
+++ b/app/src/main/java/org/wikipedia/views/ObservableWebView.java
@@ -1,9 +1,7 @@
 package org.wikipedia.views;
 
 import android.content.Context;
-import android.content.res.Configuration;
 import android.graphics.Canvas;
-import android.os.Build;
 import android.os.SystemClock;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
@@ -137,26 +135,18 @@ public class ObservableWebView extends WebView {
     }
 
     public ObservableWebView(Context context) {
-        super(getFixedContext(context));
+        super(context);
         init();
     }
 
     public ObservableWebView(Context context, AttributeSet attrs) {
-        super(getFixedContext(context), attrs);
+        super(context, attrs);
         init();
     }
 
     public ObservableWebView(Context context, AttributeSet attrs, int defStyle) {
-        super(getFixedContext(context), attrs, defStyle);
+        super(context, attrs, defStyle);
         init();
-    }
-
-    private static Context getFixedContext(Context context) {
-        // TODO: remove when this is fixed:
-        // https://issuetracker.google.com/issues/141132133
-        // On Lollipop the current version of AndroidX causes a crash that can only be resolved
-        // by constructing the WebView with a clean Context with blank configuration.
-        return Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1 ? context : context.createConfigurationContext(new Configuration());
     }
 
     private void init() {


### PR DESCRIPTION
The previous fix worked, but it introduced a few undesirable side effects (e.g. crashing when long-pressing the WebView).  This updated fix is more robust.