### PR TITLE
Fix: correctly extract lead image URL.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageProperties.java
+++ b/app/src/main/java/org/wikipedia/page/PageProperties.java
@@ -8,6 +8,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.dataclient.page.PageLeadProperties;
 import org.wikipedia.dataclient.page.PageSummary;
@@ -62,7 +63,7 @@ public class PageProperties implements Parcelable {
         geo = pageSummary.getGeo();
         languageCount = 1;
         lastModified = new Date();
-        leadImageName = pageSummary.getLeadImageName();
+        leadImageName = UriUtil.decodeURL(StringUtils.defaultString(pageSummary.getLeadImageName()));
         leadImageUrl = pageSummary.getThumbnailUrl() != null
                 ? UriUtil.resolveProtocolRelativeUrl(ImageUrlUtil.getUrlForPreferredSize(pageSummary.getThumbnailUrl(), DimenUtil.calculateLeadImageWidth())) : null;
         String lastModifiedText = pageSummary.getTimestamp();


### PR DESCRIPTION
The new way of extracting the URL from the Summary response doesn't take into account URL-encoded characters, which need to be decoded.  This breaks the functionality of being able to add image captions for the lead image.