### PR TITLE
Remove unused variables and class from PageFragmentLoadState

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -704,7 +704,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == Constants.ACTIVITY_REQUEST_EDIT_SECTION
                 && resultCode == EditHandler.RESULT_REFRESH_PAGE) {
-            pageFragmentLoadState.backFromEditing(data);
             FeedbackUtil.showMessage(requireActivity(), R.string.edit_saved_successfully);
             // and reload the page...
             loadPage(model.getTitleOriginal(), model.getCurEntry(), false, false);

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -1,6 +1,5 @@
 package org.wikipedia.page;
 
-import android.content.Intent;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -16,7 +15,6 @@ import org.wikipedia.dataclient.okhttp.OfflineCacheInterceptor;
 import org.wikipedia.dataclient.page.PageClient;
 import org.wikipedia.dataclient.page.PageLead;
 import org.wikipedia.edit.EditHandler;
-import org.wikipedia.edit.EditSectionActivity;
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.leadimages.LeadImagesHandler;
 import org.wikipedia.page.tabs.Tab;
@@ -56,11 +54,6 @@ public class PageFragmentLoadState {
 
     @NonNull private Tab currentTab = new Tab();
 
-    @NonNull private final SequenceNumber sequenceNumber = new SequenceNumber();
-
-    private int sectionTargetFromIntent;
-    private String sectionTargetFromTitle;
-
     private ErrorCallback networkErrorCallback;
 
     // copied fields
@@ -97,10 +90,6 @@ public class PageFragmentLoadState {
         }
 
         loading = true;
-
-        // increment our sequence number, so that any async tasks that depend on the sequence
-        // will invalidate themselves upon completion.
-        sequenceNumber.increase();
 
         pageLoadCheckReadingLists();
     }
@@ -172,11 +161,6 @@ public class PageFragmentLoadState {
         this.editHandler = editHandler;
     }
 
-    public void backFromEditing(Intent data) {
-        //Retrieve section ID from intent, and find correct section, so where know where to scroll to
-        sectionTargetFromIntent = data.getIntExtra(EditSectionActivity.EXTRA_SECTION_ID, 0);
-    }
-
     public void onConfigurationChanged() {
         leadImagesHandler.loadLeadImage();
         bridge.execute(JavaScriptActionHandler.setTopMargin(leadImagesHandler.getTopMargin()));
@@ -215,9 +199,6 @@ public class PageFragmentLoadState {
             return;
         }
         fragment.updateBookmarkAndMenuOptions();
-        // stage any section-specific link target from the title, since the title may be
-        // replaced (normalized)
-        sectionTargetFromTitle = model.getTitle().getFragment();
 
         networkErrorCallback = errorCallback;
         if (!fragment.isAdded()) {
@@ -324,26 +305,5 @@ public class PageFragmentLoadState {
 
         model.getTitle().setThumbUrl(pageImage.getImageName());
         model.getTitleOriginal().setThumbUrl(pageImage.getImageName());
-    }
-
-    /**
-     * Monotonically increasing sequence number to maintain synchronization when loading page
-     * content asynchronously between the Java and JavaScript layers, as well as between synchronous
-     * methods and asynchronous callbacks on the UI thread.
-     */
-    private static class SequenceNumber {
-        private int sequence;
-
-        void increase() {
-            ++sequence;
-        }
-
-        int get() {
-            return sequence;
-        }
-
-        boolean inSync(int sequence) {
-            return this.sequence == sequence;
-        }
     }
 }


### PR DESCRIPTION
These are pretty old logic and should be fine to be removed.

I've tested it with some edits and it does not affect the app.