### PR TITLE
Prevent to fetch user contributions if user is not logged in

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -100,6 +100,10 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     private fun fetchUserContributions() {
+        if (!AccountUtil.isLoggedIn()) {
+            return
+        }
+
         updateDisplayedTasks(null)
         contributionsText.visibility = View.GONE
         progressBar.visibility = View.VISIBLE


### PR DESCRIPTION
Since we move the Suggested edits to the navigation tab, the `SuggestedEditsTasksFragment.kt` will be loaded if we visit `History`, and we will see an error message about "You must be logged in ..."