### PR TITLE
Add subtitle to suggested edits explore feed cards

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCard.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCard.kt
@@ -9,6 +9,7 @@ import org.wikipedia.descriptions.DescriptionEditActivity.Action
 import org.wikipedia.feed.model.CardType
 import org.wikipedia.feed.model.WikiSiteCard
 import org.wikipedia.suggestededits.SuggestedEditsSummary
+import org.wikipedia.util.DateUtil
 
 class SuggestedEditsCard(
         wiki: WikiSite,
@@ -24,6 +25,10 @@ class SuggestedEditsCard(
 
     override fun title(): String {
         return WikipediaApp.getInstance().getString(R.string.suggested_edits_feed_card_title)
+    }
+
+    override fun subtitle(): String {
+        return DateUtil.getFeedCardDateString(age)
     }
 
     fun logImpression() {

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -107,9 +107,10 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
 
     private fun header(card: SuggestedEditsCard) {
         headerView!!.setTitle(card.title())
+                .setSubtitle(card.subtitle())
                 .setImage(R.drawable.ic_mode_edit_white_24dp)
                 .setImageCircleColor(R.color.base30)
-                .setLangCode(if (card.action == TRANSLATE_CAPTION || card.action == TRANSLATE_DESCRIPTION) card.wikiSite().languageCode() else "")
+                .setLangCode(if (card.action == TRANSLATE_CAPTION || card.action == TRANSLATE_DESCRIPTION) card.targetSummary!!.lang else "")
                 .setCard(card)
                 .setCallback(callback)
     }


### PR DESCRIPTION
Not seeing the date string subtitle and correct language indicator on the translate cards. This should update them correctly.