### PR TITLE
Remove unused preference settings in preference loader

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.java
+++ b/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.java
@@ -11,7 +11,6 @@ import androidx.preference.TwoStatePreference;
 
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
-import org.wikipedia.crash.RemoteLogException;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.PageActivity;
@@ -21,7 +20,6 @@ import org.wikipedia.readinglist.database.ReadingListDbHelper;
 import org.wikipedia.readinglist.database.ReadingListPage;
 import org.wikipedia.suggestededits.provider.MissingDescriptionProvider;
 import org.wikipedia.util.StringUtil;
-import org.wikipedia.util.log.L;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -104,12 +102,6 @@ class DeveloperSettingsPreferenceLoader extends BasePreferenceLoader {
         findPreference(context.getString(R.string.preferences_developer_crash_key))
                 .setOnPreferenceClickListener(preference -> {
                     throw new TestException("User tested crash functionality.");
-                });
-
-        findPreference(R.string.preference_key_remote_log)
-                .setOnPreferenceChangeListener((preference, newValue) -> {
-                    L.logRemoteError(new RemoteLogException(newValue.toString()));
-                    return true;
                 });
 
         findPreference(R.string.preference_key_add_articles)


### PR DESCRIPTION
Since we removed `preference_key_remote_log`, we should also remove the preference setting in preference loader to prevent crash.