### PR TITLE
Fix further native linking errors in Fresco.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,13 +146,6 @@ android {
 apply from: '../gradle/src/test.gradle'
 apply from: '../gradle/src/checkstyle.gradle'
 
-// TODO: remove when Fresco updates its bundled version of soloader.
-configurations.all {
-    resolutionStrategy {
-        force "com.facebook.soloader:soloader:0.8.0"
-    }
-}
-
 dependencies {
 
     // To keep the Maven Central dependencies up-to-date


### PR DESCRIPTION
This should catch a wider range of native .so linking errors, until Fresco finally fixes things internally, or we switch to another library.