### PR TITLE
Prevent showing the error page when the user has no edits

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -266,6 +266,9 @@ class SuggestedEditsTasksFragment : Fragment() {
                             .observeOn(AndroidSchedulers.mainThread())
                 }
                 .flatMap { entities ->
+                    if (entities.entities() == null) {
+                        return@flatMap Observable.just(0L)
+                    }
                     val langArticleMap = HashMap<String, ArrayList<String>>()
                     for (entityKey in entities.entities()!!.keys) {
                         val entity = entities.entities()!![entityKey]!!


### PR DESCRIPTION
If a newly created account enters the Suggested edit page, it should not show the error page to the user when the `entities.entities()` is `null`.