### PR TITLE
Fix: adding HTML support on the "read more" item title

### DIFF
--- a/app/src/main/java/org/wikipedia/page/bottomcontent/BottomContentView.java
+++ b/app/src/main/java/org/wikipedia/page/bottomcontent/BottomContentView.java
@@ -398,7 +398,7 @@ public class BottomContentView extends LinearLayoutOverWebView
             PageTitle pageTitle = result.getPageTitle(page.getTitle().getWikiSite());
             itemView.setItem(result);
             itemView.setCallback(this);
-            itemView.setTitle(result.getDisplayTitle());
+            itemView.setTitle(StringUtil.fromHtml(result.getDisplayTitle()));
             itemView.setDescription(StringUtils.capitalize(pageTitle.getDescription()));
             itemView.setImageUrl(pageTitle.getThumbUrl());
             return itemView;


### PR DESCRIPTION
Some `displayTitle`s have `<i></i>` and the app should support that.
https://en.wikipedia.org/wiki/Jon_Favreau