### PR TITLE
Fix/update the API calls used for applying tags to images.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -251,6 +251,14 @@ public interface Service {
     @NonNull Observable<Entities> getWikidataLabelsAndDescriptions(@Query("ids") @NonNull String idList);
 
     @Headers("Cache-Control: no-cache")
+    @POST(MW_API_PREFIX + "action=wbsetclaim&errorlang=uselang")
+    @FormUrlEncoded
+    Observable<MwPostResponse> postSetClaim(@NonNull @Field("claim") String claim,
+                                            @NonNull @Field("token") String token,
+                                            @Nullable @Field("summary") String summary,
+                                            @Nullable @Field("tags") String tags);
+
+    @Headers("Cache-Control: no-cache")
     @POST(MW_API_PREFIX + "action=wbsetdescription&errorlang=uselang")
     @FormUrlEncoded
     @SuppressWarnings("checkstyle:parameternumber")


### PR DESCRIPTION
The existing Machine Vision API no longer applies the image tags to the Commons item automatically for us.  Therefore we must use the `wbsetclaim` API ourselves.  This is actually good because we will eventually need to do this anyway when we allow the user to set a "custom" tag.