### PR TITLE
Analytics fix: use updated FindInPage schema.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/FindInPageFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/FindInPageFunnel.java
@@ -8,7 +8,7 @@ import org.wikipedia.dataclient.WikiSite;
 
 public class FindInPageFunnel extends TimedFunnel {
     private static final String SCHEMA_NAME = "MobileWikiAppFindInPage";
-    private static final int REV_ID = 18115552;
+    private static final int REV_ID = 19690671;
 
     private final int pageId;
     private int pageHeight;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T147196
Just by using the new schema version, it should fix the errors that are being seen by Analytics.
(I updated the [schema](https://meta.wikimedia.org/wiki/Schema:MobileWikiAppFindInPage) to no longer require the `findText` parameter.)