### PR TITLE
Remove namespace when setting new API text to PageTitle in LinkPreviewDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
@@ -230,7 +230,7 @@ public class LinkPreviewDialog extends ExtendedBottomSheetDialogFragment
                     }
 
                     // TODO: remove after the restbase endpoint supports ZH variants
-                    pageTitle.setText(summary.getTitle());
+                    pageTitle.setText(StringUtil.removeNamespace(summary.getTitle()));
                     showPreview(new LinkPreviewContents(summary, pageTitle.getWikiSite()));
                 }, caught -> {
                     L.e(caught);


### PR DESCRIPTION
Since the `PageTitle` has already contained the `namespace` when creating the `PageTitle`, we should remove the `namespace` when setting the new text to it.