### PR TITLE
Prevent crashes when loading page

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -280,6 +280,10 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         return editHandler;
     }
 
+    public ToCHandler getTocHandler() {
+        return tocHandler;
+    }
+
     public ViewGroup getContainerView() {
         return containerView;
     }
@@ -843,7 +847,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     }
 
     public void onPageLoadComplete() {
-        editHandler.setPage(model.getPage());
         refreshView.setEnabled(true);
         refreshView.setRefreshing(false);
         requireActivity().invalidateOptionsMenu();
@@ -863,8 +866,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         }
 
         if (!errorState) {
-            setupToC(model, pageFragmentLoadState.isFirstPage());
-            editHandler.setPage(model.getPage());
             webView.setVisibility(View.VISIBLE);
         }
 
@@ -930,11 +931,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
 
     CommunicationBridge getBridge() {
         return bridge;
-    }
-
-    private void setupToC(@NonNull PageViewModel model, boolean isFirstPage) {
-        tocHandler.setupToC(model.getPage(), model.getTitle().getWikiSite(), isFirstPage);
-        tocHandler.setEnabled(true);
     }
 
     private void setBookmarkIconForPageSavedState(boolean pageSaved) {

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -267,6 +267,9 @@ public class PageFragmentLoadState {
         leadImagesHandler.loadLeadImage();
 
         fragment.setToolbarFadeEnabled(leadImagesHandler.isLeadImageEnabled());
+        fragment.getEditHandler().setPage(page);
+        fragment.getTocHandler().setupToC(page, page.getTitle().getWikiSite(), isFirstPage());
+        fragment.getTocHandler().setEnabled(true);
         fragment.requireActivity().invalidateOptionsMenu();
 
         // Update our history entry, in case the Title was changed (i.e. normalized)


### PR DESCRIPTION
Sometimes the `model.getPage()` will be a `null` object, and it will cause crashes.

It is often reproducible on the Chinese articles on trending. 