### PR TITLE
Make the "new" text disappear after the first successful image tag edit.

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -866,6 +866,13 @@ public final class Prefs {
         setBoolean(R.string.preference_key_image_tags_onboarding_shown, showOnboarding);
     }
 
+    public static boolean isSuggestedEditsImageTagsNew() {
+        return getBoolean(R.string.preference_key_suggested_edits_image_tags_new, true);
+    }
+
+    public static void setSuggestedEditsImageTagsNew(boolean enabled) {
+        setBoolean(R.string.preference_key_suggested_edits_image_tags_new, enabled);
+    }
 
     private Prefs() { }
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -28,6 +28,7 @@ import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.dataclient.mwapi.media.MediaHelper
 import org.wikipedia.login.LoginClient.LoginFailedException
 import org.wikipedia.page.LinkMovementMethodExt
+import org.wikipedia.settings.Prefs
 import org.wikipedia.suggestededits.provider.MissingDescriptionProvider
 import org.wikipedia.util.*
 import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
@@ -290,6 +291,8 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
 
     private fun onSuccess() {
         publishProgressText.setText(R.string.suggested_edits_image_tags_published)
+
+        Prefs.setSuggestedEditsImageTagsNew(false)
 
         val duration = 500L
         publishProgressCheck.alpha = 0f

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -27,6 +27,7 @@ import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
 import org.wikipedia.language.LanguageSettingsInvokeSource
 import org.wikipedia.main.MainActivity
+import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
 import org.wikipedia.util.*
 import org.wikipedia.util.log.L
@@ -315,6 +316,9 @@ class SuggestedEditsTasksFragment : Fragment() {
     private fun setFinalUIState() {
         clearContents()
 
+        addImageTagsTask.new = Prefs.isSuggestedEditsImageTagsNew()
+        tasksRecyclerView.adapter!!.notifyDataSetChanged()
+
         if (SuggestedEditsUserStats.totalEdits == 0) {
             contributionsStatsView.visibility = GONE
             editQualityStatsView.visibility = GONE
@@ -382,7 +386,6 @@ class SuggestedEditsTasksFragment : Fragment() {
         addImageTagsTask.description = getString(R.string.suggested_edits_image_tags_task_detail)
         addImageTagsTask.imageDrawable = R.drawable.ic_image_tag
         addImageTagsTask.translatable = false
-        addImageTagsTask.new = true
 
         // TODO: remove condition when ready
         if (ReleaseUtil.isPreBetaRelease()) {

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -106,6 +106,7 @@
     <string name="preference_key_show_image_tags_tooltip">showImageTagsTooltip</string>
     <string name="preference_key_visited_article_page">hasVisitedArticlePage</string>
     <string name="preference_key_match_system_theme">matchSystemTheme</string>
+    <string name="preference_key_suggested_edits_image_tags_new">suggestedEditsImageTagsNew</string>
     <string name="preference_key_suggested_edits_pause_date">suggestedEditsPauseDate</string>
     <string name="preference_key_suggested_edits_pause_reverts">suggestedEditsPauseReverts</string>
     <string name="preference_key_suggested_edits_override_counts">suggestedEditsOverrideCounts</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -742,7 +742,7 @@
     <string name="suggested_edits_image_tags_onboarding_text">By confirming suggested tags, you can help make images easier to search for.\n\nTags are computer suggested but need to be validated by humans to ensure accuracy.</string>
     <string name="suggested_edits_image_tags_onboarding_note">Only tags that you choose will be added to images.</string>
     <string name="suggested_edits_image_tags_snackbar">Add image tags to make them easier for others to find.</string>
-    <string name="suggested_edits_image_tags_task_detail">Tag images to make them easier for others to find. Tags are suggested automatically, but need to be verified by you.</string>
+    <string name="suggested_edits_image_tags_task_detail">Tag images to make them easier for others to find. They are computer suggested, but need to be validated.</string>
     <string name="suggested_edits_image_tags_choose">Choose matching tags</string>
     <string name="suggested_edits_image_tags_select_title">You haven\'t selected any tags for this image</string>
     <string name="suggested_edits_image_tags_select_text">Only tags that you choose will be added to images. Tags that are not selected will be marked as rejected. Are you sure you want to mark all tags as rejected?</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -226,6 +226,10 @@
             android:title="@string/preference_key_show_description_edit_success_prompt" />
 
         <SwitchPreferenceCompat
+            android:key="@string/preference_key_suggested_edits_image_tags_new"
+            android:title="@string/preference_key_suggested_edits_image_tags_new" />
+
+        <SwitchPreferenceCompat
             android:key="@string/preference_key_image_tags_onboarding_shown"
             android:title="@string/preference_key_image_tags_onboarding_shown" />
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T241840