### PR TITLE
Show article title HTML tag properly on the feature article card

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCardView.java
@@ -99,7 +99,7 @@ public class FeaturedArticleCardView extends DefaultFeedCardView<FeaturedArticle
     }
 
     private void articleTitle(@NonNull String articleTitle) {
-        articleTitleView.setText(articleTitle);
+        articleTitleView.setText(StringUtil.fromHtml(articleTitle));
     }
 
     private void articleSubtitle(@Nullable String articleSubtitle) {


### PR DESCRIPTION
The article title of the feature article on Dec 19, 2019, has a `<i></i>` tag, and we should support that.