### PR TITLE
Use AndroidAppV3 to get latest announcement API content

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementClient.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementClient.java
@@ -31,7 +31,7 @@ import static org.wikipedia.feed.announcement.Announcement.PLACEMENT_FEED;
 
 public class AnnouncementClient implements FeedClient {
     private static final String PLATFORM_CODE = "AndroidApp";
-    private static final String PLATFORM_CODE_NEW = "AndroidAppV2";
+    private static final String PLATFORM_CODE_NEW = "AndroidAppV3";
 
     private CompositeDisposable disposables = new CompositeDisposable();
 

--- a/app/src/test/res/raw/announce_2016_11_21.json
+++ b/app/src/test/res/raw/announce_2016_11_21.json
@@ -26,7 +26,7 @@
       "start_time": "2016-11-15T17:11:12Z",
       "end_time": "2016-11-30T17:11:12Z",
       "platforms": [
-        "AndroidAppV2"
+        "AndroidAppV3"
       ],
       "text": "Answer three questions and help us improve Wikipedia.",
       "action": {
@@ -46,7 +46,7 @@
       "start_time": "2016-11-15T17:11:12Z",
       "end_time": "2016-11-30T17:11:12Z",
       "platforms": [
-        "AndroidAppV2"
+        "AndroidAppV3"
       ],
       "text": "Help Wikipedia by making a donation.",
       "image_url" : "https://image.url",
@@ -67,7 +67,7 @@
       "start_time": null,
       "end_time": null,
       "platforms": [
-        "AndroidAppV2"
+        "AndroidAppV3"
       ],
       "text": "Help Wikipedia by making a donation.",
       "action": {
@@ -84,7 +84,7 @@
       "id": "AnnouncementWithNoDates",
       "type": "fundraising",
       "platforms": [
-        "AndroidAppV2"
+        "AndroidAppV3"
       ],
       "text": "Help Wikipedia by making a donation.",
       "action": {
@@ -103,7 +103,7 @@
       "start_time": "2016-11-15T17:11:12Z",
       "end_time": "2016-11-30T17:11:12Z",
       "platforms": [
-        "AndroidAppV2"
+        "AndroidAppV3"
       ],
       "text": "Help Wikipedia by making a donation.",
       "action": {
@@ -117,7 +117,7 @@
       "start_time": "2016-11-15T17:11:12Z",
       "end_time": "2016-11-30T17:11:12Z",
       "platforms": [
-        "AndroidAppV2"
+        "AndroidAppV3"
       ],
       "text": "Help Wikipedia by making a donation.",
       "image_url" : "https://image.url",
@@ -141,7 +141,7 @@
       "start_time": "2016-11-15T17:11:12Z",
       "end_time": "2016-11-30T17:11:12Z",
       "platforms": [
-        "AndroidAppV2"
+        "AndroidAppV3"
       ],
       "text": "Help Wikipedia by making a donation.",
       "image_url" : "https://image.url",


### PR DESCRIPTION
The release version `302` and `303` contains the new announcement logic to not show card on feed, which should not happen.

This PR associate with the patch on Gerrit and hopefully, it can solve the issue: https://gerrit.wikimedia.org/r/#/c/mediawiki/services/wikifeeds/+/553391/