### PR TITLE
Improve handling of wikibase POST responses.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/DescriptionEditFunnel.java
+++ b/app/src/main/java/org/wikipedia/analytics/DescriptionEditFunnel.java
@@ -60,9 +60,10 @@ public class DescriptionEditFunnel extends EditFunnel {
         );
     }
 
-    public void logSaved() {
+    public void logSaved(long revID) {
         log(
                 "action", "saved",
+                "revID", revID,
                 "wikidataDescriptionEdit", type.toLogString()
         );
     }

--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -11,11 +11,12 @@ import org.wikipedia.dataclient.mwapi.MwParseResponse;
 import org.wikipedia.dataclient.mwapi.MwPostResponse;
 import org.wikipedia.dataclient.mwapi.MwQueryResponse;
 import org.wikipedia.dataclient.mwapi.SiteMatrix;
+import org.wikipedia.dataclient.wikidata.Entities;
+import org.wikipedia.dataclient.wikidata.EntityPostResponse;
 import org.wikipedia.edit.Edit;
 import org.wikipedia.edit.preview.EditPreview;
 import org.wikipedia.login.LoginClient;
 import org.wikipedia.search.PrefixSearchResponse;
-import org.wikipedia.wikidata.Entities;
 
 import io.reactivex.Observable;
 import retrofit2.Call;
@@ -253,16 +254,16 @@ public interface Service {
     @Headers("Cache-Control: no-cache")
     @POST(MW_API_PREFIX + "action=wbsetclaim&errorlang=uselang")
     @FormUrlEncoded
-    Observable<MwPostResponse> postSetClaim(@NonNull @Field("claim") String claim,
-                                            @NonNull @Field("token") String token,
-                                            @Nullable @Field("summary") String summary,
-                                            @Nullable @Field("tags") String tags);
+    Observable<EntityPostResponse> postSetClaim(@NonNull @Field("claim") String claim,
+                                                @NonNull @Field("token") String token,
+                                                @Nullable @Field("summary") String summary,
+                                                @Nullable @Field("tags") String tags);
 
     @Headers("Cache-Control: no-cache")
     @POST(MW_API_PREFIX + "action=wbsetdescription&errorlang=uselang")
     @FormUrlEncoded
     @SuppressWarnings("checkstyle:parameternumber")
-    Observable<MwPostResponse> postDescriptionEdit(@NonNull @Field("language") String language,
+    Observable<EntityPostResponse> postDescriptionEdit(@NonNull @Field("language") String language,
                                                    @NonNull @Field("uselang") String useLang,
                                                    @NonNull @Field("site") String site,
                                                    @NonNull @Field("title") String title,
@@ -275,7 +276,7 @@ public interface Service {
     @POST(MW_API_PREFIX + "action=wbsetlabel&errorlang=uselang")
     @FormUrlEncoded
     @SuppressWarnings("checkstyle:parameternumber")
-    Observable<MwPostResponse> postLabelEdit(@NonNull @Field("language") String language,
+    Observable<EntityPostResponse> postLabelEdit(@NonNull @Field("language") String language,
                                              @NonNull @Field("uselang") String useLang,
                                              @NonNull @Field("site") String site,
                                              @NonNull @Field("title") String title,

--- a/app/src/main/java/org/wikipedia/dataclient/wikidata/Entities.java
+++ b/app/src/main/java/org/wikipedia/dataclient/wikidata/Entities.java
@@ -1,4 +1,4 @@
-package org.wikipedia.wikidata;
+package org.wikipedia.dataclient.wikidata;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -40,6 +40,7 @@ public class Entities extends MwResponse implements PostProcessingTypeAdapter.Po
         @Nullable private Map<String, Label> descriptions;
         @Nullable private Map<String, SiteLink> sitelinks;
         @Nullable private String missing;
+        private long lastrevid;
 
         @NonNull public String id() {
             return StringUtils.defaultString(id);
@@ -57,8 +58,12 @@ public class Entities extends MwResponse implements PostProcessingTypeAdapter.Po
             return sitelinks != null ? sitelinks : Collections.emptyMap();
         }
 
-        boolean isMissing() {
+        public boolean isMissing() {
             return "-1".equals(id) && missing != null;
+        }
+
+        public long getLastRevId() {
+            return lastrevid;
         }
     }
 

--- a/app/src/main/java/org/wikipedia/dataclient/wikidata/EntityPostResponse.java
+++ b/app/src/main/java/org/wikipedia/dataclient/wikidata/EntityPostResponse.java
@@ -1,0 +1,14 @@
+package org.wikipedia.dataclient.wikidata;
+
+import androidx.annotation.Nullable;
+
+import org.wikipedia.dataclient.mwapi.MwPostResponse;
+
+@SuppressWarnings("unused")
+public class EntityPostResponse extends MwPostResponse {
+    @Nullable private Entities.Entity entity;
+
+    @Nullable public Entities.Entity getEntity() {
+        return entity;
+    }
+}

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
@@ -27,9 +27,9 @@ import org.wikipedia.dataclient.Service;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.mwapi.MwException;
-import org.wikipedia.dataclient.mwapi.MwPostResponse;
 import org.wikipedia.dataclient.mwapi.MwServiceError;
 import org.wikipedia.dataclient.retrofit.RetrofitException;
+import org.wikipedia.dataclient.wikidata.EntityPostResponse;
 import org.wikipedia.descriptions.DescriptionEditActivity.Action;
 import org.wikipedia.json.GsonMarshaller;
 import org.wikipedia.json.GsonUnmarshaller;
@@ -324,7 +324,7 @@ public class DescriptionEditFragment extends Fragment {
                         if (response.getSuccessVal() > 0) {
                             new Handler().postDelayed(successRunnable, TimeUnit.SECONDS.toMillis(4));
                             if (funnel != null) {
-                                funnel.logSaved();
+                                funnel.logSaved(response.getEntity() != null ? response.getEntity().getLastRevId() : 0);
                             }
                         } else {
                             editFailed(RetrofitException.unexpectedError(new RuntimeException(
@@ -354,7 +354,7 @@ public class DescriptionEditFragment extends Fragment {
                     }));
         }
 
-        private Observable<MwPostResponse> getPostObservable(@NonNull String editToken, @Nullable String languageCode) {
+        private Observable<EntityPostResponse> getPostObservable(@NonNull String editToken, @Nullable String languageCode) {
             if (action == ADD_CAPTION || action == TRANSLATE_CAPTION) {
                 return ServiceFactory.get(wikiCommons).postLabelEdit(pageTitle.getWikiSite().languageCode(),
                         pageTitle.getWikiSite().languageCode(), commonsDbName,

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -476,13 +476,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
 
         bridge.execute(JavaScriptActionHandler.setFooter(model));
 
-        bridge.evaluate(JavaScriptActionHandler.getRevision(), revision -> {
-            try {
-                this.revision = Long.parseLong(revision.replace("\"", ""));
-            } catch (NumberFormatException ignore) {
-                //
-            }
-        });
+        bridge.evaluate(JavaScriptActionHandler.getRevision(), revision -> this.revision = Long.parseLong(revision.replace("\"", "")));
 
         bridge.evaluate(JavaScriptActionHandler.getSections(), value -> {
             Section[] secArray = GsonUtil.getDefaultGson().fromJson(value, Section[].class);

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -476,7 +476,13 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
 
         bridge.execute(JavaScriptActionHandler.setFooter(model));
 
-        bridge.evaluate(JavaScriptActionHandler.getRevision(), revision -> this.revision = Long.parseLong(revision.replace("\"", "")));
+        bridge.evaluate(JavaScriptActionHandler.getRevision(), revision -> {
+            try {
+                this.revision = Long.parseLong(revision.replace("\"", ""));
+            } catch (NumberFormatException ignore) {
+                //
+            }
+        });
 
         bridge.evaluate(JavaScriptActionHandler.getSections(), value -> {
             Section[] secArray = GsonUtil.getDefaultGson().fromJson(value, Section[].class);

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -33,6 +33,7 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwPostResponse
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.dataclient.mwapi.media.MediaHelper
+import org.wikipedia.dataclient.wikidata.EntityPostResponse
 import org.wikipedia.login.LoginClient.LoginFailedException
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.settings.Prefs
@@ -283,7 +284,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
         csrfClient.request(false, object : CsrfTokenClient.Callback {
             override fun success(token: String) {
 
-                val claimObservables = ArrayList<ObservableSource<MwPostResponse>>()
+                val claimObservables = ArrayList<ObservableSource<EntityPostResponse>>()
                 for (label in acceptedLabels) {
                     val claimTemplate = "{\"mainsnak\":" +
                             "{\"snaktype\":\"value\",\"property\":\"P180\"," +

--- a/app/src/main/java/org/wikipedia/suggestededits/provider/SuggestedEditItem.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/SuggestedEditItem.kt
@@ -1,8 +1,8 @@
 package org.wikipedia.suggestededits.provider
 
 import com.google.gson.annotations.SerializedName
+import org.wikipedia.dataclient.wikidata.Entities
 import org.wikipedia.gallery.GalleryItem
-import org.wikipedia.wikidata.Entities
 
 class SuggestedEditItem {
     private val pageid: Int = 0


### PR DESCRIPTION
This correctly parses the response given by Wikibase when adding descriptions or captions, so that we can get the resulting revision ID to pass to analytics, among other things.