### PR TITLE
Use default action mode backpress behavior on searching

### DIFF
--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.java
@@ -565,11 +565,6 @@ public class HistoryFragment extends Fragment implements BackPressedHandler {
         }
 
         @Override
-        protected boolean finishActionModeIfKeyboardHiding() {
-            return true;
-        }
-
-        @Override
         protected Context getParentContext() {
             return requireContext();
         }

--- a/app/src/main/java/org/wikipedia/history/SearchActionModeCallback.java
+++ b/app/src/main/java/org/wikipedia/history/SearchActionModeCallback.java
@@ -30,9 +30,6 @@ public abstract class SearchActionModeCallback implements ActionMode.Callback {
 
             @Override
             public void onQueryTextFocusChange() {
-                if (finishActionModeIfKeyboardHiding()) {
-                    mode.finish();
-                }
             }
         }));
 
@@ -42,8 +39,6 @@ public abstract class SearchActionModeCallback implements ActionMode.Callback {
     protected abstract String getSearchHintString();
 
     protected abstract void onQueryChange(String s);
-
-    protected abstract boolean finishActionModeIfKeyboardHiding();
 
     protected abstract Context getParentContext();
 

--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.java
@@ -171,11 +171,6 @@ public class LangLinksActivity extends BaseActivity {
         }
 
         @Override
-        protected boolean finishActionModeIfKeyboardHiding() {
-            return false;
-        }
-
-        @Override
         protected Context getParentContext() {
             return LangLinksActivity.this;
         }

--- a/app/src/main/java/org/wikipedia/language/LanguagesListActivity.java
+++ b/app/src/main/java/org/wikipedia/language/LanguagesListActivity.java
@@ -157,11 +157,6 @@ public class LanguagesListActivity extends BaseActivity {
         }
 
         @Override
-        protected boolean finishActionModeIfKeyboardHiding() {
-            return false;
-        }
-
-        @Override
         protected Context getParentContext() {
             return LanguagesListActivity.this;
         }

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
@@ -649,11 +649,6 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
         }
 
         @Override
-        protected boolean finishActionModeIfKeyboardHiding() {
-            return true;
-        }
-
-        @Override
         protected Context getParentContext() {
             return NotificationActivity.this;
         }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
@@ -854,11 +854,6 @@ public class ReadingListFragment extends Fragment implements ReadingListItemActi
         }
 
         @Override
-        protected boolean finishActionModeIfKeyboardHiding() {
-            return true;
-        }
-
-        @Override
         protected Context getParentContext() {
             return requireContext();
         }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
@@ -681,11 +681,6 @@ public class ReadingListsFragment extends Fragment implements
         }
 
         @Override
-        protected boolean finishActionModeIfKeyboardHiding() {
-            return true;
-        }
-
-        @Override
         protected Context getParentContext() {
             return requireContext();
         }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T238349

The removed overriding method was made because of this ticket: 
https://phabricator.wikimedia.org/T188569

It would be better if we follow the default behavior. 