### PR TITLE
Fix potential crash upon starting Search fragment.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.java
@@ -406,7 +406,8 @@ public class DescriptionEditFragment extends Fragment {
 
         @Override
         public void onVoiceInputClick() {
-            Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
+            Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+                    .putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
             try {
                 startActivityForResult(intent, Constants.ACTIVITY_REQUEST_VOICE_SEARCH);
             } catch (ActivityNotFoundException a) {

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -246,7 +246,8 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
     }
 
     @Override public void onFeedVoiceSearchRequested() {
-        Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
+        Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+                .putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
         try {
             startActivityForResult(intent, Constants.ACTIVITY_REQUEST_VOICE_SEARCH);
         } catch (ActivityNotFoundException a) {

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.java
@@ -182,10 +182,6 @@ public class SearchFragment extends Fragment implements SearchResultsFragment.Ca
         toolbar.setNavigationOnClickListener((v) -> requireActivity().finish());
 
         initSearchView();
-
-        if (!TextUtils.isEmpty(query)) {
-            showPanel(PANEL_SEARCH_RESULTS);
-        }
         return view;
     }
 
@@ -195,6 +191,10 @@ public class SearchFragment extends Fragment implements SearchResultsFragment.Ca
         setUpLanguageScroll(0);
         startSearch(query, false);
         searchView.setCloseButtonVisibility(query);
+
+        if (!TextUtils.isEmpty(query)) {
+            showPanel(PANEL_SEARCH_RESULTS);
+        }
     }
 
     @Override


### PR DESCRIPTION
This also adds a required parameter (according to the [documentation](https://developer.android.com/reference/android/speech/RecognizerIntent#ACTION_RECOGNIZE_SPEECH)) for launching the Voice input dialog, which may fix some obscure errors:

https://phabricator.wikimedia.org/T246515