### PR TITLE
Make Suggested Edit feed cards dependent on paused/disabled state.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/EditorTaskCounts.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
 import org.wikipedia.json.GsonUtil;
+import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.DateUtil;
 
 import java.text.ParseException;
@@ -39,6 +40,20 @@ public class EditorTaskCounts {
         return editsPerLanguage == null ? Collections.emptyMap() : editsPerLanguage;
     }
 
+    public int getTotalEdits() {
+        int totalEdits = 0;
+        for (int count : getDescriptionEditsPerLanguage().values()) {
+            totalEdits += count;
+        }
+        for (int count : getCaptionEditsPerLanguage().values()) {
+            totalEdits += count;
+        }
+        if (Prefs.shouldOverrideSuggestedEditCounts()) {
+            totalEdits = Prefs.getOverrideSuggestedEditCount();
+        }
+        return totalEdits;
+    }
+
     @NonNull
     public Map<String, Integer> getDescriptionRevertsPerLanguage() {
         Map<String, Integer> revertsPerLanguage = null;
@@ -55,6 +70,20 @@ public class EditorTaskCounts {
             revertsPerLanguage = GsonUtil.getDefaultGson().fromJson(revertCounts, Counts.class).appCaptionEdits;
         }
         return revertsPerLanguage == null ? Collections.emptyMap() : revertsPerLanguage;
+    }
+
+    public int getTotalReverts() {
+        int totalReverts = 0;
+        for (int count : getDescriptionRevertsPerLanguage().values()) {
+            totalReverts += count;
+        }
+        for (int count : getCaptionRevertsPerLanguage().values()) {
+            totalReverts += count;
+        }
+        if (Prefs.shouldOverrideSuggestedEditCounts()) {
+            totalReverts = Prefs.getOverrideSuggestedRevertCount();
+        }
+        return totalReverts;
     }
 
     public int getEditStreak() {

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
@@ -15,7 +15,7 @@ import org.wikipedia.feed.model.Card
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageTitle
 import org.wikipedia.suggestededits.SuggestedEditsSummary
-import org.wikipedia.suggestededits.SuggestedEditsTasksFragment
+import org.wikipedia.suggestededits.SuggestedEditsUserStats
 import org.wikipedia.suggestededits.provider.MissingDescriptionProvider
 import org.wikipedia.util.StringUtil
 import java.util.*
@@ -40,10 +40,10 @@ class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource)
         if (age == 0) {
             // In the background, fetch the user's latest contribution stats, so that we can update whether the
             // Suggested Edits feature is paused or disabled, the next time the feed is refreshed.
-            SuggestedEditsTasksFragment.updateStatsInBackground()
+            SuggestedEditsUserStats.updateStatsInBackground()
         }
 
-        if (SuggestedEditsTasksFragment.isDisabled() || SuggestedEditsTasksFragment.maybePauseAndGetEndDate() != null) {
+        if (SuggestedEditsUserStats.isDisabled() || SuggestedEditsUserStats.maybePauseAndGetEndDate() != null) {
             FeedCoordinator.postCardsToCallback(cb, Collections.emptyList())
             return
         }

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
@@ -15,8 +15,10 @@ import org.wikipedia.feed.model.Card
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageTitle
 import org.wikipedia.suggestededits.SuggestedEditsSummary
+import org.wikipedia.suggestededits.SuggestedEditsTasksFragment
 import org.wikipedia.suggestededits.provider.MissingDescriptionProvider
 import org.wikipedia.util.StringUtil
+import java.util.*
 
 class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource) : FeedClient {
     interface Callback {
@@ -34,6 +36,18 @@ class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource)
     override fun request(context: Context, wiki: WikiSite, age: Int, cb: FeedClient.Callback) {
         this.age = age
         cancel()
+
+        if (age == 0) {
+            // In the background, fetch the user's latest contribution stats, so that we can update whether the
+            // Suggested Edits feature is paused or disabled, the next time the feed is refreshed.
+            SuggestedEditsTasksFragment.updateStatsInBackground()
+        }
+
+        if (SuggestedEditsTasksFragment.isDisabled() || SuggestedEditsTasksFragment.maybePauseAndGetEndDate() != null) {
+            FeedCoordinator.postCardsToCallback(cb, Collections.emptyList())
+            return
+        }
+
         fetchSuggestedEditForType(cb, null)
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsUserStats.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsUserStats.kt
@@ -1,0 +1,79 @@
+package org.wikipedia.suggestededits
+
+import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import org.wikipedia.dataclient.Service
+import org.wikipedia.dataclient.ServiceFactory
+import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.mwapi.MwQueryResponse
+import org.wikipedia.settings.Prefs
+import java.util.*
+import kotlin.math.ceil
+
+object SuggestedEditsUserStats {
+    private const val REVERT_SEVERITY_PAUSE_THRESHOLD = 5
+    private const val REVERT_SEVERITY_DISABLE_THRESHOLD = 7
+    private const val PAUSE_DURATION_DAYS = 7
+
+    var totalEdits: Int = 0
+    var totalReverts: Int = 0
+
+    fun getEditCountsObservable(): Observable<MwQueryResponse> {
+        return ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).editorTaskCounts
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnNext {
+                    val editorTaskCounts = it.query()!!.editorTaskCounts()!!
+                    totalEdits = editorTaskCounts.totalEdits
+                    totalReverts = editorTaskCounts.totalReverts
+                    maybePauseAndGetEndDate()
+                }
+    }
+
+    fun updateStatsInBackground() {
+        getEditCountsObservable().subscribe()
+    }
+
+    fun getRevertSeverity(): Int {
+        return if (totalEdits <= 100) totalReverts else ceil(totalReverts.toFloat() / totalEdits.toFloat() * 100f).toInt()
+    }
+
+    fun isDisabled(): Boolean {
+        return getRevertSeverity() > REVERT_SEVERITY_DISABLE_THRESHOLD
+    }
+
+    fun maybePauseAndGetEndDate(): Date? {
+        val pauseDate = Prefs.getSuggestedEditsPauseDate()
+        var pauseEndDate: Date? = null
+
+        // Are we currently in a pause period?
+        if (pauseDate.time != 0L) {
+            val cal = Calendar.getInstance()
+            cal.time = pauseDate
+            cal.add(Calendar.DAY_OF_YEAR, PAUSE_DURATION_DAYS)
+            pauseEndDate = cal.time
+
+            if (Date().after((pauseEndDate))) {
+                // We've exceeded the pause period, so remove it.
+                Prefs.setSuggestedEditsPauseDate(Date(0))
+                pauseEndDate = null
+            }
+        }
+
+        if (getRevertSeverity() > REVERT_SEVERITY_PAUSE_THRESHOLD) {
+            // Do we need to impose a new pause?
+            if (totalReverts > Prefs.getSuggestedEditsPauseReverts()) {
+                val cal = Calendar.getInstance()
+                cal.time = Date()
+                Prefs.setSuggestedEditsPauseDate(cal.time)
+                Prefs.setSuggestedEditsPauseReverts(totalReverts)
+
+                cal.add(Calendar.DAY_OF_YEAR, PAUSE_DURATION_DAYS)
+                pauseEndDate = cal.time
+            }
+        }
+        return pauseEndDate
+    }
+}
+


### PR DESCRIPTION
This will make the Suggested Edit feed cards no longer appear if the feature is paused or disabled. Note: it may be necessary to refresh the feed for the updating to take effect.