### PR TITLE
Don't hide the WebView while loading the article.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -626,7 +626,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
      */
     public void loadPage(@NonNull PageTitle title, @NonNull HistoryEntry entry,
                          boolean pushBackStack, int stagedScrollY, boolean isRefresh) {
-        webView.setVisibility(View.GONE);
         // clear the title in case the previous page load had failed.
         clearActivityActionBarTitle();
 


### PR DESCRIPTION
The page loading is now performant enough (and doesn't have a lot of jitter) that we don't really need to hide the WebView while it loads.