### PR TITLE
Explicitly specify okhttp version to use for test builds.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -213,6 +213,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation mockitoCore
     testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttpVersion"
     testImplementation "commons-io:commons-io:2.6"
 


### PR DESCRIPTION
This can cause Robolectric to fail if there's a newer version of okhttp cached on the testing machine.