### PR TITLE
Update the deprecated FragmentStatePagerAdapter()

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
@@ -293,7 +293,8 @@ class SuggestedEditsCardsFragment : Fragment() {
         }
     }
 
-    private class ViewPagerAdapter internal constructor(activity: AppCompatActivity): FragmentStatePagerAdapter(activity.supportFragmentManager) {
+    private class ViewPagerAdapter internal constructor(activity: AppCompatActivity): FragmentStatePagerAdapter(activity.supportFragmentManager,
+            BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
         override fun getCount(): Int {
             return Integer.MAX_VALUE


### PR DESCRIPTION
The current one is deprecated and keeps showing a warning message in the CI build log.
https://developer.android.com/reference/androidx/fragment/app/FragmentStatePagerAdapter