### PR TITLE
Upgrade to LeakCanary 2.2.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -158,7 +158,6 @@ dependencies {
     String espressoVersion = '3.1.1'
     String frescoVersion = '2.1.0' // When updating this version, resync file copies under app/src/main/java/com/facebook
     String mockitoCore = 'org.mockito:mockito-core:1.9.5'
-    String leakCanaryVersion = '1.6.2'
     String kotlinCoroutinesVersion = '1.2.1'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
@@ -200,15 +199,7 @@ dependencies {
 
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterknifeVersion"
 
-    android.productFlavors.each { flavor ->
-        String dep
-        if('dev' == flavor.name) {
-            dep = "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
-        } else {
-            dep = "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
-        }
-        "${flavor.name}Implementation" dep
-    }
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation mockitoCore

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -158,6 +158,7 @@ dependencies {
     String espressoVersion = '3.1.1'
     String frescoVersion = '2.1.0' // When updating this version, resync file copies under app/src/main/java/com/facebook
     String mockitoCore = 'org.mockito:mockito-core:1.9.5'
+    String leakCanaryVersion = '2.2'
     String kotlinCoroutinesVersion = '1.2.1'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
@@ -199,7 +200,9 @@ dependencies {
 
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterknifeVersion"
 
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
+    // For release builds, this provides a nearly no-op AppWatcher.
+    implementation "com.squareup.leakcanary:leakcanary-object-watcher-android:$leakCanaryVersion"
 
     testImplementation 'junit:junit:4.12'
     testImplementation mockitoCore

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -19,8 +19,6 @@ import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.imagepipeline.nativecode.ImagePipelineNativeLoader;
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.crashes.Crashes;
-import com.squareup.leakcanary.LeakCanary;
-import com.squareup.leakcanary.RefWatcher;
 
 import org.wikipedia.analytics.FunnelManager;
 import org.wikipedia.analytics.SessionFunnel;
@@ -67,6 +65,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
+import leakcanary.AppWatcher;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.wikipedia.settings.Prefs.getTextSizeMultiplier;
@@ -86,7 +85,6 @@ public class WikipediaApp extends Application {
     private String userAgent;
     private WikiSite wiki;
     private AppCenterCrashesListener crashListener;
-    private RefWatcher refWatcher;
     private RxBus bus;
     private Theme currentTheme = Theme.getFallback();
     private List<Tab> tabList = new ArrayList<>();
@@ -103,10 +101,6 @@ public class WikipediaApp extends Application {
 
     public SessionFunnel getSessionFunnel() {
         return sessionFunnel;
-    }
-
-    public RefWatcher getRefWatcher() {
-        return refWatcher;
     }
 
     public RxBus getBus() {
@@ -160,7 +154,15 @@ public class WikipediaApp extends Application {
 
         initExceptionHandling();
 
-        refWatcher = Prefs.isMemoryLeakTestEnabled() ? LeakCanary.install(this) : RefWatcher.DISABLED;
+        if (Prefs.isMemoryLeakTestEnabled()) {
+            AppWatcher.setConfig(new AppWatcher.Config.Builder(AppWatcher.getConfig())
+                    .enabled(true)
+                    .watchActivities(true)
+                    .watchFragments(true)
+                    .build());
+        } else {
+            AppWatcher.setConfig(new AppWatcher.Config.Builder(AppWatcher.getConfig()).enabled(false).build());
+        }
 
         // See Javadocs and http://developer.android.com/tools/support-library/index.html#rev23-4-0
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.java
@@ -287,7 +287,6 @@ public class FeedFragment extends Fragment implements BackPressedHandler {
     public void onDestroy() {
         super.onDestroy();
         coordinator.reset();
-        app.getRefWatcher().watch(this);
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
@@ -31,7 +31,6 @@ import com.facebook.samples.zoomable.DoubleTapGestureListener;
 
 import org.wikipedia.Constants;
 import org.wikipedia.R;
-import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.FragmentUtil;
 import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.ServiceFactory;
@@ -79,7 +78,6 @@ public class GalleryItemFragment extends Fragment {
 
     private MediaController mediaController;
 
-    @NonNull private WikipediaApp app = WikipediaApp.getInstance();
     @Nullable private PageTitle pageTitle;
     @Nullable private MediaListItem mediaListItem;
 
@@ -161,12 +159,6 @@ public class GalleryItemFragment extends Fragment {
 
     private void updateProgressBar(boolean visible) {
         progressBar.setVisibility(visible ? View.VISIBLE : View.GONE);
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        app.getRefWatcher().watch(this);
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.java
@@ -173,12 +173,6 @@ public class HistoryFragment extends Fragment implements BackPressedHandler {
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-        app.getRefWatcher().watch(this);
-    }
-
-    @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.menu_history, menu);
     }

--- a/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.java
+++ b/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.java
@@ -9,7 +9,6 @@ import androidx.annotation.NonNull;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import org.wikipedia.R;
-import org.wikipedia.WikipediaApp;
 import org.wikipedia.util.DimenUtil;
 
 /**
@@ -28,12 +27,6 @@ public class ExtendedBottomSheetDialogFragment extends BottomSheetDialogFragment
     public void onStart() {
         super.onStart();
         setWindowLayout();
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        WikipediaApp.getInstance().getRefWatcher().watch(this);
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/page/NoDimBottomSheetDialog.java
+++ b/app/src/main/java/org/wikipedia/page/NoDimBottomSheetDialog.java
@@ -9,8 +9,6 @@ import androidx.annotation.NonNull;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 
-import org.wikipedia.WikipediaApp;
-
 /**
  * Descendant of BottomSheetDialog that prevents the background from being dimmed.
  */
@@ -23,12 +21,6 @@ public class NoDimBottomSheetDialog extends BottomSheetDialog {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         getWindow().setDimAmount(0f);
-    }
-
-    @Override
-    public void onStop() {
-        super.onStop();
-        WikipediaApp.getInstance().getRefWatcher().watch(this);
     }
 
     protected void startExpanded() {

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -339,12 +339,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-        app.getRefWatcher().watch(this);
-    }
-
-    @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         setHasOptionsMenu(true);

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
@@ -117,12 +117,6 @@ public class ReadingListsFragment extends Fragment implements
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-        WikipediaApp.getInstance().getRefWatcher().watch(this);
-    }
-
-    @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_reading_lists, container, false);
         unbinder = ButterKnife.bind(this, view);


### PR DESCRIPTION
This is actually a very nice upgrade that greatly simplifies the code necessary to watch for leaks. We no longer need to manually manage our own `RefWatcher`.