### PR TITLE
Follow-up / corrections to History table updates.

### DIFF
--- a/app/src/main/java/org/wikipedia/database/contract/PageHistoryContract.java
+++ b/app/src/main/java/org/wikipedia/database/contract/PageHistoryContract.java
@@ -25,7 +25,7 @@ public final class PageHistoryContract {
         IntColumn SOURCE = new IntColumn(TABLE, "source", "integer");
         IntColumn TIME_SPENT = new IntColumn(TABLE, "timeSpent", "integer"); // seconds
 
-        String[] SELECTION = DbUtil.qualifiedNames(SITE, LANG, NAMESPACE, DISPLAY_TITLE);
+        String[] SELECTION = DbUtil.qualifiedNames(SITE, LANG, NAMESPACE, API_TITLE);
     }
 
     public interface Page extends Col {

--- a/app/src/main/java/org/wikipedia/database/contract/PageImageHistoryContract.java
+++ b/app/src/main/java/org/wikipedia/database/contract/PageImageHistoryContract.java
@@ -20,7 +20,7 @@ public interface PageImageHistoryContract {
         StrColumn NAMESPACE = new StrColumn(TABLE, "namespace", "string");
         StrColumn IMAGE_NAME = new StrColumn(TABLE, "imageName", "string");
 
-        String[] SELECTION = DbUtil.qualifiedNames(SITE, LANG, NAMESPACE, DISPLAY_TITLE);
+        String[] SELECTION = DbUtil.qualifiedNames(SITE, LANG, NAMESPACE, API_TITLE);
     }
 
     interface Image extends Col {

--- a/app/src/main/java/org/wikipedia/database/contract/ReadingListPageContract.java
+++ b/app/src/main/java/org/wikipedia/database/contract/ReadingListPageContract.java
@@ -31,7 +31,7 @@ public interface ReadingListPageContract {
         LongColumn SIZEBYTES = new LongColumn(TABLE, "sizeBytes", "integer");
         LongColumn REMOTEID = new LongColumn(TABLE, "remoteId", "integer not null");
 
-        String[] SELECTION = DbUtil.qualifiedNames(DISPLAY_TITLE);
+        String[] SELECTION = DbUtil.qualifiedNames(API_TITLE);
         String[] ALL = DbUtil.qualifiedNames(ID, LISTID, SITE, LANG, NAMESPACE, DISPLAY_TITLE, API_TITLE, MTIME, ATIME,
                 THUMBNAIL_URL, DESCRIPTION, REVID, OFFLINE, STATUS, SIZEBYTES, REMOTEID);
     }

--- a/app/src/main/java/org/wikipedia/history/HistoryEntryDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryEntryDatabaseTable.java
@@ -39,7 +39,7 @@ public class HistoryEntryDatabaseTable extends DatabaseTable<HistoryEntry> {
         ContentValues contentValues = new ContentValues();
         contentValues.put(Col.SITE.getName(), obj.getTitle().getWikiSite().authority());
         contentValues.put(Col.LANG.getName(), obj.getTitle().getWikiSite().languageCode());
-        contentValues.put(Col.API_TITLE.getName(), obj.getTitle().getPrefixedText());
+        contentValues.put(Col.API_TITLE.getName(), obj.getTitle().getText());
         contentValues.put(Col.DISPLAY_TITLE.getName(), obj.getTitle().getDisplayText());
         contentValues.put(Col.NAMESPACE.getName(), obj.getTitle().getNamespace());
         contentValues.put(Col.TIMESTAMP.getName(), obj.getTimestamp().getTime());
@@ -79,7 +79,7 @@ public class HistoryEntryDatabaseTable extends DatabaseTable<HistoryEntry> {
                 obj.getTitle().getWikiSite().authority(),
                 obj.getTitle().getWikiSite().languageCode(),
                 obj.getTitle().getNamespace(),
-                obj.getTitle().getDisplayText()
+                obj.getTitle().getText()
         };
     }
 

--- a/app/src/main/java/org/wikipedia/history/UpdateHistoryTask.java
+++ b/app/src/main/java/org/wikipedia/history/UpdateHistoryTask.java
@@ -32,13 +32,13 @@ public class UpdateHistoryTask implements Action {
 
     private int getPreviousTimeSpent(@NonNull DatabaseClient<HistoryEntry> client) {
         int timeSpent = 0;
-        String selection = ":siteCol == ? and :langCol == ? and :displayTitleCol == ?"
+        String selection = ":siteCol == ? and :langCol == ? and :apiTitleCol == ?"
                 .replaceAll(":siteCol", PageHistoryContract.Page.SITE.qualifiedName())
                 .replaceAll(":langCol", PageHistoryContract.Page.LANG.qualifiedName())
-                .replaceAll(":displayTitleCol", PageHistoryContract.Page.DISPLAY_TITLE.qualifiedName());
+                .replaceAll(":apiTitleCol", PageHistoryContract.Page.API_TITLE.qualifiedName());
         String[] selectionArgs = new String[]{entry.getTitle().getWikiSite().authority(),
                 entry.getTitle().getWikiSite().languageCode(),
-                entry.getTitle().getDisplayText()};
+                entry.getTitle().getText()};
         Cursor cursor = client.select(selection, selectionArgs, null);
         if (cursor.moveToFirst()) {
             timeSpent = PageHistoryContract.Col.TIME_SPENT.val(cursor);

--- a/app/src/main/java/org/wikipedia/pageimages/PageImageDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/pageimages/PageImageDatabaseTable.java
@@ -72,7 +72,7 @@ public class PageImageDatabaseTable extends DatabaseTable<PageImage> {
                 obj.getTitle().getWikiSite().authority(),
                 obj.getTitle().getWikiSite().languageCode(),
                 obj.getTitle().getNamespace(),
-                obj.getTitle().getDisplayText()
+                obj.getTitle().getText()
         };
     }
 


### PR DESCRIPTION
At the database level, the `SELECTION` keys for retrieving History rows should still use the old `apiTitle` parameter, instead of the new `displayTitle` parameter.  This results in upgrade-related bugs, such as History items being duplicated when being visited after upgrading.