### PR TITLE
Don't request full page contents in PageCacher.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageCacher.java
+++ b/app/src/main/java/org/wikipedia/page/PageCacher.java
@@ -5,18 +5,11 @@ import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 
 import org.wikipedia.WikipediaApp;
-import org.wikipedia.dataclient.RestService;
 import org.wikipedia.dataclient.ServiceFactory;
-import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory;
-import org.wikipedia.dataclient.page.PageSummary;
-import org.wikipedia.util.UriUtil;
 import org.wikipedia.util.log.L;
 
-import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
-import okhttp3.Request;
-import retrofit2.Response;
 
 final class PageCacher {
 
@@ -24,7 +17,8 @@ final class PageCacher {
     static void loadIntoCache(@NonNull PageTitle title) {
         L.d("Loading page into cache: " + title.getPrefixedText());
 
-        Observable.zip(summaryReq(title), mobileHtmlReq(title), (summaryRsp, mobileHtmlRsp) -> summaryRsp)
+        ServiceFactory.getRest(title.getWikiSite())
+                .getSummaryResponse(title.getPrefixedText(), null, null, null, null, null)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(summaryRsp -> {
@@ -36,26 +30,6 @@ final class PageCacher {
                         }
                     }
                 }, L::e);
-    }
-
-    private static Observable<okhttp3.Response> mobileHtmlReq(@NonNull PageTitle pageTitle) {
-        Request request = new Request.Builder().url(UriUtil.resolveProtocolRelativeUrl(pageTitle.getWikiSite(),
-                UriUtil.encodeOkHttpUrl(pageTitle.getWikiSite().url() + RestService.REST_API_PREFIX + RestService.PAGE_HTML_ENDPOINT,
-                        pageTitle.getPrefixedText())))
-                .addHeader("Accept-Language", WikipediaApp.getInstance().getAcceptLanguage(pageTitle.getWikiSite()))
-                .build();
-
-        return Observable.create(emitter -> {
-            okhttp3.Response response = OkHttpConnectionFactory.getClient().newCall(request).execute();
-            emitter.onNext(response);
-            emitter.onComplete();
-        });
-    }
-
-    @NonNull
-    private static Observable<Response<PageSummary>> summaryReq(@NonNull PageTitle title) {
-        return ServiceFactory.getRest(title.getWikiSite())
-                .getSummaryResponse(title.getPrefixedText(), null, null, null, null, null);
     }
 
     private PageCacher() { }


### PR DESCRIPTION
The `PageCacher` is a weird class that is only used when the user loads a title in a new tab. It automatically fetches the PageSummary for that title, and injects the thumbnail for the title into the Tab structure.  However, it was also loading the full `mobile-html` contents for the title, apparently for no reason.