### PR TITLE
Fixes cutting-off of tablayout label

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
-    implementation "com.google.android.material:material:1.0.0"
+    implementation "com.google.android.material:material:1.1.0-beta01"
     implementation "androidx.core:core:1.1.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'


### PR DESCRIPTION
Looks like they fixed the long label cutting off issue here: https://issuetracker.google.com/issues/115754572 but it is still just in beta, and also the BottomContentView looks weird when upgraded, although it fixes the label issue. So waiting for a stable version.

![label1](https://user-images.githubusercontent.com/9540770/66596585-02e63e00-eb52-11e9-95c7-f7ac7bb28180.png)
![label2](https://user-images.githubusercontent.com/9540770/66596586-02e63e00-eb52-11e9-9dd8-f8f293f7b3db.png)
