### PR TITLE
Radically refactor InvokeSource.

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.java
+++ b/app/src/main/java/org/wikipedia/Constants.java
@@ -44,6 +44,7 @@ public final class Constants {
     public static final String INTENT_EXTRA_NOTIFICATION_SYNC_CANCEL = "syncCancel";
     public static final String INTENT_EXTRA_GO_TO_MAIN_TAB = "goToMainTab";
     public static final String INTENT_EXTRA_INVOKE_SOURCE = "invokeSource";
+    public static final String INTENT_EXTRA_ACTION = "intentAction";
 
     public static final int MAX_SUGGESTION_RESULTS = 3;
     public static final int SUGGESTION_REQUEST_ITEMS = 5;
@@ -59,40 +60,44 @@ public final class Constants {
     public static final int MIN_LANGUAGES_TO_UNLOCK_TRANSLATION = 2;
 
     public enum InvokeSource {
-        CONTEXT_MENU,
-        LINK_PREVIEW_MENU,
-        PAGE_OVERFLOW_MENU,
-        NAV_MENU,
-        MAIN_ACTIVITY,
-        PAGE_ACTIVITY,
-        NEWS_ACTIVITY,
-        READING_LIST_ACTIVITY,
-        MOST_READ_ACTIVITY,
-        RANDOM_ACTIVITY,
-        ON_THIS_DAY_ACTIVITY,
-        READ_MORE_BOOKMARK_BUTTON,
-        BOOKMARK_BUTTON,
-        SUGGESTED_EDITS_ADD_DESC,
-        SUGGESTED_EDITS_TRANSLATE_DESC,
-        SUGGESTED_EDITS_ADD_CAPTION,
-        SUGGESTED_EDITS_TRANSLATE_CAPTION,
-        FEED_CARD_SUGGESTED_EDITS_ADD_DESC,
-        FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC,
-        FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION,
-        FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION,
-        SUGGESTED_EDITS_ONBOARDING,
-        ONBOARDING_DIALOG,
-        FEED,
-        NOTIFICATION,
-        APP_SHORTCUTS,
-        TOOLBAR,
-        WIDGET,
-        INTENT_SHARE,
-        INTENT_PROCESS_TEXT,
-        FEED_BAR,
-        VOICE,
-        ON_THIS_DAY_CARD_BODY,
-        ON_THIS_DAY_CARD_FOOTER
+        CONTEXT_MENU("contextMenu"),
+        LINK_PREVIEW_MENU("linkPreviewMenu"),
+        PAGE_OVERFLOW_MENU("pageOverflowMenu"),
+        NAV_MENU("navMenu"),
+        MAIN_ACTIVITY("main"),
+        PAGE_ACTIVITY("page"),
+        NEWS_ACTIVITY("news"),
+        READING_LIST_ACTIVITY("readingList"),
+        MOST_READ_ACTIVITY("mostRead"),
+        RANDOM_ACTIVITY("random"),
+        ON_THIS_DAY_ACTIVITY("onThisDay"),
+        GALLERY_ACTIVITY("gallery"),
+        READ_MORE_BOOKMARK_BUTTON("readMoreBookmark"),
+        BOOKMARK_BUTTON("bookmark"),
+        SUGGESTED_EDITS("suggestedEdits"),
+        ONBOARDING_DIALOG("onboarding"),
+        FEED("feed"),
+        NOTIFICATION("notification"),
+        APP_SHORTCUTS("appShortcuts"),
+        TOOLBAR("toolbar"),
+        WIDGET("widget"),
+        INTENT_SHARE("intentShare"),
+        INTENT_PROCESS_TEXT("intentProcessText"),
+        FEED_BAR("feedBar"),
+        VOICE("voice"),
+        ON_THIS_DAY_CARD_BODY("onThisDayCard"),
+        ON_THIS_DAY_CARD_FOOTER("onThisDayCardFooter"),
+        LEAD_IMAGE("leadImage");
+
+        private String name;
+
+        InvokeSource(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
     }
 
     private Constants() { }

--- a/app/src/main/java/org/wikipedia/analytics/DescriptionEditFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/DescriptionEditFunnel.java
@@ -2,6 +2,8 @@ package org.wikipedia.analytics;
 
 import androidx.annotation.NonNull;
 
+import org.json.JSONObject;
+import org.wikipedia.Constants;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.page.PageTitle;
 
@@ -23,10 +25,18 @@ public class DescriptionEditFunnel extends EditFunnel {
     }
 
     @NonNull private final Type type;
+    @NonNull private final Constants.InvokeSource source;
 
-    public DescriptionEditFunnel(@NonNull WikipediaApp app, @NonNull PageTitle title, @NonNull Type type) {
+    public DescriptionEditFunnel(@NonNull WikipediaApp app, @NonNull PageTitle title, @NonNull Type type, @NonNull Constants.InvokeSource source) {
         super(app, title);
         this.type = type;
+        this.source = source;
+    }
+
+    @Override
+    protected JSONObject preprocessData(@NonNull JSONObject eventData) {
+        preprocessData(eventData, "source", source.getName());
+        return super.preprocessData(eventData);
     }
 
     @Override public void logStart() {

--- a/app/src/main/java/org/wikipedia/analytics/EditFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/EditFunnel.java
@@ -10,7 +10,7 @@ import org.wikipedia.page.PageTitle;
 
 public class EditFunnel extends Funnel {
     private static final String SCHEMA_NAME = "MobileWikiAppEdit";
-    private static final int REV_ID = 18115551;
+    private static final int REV_ID = 19631190;
 
     private final PageTitle title;
 

--- a/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.java
@@ -7,23 +7,17 @@ import com.google.gson.annotations.SerializedName;
 import org.json.JSONObject;
 import org.wikipedia.Constants.InvokeSource;
 import org.wikipedia.WikipediaApp;
+import org.wikipedia.descriptions.DescriptionEditActivity.Action;
 import org.wikipedia.json.GsonUtil;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.wikipedia.Constants.InvokeSource.FEED;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_ADD_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.NAV_MENU;
-import static org.wikipedia.Constants.InvokeSource.NOTIFICATION;
-import static org.wikipedia.Constants.InvokeSource.ONBOARDING_DIALOG;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_DESC;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_DESC;
+import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_DESCRIPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION;
 
 public final class SuggestedEditsFunnel extends TimedFunnel {
     private static SuggestedEditsFunnel INSTANCE;
@@ -61,10 +55,10 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
     }
 
     public static SuggestedEditsFunnel get() {
-        if (INSTANCE != null && INSTANCE.invokeSource != NAV_MENU) {
+        if (INSTANCE != null && INSTANCE.invokeSource != SUGGESTED_EDITS) {
             return INSTANCE;
         }
-        return get(NAV_MENU);
+        return get(SUGGESTED_EDITS);
     }
 
     public static void reset() {
@@ -75,28 +69,28 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
         preprocessData(eventData, "session_token", parentSessionToken);
     }
 
-    public void impression(InvokeSource source) {
-        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
+    public void impression(Action action) {
+        if (action == ADD_DESCRIPTION) {
             statsCollection.addDescriptionStats.impressions++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (action == TRANSLATE_DESCRIPTION) {
             statsCollection.translateDescriptionStats.impressions++;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+        } else if (action == ADD_CAPTION) {
             statsCollection.addCaptionStats.impressions++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+        } else if (action == TRANSLATE_CAPTION) {
             statsCollection.translateCaptionStats.impressions++;
         }
     }
 
 
-    public void click(String title, InvokeSource source) {
+    public void click(String title, Action action) {
         SuggestedEditStats stats;
-        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
+        if (action == ADD_DESCRIPTION) {
             stats = statsCollection.addDescriptionStats;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (action == TRANSLATE_DESCRIPTION) {
             stats = statsCollection.translateDescriptionStats;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+        } else if (action == ADD_CAPTION) {
             stats = statsCollection.addCaptionStats;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+        } else if (action == TRANSLATE_CAPTION) {
             stats = statsCollection.translateCaptionStats;
         } else {
             return;
@@ -112,38 +106,38 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
         }
     }
 
-    public void cancel(InvokeSource source) {
-        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
+    public void cancel(Action action) {
+        if (action == ADD_DESCRIPTION) {
             statsCollection.addDescriptionStats.cancels++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (action == TRANSLATE_DESCRIPTION) {
             statsCollection.translateDescriptionStats.cancels++;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+        } else if (action == ADD_CAPTION) {
             statsCollection.addCaptionStats.cancels++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+        } else if (action == TRANSLATE_CAPTION) {
             statsCollection.translateCaptionStats.cancels++;
         }
     }
 
-    public void success(InvokeSource source) {
-        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
+    public void success(Action action) {
+        if (action == ADD_DESCRIPTION) {
             statsCollection.addDescriptionStats.successes++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (action == TRANSLATE_DESCRIPTION) {
             statsCollection.translateDescriptionStats.successes++;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+        } else if (action == ADD_CAPTION) {
             statsCollection.addCaptionStats.successes++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+        } else if (action == TRANSLATE_CAPTION) {
             statsCollection.translateCaptionStats.successes++;
         }
     }
 
-    public void failure(InvokeSource source) {
-        if (source == SUGGESTED_EDITS_ADD_DESC || source == FEED_CARD_SUGGESTED_EDITS_ADD_DESC) {
+    public void failure(Action action) {
+        if (action == ADD_DESCRIPTION) {
             statsCollection.addDescriptionStats.failures++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        } else if (action == TRANSLATE_DESCRIPTION) {
             statsCollection.translateDescriptionStats.failures++;
-        } else if (source == SUGGESTED_EDITS_ADD_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+        } else if (action == ADD_CAPTION) {
             statsCollection.addCaptionStats.failures++;
-        } else if (source == SUGGESTED_EDITS_TRANSLATE_CAPTION || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+        } else if (action == TRANSLATE_CAPTION) {
             statsCollection.translateCaptionStats.failures++;
         }
     }
@@ -161,10 +155,7 @@ public final class SuggestedEditsFunnel extends TimedFunnel {
                 "edit_tasks", GsonUtil.getDefaultGson().toJson(statsCollection),
                 "help_opened", helpOpenedCount,
                 "scorecard_opened", contributionsOpenedCount,
-                "source", (invokeSource == ONBOARDING_DIALOG ? "dialog"
-                        : invokeSource == NOTIFICATION ? "notification"
-                        : invokeSource == FEED ? "feed"
-                        : "menu")
+                "source", (invokeSource.getName())
         );
     }
 

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.java
@@ -23,27 +23,31 @@ import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.ShareUtil;
 import org.wikipedia.views.ImagePreviewDialog;
 
+import static org.wikipedia.Constants.INTENT_EXTRA_ACTION;
 import static org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE;
 import static org.wikipedia.Constants.InvokeSource;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION;
 import static org.wikipedia.Constants.InvokeSource.LINK_PREVIEW_MENU;
 import static org.wikipedia.Constants.InvokeSource.PAGE_ACTIVITY;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_DESC;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION;
 import static org.wikipedia.util.DeviceUtil.hideSoftKeyboard;
 
 public class DescriptionEditActivity extends SingleFragmentActivity<DescriptionEditFragment>
         implements DescriptionEditFragment.Callback, LinkPreviewDialog.Callback {
 
+    public enum Action {
+        ADD_DESCRIPTION,
+        TRANSLATE_DESCRIPTION,
+        ADD_CAPTION,
+        TRANSLATE_CAPTION
+    }
+
     private static final String EXTRA_TITLE = "title";
     private static final String EXTRA_HIGHLIGHT_TEXT = "highlightText";
-    private static final String EXTRA_INVOKE_SOURCE = "invokeSource";
     private static final String EXTRA_SOURCE_SUMMARY = "sourceSummary";
     private static final String EXTRA_TARGET_SUMMARY = "targetSummary";
-    private InvokeSource invokeSource;
+    private Action action;
     private ExclusiveBottomSheetPresenter bottomSheetPresenter = new ExclusiveBottomSheetPresenter();
 
     public static Intent newIntent(@NonNull Context context,
@@ -51,13 +55,15 @@ public class DescriptionEditActivity extends SingleFragmentActivity<DescriptionE
                                    @Nullable String highlightText,
                                    @Nullable SuggestedEditsSummary sourceSummary,
                                    @Nullable SuggestedEditsSummary targetSummary,
+                                   @NonNull Action action,
                                    @NonNull InvokeSource invokeSource) {
         return new Intent(context, DescriptionEditActivity.class)
                 .putExtra(EXTRA_TITLE, GsonMarshaller.marshal(title))
                 .putExtra(EXTRA_HIGHLIGHT_TEXT, highlightText)
                 .putExtra(EXTRA_SOURCE_SUMMARY, sourceSummary == null ? null : GsonMarshaller.marshal(sourceSummary))
                 .putExtra(EXTRA_TARGET_SUMMARY, targetSummary == null ? null : GsonMarshaller.marshal(targetSummary))
-                .putExtra(EXTRA_INVOKE_SOURCE, invokeSource);
+                .putExtra(INTENT_EXTRA_ACTION, action)
+                .putExtra(INTENT_EXTRA_INVOKE_SOURCE, invokeSource);
     }
 
     @Override
@@ -67,23 +73,22 @@ public class DescriptionEditActivity extends SingleFragmentActivity<DescriptionE
     }
 
     @Override
-    public void onBottomBarContainerClicked(@NonNull InvokeSource invokeSource) {
+    public void onBottomBarContainerClicked(@NonNull Action action) {
         SuggestedEditsSummary summary;
 
-        if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        if (action == TRANSLATE_DESCRIPTION) {
             summary = GsonUnmarshaller.unmarshal(SuggestedEditsSummary.class, getIntent().getStringExtra(EXTRA_TARGET_SUMMARY));
         } else {
             summary = GsonUnmarshaller.unmarshal(SuggestedEditsSummary.class, getIntent().getStringExtra(EXTRA_SOURCE_SUMMARY));
         }
 
-        if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION
-                || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+        if (action == ADD_CAPTION || action == TRANSLATE_CAPTION) {
             bottomSheetPresenter.show(getSupportFragmentManager(),
-                    ImagePreviewDialog.Companion.newInstance(summary, invokeSource));
+                    ImagePreviewDialog.Companion.newInstance(summary, action));
         } else {
             bottomSheetPresenter.show(getSupportFragmentManager(),
                     LinkPreviewDialog.newInstance(new HistoryEntry(summary.getPageTitle(),
-                                    getIntent().hasExtra(EXTRA_INVOKE_SOURCE) && getIntent().getSerializableExtra(EXTRA_INVOKE_SOURCE) == PAGE_ACTIVITY
+                                    getIntent().hasExtra(INTENT_EXTRA_INVOKE_SOURCE) && getIntent().getSerializableExtra(INTENT_EXTRA_INVOKE_SOURCE) == PAGE_ACTIVITY
                                             ? HistoryEntry.SOURCE_EDIT_DESCRIPTION : HistoryEntry.SOURCE_SUGGESTED_EDITS),
                             null, true));
         }
@@ -120,14 +125,16 @@ public class DescriptionEditActivity extends SingleFragmentActivity<DescriptionE
 
     @Override
     public DescriptionEditFragment createFragment() {
-        invokeSource = (InvokeSource) getIntent().getSerializableExtra(INTENT_EXTRA_INVOKE_SOURCE);
+        InvokeSource invokeSource = (InvokeSource) getIntent().getSerializableExtra(INTENT_EXTRA_INVOKE_SOURCE);
+        action = (Action) getIntent().getSerializableExtra(INTENT_EXTRA_ACTION);
         PageTitle title = GsonUnmarshaller.unmarshal(PageTitle.class, getIntent().getStringExtra(EXTRA_TITLE));
-        SuggestedEditsFunnel.get().click(title.getDisplayText(), invokeSource);
+        SuggestedEditsFunnel.get().click(title.getDisplayText(), action);
 
         return DescriptionEditFragment.newInstance(title,
                 getIntent().getStringExtra(EXTRA_HIGHLIGHT_TEXT),
                 getIntent().getStringExtra(EXTRA_SOURCE_SUMMARY),
                 getIntent().getStringExtra(EXTRA_TARGET_SUMMARY),
+                action,
                 invokeSource);
     }
 
@@ -137,7 +144,7 @@ public class DescriptionEditActivity extends SingleFragmentActivity<DescriptionE
             getFragment().editView.loadReviewContent(false);
         } else {
             hideSoftKeyboard(this);
-            SuggestedEditsFunnel.get().cancel(invokeSource);
+            SuggestedEditsFunnel.get().cancel(action);
             super.onBackPressed();
         }
     }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
@@ -31,6 +31,7 @@ import org.wikipedia.dataclient.mwapi.MwPostResponse;
 import org.wikipedia.dataclient.mwapi.MwServiceError;
 import org.wikipedia.dataclient.page.PageClientFactory;
 import org.wikipedia.dataclient.retrofit.RetrofitException;
+import org.wikipedia.descriptions.DescriptionEditActivity.Action;
 import org.wikipedia.json.GsonMarshaller;
 import org.wikipedia.json.GsonUnmarshaller;
 import org.wikipedia.login.LoginClient.LoginFailedException;
@@ -55,17 +56,15 @@ import io.reactivex.schedulers.Schedulers;
 
 import static android.app.Activity.RESULT_OK;
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_DESCRIPTION_EDIT_SUCCESS;
+import static org.wikipedia.Constants.INTENT_EXTRA_ACTION;
 import static org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE;
 import static org.wikipedia.Constants.InvokeSource;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_ADD_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION;
 import static org.wikipedia.Constants.InvokeSource.PAGE_ACTIVITY;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_DESC;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_DESC;
+import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_DESCRIPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION;
 import static org.wikipedia.descriptions.DescriptionEditUtil.ABUSEFILTER_DISALLOWED;
 import static org.wikipedia.descriptions.DescriptionEditUtil.ABUSEFILTER_WARNING;
 import static org.wikipedia.suggestededits.SuggestedEditsCardsActivity.EXTRA_SOURCE_ADDED_CONTRIBUTION;
@@ -75,13 +74,14 @@ public class DescriptionEditFragment extends Fragment {
 
     public interface Callback {
         void onDescriptionEditSuccess();
-        void onBottomBarContainerClicked(@NonNull InvokeSource invokeSource);
+        void onBottomBarContainerClicked(@NonNull DescriptionEditActivity.Action action);
     }
 
     private static final String ARG_TITLE = "title";
     private static final String ARG_REVIEWING = "inReviewing";
     private static final String ARG_DESCRIPTION = "description";
     private static final String ARG_HIGHLIGHT_TEXT = "highlightText";
+    private static final String ARG_ACTION = "action";
     private static final String ARG_INVOKE_SOURCE = "invokeSource";
     private static final String ARG_SOURCE_SUMMARY = "sourceSummary";
     private static final String ARG_TARGET_SUMMARY = "targetSummary";
@@ -94,6 +94,7 @@ public class DescriptionEditFragment extends Fragment {
     @Nullable private String highlightText;
     @Nullable private CsrfTokenClient csrfClient;
     @Nullable private DescriptionEditFunnel funnel;
+    private Action action;
     private InvokeSource invokeSource;
     private CompositeDisposable disposables = new CompositeDisposable();
 
@@ -103,12 +104,12 @@ public class DescriptionEditFragment extends Fragment {
                 Prefs.incrementTotalAnonDescriptionsEdited();
             }
 
-            if (isSuggestedEdits()) {
+            if (invokeSource == SUGGESTED_EDITS) {
                 SuggestedEditsSurvey.onEditSuccess();
             }
 
             Prefs.setLastDescriptionEditTime(new Date().getTime());
-            SuggestedEditsFunnel.get().success(invokeSource);
+            SuggestedEditsFunnel.get().success(action);
 
             if (getActivity() == null)  {
                 return;
@@ -122,6 +123,7 @@ public class DescriptionEditFragment extends Fragment {
                 Intent intent = new Intent();
                 intent.putExtra(EXTRA_SOURCE_ADDED_CONTRIBUTION, editView.getDescription());
                 intent.putExtra(INTENT_EXTRA_INVOKE_SOURCE, invokeSource);
+                intent.putExtra(INTENT_EXTRA_ACTION, action);
                 requireActivity().setResult(RESULT_OK, intent);
                 hideSoftKeyboard(requireActivity());
                 requireActivity().finish();
@@ -129,17 +131,12 @@ public class DescriptionEditFragment extends Fragment {
         }
     };
 
-    private boolean isSuggestedEdits() {
-        return invokeSource == FEED_CARD_SUGGESTED_EDITS_ADD_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC
-                || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION || invokeSource == SUGGESTED_EDITS_ADD_DESC || invokeSource == SUGGESTED_EDITS_ADD_CAPTION
-                || invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION;
-    }
-
     @NonNull
     public static DescriptionEditFragment newInstance(@NonNull PageTitle title,
                                                       @Nullable String highlightText,
                                                       @Nullable String sourceSummary,
                                                       @Nullable String targetSummary,
+                                                      @NonNull Action action,
                                                       @NonNull InvokeSource source) {
         DescriptionEditFragment instance = new DescriptionEditFragment();
         Bundle args = new Bundle();
@@ -147,6 +144,7 @@ public class DescriptionEditFragment extends Fragment {
         args.putString(ARG_HIGHLIGHT_TEXT, highlightText);
         args.putString(ARG_SOURCE_SUMMARY, sourceSummary);
         args.putString(ARG_TARGET_SUMMARY, targetSummary);
+        args.putSerializable(ARG_ACTION, action);
         args.putSerializable(ARG_INVOKE_SOURCE, source);
         instance.setArguments(args);
         return instance;
@@ -159,6 +157,7 @@ public class DescriptionEditFragment extends Fragment {
                 ? DescriptionEditFunnel.Type.NEW
                 : DescriptionEditFunnel.Type.EXISTING;
         highlightText = getArguments().getString(ARG_HIGHLIGHT_TEXT);
+        action = (Action) getArguments().getSerializable(ARG_ACTION);
         invokeSource = (InvokeSource) getArguments().getSerializable(ARG_INVOKE_SOURCE);
 
         if (getArguments().getString(ARG_SOURCE_SUMMARY) != null) {
@@ -169,7 +168,7 @@ public class DescriptionEditFragment extends Fragment {
             targetSummary = GsonUnmarshaller.unmarshal(SuggestedEditsSummary.class, getArguments().getString(ARG_TARGET_SUMMARY));
         }
 
-        funnel = new DescriptionEditFunnel(WikipediaApp.getInstance(), pageTitle, type);
+        funnel = new DescriptionEditFunnel(WikipediaApp.getInstance(), pageTitle, type, invokeSource);
         funnel.logStart();
     }
 
@@ -244,7 +243,7 @@ public class DescriptionEditFragment extends Fragment {
     }
 
     private void setUpEditView(Bundle savedInstanceState) {
-        editView.setInvokeSource(invokeSource);
+        editView.setAction(action);
         editView.setPageTitle(pageTitle);
         editView.setHighlightText(highlightText);
         editView.setCallback(new EditViewCallback());
@@ -275,7 +274,7 @@ public class DescriptionEditFragment extends Fragment {
 
                 cancelCalls();
 
-                if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+                if (action == ADD_CAPTION || action == TRANSLATE_CAPTION) {
                     csrfClient = new CsrfTokenClient(wikiCommons, wikiCommons);
                 } else {
                     csrfClient = new CsrfTokenClient(wikiData, pageTitle.getWikiSite());
@@ -358,19 +357,19 @@ public class DescriptionEditFragment extends Fragment {
         }
 
         private Observable<MwPostResponse> getPostObservable(@NonNull String editToken, @Nullable String languageCode) {
-            if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+            if (action == ADD_CAPTION || action == TRANSLATE_CAPTION) {
                 return ServiceFactory.get(wikiCommons).postLabelEdit(pageTitle.getWikiSite().languageCode(),
                         pageTitle.getWikiSite().languageCode(), commonsDbName,
                         pageTitle.getConvertedText(), editView.getDescription(),
-                        invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION ? SuggestedEditsFunnel.SUGGESTED_EDITS_ADD_COMMENT
-                                : invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION ? SuggestedEditsFunnel.SUGGESTED_EDITS_TRANSLATE_COMMENT : null,
+                        action == ADD_CAPTION ? SuggestedEditsFunnel.SUGGESTED_EDITS_ADD_COMMENT
+                                : action == TRANSLATE_CAPTION ? SuggestedEditsFunnel.SUGGESTED_EDITS_TRANSLATE_COMMENT : null,
                         editToken, AccountUtil.isLoggedIn() ? "user" : null);
             } else {
                 return ServiceFactory.get(wikiData).postDescriptionEdit(languageCode,
                         pageTitle.getWikiSite().languageCode(), pageTitle.getWikiSite().dbName(),
                         pageTitle.getConvertedText(), editView.getDescription(),
-                        invokeSource == SUGGESTED_EDITS_ADD_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_ADD_DESC ? SuggestedEditsFunnel.SUGGESTED_EDITS_ADD_COMMENT
-                                : invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC ? SuggestedEditsFunnel.SUGGESTED_EDITS_TRANSLATE_COMMENT : null,
+                        action == ADD_DESCRIPTION ? SuggestedEditsFunnel.SUGGESTED_EDITS_ADD_COMMENT
+                                : action == TRANSLATE_DESCRIPTION ? SuggestedEditsFunnel.SUGGESTED_EDITS_TRANSLATE_COMMENT : null,
                         editToken, AccountUtil.isLoggedIn() ? "user" : null);
             }
         }
@@ -384,7 +383,7 @@ public class DescriptionEditFragment extends Fragment {
             if (funnel != null && logError) {
                 funnel.logError(caught.getMessage());
             }
-            SuggestedEditsFunnel.get().cancel(invokeSource);
+            SuggestedEditsFunnel.get().cancel(action);
         }
 
         @Override
@@ -404,7 +403,7 @@ public class DescriptionEditFragment extends Fragment {
 
         @Override
         public void onBottomBarClick() {
-            callback().onBottomBarContainerClicked(invokeSource);
+            callback().onBottomBarContainerClicked(action);
         }
 
         @Override

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
@@ -22,6 +22,7 @@ import com.google.android.material.textfield.TextInputLayout;
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
+import org.wikipedia.descriptions.DescriptionEditActivity.Action;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.suggestededits.SuggestedEditsSummary;
 import org.wikipedia.util.DeviceUtil;
@@ -36,16 +37,10 @@ import butterknife.OnClick;
 import butterknife.OnEditorAction;
 import butterknife.OnTextChanged;
 
-import static org.wikipedia.Constants.InvokeSource;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_ADD_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.PAGE_ACTIVITY;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_DESC;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_DESC;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_DESCRIPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION;
 import static org.wikipedia.util.DeviceUtil.hideSoftKeyboard;
 import static org.wikipedia.util.L10nUtil.setConditionalLayoutDirection;
 
@@ -70,7 +65,7 @@ public class DescriptionEditView extends LinearLayout {
     private Activity activity;
     private PageTitle pageTitle;
     private SuggestedEditsSummary suggestedEditsSummary;
-    private InvokeSource invokeSource;
+    private Action action;
     private boolean isTranslationEdit;
 
     public interface Callback {
@@ -115,21 +110,14 @@ public class DescriptionEditView extends LinearLayout {
     }
 
     private void setHelperText() {
-        if (invokeSource == PAGE_ACTIVITY
-                || invokeSource == SUGGESTED_EDITS_ADD_DESC
-                || invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC
-                || invokeSource == FEED_CARD_SUGGESTED_EDITS_ADD_DESC
-                || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        if (action == ADD_DESCRIPTION || action == TRANSLATE_DESCRIPTION) {
             pageDescriptionLayout.setHelperText(getContext().getString(R.string.description_edit_helper_text_lowercase_warning));
         }
     }
 
     private int getHeaderTextRes(boolean inReview) {
         if (inReview) {
-            if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION
-                    || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION
-                    || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION
-                    || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+            if (action == ADD_CAPTION || action == TRANSLATE_CAPTION) {
                 return R.string.suggested_edits_review_image_caption;
             } else {
                 return R.string.suggested_edits_review_description;
@@ -137,20 +125,17 @@ public class DescriptionEditView extends LinearLayout {
         }
 
         if (TextUtils.isEmpty(originalDescription)) {
-            if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+            if (action == TRANSLATE_DESCRIPTION) {
                 return R.string.description_edit_translate_description;
-            } else if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+            } else if (action == ADD_CAPTION) {
                 return R.string.description_edit_add_image_caption;
-            } else if (invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+            } else if (action == TRANSLATE_CAPTION) {
                 return R.string.description_edit_translate_image_caption;
             } else {
                 return R.string.description_edit_add_description;
             }
         } else {
-            if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION
-                    || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION
-                    || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION
-                    || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+            if (action == ADD_CAPTION || action == TRANSLATE_CAPTION) {
                 return R.string.description_edit_edit_image_caption;
             } else {
                 return R.string.description_edit_edit_description;
@@ -159,13 +144,13 @@ public class DescriptionEditView extends LinearLayout {
     }
 
     private CharSequence getLabelText(@NonNull String lang) {
-        if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        if (action == TRANSLATE_DESCRIPTION) {
             return getContext().getString(R.string.description_edit_translate_article_description_label_per_language,
                     WikipediaApp.getInstance().language().getAppLanguageLocalizedName(lang));
-        } else if (invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+        } else if (action == TRANSLATE_CAPTION) {
             return getContext().getString(R.string.description_edit_translate_caption_label_per_language,
                     WikipediaApp.getInstance().language().getAppLanguageLocalizedName(lang));
-        } else if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+        } else if (action == ADD_CAPTION) {
             return getContext().getString(R.string.description_edit_add_caption_label);
         } else {
             return getContext().getString(R.string.description_edit_article_description_label);
@@ -173,13 +158,13 @@ public class DescriptionEditView extends LinearLayout {
     }
 
     private CharSequence getHintText(@NonNull String lang) {
-        if (invokeSource == SUGGESTED_EDITS_TRANSLATE_DESC || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) {
+        if (action == TRANSLATE_DESCRIPTION) {
             return getContext().getString(R.string.description_edit_translate_article_description_hint_per_language,
                     WikipediaApp.getInstance().language().getAppLanguageLocalizedName(lang));
-        } else if (invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) {
+        } else if (action == TRANSLATE_CAPTION) {
             return getContext().getString(R.string.description_edit_translate_caption_hint_per_language,
                     WikipediaApp.getInstance().language().getAppLanguageLocalizedName(lang));
-        } else if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+        } else if (action == ADD_CAPTION) {
             return getContext().getString(R.string.description_edit_add_caption_hint);
         } else {
             return getContext().getString(R.string.description_edit_text_hint);
@@ -191,7 +176,7 @@ public class DescriptionEditView extends LinearLayout {
     }
 
     private void setDarkReviewScreen(boolean enabled) {
-        if (invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION) {
+        if (action == ADD_CAPTION || action == TRANSLATE_CAPTION) {
             int whiteRes = getResources().getColor(android.R.color.white);
             toolbarContainer.setBackgroundResource(enabled ? android.R.color.black : ResourceUtil.getThemedAttributeId(getContext(), R.attr.main_toolbar_color));
             saveButton.setColorFilter(enabled ? whiteRes : ResourceUtil.getThemedColor(getContext(), R.attr.themed_icon_color), PorterDuff.Mode.SRC_IN);
@@ -209,14 +194,13 @@ public class DescriptionEditView extends LinearLayout {
 
         pageSummaryContainer.setVisibility(View.VISIBLE);
         pageSummaryLabel.setText(getLabelText(sourceSummary.getLang()));
-        pageSummaryText.setText(StringUtil.strip(StringUtils.capitalize(StringUtil.removeHTMLTags(isTranslationEdit || invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION
+        pageSummaryText.setText(StringUtil.strip(StringUtils.capitalize(StringUtil.removeHTMLTags(isTranslationEdit || action == ADD_CAPTION
                 ? sourceSummary.getDescription() : sourceSummary.getExtractHtml()))));
-        if (pageSummaryText.getText().toString().isEmpty()
-                || ((invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION))
+        if (pageSummaryText.getText().toString().isEmpty() || (action == ADD_CAPTION)
                 && !TextUtils.isEmpty(sourceSummary.getPageTitle().getDescription())) {
             pageSummaryContainer.setVisibility(GONE);
         }
-        setConditionalLayoutDirection(pageSummaryContainer, (isTranslationEdit) ? sourceSummary.getLang() : pageTitle.getWikiSite().languageCode());
+        setConditionalLayoutDirection(pageSummaryContainer, isTranslationEdit ? sourceSummary.getLang() : pageTitle.getWikiSite().languageCode());
         setUpBottomBar();
     }
 
@@ -236,7 +220,7 @@ public class DescriptionEditView extends LinearLayout {
 
     public void loadReviewContent(boolean enabled) {
         if (enabled) {
-            pageReviewContainer.setSummary(suggestedEditsSummary, getDescription(), invokeSource == SUGGESTED_EDITS_ADD_CAPTION || invokeSource == SUGGESTED_EDITS_TRANSLATE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION || invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION);
+            pageReviewContainer.setSummary(suggestedEditsSummary, getDescription(), action == ADD_CAPTION || action == TRANSLATE_CAPTION);
             pageReviewContainer.show();
             bottomBarContainer.hide();
             descriptionEditContainer.setVisibility(GONE);
@@ -353,8 +337,8 @@ public class DescriptionEditView extends LinearLayout {
         progressBar.setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
-    public void setInvokeSource(InvokeSource source) {
-        invokeSource = source;
-        isTranslationEdit = (source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC || source == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION || source == SUGGESTED_EDITS_TRANSLATE_DESC || source == SUGGESTED_EDITS_TRANSLATE_CAPTION);
+    public void setAction(Action action) {
+        this.action = action;
+        isTranslationEdit = (action == TRANSLATE_CAPTION || action == TRANSLATE_DESCRIPTION);
     }
 }

--- a/app/src/main/java/org/wikipedia/feed/FeedContentType.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedContentType.java
@@ -4,10 +4,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
-import org.wikipedia.Constants.InvokeSource;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
+import org.wikipedia.descriptions.DescriptionEditActivity.Action;
 import org.wikipedia.feed.accessibility.AccessibilityCardClient;
 import org.wikipedia.feed.aggregated.AggregatedFeedContentClient;
 import org.wikipedia.feed.becauseyouread.BecauseYouReadClient;
@@ -25,10 +25,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_ADD_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC;
-import static org.wikipedia.Constants.InvokeSource.FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_DESCRIPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION;
 
 public enum FeedContentType implements EnumCode {
     NEWS(0, R.string.view_card_news_title, R.string.feed_item_type_news, true) {
@@ -92,7 +92,7 @@ public enum FeedContentType implements EnumCode {
         @Override
         public FeedClient newClient(AggregatedFeedContentClient aggregatedClient, int age) {
             if (isEnabled() && AccountUtil.isLoggedIn() && WikipediaApp.getInstance().isOnline()) {
-                List<InvokeSource> unlockedTypes = getUnlockedEditingPrivileges();
+                List<Action> unlockedTypes = getUnlockedEditingPrivileges();
                 if (unlockedTypes.size() > 0) {
                     return new SuggestedEditsFeedClient(unlockedTypes.get(age % unlockedTypes.size()));
                 }
@@ -108,12 +108,12 @@ public enum FeedContentType implements EnumCode {
         }
     };
 
-    List<InvokeSource> getUnlockedEditingPrivileges() {
-        List<InvokeSource> unlockedTypes = new ArrayList<>();
-        unlockedTypes.add(FEED_CARD_SUGGESTED_EDITS_ADD_DESC);
-        unlockedTypes.add(FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC);
-        unlockedTypes.add(FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION);
-        unlockedTypes.add(FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION);
+    List<Action> getUnlockedEditingPrivileges() {
+        List<Action> unlockedTypes = new ArrayList<>();
+        unlockedTypes.add(ADD_DESCRIPTION);
+        unlockedTypes.add(TRANSLATE_DESCRIPTION);
+        unlockedTypes.add(ADD_CAPTION);
+        unlockedTypes.add(TRANSLATE_CAPTION);
         return unlockedTypes;
     }
 

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCard.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCard.kt
@@ -5,12 +5,13 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.SuggestedEditsFunnel
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.descriptions.DescriptionEditActivity.Action
 import org.wikipedia.feed.model.CardType
 import org.wikipedia.feed.model.WikiSiteCard
 import org.wikipedia.suggestededits.SuggestedEditsSummary
 
 class SuggestedEditsCard(wiki: WikiSite,
-                         val invokeSource: InvokeSource,
+                         val action: Action,
                          val sourceSummary: SuggestedEditsSummary?,
                          val targetSummary: SuggestedEditsSummary?,
                          val age: Int) : WikiSiteCard(wiki) {
@@ -24,6 +25,6 @@ class SuggestedEditsCard(wiki: WikiSite,
     }
 
     fun logImpression() {
-        SuggestedEditsFunnel.get(InvokeSource.FEED).impression(invokeSource)
+        SuggestedEditsFunnel.get(InvokeSource.FEED).impression(action)
     }
 }

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -1,15 +1,14 @@
 package org.wikipedia.feed.suggestededits
 
-
 import android.content.Context
 import android.net.Uri
 import android.view.View
 import io.reactivex.annotations.NonNull
 import kotlinx.android.synthetic.main.view_suggested_edit_card.view.*
-import org.wikipedia.Constants.InvokeSource.*
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
 import org.wikipedia.feed.view.DefaultFeedCardView
 import org.wikipedia.feed.view.FeedAdapter
 import org.wikipedia.util.StringUtil
@@ -29,7 +28,7 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
     }
 
     fun isTranslation(): Boolean {
-        return card!!.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC || card!!.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION
+        return card!!.action == TRANSLATE_DESCRIPTION || card!!.action == TRANSLATE_CAPTION
     }
 
     override fun setCard(@NonNull card: SuggestedEditsCard) {
@@ -54,17 +53,17 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
 
     private fun updateContents() {
         viewArticleSubtitle.visibility = View.GONE
-        when (card!!.invokeSource) {
-            FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC -> showTranslateDescriptionUI()
-            FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION -> showAddImageCaptionUI()
-            FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION -> showTranslateImageCaptionUI()
+        when (card!!.action) {
+            TRANSLATE_DESCRIPTION -> showTranslateDescriptionUI()
+            ADD_CAPTION -> showAddImageCaptionUI()
+            TRANSLATE_CAPTION -> showTranslateImageCaptionUI()
             else -> showAddDescriptionUI()
         }
     }
 
     private fun showAddDescriptionUI() {
         viewArticleTitle.text = StringUtil.fromHtml(card!!.sourceSummary!!.displayTitle!!)
-        callToActionText.text = if (card!!.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) context.getString(R.string.suggested_edits_feed_card_add_translation_in_language_button, app.language().getAppLanguageCanonicalName(card!!.targetSummary!!.lang)) else context.getString(R.string.suggested_edits_feed_card_add_description_button)
+        callToActionText.text = if (card!!.action == TRANSLATE_DESCRIPTION) context.getString(R.string.suggested_edits_feed_card_add_translation_in_language_button, app.language().getAppLanguageCanonicalName(card!!.targetSummary!!.lang)) else context.getString(R.string.suggested_edits_feed_card_add_description_button)
         showImageOrExtract()
     }
 
@@ -81,7 +80,7 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
         divider.visibility = View.GONE
         viewArticleImage.loadImage(Uri.parse(card!!.sourceSummary!!.thumbnailUrl))
         viewArticleTitle.text = StringUtil.removeNamespace(card!!.sourceSummary!!.displayTitle!!)
-        callToActionText.text = if (card!!.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION) context.getString(R.string.suggested_edits_feed_card_translate_image_caption, app.language().getAppLanguageCanonicalName(card!!.targetSummary!!.lang)) else context.getString(R.string.suggested_edits_feed_card_add_image_caption)
+        callToActionText.text = if (card!!.action == TRANSLATE_CAPTION) context.getString(R.string.suggested_edits_feed_card_translate_image_caption, app.language().getAppLanguageCanonicalName(card!!.targetSummary!!.lang)) else context.getString(R.string.suggested_edits_feed_card_add_image_caption)
     }
 
     private fun showTranslateImageCaptionUI() {
@@ -110,13 +109,13 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
         headerView!!.setTitle(card.title())
                 .setImage(R.drawable.ic_mode_edit_white_24dp)
                 .setImageCircleColor(R.color.base30)
-                .setLangCode(if (card.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION || card.invokeSource == FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC) card.wikiSite().languageCode() else "")
+                .setLangCode(if (card.action == TRANSLATE_CAPTION || card.action == TRANSLATE_DESCRIPTION) card.wikiSite().languageCode() else "")
                 .setCard(card)
                 .setCallback(callback)
     }
 
     fun refreshCardContent() {
-        SuggestedEditsFeedClient(card!!.invokeSource).fetchSuggestedEditForType(null, this)
+        SuggestedEditsFeedClient(card!!.action).fetchSuggestedEditForType(null, this)
     }
 
     override fun updateCardContent(card: SuggestedEditsCard) {

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
-import org.wikipedia.Constants
-import org.wikipedia.Constants.InvokeSource.*
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.descriptions.DescriptionEditActivity
+import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
 import org.wikipedia.feed.FeedCoordinator
 import org.wikipedia.feed.dataclient.FeedClient
 import org.wikipedia.feed.model.Card
@@ -20,7 +20,7 @@ import org.wikipedia.suggestededits.provider.MissingDescriptionProvider
 import org.wikipedia.util.StringUtil
 import java.util.*
 
-class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource) : FeedClient {
+class SuggestedEditsFeedClient(private var action: DescriptionEditActivity.Action) : FeedClient {
     interface Callback {
         fun updateCardContent(card: SuggestedEditsCard)
     }
@@ -56,14 +56,14 @@ class SuggestedEditsFeedClient(private var invokeSource: Constants.InvokeSource)
     }
 
     private fun toSuggestedEditsCard(wiki: WikiSite): SuggestedEditsCard {
-        return SuggestedEditsCard(wiki, invokeSource, sourceSummary, targetSummary, age)
+        return SuggestedEditsCard(wiki, action, sourceSummary, targetSummary, age)
     }
 
     fun fetchSuggestedEditForType(cb: FeedClient.Callback?, callback: Callback?) {
-        when (invokeSource) {
-            FEED_CARD_SUGGESTED_EDITS_TRANSLATE_DESC -> getArticleToTranslateDescription(cb, callback)
-            FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION -> getImageToAddCaption(cb, callback)
-            FEED_CARD_SUGGESTED_EDITS_TRANSLATE_IMAGE_CAPTION -> getImageToTranslateCaption(cb, callback)
+        when (action) {
+            TRANSLATE_DESCRIPTION -> getArticleToTranslateDescription(cb, callback)
+            ADD_CAPTION -> getImageToAddCaption(cb, callback)
+            TRANSLATE_CAPTION -> getImageToTranslateCaption(cb, callback)
             else -> getArticleToAddDescription(cb, callback)
         }
     }

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -76,11 +76,12 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 
-import static org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE;
+import static org.wikipedia.Constants.INTENT_EXTRA_ACTION;
+import static org.wikipedia.Constants.InvokeSource.GALLERY_ACTIVITY;
 import static org.wikipedia.Constants.InvokeSource.LINK_PREVIEW_MENU;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_CAPTION;
 import static org.wikipedia.Constants.PREFERRED_GALLERY_IMAGE_SIZE;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTION;
 import static org.wikipedia.util.StringUtil.addUnderscores;
 import static org.wikipedia.util.StringUtil.removeUnderscores;
 import static org.wikipedia.util.StringUtil.strip;
@@ -303,7 +304,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     public void onActivityResult(int requestCode, int resultCode, final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == ACTIVITY_REQUEST_DESCRIPTION_EDIT && resultCode == RESULT_OK) {
-            FeedbackUtil.showMessage(this, data.getSerializableExtra(INTENT_EXTRA_INVOKE_SOURCE) == SUGGESTED_EDITS_ADD_CAPTION
+            FeedbackUtil.showMessage(this, data.getSerializableExtra(INTENT_EXTRA_ACTION) == ADD_CAPTION
                     ? getString(R.string.description_edit_success_saved_image_caption_snackbar)
                     : getString(R.string.description_edit_success_saved_image_caption_in_lang_snackbar, app.language().getAppLanguageLocalizedName(targetLanguageCode)));
             layOutGalleryDescription();
@@ -326,7 +327,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
                 title.getDisplayText(), title.getDisplayText(), StringUtils.defaultIfBlank(StringUtil.fromHtml(item.getMediaInfo().getMetadata().imageDescription()).toString(), null),
                 item.getMediaInfo().getThumbUrl(), null, null, null, null);
 
-        startActivityForResult(DescriptionEditActivity.newIntent(this, title, null, summary, null, SUGGESTED_EDITS_ADD_CAPTION),
+        startActivityForResult(DescriptionEditActivity.newIntent(this, title, null, summary, null, ADD_CAPTION, GALLERY_ACTIVITY),
                 ACTIVITY_REQUEST_DESCRIPTION_EDIT);
     }
 
@@ -357,7 +358,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
                 null, null, null, null);
 
         startActivityForResult(DescriptionEditActivity.newIntent(this, targetTitle, null, sourceSummary, targetSummary,
-                (sourceSummary.getLang().equals(targetSummary.getLang())) ? SUGGESTED_EDITS_ADD_CAPTION : SUGGESTED_EDITS_TRANSLATE_CAPTION),
+                (sourceSummary.getLang().equals(targetSummary.getLang())) ? ADD_CAPTION : TRANSLATE_CAPTION, GALLERY_ACTIVITY),
                 ACTIVITY_REQUEST_DESCRIPTION_EDIT);
     }
 

--- a/app/src/main/java/org/wikipedia/onboarding/SuggestedEditsOnboardingActivity.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/SuggestedEditsOnboardingActivity.kt
@@ -2,20 +2,19 @@ package org.wikipedia.onboarding
 
 import android.content.Context
 import android.content.Intent
-import org.wikipedia.Constants
 import org.wikipedia.activity.SingleFragmentActivity
 import org.wikipedia.onboarding.SuggestedEditsOnboardingFragment.Companion.newInstance
 
 class SuggestedEditsOnboardingActivity : SingleFragmentActivity<SuggestedEditsOnboardingFragment>() {
 
     override fun createFragment(): SuggestedEditsOnboardingFragment {
-        return newInstance(intent.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as Constants.InvokeSource)
+        return newInstance()
     }
 
     companion object {
         @JvmStatic
-        fun newIntent(context: Context, source: Constants.InvokeSource): Intent {
-            return Intent(context, SuggestedEditsOnboardingActivity::class.java).putExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE, source)
+        fun newIntent(context: Context): Intent {
+            return Intent(context, SuggestedEditsOnboardingActivity::class.java)
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/onboarding/SuggestedEditsOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/SuggestedEditsOnboardingFragment.kt
@@ -7,8 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_suggested_edits_onboarding.*
-import org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE
-import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.settings.Prefs
 
@@ -28,12 +26,8 @@ class SuggestedEditsOnboardingFragment : Fragment() {
     }
 
     companion object {
-        fun newInstance(invokeSource: InvokeSource): SuggestedEditsOnboardingFragment {
-            val suggestedEditsOnboardingFragment = SuggestedEditsOnboardingFragment()
-            val args = Bundle()
-            args.putSerializable(INTENT_EXTRA_INVOKE_SOURCE, invokeSource)
-            suggestedEditsOnboardingFragment.arguments = args
-            return suggestedEditsOnboardingFragment
+        fun newInstance(): SuggestedEditsOnboardingFragment {
+            return SuggestedEditsOnboardingFragment()
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -82,10 +82,10 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.functions.Consumer;
 
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_SETTINGS;
-import static org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE;
+import static org.wikipedia.Constants.INTENT_EXTRA_ACTION;
 import static org.wikipedia.Constants.InvokeSource.LINK_PREVIEW_MENU;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_CAPTION;
 import static org.wikipedia.Constants.InvokeSource.TOOLBAR;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_CAPTION;
 import static org.wikipedia.settings.Prefs.isLinkPreviewEnabled;
 import static org.wikipedia.util.UriUtil.visitInExternalBrowser;
 
@@ -698,7 +698,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
                 && resultCode == RESULT_OK) {
             pageFragment.refreshPage();
             String editLanguage = StringUtils.defaultString(pageFragment.getLeadImageEditLang(), app.language().getAppLanguageCode());
-            FeedbackUtil.makeSnackbar(this, data.getSerializableExtra(INTENT_EXTRA_INVOKE_SOURCE) == SUGGESTED_EDITS_ADD_CAPTION
+            FeedbackUtil.makeSnackbar(this, data.getSerializableExtra(INTENT_EXTRA_ACTION) == ADD_CAPTION
                     ? getString(R.string.description_edit_success_saved_image_caption_snackbar)
                     : getString(R.string.description_edit_success_saved_image_caption_in_lang_snackbar, app.language().getAppLanguageLocalizedName(editLanguage)), FeedbackUtil.LENGTH_DEFAULT)
                     .setAction(R.string.suggested_edits_article_cta_snackbar_action, v -> pageFragment.openImageInGallery(editLanguage)).show();

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -100,6 +100,7 @@ import static android.app.Activity.RESULT_OK;
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_GALLERY;
 import static org.wikipedia.Constants.InvokeSource.BOOKMARK_BUTTON;
 import static org.wikipedia.Constants.InvokeSource.PAGE_ACTIVITY;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_DESCRIPTION;
 import static org.wikipedia.descriptions.DescriptionEditTutorialActivity.DESCRIPTION_SELECTED_TEXT;
 import static org.wikipedia.feed.announcement.Announcement.PLACEMENT_ARTICLE;
 import static org.wikipedia.feed.announcement.AnnouncementClient.shouldShow;
@@ -1009,7 +1010,7 @@ public class PageFragment extends Fragment implements BackPressedHandler {
             SuggestedEditsSummary sourceSummary = new SuggestedEditsSummary(getTitle().getPrefixedText(), getTitle().getWikiSite().languageCode(), getTitle(),
                     getTitle().getDisplayText(), getTitle().getDisplayText(), getTitle().getDescription(), getTitle().getThumbUrl(),
                     null, null, null, null);
-            startActivityForResult(DescriptionEditActivity.newIntent(requireContext(), getTitle(), text, sourceSummary, null, PAGE_ACTIVITY),
+            startActivityForResult(DescriptionEditActivity.newIntent(requireContext(), getTitle(), text, sourceSummary, null, ADD_DESCRIPTION, PAGE_ACTIVITY),
                     Constants.ACTIVITY_REQUEST_DESCRIPTION_EDIT);
         }
     }

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -41,9 +41,10 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
 
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_IMAGE_CAPTION_EDIT;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_ADD_CAPTION;
-import static org.wikipedia.Constants.InvokeSource.SUGGESTED_EDITS_TRANSLATE_CAPTION;
+import static org.wikipedia.Constants.InvokeSource.LEAD_IMAGE;
 import static org.wikipedia.Constants.MIN_LANGUAGES_TO_UNLOCK_TRANSLATION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_CAPTION;
+import static org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTION;
 import static org.wikipedia.settings.Prefs.isImageDownloadEnabled;
 import static org.wikipedia.util.DimenUtil.leadImageHeightForDevice;
 
@@ -223,7 +224,7 @@ public class LeadImagesHandler {
                 if (callToActionIsTranslation ? (callToActionTargetSummary != null && callToActionSourceSummary != null) : callToActionSourceSummary != null) {
                     getActivity().startActivityForResult(DescriptionEditActivity.newIntent(getActivity(),
                             callToActionIsTranslation ? callToActionTargetSummary.getPageTitle() : callToActionSourceSummary.getPageTitle(), null,
-                            callToActionSourceSummary, callToActionTargetSummary, callToActionIsTranslation ? SUGGESTED_EDITS_TRANSLATE_CAPTION : SUGGESTED_EDITS_ADD_CAPTION),
+                            callToActionSourceSummary, callToActionTargetSummary, callToActionIsTranslation ? TRANSLATE_CAPTION : ADD_CAPTION, LEAD_IMAGE),
                             ACTIVITY_REQUEST_IMAGE_CAPTION_EDIT);
                 }
             }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsActivity.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsActivity.kt
@@ -5,10 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import org.wikipedia.Constants.InvokeSource
-import org.wikipedia.Constants.InvokeSource.*
+import org.wikipedia.Constants.INTENT_EXTRA_ACTION
 import org.wikipedia.R
 import org.wikipedia.activity.SingleFragmentActivity
+import org.wikipedia.descriptions.DescriptionEditActivity.Action
+import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
 import org.wikipedia.suggestededits.SuggestedEditsCardsFragment.Companion.newInstance
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ResourceUtil
@@ -18,12 +19,12 @@ class SuggestedEditsCardsActivity : SingleFragmentActivity<SuggestedEditsCardsFr
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
-        supportActionBar!!.title = getString(getActionBarTitleRes(intent.getSerializableExtra(EXTRA_SOURCE) as InvokeSource))
+        supportActionBar!!.title = getString(getActionBarTitleRes(intent.getSerializableExtra(INTENT_EXTRA_ACTION) as Action))
         setStatusBarColor(ResourceUtil.getThemedAttributeId(this, R.attr.suggestions_background_color))
     }
 
     override fun createFragment(): SuggestedEditsCardsFragment {
-        return newInstance(intent.getSerializableExtra(EXTRA_SOURCE) as InvokeSource)
+        return newInstance(intent.getSerializableExtra(INTENT_EXTRA_ACTION) as Action)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -42,15 +43,15 @@ class SuggestedEditsCardsActivity : SingleFragmentActivity<SuggestedEditsCardsFr
         }
     }
 
-    private fun getActionBarTitleRes(invokeSource: InvokeSource): Int {
-        return when(invokeSource) {
-            SUGGESTED_EDITS_TRANSLATE_DESC -> {
+    private fun getActionBarTitleRes(action: Action): Int {
+        return when(action) {
+            TRANSLATE_DESCRIPTION -> {
                 R.string.suggested_edits_translate_descriptions
             }
-            SUGGESTED_EDITS_ADD_CAPTION -> {
+            ADD_CAPTION -> {
                 R.string.suggested_edits_add_image_captions
             }
-            SUGGESTED_EDITS_TRANSLATE_CAPTION -> {
+            TRANSLATE_CAPTION -> {
                 R.string.suggested_edits_translate_image_captions
             }
             else -> R.string.suggested_edits_add_descriptions
@@ -58,11 +59,10 @@ class SuggestedEditsCardsActivity : SingleFragmentActivity<SuggestedEditsCardsFr
     }
 
     companion object {
-        const val EXTRA_SOURCE = "source"
         const val EXTRA_SOURCE_ADDED_CONTRIBUTION = "addedContribution"
 
-        fun newIntent(context: Context, source: InvokeSource): Intent {
-            return Intent(context, SuggestedEditsCardsActivity::class.java).putExtra(EXTRA_SOURCE, source)
+        fun newIntent(context: Context, action: Action): Intent {
+            return Intent(context, SuggestedEditsCardsActivity::class.java).putExtra(INTENT_EXTRA_ACTION, action)
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -13,11 +13,11 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_suggested_edits_cards_item.*
 import kotlinx.android.synthetic.main.view_image_detail_horizontal.view.*
-import org.wikipedia.Constants.InvokeSource.*
 import org.wikipedia.R
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageTitle
 import org.wikipedia.suggestededits.provider.MissingDescriptionProvider
@@ -80,8 +80,8 @@ class SuggestedEditsCardsItemFragment : Fragment() {
     }
 
     private fun getArticleWithMissingDescription() {
-        when (parent().source) {
-            SUGGESTED_EDITS_TRANSLATE_DESC -> {
+        when (parent().action) {
+            TRANSLATE_DESCRIPTION -> {
                 disposables.add(MissingDescriptionProvider.getNextArticleWithMissingDescription(WikiSite.forLanguageCode(parent().langFromCode), parent().langToCode, true)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
@@ -116,7 +116,7 @@ class SuggestedEditsCardsItemFragment : Fragment() {
                         }, { this.setErrorState(it) })!!)
             }
 
-            SUGGESTED_EDITS_ADD_CAPTION -> {
+            ADD_CAPTION -> {
                 disposables.add(MissingDescriptionProvider.getNextImageWithMissingCaption(parent().langFromCode)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
@@ -155,7 +155,7 @@ class SuggestedEditsCardsItemFragment : Fragment() {
                         }, { this.setErrorState(it) })!!)
             }
 
-            SUGGESTED_EDITS_TRANSLATE_CAPTION -> {
+            TRANSLATE_CAPTION -> {
                 var fileCaption: String? = null
                 disposables.add(MissingDescriptionProvider.getNextImageWithMissingCaption(parent().langFromCode, parent().langToCode)
                         .subscribeOn(Schedulers.io())
@@ -256,7 +256,7 @@ class SuggestedEditsCardsItemFragment : Fragment() {
             return
         }
 
-        if (parent().source == SUGGESTED_EDITS_ADD_DESC || parent().source == SUGGESTED_EDITS_TRANSLATE_DESC) {
+        if (parent().action == ADD_DESCRIPTION || parent().action == TRANSLATE_DESCRIPTION) {
             updateDescriptionContents()
         } else {
             updateCaptionContents()
@@ -266,7 +266,7 @@ class SuggestedEditsCardsItemFragment : Fragment() {
     private fun updateDescriptionContents() {
         viewArticleTitle.text = StringUtil.fromHtml(sourceSummary!!.displayTitle)
 
-        if (parent().source == SUGGESTED_EDITS_TRANSLATE_DESC) {
+        if (parent().action == TRANSLATE_DESCRIPTION) {
             viewArticleSubtitleContainer.visibility = VISIBLE
             viewArticleSubtitle.text = (if (addedContribution.isNotEmpty()) addedContribution else sourceSummary!!.description)?.capitalize()
         }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -16,7 +16,6 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_suggested_edits_tasks.*
 import org.wikipedia.Constants
 import org.wikipedia.Constants.ACTIVITY_REQUEST_ADD_A_LANGUAGE
-import org.wikipedia.Constants.InvokeSource.*
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
@@ -24,6 +23,7 @@ import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
+import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
 import org.wikipedia.language.LanguageSettingsInvokeSource
 import org.wikipedia.main.MainActivity
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
@@ -32,9 +32,6 @@ import org.wikipedia.util.log.L
 import org.wikipedia.views.DefaultRecyclerAdapter
 import org.wikipedia.views.DefaultViewHolder
 import org.wikipedia.views.DrawableItemDecoration
-import kotlin.collections.ArrayList
-import kotlin.collections.HashMap
-import kotlin.collections.HashSet
 
 class SuggestedEditsTasksFragment : Fragment() {
     private lateinit var addDescriptionsTask: SuggestedEditsTask
@@ -394,9 +391,9 @@ class SuggestedEditsTasksFragment : Fragment() {
                 return
             }
             if (task == addDescriptionsTask) {
-                startActivity(SuggestedEditsCardsActivity.newIntent(requireActivity(), if (isTranslate) SUGGESTED_EDITS_TRANSLATE_DESC else SUGGESTED_EDITS_ADD_DESC))
+                startActivity(SuggestedEditsCardsActivity.newIntent(requireActivity(), if (isTranslate) TRANSLATE_DESCRIPTION else ADD_DESCRIPTION))
             } else if (task == addImageCaptionsTask) {
-                startActivity(SuggestedEditsCardsActivity.newIntent(requireActivity(), if (isTranslate) SUGGESTED_EDITS_TRANSLATE_CAPTION else SUGGESTED_EDITS_ADD_CAPTION))
+                startActivity(SuggestedEditsCardsActivity.newIntent(requireActivity(), if (isTranslate) TRANSLATE_CAPTION else ADD_CAPTION))
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -14,11 +14,11 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.dialog_image_preview.*
 import kotlinx.android.synthetic.main.view_image_detail.view.*
-import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.descriptions.DescriptionEditActivity.Action
 import org.wikipedia.json.GsonMarshaller
 import org.wikipedia.json.GsonUnmarshaller
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
@@ -36,13 +36,13 @@ import org.wikipedia.util.log.L
 class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.OnDismissListener {
 
     private lateinit var suggestedEditsSummary: SuggestedEditsSummary
-    private lateinit var invokeSource: InvokeSource
+    private lateinit var action: Action
     private val disposables = CompositeDisposable()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val rootView = inflater.inflate(R.layout.dialog_image_preview, container)
         suggestedEditsSummary = GsonUnmarshaller.unmarshal(SuggestedEditsSummary::class.java, arguments!!.getString(ARG_SUMMARY))
-        invokeSource = arguments!!.getSerializable(ARG_INVOKE_SOURCE) as InvokeSource
+        action = arguments!!.getSerializable(ARG_ACTION) as Action
         setConditionalLayoutDirection(rootView, suggestedEditsSummary.lang)
         enableFullWidthDialog()
         return rootView
@@ -103,7 +103,7 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
     }
 
     private fun setImageDetails() {
-        if ((invokeSource == InvokeSource.SUGGESTED_EDITS_ADD_CAPTION || invokeSource == InvokeSource.FEED_CARD_SUGGESTED_EDITS_IMAGE_CAPTION)
+        if ((action == Action.ADD_CAPTION)
                 && suggestedEditsSummary.pageTitle.description.isNullOrEmpty()) {
             // Show the image description when a structured caption does not exist.
             addDetailPortion(getString(R.string.suggested_edits_image_preview_dialog_description_in_language_title,
@@ -160,13 +160,13 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
 
     companion object {
         private const val ARG_SUMMARY = "summary"
-        private const val ARG_INVOKE_SOURCE = "invokeSource"
+        private const val ARG_ACTION = "action"
 
-        fun newInstance(suggestedEditsSummary: SuggestedEditsSummary, invokeSource: InvokeSource): ImagePreviewDialog {
+        fun newInstance(suggestedEditsSummary: SuggestedEditsSummary, action: Action): ImagePreviewDialog {
             val dialog = ImagePreviewDialog()
             val args = Bundle()
             args.putString(ARG_SUMMARY, GsonMarshaller.marshal(suggestedEditsSummary))
-            args.putSerializable(ARG_INVOKE_SOURCE, invokeSource)
+            args.putSerializable(ARG_ACTION, action)
             dialog.arguments = args
             return dialog
         }


### PR DESCRIPTION
This does a couple of things:
- Splits off the `SUGGESTED_EDITS_...` invoke source constants into a separate `Action` enum, since these constants are not really "sources", and were conflating different types of functionality and intention.  `InvokeSource` should be generally used for analytics/funnels, and should not be used for logic and behavior.  Observe how the logic everywhere is simplified a bit.
- Endowed the `InvokeSource` constants with a string representation which can be passed directly into a funnel that accepts a string "source" parameter.
- Updated the `MobileWikiAppEdit` funnel to accept an (optional) source parameter.