### PR TITLE
Stop suppressing Gothic language selection.

### DIFF
--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
@@ -57,8 +57,6 @@ public class LangLinksActivity extends BaseActivity {
     public static final String ACTION_LANGLINKS_FOR_TITLE = "org.wikipedia.langlinks_for_title";
     public static final String EXTRA_PAGETITLE = "org.wikipedia.pagetitle";
 
-    private static final String GOTHIC_LANGUAGE_CODE = "got";
-
     private List<PageTitle> languageEntries;
     private PageTitle title;
 
@@ -251,10 +249,7 @@ public class LangLinksActivity extends BaseActivity {
             PageTitle link = it.next();
             String languageCode = link.getWikiSite().languageCode();
 
-            if (GOTHIC_LANGUAGE_CODE.equals(languageCode)) {
-                // Remove Gothic since it causes Android to segfault.
-                it.remove();
-            } else if ("be-x-old".equals(languageCode)) {
+            if ("be-x-old".equals(languageCode)) {
                 // Replace legacy name of тарашкевіца language with the correct name.
                 // TODO: Can probably be removed when T111853 is resolved.
                 it.remove();

--- a/app/src/main/java/org/wikipedia/staticdata/FileAliasData.java
+++ b/app/src/main/java/org/wikipedia/staticdata/FileAliasData.java
@@ -21,7 +21,7 @@ public final class FileAliasData {
 
     @SuppressWarnings({"checkstyle:methodlength", "SpellCheckingInspection"})
     private static Map<String, String> newMap() {
-        final int size = 298;
+        final int size = 299;
         Map<String, String> map = new HashMap<>(size);
         map.put("ab", "Афаил");
         map.put("ace", "Beureukaih");
@@ -115,6 +115,7 @@ public final class FileAliasData {
         map.put("gn", "Ta'ãnga");
         map.put("gom", "फायल");
         map.put("gor", "Berkas");
+        map.put("got", "𐍆𐌴𐌹𐌻𐌰");
         map.put("gu", "ચિત્ર");
         map.put("gv", "Coadan");
         map.put("ha", "File");

--- a/app/src/main/java/org/wikipedia/staticdata/MainPageNameData.java
+++ b/app/src/main/java/org/wikipedia/staticdata/MainPageNameData.java
@@ -21,7 +21,7 @@ public final class MainPageNameData {
 
     @SuppressWarnings({"checkstyle:methodlength", "SpellCheckingInspection"})
     private static Map<String, String> newMap() {
-        final int size = 298;
+        final int size = 299;
         Map<String, String> map = new HashMap<>(size);
         map.put("ab", "Ихадоу адаҟьа");
         map.put("ace", "Ôn Keue");
@@ -115,6 +115,7 @@ public final class MainPageNameData {
         map.put("gn", "Ape");
         map.put("gom", "मुखेल पान");
         map.put("gor", "Halaman Bungaliyo");
+        map.put("got", "𐌰𐌽𐌰𐍃𐍄𐍉𐌳𐌴𐌹𐌽𐌹𐌻𐌰𐌿𐍆𐍃");
         map.put("gu", "મુખપૃષ્ઠ");
         map.put("gv", "Ard-ghuillag");
         map.put("ha", "Babban shafi");

--- a/app/src/main/java/org/wikipedia/staticdata/SpecialAliasData.java
+++ b/app/src/main/java/org/wikipedia/staticdata/SpecialAliasData.java
@@ -21,7 +21,7 @@ public final class SpecialAliasData {
 
     @SuppressWarnings({"checkstyle:methodlength", "SpellCheckingInspection"})
     private static Map<String, String> newMap() {
-        final int size = 298;
+        final int size = 299;
         Map<String, String> map = new HashMap<>(size);
         map.put("ab", "Цастәи");
         map.put("ace", "Kusuih");
@@ -115,6 +115,7 @@ public final class SpecialAliasData {
         map.put("gn", "Mba'echĩchĩ");
         map.put("gom", "विशेश");
         map.put("gor", "Spesial");
+        map.put("got", "Special");
         map.put("gu", "વિશેષ");
         map.put("gv", "Er lheh");
         map.put("ha", "Special");

--- a/app/src/main/res/values/languages_list.xml
+++ b/app/src/main/res/values/languages_list.xml
@@ -261,6 +261,7 @@
     <item>cu</item>
     <item>bug</item>
     <item>kg</item>
+    <item>got</item>
     <item>inh</item>
     <item>ch</item>
     <item>pnt</item>
@@ -560,6 +561,7 @@
     <item>словѣньскъ / ⰔⰎⰑⰂⰡⰐⰠⰔⰍⰟ</item>
     <item>ᨅᨔ ᨕᨘᨁᨗ</item>
     <item>Kongo</item>
+    <item>𐌲𐌿𐍄𐌹𐍃𐌺</item>
     <item>ГӀалгӀай</item>
     <item>Chamoru</item>
     <item>Ποντιακά</item>
@@ -859,6 +861,7 @@
     <item>Church Slavic</item>
     <item>Buginese</item>
     <item>Kongo</item>
+    <item>Gothic</item>
     <item>Ingush</item>
     <item>Chamorro</item>
     <item>Pontic</item>

--- a/scripts/generate_wiki_languages.py
+++ b/scripts/generate_wiki_languages.py
@@ -39,10 +39,6 @@ for key, value in data[u"sitematrix"].items():
     if type(value) is not dict:
         continue
     language_code = value[u"code"]
-    if language_code == 'got':
-        # 'got' is Gothic Runes, which lie outside the Basic Multilingual Plane
-        # Android segfaults on these. So let's ignore those.
-        continue
     site_list = value[u"site"]
     if type(site_list) is not list:
         continue

--- a/scripts/make-templates.py
+++ b/scripts/make-templates.py
@@ -20,13 +20,9 @@ NORWEGIAN_BOKMAL_LANG = "nb"
 
 # Wikis that cause problems and hence we pretend
 # do not exist.
-# - "got" -> Gothic runes wiki. The name of got in got
-#   contains characters outside the Unicode BMP. Android
-#   hard crashes on these. Let's ignore these fellas
-#   for now.
 # - "mo" -> Moldovan, which automatically redirects to Romanian (ro),
 #   which already exists in our list.
-OSTRICH_WIKIS = [u"got", "mo"]
+OSTRICH_WIKIS = ["mo"]
 
 
 # Represents a single wiki, along with arbitrary properties of that wiki


### PR DESCRIPTION
Very old versions of Android (e.g. API 15 or lower) used to have problems displaying Gothic characters because they are outside the Unicode BMP.  More recent versions of Android are handling this properly, so we no longer need to explicitly remove the Gothic language from our selections.