### PR TITLE
Update AppCenter sdk version.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -193,7 +193,7 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
     implementation 'com.getkeepsafe.taptargetview:taptargetview:1.12.0'
     implementation "com.jakewharton:butterknife:$butterknifeVersion"
-    implementation 'com.microsoft.appcenter:appcenter-crashes:2.5.0'
+    implementation 'com.microsoft.appcenter:appcenter-crashes:3.0.0'
     implementation 'org.apache.commons:commons-lang3:3.9'
     implementation 'org.jsoup:jsoup:1.12.1'
 


### PR DESCRIPTION
This should fix certain crashes from within AppCenter, namely https://github.com/microsoft/appcenter-sdk-android/issues/1348