### PR TITLE
Remove style tags from HTML text

### DIFF
--- a/app/src/main/java/org/wikipedia/page/references/ReferenceDialog.java
+++ b/app/src/main/java/org/wikipedia/page/references/ReferenceDialog.java
@@ -96,7 +96,7 @@ public class ReferenceDialog extends BottomSheetDialog {
             LayoutInflater inflater = LayoutInflater.from(container.getContext());
             View view = inflater.inflate(R.layout.view_reference_pager_item, container, false);
             TextView pagerReferenceText = view.findViewById(R.id.reference_text);
-            pagerReferenceText.setText(StringUtil.fromHtml(references.get(position).getContent()));
+            pagerReferenceText.setText(StringUtil.fromHtml(StringUtil.removeStyleTags(references.get(position).getContent())));
             pagerReferenceText.setMovementMethod(new LinkMovementMethodExt(referenceLinkHandler));
 
             TextView pagerTitleText = view.findViewById(R.id.reference_title_text);

--- a/app/src/main/java/org/wikipedia/util/StringUtil.java
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.java
@@ -130,6 +130,10 @@ public final class StringUtil {
         return fromHtml(text).toString();
     }
 
+    public static String removeStyleTags(@NonNull String text) {
+        return text.replaceAll("<style.*?</style>", "");
+    }
+
     public static String sanitizeText(@NonNull String selectedText) {
         return selectedText.replaceAll("\\[\\d+\\]", "") // [1]
                 // https://en.wikipedia.org/wiki/Phonetic_symbols_in_Unicode


### PR DESCRIPTION
The first reference in the article [Line_Corporation]( https://en.wikipedia.org/wiki/Line_Corporation) contains a `<style>*</style>` tag, which does not show properly.

Reference endpoint:
https://en.wikipedia.org/api/rest_v1/page/references/Line_Corporation