### PR TITLE
Basic push notification support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
@@ -174,6 +175,8 @@ dependencies {
     implementation "androidx.preference:preference:1.1.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation 'com.google.android:flexbox:2.0.1'
+    implementation 'com.google.firebase:firebase-messaging:20.1.0'
+    implementation 'com.google.firebase:firebase-analytics:17.2.2'
 
     implementation ('com.github.michael-rapp:chrome-like-tab-switcher:0.4.6') {
         exclude group: 'org.jetbrains'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -341,6 +341,14 @@
             android:name=".savedpages.SavedPageSyncService"
             android:permission="android.permission.BIND_JOB_SERVICE" />
 
+        <service
+            android:name=".firebase.WikipediaAppFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <receiver android:name=".savedpages.SavedPageSyncNotification" />
 
     </application>

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -43,6 +43,7 @@ import org.wikipedia.language.AppLanguageState;
 import org.wikipedia.notifications.NotificationPollBroadcastReceiver;
 import org.wikipedia.page.tabs.Tab;
 import org.wikipedia.pageimages.PageImage;
+import org.wikipedia.push.WikipediaAppPushServiceClient;
 import org.wikipedia.search.RecentSearch;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.settings.RemoteConfig;
@@ -208,6 +209,10 @@ public class WikipediaApp extends Application {
 
         // Kick the notification receiver, in case it hasn't yet been started by the system.
         NotificationPollBroadcastReceiver.startPollTask(this);
+
+        if (Prefs.getPushNotificationsEnabled()) {
+            WikipediaAppPushServiceClient.getInstance(this).updateSubscriptionState();
+        }
     }
 
     public int getVersionCode() {

--- a/app/src/main/java/org/wikipedia/dataclient/PushService.java
+++ b/app/src/main/java/org/wikipedia/dataclient/PushService.java
@@ -1,0 +1,39 @@
+package org.wikipedia.dataclient;
+
+import androidx.annotation.NonNull;
+
+import org.wikipedia.push.PushServiceSubscriptionResponse;
+
+import io.reactivex.Observable;
+import retrofit2.Response;
+import retrofit2.http.DELETE;
+import retrofit2.http.Field;
+import retrofit2.http.FormUrlEncoded;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+public interface PushService {
+
+    String PROTOCOL = "gcm";
+
+    @FormUrlEncoded
+    @POST("subscribers")
+    @NonNull Observable<PushServiceSubscriptionResponse> subscribe(
+        @NonNull @Field("proto") String protocol,
+        @NonNull @Field("lang") String language,
+        @NonNull @Field("token") String token
+    );
+
+    @FormUrlEncoded
+    @POST("subscriber/{id}")
+    @NonNull Observable<Response<Void>> updateSubscription(
+        @NonNull @Path("id") String subscriberId,
+        @NonNull @Field("lang") String language
+    );
+
+    @DELETE("subscriber/{id}")
+    @NonNull Observable<Response<Void>> deleteSubscription(
+        @NonNull @Path("id") String subscriberId
+    );
+
+}

--- a/app/src/main/java/org/wikipedia/firebase/FirebaseStateManager.java
+++ b/app/src/main/java/org/wikipedia/firebase/FirebaseStateManager.java
@@ -1,0 +1,26 @@
+package org.wikipedia.firebase;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
+
+import org.wikipedia.util.Callback;
+
+public final class FirebaseStateManager {
+
+    public static void getCurrentToken(@NonNull Callback<String, Exception> callback) {
+        FirebaseInstanceId.getInstance().getInstanceId().addOnCompleteListener(
+                (@NonNull Task<InstanceIdResult> task) -> {
+                    if (task.isSuccessful()) {
+                        callback.onSuccess(task.getResult().getToken());
+                    } else {
+                        callback.onFailure(task.getException());
+                    }
+                });
+    }
+
+    private FirebaseStateManager() { }
+
+}

--- a/app/src/main/java/org/wikipedia/firebase/WikipediaAppFirebaseMessagingService.java
+++ b/app/src/main/java/org/wikipedia/firebase/WikipediaAppFirebaseMessagingService.java
@@ -1,0 +1,33 @@
+package org.wikipedia.firebase;
+
+import androidx.annotation.NonNull;
+
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+import org.wikipedia.push.WikipediaAppPushServiceClient;
+import org.wikipedia.settings.Prefs;
+import org.wikipedia.util.log.L;
+
+public class WikipediaAppFirebaseMessagingService extends FirebaseMessagingService {
+
+    @Override
+    public void onMessageReceived(@NonNull RemoteMessage message) {
+        super.onMessageReceived(message);
+        // TODO: Perform any special handling needed here
+    }
+
+    @Override
+    public void onNewToken(@NonNull String token) {
+        super.onNewToken(token);
+        if (!token.equals(Prefs.getCurrentFirebaseToken())) {
+            Prefs.setCurrentFirebaseToken(token);
+            Prefs.setPushServiceSubscriberId(null);
+            if (Prefs.getPushNotificationsEnabled()) {
+                WikipediaAppPushServiceClient.getInstance(this).updateSubscriptionState();
+            }
+        }
+        L.d("Received new token: " + token);
+    }
+
+}

--- a/app/src/main/java/org/wikipedia/push/PushServiceSubscriptionResponse.java
+++ b/app/src/main/java/org/wikipedia/push/PushServiceSubscriptionResponse.java
@@ -1,0 +1,16 @@
+package org.wikipedia.push;
+
+import androidx.annotation.Nullable;
+
+public class PushServiceSubscriptionResponse {
+    private long created;
+    private long updated;
+    @Nullable private String id;
+    @Nullable private String proto;
+    @Nullable private String token;
+    @Nullable private String lang;
+
+    @Nullable public String id() {
+        return id;
+    }
+}

--- a/app/src/main/java/org/wikipedia/push/WikipediaAppPushServiceClient.java
+++ b/app/src/main/java/org/wikipedia/push/WikipediaAppPushServiceClient.java
@@ -1,0 +1,109 @@
+package org.wikipedia.push;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.wikipedia.dataclient.PushService;
+import org.wikipedia.dataclient.ServiceFactory;
+import org.wikipedia.firebase.FirebaseStateManager;
+import org.wikipedia.language.AppLanguageState;
+import org.wikipedia.settings.Prefs;
+import org.wikipedia.util.Callback;
+import org.wikipedia.util.log.L;
+
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.schedulers.Schedulers;
+
+
+public final class WikipediaAppPushServiceClient {
+
+    @NonNull private PushService pushService = ServiceFactory.getPush();
+    @NonNull private CompositeDisposable disposables = new CompositeDisposable();
+    @NonNull private Context context;
+
+    public static WikipediaAppPushServiceClient getInstance(@NonNull Context context) {
+        return new WikipediaAppPushServiceClient(context);
+    }
+
+    private WikipediaAppPushServiceClient(@NonNull Context context) {
+        this.context = context;
+    }
+
+    public void updateSubscriptionState() {
+        FirebaseStateManager.getCurrentToken(new FirebaseTokenCallback(context));
+    }
+
+    public void deleteSubscription() {
+        String subscriberId = Prefs.getPushServiceSubscriberId();
+        if (subscriberId == null) {
+            L.d("No subscriber ID to delete!");
+            return;
+        }
+        disposables.add(pushService.deleteSubscription(subscriberId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        // 204
+                        rsp -> {
+                            Prefs.setPushServiceSubscriberId(null);
+                            L.d("Subscription deleted");
+                        },
+                        err -> L.e("Error deleting push service subscription", err)
+                ));
+    }
+
+    private final class FirebaseTokenCallback implements Callback<String, Exception> {
+        private Context context;
+
+        private FirebaseTokenCallback(@NonNull Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public void onSuccess(String token) {
+            Prefs.setCurrentFirebaseToken(token);
+            L.d("Received Firebase token: " + token);
+
+            String subscriberId = Prefs.getPushServiceSubscriberId();
+            AppLanguageState appLanguageState = new AppLanguageState(context);
+            String lang = appLanguageState.getAppLanguageCode();
+
+            if (subscriberId == null) {
+                disposables.add(pushService.subscribe(PushService.PROTOCOL, lang, token)
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(
+                                rsp -> {
+                                    String id = rsp.id();
+                                    if (id != null) {
+                                        Prefs.setPushServiceSubscriberId(id);
+                                        L.d("Found subscriber ID: " + id);
+                                    }
+                                },
+                                err -> L.e("Error subscribing to push service", err)
+                        )
+                );
+            } else {
+                disposables.add(pushService.updateSubscription(subscriberId, lang)
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(
+                                rsp -> L.d("Subscriber info updated"), // 204
+                                // TODO: If this 404s, the app's subscriber ID value is invalid
+                                //  (perhaps because the server has changed). Clear it and
+                                //  resubscribe.
+                                err -> L.e("Error updating push service subscription", err)
+                        ));
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            L.e("Failed to retrieve the current Firebase token", e);
+        }
+    }
+
+
+}

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -874,5 +874,29 @@ public final class Prefs {
         setBoolean(R.string.preference_key_suggested_edits_image_tags_new, enabled);
     }
 
+    public static String getPushServiceBaseUrl() {
+        return getString(R.string.preference_key_push_service_base_url, null);
+    }
+
+    public static boolean getPushNotificationsEnabled() {
+        return getBoolean(R.string.preference_key_enable_push_notifications, false);
+    }
+
+    public static String getCurrentFirebaseToken() {
+        return getString(R.string.preference_key_current_firebase_token, null);
+    }
+
+    public static void setCurrentFirebaseToken(@NonNull String s) {
+        setString(R.string.preference_key_current_firebase_token, s);
+    }
+
+    public static String getPushServiceSubscriberId() {
+        return getString(R.string.preference_key_push_service_subscriber_id, null);
+    }
+
+    public static void setPushServiceSubscriberId(@Nullable String s) {
+        setString(R.string.preference_key_push_service_subscriber_id, s);
+    }
+
     private Prefs() { }
 }

--- a/app/src/main/java/org/wikipedia/util/Callback.java
+++ b/app/src/main/java/org/wikipedia/util/Callback.java
@@ -1,0 +1,6 @@
+package org.wikipedia.util;
+
+public interface Callback<A, B> {
+    void onSuccess(A arg);
+    void onFailure(B arg);
+}

--- a/app/src/main/res/values/dev_settings_strings.xml
+++ b/app/src/main/res/values/dev_settings_strings.xml
@@ -36,6 +36,13 @@
     <string name="preferences_developer_summary_configure_articles">Type the number of articles</string>
     <string name="preferences_developer_summary_configure_reading_lists">Type the number of lists</string>
     <string name="preferences_developer_suggested_edits_category">Suggested edits</string>
+
+    <string name="preferences_developer_push_notifications_heading">Push notifications</string>
+    <string name="preferences_developer_enable_push_notifications">Enable push notifications</string>
+    <string name="preferences_developer_push_service_base_url">Push service base URL</string>
+    <string name="preferences_developer_current_firebase_token">Firebase token</string>
+    <string name="preferences_developer_push_service_subscriber_id">Push service subscriber ID</string>
+
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -113,4 +113,8 @@
     <string name="preference_key_suggested_edits_override_edits">suggestedEditsOverrideEdits</string>
     <string name="preference_key_suggested_edits_override_reverts">suggestedEditsOverrideReverts</string>
     <string name="preference_key_image_tags_onboarding_shown">imageTagsOnboardingShown</string>
+    <string name="preference_key_enable_push_notifications">enablePushNotifications</string>
+    <string name="preference_key_push_service_base_url">pushServiceBaseUrl</string>
+    <string name="preference_key_push_service_subscriber_id">pushServiceSubscriberId</string>
+    <string name="preference_key_current_firebase_token">currentFirebaseToken</string>
 </resources>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -2,6 +2,29 @@
 <androidx.preference.PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <PreferenceCategory android:title="@string/preferences_developer_push_notifications_heading">
+
+        <SwitchPreferenceCompat
+            android:key="@string/preference_key_enable_push_notifications"
+            android:title="@string/preferences_developer_enable_push_notifications" />
+
+        <org.wikipedia.settings.EditTextAutoSummarizePreference
+            style="@style/DataStringPreference"
+            android:key="@string/preference_key_push_service_base_url"
+            android:title="@string/preferences_developer_push_service_base_url" />
+
+        <!-- Entries below are intentionally read-only -->
+
+        <Preference
+            android:key="@string/preference_key_current_firebase_token"
+            android:title="@string/preferences_developer_current_firebase_token" />
+
+        <Preference
+            android:key="@string/preference_key_push_service_subscriber_id"
+            android:title="@string/preferences_developer_push_service_subscriber_id" />
+
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/preferences_developer_feature_testing_heading">
 
     </PreferenceCategory>

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.gms:google-services:4.3.3'
     }
 }
 


### PR DESCRIPTION
Adds initial support for push notifications via Firebase Cloud Messaging.
On startup, the app will retrieve an identifier token from Firebase, and
register or update its registration with the configured push notification
service, if any.

Setup steps:

1) Pull this patch and rebuild the project to pull in new required
   dependencies.

2) Retrieve the file at https://phabricator.wikimedia.org/F31621302 and
   save it as app/google-services.json.

3) Launch the app, navigate to the developer settings, and do the
   following:

     a) set the push service base URL to "https://pushd.wmflabs.org"

     b) toggle "enable push notifications" to true

   Then close and relaunch the app.

To send a test push notification, post a message payload to the
prototype service. Example:

  curl -X POST -d "title=Foo&msg=Bar" https://pushd.wmflabs.org/event/broadcast

NOTES:

* The google-services.json Firebase credentials assume that the app
  ID will be org.wikipedia.dev (i.e., the Dev flavor). Other build
  flavors will not likely work with these credentials.

* A README describing the full push service API is available at
  https://github.com/mdholloway/pushd/blob/master/README.md. Please note
  that this is currently only a prototype, and implementation details are
  very likely to change.