### PR TITLE
Prevent showing incorrect navigation bar  and status bar icons color in PageActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.java
+++ b/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.java
@@ -24,6 +24,7 @@ import org.wikipedia.activity.FragmentUtil;
 import org.wikipedia.analytics.AppearanceChangeFunnel;
 import org.wikipedia.events.WebViewInvalidateEvent;
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment;
+import org.wikipedia.page.PageActivity;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
@@ -105,7 +106,9 @@ public class ThemeChooserDialog extends ExtendedBottomSheetDialogFragment {
         });
 
         updateComponents();
-        disableBackgroundDim();
+        if (!(requireActivity() instanceof PageActivity)) {
+            disableBackgroundDim();
+        }
         return rootView;
     }
 


### PR DESCRIPTION
The `ThemeChooserDialog` has disabled the dim background, which will make the navigation bar and status bar icons show incorrectly when in the `PageActivity`. To fix the issue, we can choose to show the default dim background only when in the `PageActivity`.