### PR TITLE
Add explicit maxage parameter to siteInfo and siteMatrix API calls.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -39,6 +39,9 @@ public interface Service {
 
     int PREFERRED_THUMB_SIZE = 320;
 
+    // Maximum cache time for site-specific data, and other things not likely to change very often.
+    int SITE_INFO_MAXAGE = 86400;
+
 
     // ------- Search -------
 
@@ -84,18 +87,10 @@ public interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=videoinfo&viprop=timestamp|user|url|mime|extmetadata|derivatives&viurlwidth=" + PREFERRED_THUMB_SIZE)
     @NonNull Observable<MwQueryResponse> getMediaInfo(@NonNull @Query("titles") String titles);
 
-    /**
-     * When requesting site info, provide an explicit cache time of one day (86400s), since this
-     * information is highly unlikely to change very frequently.
-     */
-    @GET(MW_API_PREFIX + "action=sitematrix&smtype=language&smlangprop=code|name|localname&maxage=86400&smaxage=86400")
+    @GET(MW_API_PREFIX + "action=sitematrix&smtype=language&smlangprop=code|name|localname&maxage=" + SITE_INFO_MAXAGE + "&smaxage=" + SITE_INFO_MAXAGE)
     @NonNull Observable<SiteMatrix> getSiteMatrix();
 
-    /**
-     * When requesting site info, provide an explicit cache time of one day (86400s), since this
-     * information is highly unlikely to change very frequently.
-     */
-    @GET(MW_API_PREFIX + "action=query&meta=siteinfo&maxage=86400&smaxage=86400")
+    @GET(MW_API_PREFIX + "action=query&meta=siteinfo&maxage=" + SITE_INFO_MAXAGE + "&smaxage=" + SITE_INFO_MAXAGE)
     @NonNull Observable<MwQueryResponse> getSiteInfo();
 
     @GET(MW_API_PREFIX + "action=parse&prop=text&mobileformat=1&mainpage=1")

--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -84,10 +84,18 @@ public interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=videoinfo&viprop=timestamp|user|url|mime|extmetadata|derivatives&viurlwidth=" + PREFERRED_THUMB_SIZE)
     @NonNull Observable<MwQueryResponse> getMediaInfo(@NonNull @Query("titles") String titles);
 
-    @GET(MW_API_PREFIX + "action=sitematrix&smtype=language&smlangprop=code|name|localname")
+    /**
+     * When requesting site info, provide an explicit cache time of one day (86400s), since this
+     * information is highly unlikely to change very frequently.
+     */
+    @GET(MW_API_PREFIX + "action=sitematrix&smtype=language&smlangprop=code|name|localname&maxage=86400&smaxage=86400")
     @NonNull Observable<SiteMatrix> getSiteMatrix();
 
-    @GET(MW_API_PREFIX + "action=query&meta=siteinfo")
+    /**
+     * When requesting site info, provide an explicit cache time of one day (86400s), since this
+     * information is highly unlikely to change very frequently.
+     */
+    @GET(MW_API_PREFIX + "action=query&meta=siteinfo&maxage=86400&smaxage=86400")
     @NonNull Observable<MwQueryResponse> getSiteInfo();
 
     @GET(MW_API_PREFIX + "action=parse&prop=text&mobileformat=1&mainpage=1")

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -11,8 +11,7 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import android.view.LayoutInflater
 import android.view.View
-import android.view.View.GONE
-import android.view.View.VISIBLE
+import android.view.View.*
 import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.CompoundButton
@@ -130,6 +129,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
             }
             val chip = Chip(requireContext())
             chip.text = label.label
+            chip.textAlignment = TEXT_ALIGNMENT_CENTER
             chip.setChipBackgroundColorResource(ResourceUtil.getThemedAttributeId(requireContext(), R.attr.chip_background_color))
             chip.setTextColor(ResourceUtil.getThemedColor(requireContext(), R.attr.chip_text_color))
             chip.typeface = tagsHintText.typeface


### PR DESCRIPTION
This improves the caching performance of these APIs, since we don't need the absolute freshest data from these calls every time.