### PR TITLE
Wire up the app with new Revert counters, and update pause/disable logic.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
@@ -18,6 +18,7 @@ import java.util.Map;
 @SuppressWarnings("unused")
 public class EditorTaskCounts {
     @Nullable private JsonElement counts;
+    @Nullable @SerializedName("revert_counts") private JsonElement revertCounts;
     @Nullable @SerializedName("edit_streak") private JsonElement editStreak;
 
     @NonNull
@@ -36,6 +37,24 @@ public class EditorTaskCounts {
             editsPerLanguage = GsonUtil.getDefaultGson().fromJson(counts, Counts.class).appCaptionEdits;
         }
         return editsPerLanguage == null ? Collections.emptyMap() : editsPerLanguage;
+    }
+
+    @NonNull
+    public Map<String, Integer> getDescriptionRevertsPerLanguage() {
+        Map<String, Integer> revertsPerLanguage = null;
+        if (revertCounts != null && !(revertCounts instanceof JsonArray)) {
+            revertsPerLanguage = GsonUtil.getDefaultGson().fromJson(revertCounts, Counts.class).appDescriptionEdits;
+        }
+        return revertsPerLanguage == null ? Collections.emptyMap() : revertsPerLanguage;
+    }
+
+    @NonNull
+    public Map<String, Integer> getCaptionRevertsPerLanguage() {
+        Map<String, Integer> revertsPerLanguage = null;
+        if (revertCounts != null && !(revertCounts instanceof JsonArray)) {
+            revertsPerLanguage = GsonUtil.getDefaultGson().fromJson(revertCounts, Counts.class).appCaptionEdits;
+        }
+        return revertsPerLanguage == null ? Collections.emptyMap() : revertsPerLanguage;
     }
 
     public int getEditStreak() {

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -16,10 +16,13 @@ import org.wikipedia.json.SessionUnmarshaller;
 import org.wikipedia.json.TabUnmarshaller;
 import org.wikipedia.page.tabs.Tab;
 import org.wikipedia.theme.Theme;
+import org.wikipedia.util.DateUtil;
 import org.wikipedia.util.ReleaseUtil;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -797,6 +800,42 @@ public final class Prefs {
 
     public static void setShouldShowSuggestedEditsTooltip(boolean enabled) {
         setBoolean(R.string.preference_key_show_suggested_edits_tooltip, enabled);
+    }
+
+    public static Date getSuggestedEditsPauseDate() {
+        Date date = new Date(0);
+        try {
+            if (contains(R.string.preference_key_suggested_edits_pause_date)) {
+                date = DateUtil.dbDateParse(getString(R.string.preference_key_suggested_edits_pause_date, ""));
+            }
+        } catch (ParseException e) {
+            // ignore
+        }
+        return date;
+    }
+
+    public static void setSuggestedEditsPauseDate(Date date) {
+        setString(R.string.preference_key_suggested_edits_pause_date, DateUtil.dbDateFormat(date));
+    }
+
+    public static int getSuggestedEditsPauseReverts() {
+        return getInt(R.string.preference_key_suggested_edits_pause_reverts, 0);
+    }
+
+    public static void setSuggestedEditsPauseReverts(int count) {
+        setInt(R.string.preference_key_suggested_edits_pause_reverts, count);
+    }
+
+    public static boolean shouldOverrideSuggestedEditCounts() {
+        return getBoolean(R.string.preference_key_suggested_edits_override_counts, false);
+    }
+
+    public static int getOverrideSuggestedEditCount() {
+        return getInt(R.string.preference_key_suggested_edits_override_edits, 0);
+    }
+
+    public static int getOverrideSuggestedRevertCount() {
+        return getInt(R.string.preference_key_suggested_edits_override_reverts, 0);
     }
 
     private Prefs() { }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -376,10 +376,10 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     private fun maybeSetPausedOrDisabled(totalEdits:Int, totalReverts: Int): Boolean {
-        // Are we currently in a pause period?
         val pauseDate = Prefs.getSuggestedEditsPauseDate()
         var pauseEndDate: Date? = null
 
+        // Are we currently in a pause period?
         if (pauseDate.time != 0L) {
             val cal = Calendar.getInstance()
             cal.time = pauseDate
@@ -387,20 +387,20 @@ class SuggestedEditsTasksFragment : Fragment() {
             pauseEndDate = cal.time
 
             if (Date().after((pauseEndDate))) {
-                // remove the pause
+                // We've exceeded the pause period, so remove it.
                 Prefs.setSuggestedEditsPauseDate(Date(0))
                 pauseEndDate = null
             }
         }
 
         val revertSeverity = getRevertSeverity(totalEdits, totalReverts)
-        if (revertSeverity > 7) {
+        if (revertSeverity > REVERT_SEVERITY_DISABLE_THRESHOLD) {
             // Disable the whole feature.
             clearContents()
             disabledStatesView.setDisabled(getString(R.string.suggested_edits_disabled_message, AccountUtil.getUserName()))
             disabledStatesView.visibility = VISIBLE
             return true
-        } else if (revertSeverity > 5) {
+        } else if (revertSeverity > REVERT_SEVERITY_PAUSE_THRESHOLD) {
             // Do we need to impose a new pause?
             if (totalReverts > Prefs.getSuggestedEditsPauseReverts()) {
                 val cal = Calendar.getInstance()
@@ -479,6 +479,8 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     companion object {
+        const val REVERT_SEVERITY_PAUSE_THRESHOLD = 5
+        const val REVERT_SEVERITY_DISABLE_THRESHOLD = 7
         const val PAUSE_DURATION_DAYS = 7
 
         fun newInstance(): SuggestedEditsTasksFragment {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -28,11 +28,9 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.language.LanguageSettingsInvokeSource
 import org.wikipedia.main.MainActivity
+import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
-import org.wikipedia.util.DateUtil
-import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.ResourceUtil
-import org.wikipedia.util.StringUtil
+import org.wikipedia.util.*
 import org.wikipedia.util.log.L
 import org.wikipedia.views.DefaultRecyclerAdapter
 import org.wikipedia.views.DefaultViewHolder
@@ -41,6 +39,7 @@ import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.collections.HashSet
+import kotlin.math.ceil
 
 class SuggestedEditsTasksFragment : Fragment() {
     private lateinit var addDescriptionsTask: SuggestedEditsTask
@@ -52,9 +51,7 @@ class SuggestedEditsTasksFragment : Fragment() {
     private val disposables = CompositeDisposable()
     private var currentTooltip: Toast? = null
     private var totalEdits = 0
-
-    // TODO: remove when ready
-    private var editQualityState = 0
+    private var totalReverts = 0
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -63,7 +60,6 @@ class SuggestedEditsTasksFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        //Todo: remove after review
         setupTestingButtons()
 
         contributionsStatsView.setImageDrawable(R.drawable.ic_mode_edit_white_24dp)
@@ -130,7 +126,7 @@ class SuggestedEditsTasksFragment : Fragment() {
 
     private fun showEditQualityStatsViewTooltip() {
         hideCurrentTooltip()
-        currentTooltip = FeedbackUtil.showToastOverView(editQualityStatsView, getString(R.string.suggested_edits_edit_quality_stat_tooltip, 3), Toast.LENGTH_LONG)
+        currentTooltip = FeedbackUtil.showToastOverView(editQualityStatsView, getString(R.string.suggested_edits_edit_quality_stat_tooltip, totalReverts), Toast.LENGTH_LONG)
     }
 
     override fun onPause() {
@@ -189,13 +185,34 @@ class SuggestedEditsTasksFragment : Fragment() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ response ->
                     val editorTaskCounts = response.query()!!.editorTaskCounts()!!
+
+                    totalEdits = 0
+                    for (count in editorTaskCounts.descriptionEditsPerLanguage.values) {
+                        totalEdits += count
+                    }
+                    for (count in editorTaskCounts.captionEditsPerLanguage.values) {
+                        totalEdits += count
+                    }
+                    totalReverts = 0
+                    for (count in editorTaskCounts.descriptionRevertsPerLanguage.values) {
+                        totalReverts += count
+                    }
+                    for (count in editorTaskCounts.captionRevertsPerLanguage.values) {
+                        totalReverts += count
+                    }
+
+                    if (Prefs.shouldOverrideSuggestedEditCounts()) {
+                        totalEdits = Prefs.getOverrideSuggestedEditCount()
+                        totalReverts = Prefs.getOverrideSuggestedRevertCount()
+                    }
+
                     if (response.query()!!.userInfo()!!.isBlocked) {
 
                         setIPBlockedStatus()
 
-                    } else if (!maybeSetDisabledStatus(80)) { // TODO: use edit quality metric from API response
+                    } else if (!maybeSetPausedOrDisabled(totalEdits, totalReverts)) {
 
-                        editQualityStatsView.setGoodnessState((editQualityState++) % 7) // TODO: use edit quality metric from API response
+                        editQualityStatsView.setGoodnessState(getRevertSeverity(totalEdits, totalReverts))
 
                         if (editorTaskCounts.editStreak < 2) {
                             editStreakStatsView.setTitle(if (editorTaskCounts.lastEditDate.time > 0) DateUtil.getMDYDateString(editorTaskCounts.lastEditDate) else resources.getString(R.string.suggested_edits_last_edited_never))
@@ -206,13 +223,6 @@ class SuggestedEditsTasksFragment : Fragment() {
                             editStreakStatsView.setDescription(resources.getString(R.string.suggested_edits_edit_streak_label_text))
                         }
 
-                        totalEdits = 0
-                        for (count in editorTaskCounts.descriptionEditsPerLanguage.values) {
-                            totalEdits += count
-                        }
-                        for (count in editorTaskCounts.captionEditsPerLanguage.values) {
-                            totalEdits += count
-                        }
                         getPageViews()
 
                     }
@@ -361,30 +371,64 @@ class SuggestedEditsTasksFragment : Fragment() {
         disabledStatesView.visibility = VISIBLE
     }
 
-    private fun maybeSetDisabledStatus(editQuality: Int): Boolean {
-        when (editQuality) {
-            // TODO: use correct quality ranges:
-            in 0..10 -> {
-                clearContents()
-                disabledStatesView.setDisabled(getString(R.string.suggested_edits_disabled_message, AccountUtil.getUserName()))
-                disabledStatesView.visibility = VISIBLE
-                return true
-            }
-            in 11..50 -> {
-                clearContents()
-                // TODO: correctly populate the date here:
-                disabledStatesView.setPaused(getString(R.string.suggested_edits_paused_message, DateUtil.getShortDateString(Date()), AccountUtil.getUserName()))
-                disabledStatesView.visibility = VISIBLE
-                return true
+    private fun getRevertSeverity(totalEdits: Int, totalReverts: Int): Int {
+        return if (totalEdits <= 100) totalReverts else ceil(totalReverts.toFloat() / totalEdits.toFloat() * 100f).toInt()
+    }
+
+    private fun maybeSetPausedOrDisabled(totalEdits:Int, totalReverts: Int): Boolean {
+        // Are we currently in a pause period?
+        val pauseDate = Prefs.getSuggestedEditsPauseDate()
+        var pauseEndDate: Date? = null
+
+        if (pauseDate.time != 0L) {
+            val cal = Calendar.getInstance()
+            cal.time = pauseDate
+            cal.add(Calendar.DAY_OF_YEAR, PAUSE_DURATION_DAYS)
+            pauseEndDate = cal.time
+
+            if (Date().after((pauseEndDate))) {
+                // remove the pause
+                Prefs.setSuggestedEditsPauseDate(Date(0))
+                pauseEndDate = null
             }
         }
+
+        val revertSeverity = getRevertSeverity(totalEdits, totalReverts)
+        if (revertSeverity > 7) {
+            // Disable the whole feature.
+            clearContents()
+            disabledStatesView.setDisabled(getString(R.string.suggested_edits_disabled_message, AccountUtil.getUserName()))
+            disabledStatesView.visibility = VISIBLE
+            return true
+        } else if (revertSeverity > 5) {
+            // Do we need to impose a new pause?
+            if (totalReverts > Prefs.getSuggestedEditsPauseReverts()) {
+                val cal = Calendar.getInstance()
+                cal.time = Date()
+                Prefs.setSuggestedEditsPauseDate(cal.time)
+                Prefs.setSuggestedEditsPauseReverts(totalReverts)
+
+                cal.add(Calendar.DAY_OF_YEAR, PAUSE_DURATION_DAYS)
+                pauseEndDate = cal.time
+            }
+        }
+
+        if (pauseEndDate != null) {
+            clearContents()
+            disabledStatesView.setPaused(getString(R.string.suggested_edits_paused_message, DateUtil.getShortDateString(pauseEndDate), AccountUtil.getUserName()))
+            disabledStatesView.visibility = VISIBLE
+            return true
+        }
+
         disabledStatesView.visibility = GONE
         return false
     }
 
     private fun setupTestingButtons() {
-        paused.setOnClickListener { maybeSetDisabledStatus(25) }
-        disabled.setOnClickListener { maybeSetDisabledStatus(5) }
+        if (!ReleaseUtil.isPreBetaRelease()) {
+            ipBlocked.visibility = GONE
+            onboarding1.visibility = GONE
+        }
         ipBlocked.setOnClickListener { setIPBlockedStatus() }
         onboarding1.setOnClickListener { totalEdits = 0; setFinalUIState() }
     }
@@ -435,6 +479,8 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     companion object {
+        const val PAUSE_DURATION_DAYS = 7
+
         fun newInstance(): SuggestedEditsTasksFragment {
             return SuggestedEditsTasksFragment()
         }

--- a/app/src/main/java/org/wikipedia/util/DateUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.java
@@ -38,6 +38,10 @@ public final class DateUtil {
         return getCachedDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ROOT, false).format(date);
     }
 
+    public static synchronized String dbDateFormat(Date date) {
+        return getCachedDateFormat("yyyyMMddHHmmss", Locale.ROOT, true).format(date);
+    }
+
     public static synchronized Date dbDateParse(String date) throws ParseException {
         return getCachedDateFormat("yyyyMMddHHmmss", Locale.ROOT, true).parse(date);
     }

--- a/app/src/main/res/layout/fragment_suggested_edits_tasks.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_tasks.xml
@@ -146,26 +146,6 @@
                     android:padding="8dp">
 
                     <TextView
-                        android:id="@+id/paused"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:textAllCaps="true"
-                        android:textColor="?attr/colorAccent"
-                        android:textSize="10sp"
-                        android:text="Paused" />
-
-                    <TextView
-                        android:id="@+id/disabled"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:textAllCaps="true"
-                        android:textColor="?attr/colorAccent"
-                        android:textSize="10sp"
-                        android:text="Disabled" />
-
-                    <TextView
                         android:id="@+id/ipBlocked"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -107,4 +107,9 @@
     <string name="preference_key_suggested_edits_survey_clicked">suggestedEditsSurveyClicked</string>
     <string name="preference_key_show_suggested_edits_survey">showSuggestedEditsSurvey</string>
     <string name="preference_key_show_suggested_edits_tooltip">showSuggestedEditsTooltip</string>
+    <string name="preference_key_suggested_edits_pause_date">suggestedEditsPauseDate</string>
+    <string name="preference_key_suggested_edits_pause_reverts">suggestedEditsPauseReverts</string>
+    <string name="preference_key_suggested_edits_override_counts">suggestedEditsOverrideCounts</string>
+    <string name="preference_key_suggested_edits_override_edits">suggestedEditsOverrideEdits</string>
+    <string name="preference_key_suggested_edits_override_reverts">suggestedEditsOverrideReverts</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -743,8 +743,8 @@
     <string name="suggested_edits_edit_streak_stat_tooltip">How many days without break you\'ve contributed using Suggested edits</string>
     <string name="suggested_edits_page_views_stat_tooltip">Total pageviews of items you contributed to in the last 30 days with Suggested edits</string>
     <string name="suggested_edits_edit_quality_stat_tooltip">Based on how many times one of your contributions was reverted. Reverted edits: %d</string>
-    <string name="suggested_edits_paused_message"><![CDATA[<b>Suggested edits is paused until %1$s.</b> Sorry %2$s, some of your recent contributions have been reverted.\n\n Learn how to improve your editing skills on Wikipedia with the links below.]]></string>
-    <string name="suggested_edits_disabled_message"><![CDATA[<b>Suggested edits is disabled.</b> Sorry %s, too many of your recent contributions have been reverted.\n\n Learn what this means with the links below.]]></string>
+    <string name="suggested_edits_paused_message"><![CDATA[<b>Suggested edits is paused until %1$s.</b> Sorry %2$s, some of your recent contributions have been reverted.\n\n Learn how to improve your editing skills on Wikipedia with the link below.]]></string>
+    <string name="suggested_edits_disabled_message"><![CDATA[<b>Suggested edits is disabled.</b> Sorry %s, too many of your recent contributions have been reverted.\n\n Learn what this means with the link below.]]></string>
     <string name="suggested_edits_ip_blocked_message">It looks like your IP address (or range of IP addresses) is currently blocked from editing Wikipedia. Learn more about what this means by visiting the link below.</string>
     <string name="suggested_edits_editing_tips_link_text">Editing tips and tricks</string>
     <string name="suggested_edits_help_page_link_text">Suggested edits help page</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -294,6 +294,31 @@
             android:key="@string/preference_key_show_edit_tasks_onboarding"
             android:title="@string/preference_key_show_edit_tasks_onboarding" />
 
+        <org.wikipedia.settings.EditTextAutoSummarizePreference
+            style="@style/DataStringPreference"
+            android:key="@string/preference_key_suggested_edits_pause_date"
+            android:title="@string/preference_key_suggested_edits_pause_date" />
+
+        <org.wikipedia.settings.IntPreference
+            style="@style/IntPreference"
+            android:key="@string/preference_key_suggested_edits_pause_reverts"
+            android:title="@string/preference_key_suggested_edits_pause_reverts" />
+
+        <SwitchPreferenceCompat
+            android:key="@string/preference_key_suggested_edits_override_counts"
+            android:title="@string/preference_key_suggested_edits_override_counts"
+            android:summary="Use the following two fields to override suggested edit counts:"/>
+
+        <org.wikipedia.settings.IntPreference
+            style="@style/IntPreference"
+            android:key="@string/preference_key_suggested_edits_override_edits"
+            android:title="@string/preference_key_suggested_edits_override_edits" />
+
+        <org.wikipedia.settings.IntPreference
+            style="@style/IntPreference"
+            android:key="@string/preference_key_suggested_edits_override_reverts"
+            android:title="@string/preference_key_suggested_edits_override_reverts" />
+
     </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This does the heavy lifting of hooking up our logic to the new Revert counters coming from the API, and taking care of all the workflows of pausing and/or disabling the Suggested Edits feature. This also introduces a new and updated method of testing the whole feature (via developer preferences).