### PR TITLE
Fix: press back causes a crash on GalleryActivity while the image is loading

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -314,8 +314,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
 
     @OnClick(R.id.gallery_caption_edit_button) void onEditClick(View v) {
         GalleryItemFragment item = getCurrentItem();
-
-        if (item.getImageTitle() == null || item.getMediaInfo() == null || item.getMediaInfo().getMetadata() == null) {
+        if (item == null || item.getImageTitle() == null || item.getMediaInfo() == null || item.getMediaInfo().getMetadata() == null) {
             return;
         }
 
@@ -337,8 +336,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         }
 
         GalleryItemFragment item = getCurrentItem();
-
-        if (item.getImageTitle() == null || item.getMediaInfo() == null || item.getMediaInfo().getMetadata() == null) {
+        if (item == null || item.getImageTitle() == null || item.getMediaInfo() == null || item.getMediaInfo().getMetadata() == null) {
             return;
         }
 
@@ -389,11 +387,12 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         public void onPageSelected(int position) {
             // the pager has settled on a new position
             layOutGalleryDescription();
-            if (currentPosition != -1 && getCurrentItem().getImageTitle() != null && funnel != null) {
+            GalleryItemFragment item = getCurrentItem();
+            if (currentPosition != -1 && item != null && item.getImageTitle() != null && funnel != null) {
                 if (position < currentPosition) {
-                    funnel.logGallerySwipeLeft(pageTitle, getCurrentItem().getImageTitle().getDisplayText());
+                    funnel.logGallerySwipeLeft(pageTitle, item.getImageTitle().getDisplayText());
                 } else if (position > currentPosition) {
-                    funnel.logGallerySwipeRight(pageTitle, getCurrentItem().getImageTitle().getDisplayText());
+                    funnel.logGallerySwipeRight(pageTitle, item.getImageTitle().getDisplayText());
                 }
             }
             currentPosition = position;
@@ -422,8 +421,9 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     public void onBackPressed() {
         // log the "gallery close" event only upon explicit closing of the activity
         // (back button, or home-as-up button in the toolbar)
-        if (getCurrentItem().getImageTitle() != null && funnel != null) {
-            funnel.logGalleryClose(pageTitle, getCurrentItem().getImageTitle().getDisplayText());
+        GalleryItemFragment item = getCurrentItem();
+        if (item != null && item.getImageTitle() != null && funnel != null) {
+            funnel.logGalleryClose(pageTitle, item.getImageTitle().getDisplayText());
         }
         super.onBackPressed();
     }
@@ -595,7 +595,12 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         galleryPager.setPageTransformer(false, new GalleryPagerTransformer());
     }
 
+    @Nullable
     private GalleryItemFragment getCurrentItem() {
+        if (galleryAdapter.getItem(galleryPager.getCurrentItem()) == null) {
+            return null;
+        }
+
         return ((GalleryItemFragment) galleryAdapter.getItem(galleryPager.getCurrentItem()));
     }
 
@@ -604,7 +609,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
      */
     public void layOutGalleryDescription() {
         GalleryItemFragment item = getCurrentItem();
-        if (item.getImageTitle() == null || item.getMediaInfo() == null || item.getMediaInfo().getMetadata() == null) {
+        if (item == null || item.getImageTitle() == null || item.getMediaInfo() == null || item.getMediaInfo().getMetadata() == null) {
             infoContainer.setVisibility(View.GONE);
             return;
         }
@@ -620,9 +625,9 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
 
     public void updateGalleryDescription() {
         updateProgressBar(false);
-        GalleryItemFragment item = getCurrentItem();
 
-        if (item.getImageTitle() == null || item.getMediaInfo() == null || item.getMediaInfo().getMetadata() == null) {
+        GalleryItemFragment item = getCurrentItem();
+        if (item == null || item.getImageTitle() == null || item.getMediaInfo() == null || item.getMediaInfo().getMetadata() == null) {
             infoContainer.setVisibility(View.GONE);
             return;
         }
@@ -756,10 +761,13 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         }
 
         @Override
-        @NonNull
+        @Nullable // don't remove this, it needs to be @Nullable.
         public Fragment getItem(int position) {
+            if (list.size() <= position || position < 0) {
+                return null;
+            }
             // instantiate a new fragment if it doesn't exist
-            if (fragmentArray.get(position) == null) {
+            if (fragmentArray.get(position) == null && !list.isEmpty()) {
                 fragmentArray.put(position, GalleryItemFragment
                         .newInstance(pageTitle, list.get(position)));
             }

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -767,7 +767,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
                 return null;
             }
             // instantiate a new fragment if it doesn't exist
-            if (fragmentArray.get(position) == null && !list.isEmpty()) {
+            if (fragmentArray.get(position) == null) {
                 fragmentArray.put(position, GalleryItemFragment
                         .newInstance(pageTitle, list.get(position)));
             }


### PR DESCRIPTION
The `getItem()` is not actually `NonNull`, and maybe we should rewrite it later. 

The current solution was copied from the previous logic, and the following steps is the way of reproducing it:

1. Click on any random images to open the gallery.
2. If the image is still loading, press the back button.
3. You will see the crash log on the Logcat by searching `Gallery`.