### PR TITLE
Add srcset data class for media-list endpoint

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
+++ b/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
@@ -55,14 +55,14 @@ public class MediaListItem implements Serializable {
         @Nullable private String src;
         @Nullable private String scale;
 
-        @Nullable
+        @NonNull
         public String getSrc() {
-            return src;
+            return StringUtils.defaultString(src);
         }
 
-        @Nullable
+        @NonNull
         public String getScale() {
-            return scale;
+            return StringUtils.defaultString(scale);
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
+++ b/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
@@ -10,6 +10,8 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @SuppressWarnings("unused")
 public class MediaListItem implements Serializable {
@@ -51,6 +53,31 @@ public class MediaListItem implements Serializable {
         return srcSets != null ? srcSets : Collections.emptyList();
     }
 
+    @NonNull
+    public String getImageUrl(int preferredSize) {
+        Pattern pattern = Pattern.compile("/(\\d+)px-");
+
+        String imageUrl = getSrcSets().get(getSrcSets().size() - 1).getSrc();
+        int previousSize = 0;
+        for (ImageSrcSet srcSet : getSrcSets()) {
+            Matcher matcher = pattern.matcher(srcSet.getSrc());
+            if (matcher.find() && matcher.group(1) != null) {
+                int currentSize = Integer.parseInt(matcher.group(1));
+
+                if (currentSize == preferredSize) {
+                    imageUrl = srcSet.getSrc();
+                    break;
+                } else if (preferredSize < currentSize && preferredSize > previousSize) {
+                    imageUrl = srcSet.getSrc();
+                    break;
+                }
+                previousSize = currentSize;
+            }
+        }
+
+        return StringUtils.defaultString(imageUrl);
+    }
+
     public class ImageSrcSet implements Serializable {
         @Nullable private String src;
         @Nullable private String scale;
@@ -58,11 +85,6 @@ public class MediaListItem implements Serializable {
         @NonNull
         public String getSrc() {
             return StringUtils.defaultString(src);
-        }
-
-        @NonNull
-        public String getScale() {
-            return StringUtils.defaultString(scale);
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
+++ b/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
@@ -56,26 +56,19 @@ public class MediaListItem implements Serializable {
     @NonNull
     public String getImageUrl(int preferredSize) {
         Pattern pattern = Pattern.compile("/(\\d+)px-");
-
-        String imageUrl = getSrcSets().get(getSrcSets().size() - 1).getSrc();
-        int previousSize = 0;
+        String imageUrl = getSrcSets().get(0).getSrc();
+        int lastSizeDistance = Integer.MAX_VALUE;
         for (ImageSrcSet srcSet : getSrcSets()) {
             Matcher matcher = pattern.matcher(srcSet.getSrc());
             if (matcher.find() && matcher.group(1) != null) {
-                int currentSize = Integer.parseInt(matcher.group(1));
-
-                if (currentSize == preferredSize) {
+                int currentSizeDistance = Math.abs(Integer.parseInt(matcher.group(1)) - preferredSize);
+                if (currentSizeDistance < lastSizeDistance) {
                     imageUrl = srcSet.getSrc();
-                    break;
-                } else if (preferredSize < currentSize && preferredSize > previousSize) {
-                    imageUrl = srcSet.getSrc();
-                    break;
+                    lastSizeDistance = currentSizeDistance;
                 }
-                previousSize = currentSize;
             }
         }
-
-        return StringUtils.defaultString(imageUrl);
+        return imageUrl;
     }
 
     public class ImageSrcSet implements Serializable {

--- a/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
+++ b/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
@@ -8,6 +8,8 @@ import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
 
 @SuppressWarnings("unused")
 public class MediaListItem implements Serializable {
@@ -16,6 +18,7 @@ public class MediaListItem implements Serializable {
     @Nullable private String type;
     @Nullable private TextInfo caption;
     private boolean showInGallery;
+    @Nullable @SerializedName("srcset") private List<ImageSrcSet> srcSets;
 
     public MediaListItem() {
     }
@@ -41,5 +44,25 @@ public class MediaListItem implements Serializable {
     @NonNull
     public String getTitle() {
         return StringUtils.defaultString(title);
+    }
+
+    @NonNull
+    public List<ImageSrcSet> getSrcSets() {
+        return srcSets != null ? srcSets : Collections.emptyList();
+    }
+
+    public class ImageSrcSet implements Serializable {
+        @Nullable private String src;
+        @Nullable private String scale;
+
+        @Nullable
+        public String getSrc() {
+            return src;
+        }
+
+        @Nullable
+        public String getScale() {
+            return scale;
+        }
     }
 }


### PR DESCRIPTION
The `page/media-list` has the `srcset`, which provides the image URLs and their scales. It will be used in the #546 when downloading images for offline use.