### PR TITLE
Make the NavTab full width to match the NavTabOverlay icon position

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
@@ -117,4 +117,7 @@
     <dimen name="suggested_edits_message_textview_text_size">14sp</dimen>
     <dimen name="suggested_edits_top_tooltip_margin">32dp</dimen>
 
+    <!-- Bottom navigation values, they override the NavTab item width to make the entire NavTab be in full width -->
+    <dimen name="design_bottom_navigation_item_max_width" tools:override="true">600dp</dimen>
+    <dimen name="design_bottom_navigation_active_item_max_width" tools:override="true">600dp</dimen>
 </resources>


### PR DESCRIPTION
The pulsing icon will mismatch its position when the device is on the landscape mode, it is because of the default behavior of the `BottomNavigationView`.

https://stackoverflow.com/a/41433309/4545041

One of the possible (easiest) solutions is to change the item max-width of each NavTab item and make the parent NavTab view becomes full width.