### PR TITLE
User proper article title to request reset html

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -249,7 +249,7 @@ public class PageFragmentLoadState {
                 }));
 
         // And finally, start blasting the HTML into the WebView.
-        bridge.resetHtml(model.getTitle().getWikiSite().url(), model.getTitle().getPrefixedText());
+        bridge.resetHtml(model.getTitle().getWikiSite().url(), model.getTitle().getConvertedText());
     }
 
     private void updateThumbnail(String thumbUrl) {


### PR DESCRIPTION
Before we ripping out the `getConvertedText()`, we should use it when requesting endpoints.