### PR TITLE
Fix: properly display license icons in Gallery.

### DIFF
--- a/app/src/main/res/layout/activity_gallery.xml
+++ b/app/src/main/res/layout/activity_gallery.xml
@@ -159,24 +159,24 @@
             android:paddingEnd="@dimen/activity_horizontal_margin"
             android:paddingBottom="16dp">
 
-            <FrameLayout
+            <LinearLayout
                 android:id="@+id/gallery_license_container"
-                android:layout_width="18dp"
-                android:layout_height="18dp">
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
 
                 <androidx.appcompat.widget.AppCompatImageView
                     android:id="@+id/gallery_license_icon"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
+                    android:layout_width="18dp"
+                    android:layout_height="18dp"
                     android:contentDescription="@null"
                     app:tint="@color/white70"
                     tools:src="@drawable/ic_license_cc" />
 
                 <androidx.appcompat.widget.AppCompatImageView
                     android:id="@+id/gallery_license_icon_by"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="8dp"
+                    android:layout_width="18dp"
+                    android:layout_height="18dp"
+                    android:layout_marginStart="4dp"
                     android:contentDescription="@null"
                     android:visibility="gone"
                     app:tint="@color/white70"
@@ -184,14 +184,14 @@
 
                 <androidx.appcompat.widget.AppCompatImageView
                     android:id="@+id/gallery_license_icon_sa"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="8dp"
+                    android:layout_width="18dp"
+                    android:layout_height="18dp"
+                    android:layout_marginStart="4dp"
                     android:contentDescription="@null"
                     android:visibility="gone"
                     app:tint="@color/white70"
                     tools:src="@drawable/ic_license_sharealike" />
-            </FrameLayout>
+            </LinearLayout>
 
             <org.wikipedia.views.AppTextView
                 android:id="@+id/gallery_credit_text"


### PR DESCRIPTION
The icons for CC-BY-SA were not being displayed properly.
For example, go to [[Jellyfish]] and click on the lead image.