### PR TITLE
Make mobile-html calls work correctly with developer base URL.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -17,6 +17,7 @@ import com.google.gson.JsonObject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.dataclient.RestService;
+import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.json.GsonUtil;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.UriUtil;
@@ -68,12 +69,12 @@ public class CommunicationBridge {
         flushMessages();
     }
 
-    public void resetHtml(@NonNull String wikiUrl, @NonNull PageTitle pageTitle) {
+    public void resetHtml(@NonNull PageTitle pageTitle) {
         isDOMReady = false;
         pendingJSMessages.clear();
         pendingEvals.clear();
         communicationBridgeListener.getWebView().loadUrl(UriUtil
-                .encodeOkHttpUrl(wikiUrl + RestService.REST_API_PREFIX + RestService.PAGE_HTML_ENDPOINT,
+                .encodeOkHttpUrl(ServiceFactory.getRestBasePath(pageTitle.getWikiSite()) + RestService.PAGE_HTML_ENDPOINT,
                         pageTitle.getPrefixedText()));
     }
 

--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -5,7 +5,7 @@ import org.wikipedia.BuildConfig
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
-import org.wikipedia.dataclient.RestService
+import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageTitle
 import org.wikipedia.page.PageViewModel
@@ -140,7 +140,7 @@ object JavaScriptActionHandler {
                 "       }," +
                 "   readMore: { " +
                 "       itemCount: 3," +
-                "       baseURL: '${model.title?.wikiSite?.url() + RestService.REST_API_PREFIX}'" +
+                "       baseURL: '${ServiceFactory.getRestBasePath(model.title?.wikiSite!!)}'" +
                 "   }" +
                 "})"
     }

--- a/app/src/main/java/org/wikipedia/dataclient/RestService.java
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.java
@@ -39,8 +39,8 @@ public interface RestService {
     String ACCEPT_HEADER_SUMMARY = ACCEPT_HEADER_PREFIX + "Summary/1.2.0\"";
     String ACCEPT_HEADER_DEFINITION = ACCEPT_HEADER_PREFIX + "definition/0.7.2\"";
 
-    String PAGE_HTML_ENDPOINT = "/page/mobile-html/";
-    String PAGE_HTML_PREVIEW_ENDPOINT = REST_API_PREFIX + "/transform/wikitext/to/mobile-html/";
+    String PAGE_HTML_ENDPOINT = "page/mobile-html/";
+    String PAGE_HTML_PREVIEW_ENDPOINT = "transform/wikitext/to/mobile-html/";
 
     /**
      * Gets a page summary for a given title -- for link previews

--- a/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.java
+++ b/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.java
@@ -30,9 +30,7 @@ public final class ServiceFactory {
         if (SERVICE_CACHE.get(hashCode) != null) {
             return SERVICE_CACHE.get(hashCode);
         }
-
-        Retrofit r = createRetrofit(wiki, TextUtils.isEmpty(Prefs.getMediaWikiBaseUrl()) ? wiki.url() + "/" : Prefs.getMediaWikiBaseUrl());
-
+        Retrofit r = createRetrofit(wiki, getBasePath(wiki));
         Service s = r.create(Service.class);
         SERVICE_CACHE.put(hashCode, s);
         return s;
@@ -44,9 +42,7 @@ public final class ServiceFactory {
             return REST_SERVICE_CACHE.get(hashCode);
         }
 
-        Retrofit r = createRetrofit(wiki, TextUtils.isEmpty(Prefs.getRestbaseUriFormat())
-                        ? wiki.url() + "/" + RestService.REST_API_PREFIX
-                        : String.format(Prefs.getRestbaseUriFormat(), "https", wiki.authority()));
+        Retrofit r = createRetrofit(wiki, getRestBasePath(wiki));
 
         RestService s = r.create(RestService.class);
         REST_SERVICE_CACHE.put(hashCode, s);
@@ -56,6 +52,16 @@ public final class ServiceFactory {
     public static <T> T get(@NonNull WikiSite wiki, @Nullable String baseUrl, Class<T> service) {
         Retrofit r = createRetrofit(wiki, TextUtils.isEmpty(baseUrl) ? wiki.url() + "/" : baseUrl);
         return r.create(service);
+    }
+
+    public static String getBasePath(@NonNull WikiSite wiki) {
+        return TextUtils.isEmpty(Prefs.getMediaWikiBaseUrl()) ? wiki.url() + "/" : Prefs.getMediaWikiBaseUrl();
+    }
+
+    public static String getRestBasePath(@NonNull WikiSite wiki) {
+        return TextUtils.isEmpty(Prefs.getRestbaseUriFormat())
+                ? wiki.url() + "/" + RestService.REST_API_PREFIX
+                : String.format(Prefs.getRestbaseUriFormat(), "https", wiki.authority());
     }
 
     private static Retrofit createRetrofit(@NonNull WikiSite wiki, @NonNull String baseUrl) {

--- a/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.java
+++ b/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.java
@@ -41,9 +41,7 @@ public final class ServiceFactory {
         if (REST_SERVICE_CACHE.get(hashCode) != null) {
             return REST_SERVICE_CACHE.get(hashCode);
         }
-
         Retrofit r = createRetrofit(wiki, getRestBasePath(wiki));
-
         RestService s = r.create(RestService.class);
         REST_SERVICE_CACHE.put(hashCode, s);
         return s;
@@ -54,14 +52,18 @@ public final class ServiceFactory {
         return r.create(service);
     }
 
-    public static String getBasePath(@NonNull WikiSite wiki) {
+    private static String getBasePath(@NonNull WikiSite wiki) {
         return TextUtils.isEmpty(Prefs.getMediaWikiBaseUrl()) ? wiki.url() + "/" : Prefs.getMediaWikiBaseUrl();
     }
 
     public static String getRestBasePath(@NonNull WikiSite wiki) {
-        return TextUtils.isEmpty(Prefs.getRestbaseUriFormat())
+        String path = TextUtils.isEmpty(Prefs.getRestbaseUriFormat())
                 ? wiki.url() + "/" + RestService.REST_API_PREFIX
                 : String.format(Prefs.getRestbaseUriFormat(), "https", wiki.authority());
+        if (!path.endsWith("/")) {
+            path += "/";
+        }
+        return path;
     }
 
     private static Retrofit createRetrofit(@NonNull WikiSite wiki, @NonNull String baseUrl) {

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -22,6 +22,7 @@ import org.wikipedia.WikipediaApp;
 import org.wikipedia.analytics.EditFunnel;
 import org.wikipedia.bridge.CommunicationBridge;
 import org.wikipedia.bridge.CommunicationBridge.CommunicationBridgeListener;
+import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.dataclient.okhttp.OkHttpWebViewClient;
 import org.wikipedia.edit.EditSectionActivity;
@@ -209,7 +210,7 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
     public void showPreview(final PageTitle title, final String wikiText) {
         hideSoftKeyboard(requireActivity());
         parentActivity.showProgressBar(true);
-        String url = model.getTitle().getWikiSite().uri() + PAGE_HTML_PREVIEW_ENDPOINT + title.getPrefixedText();
+        String url = UriUtil.encodeOkHttpUrl(ServiceFactory.getRestBasePath(model.getTitle().getWikiSite()) + PAGE_HTML_PREVIEW_ENDPOINT, title.getPrefixedText());
         String postData;
         postData = "wikitext=" + UriUtil.encodeURL(wikiText);
         webview.postUrl(url, postData.getBytes());

--- a/app/src/main/java/org/wikipedia/page/PageCacher.java
+++ b/app/src/main/java/org/wikipedia/page/PageCacher.java
@@ -40,7 +40,7 @@ final class PageCacher {
 
     private static Observable<okhttp3.Response> mobileHtmlReq(@NonNull PageTitle pageTitle) {
         Request request = new Request.Builder().url(UriUtil.resolveProtocolRelativeUrl(pageTitle.getWikiSite(),
-                UriUtil.encodeOkHttpUrl(pageTitle.getWikiSite().url() + RestService.REST_API_PREFIX + RestService.PAGE_HTML_ENDPOINT,
+                UriUtil.encodeOkHttpUrl(ServiceFactory.getRestBasePath(pageTitle.getWikiSite()) + RestService.PAGE_HTML_ENDPOINT,
                         pageTitle.getPrefixedText())))
                 .addHeader("Accept-Language", WikipediaApp.getInstance().getAcceptLanguage(pageTitle.getWikiSite()))
                 .build();

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -966,7 +966,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         linkHandler = new LinkHandler(requireActivity()) {
             @Override public void onPageLinkClicked(@NonNull String anchor, @NonNull String linkText) {
                 dismissBottomSheet();
-                if (anchor.startsWith("cite")) {
+                if (anchor.startsWith("cite_note")) {
                     // It's a link to another reference within the page.
                     disposables.add(getReferences()
                             .subscribeOn(Schedulers.io())
@@ -1029,6 +1029,12 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
                             showBottomSheet(new ReferenceDialog(requireActivity(), selectedIndex, adjacentReferencesList, linkHandler));
                         }
                     }, L::d));
+        });
+        bridge.addListener("back_link", (String messageType, JsonObject payload) -> {
+            JsonArray backLinks = payload.getAsJsonArray("backLinks");
+            if (backLinks.size() > 0) {
+                linkHandler.onPageLinkClicked(backLinks.get(0).getAsJsonObject().get("id").getAsString(), "");
+            }
         });
         bridge.addListener("image", (String messageType, JsonObject messagePayload) -> {
             String href = decodeURL(messagePayload.get("href").getAsString());

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -232,7 +232,7 @@ public class PageFragmentLoadState {
                         }));
 
         // And finally, start blasting the HTML into the WebView.
-        bridge.resetHtml(model.getTitle().getWikiSite().url(), model.getTitle());
+        bridge.resetHtml(model.getTitle());
     }
 
     private void showPageOfflineMessage(@Nullable String dateHeader) {

--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.java
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.java
@@ -302,7 +302,7 @@ public class SavedPageSyncService extends JobIntentService {
 
     private Observable<okhttp3.Response> reqMobileHTML(@NonNull PageTitle pageTitle) {
         Request request = makeUrlRequest(CacheControl.FORCE_NETWORK, pageTitle.getWikiSite(),
-                UriUtil.encodeOkHttpUrl(pageTitle.getWikiSite().url() + RestService.REST_API_PREFIX + RestService.PAGE_HTML_ENDPOINT,
+                UriUtil.encodeOkHttpUrl(ServiceFactory.getRestBasePath(pageTitle.getWikiSite()) + RestService.PAGE_HTML_ENDPOINT,
                         pageTitle.getPrefixedText()))
                 .addHeader("Accept-Language", WikipediaApp.getInstance().getAcceptLanguage(pageTitle.getWikiSite()))
                 .addHeader(OfflineCacheInterceptor.SAVE_HEADER, OfflineCacheInterceptor.SAVE_HEADER_SAVE)

--- a/app/src/main/java/org/wikipedia/util/SavedPagesConversionUtil.java
+++ b/app/src/main/java/org/wikipedia/util/SavedPagesConversionUtil.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.Constants;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.RestService;
+import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.okhttp.OfflineCacheInterceptor;
 import org.wikipedia.dataclient.page.PageLead;
 import org.wikipedia.json.GsonUnmarshaller;
@@ -31,13 +32,12 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 import okio.ByteString;
 
-import static org.wikipedia.dataclient.RestService.REST_API_PREFIX;
 import static org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory.CACHE_DIR_NAME;
 
 // TODO: remove after two releases.
 public final class SavedPagesConversionUtil {
-    private static final String LEAD_SECTION_ENDPOINT = "/page/mobile-sections-lead/";
-    private static final String REMAINING_SECTIONS_ENDPOINT = "/page/mobile-sections-remaining/";
+    private static final String LEAD_SECTION_ENDPOINT = "page/mobile-sections-lead/";
+    private static final String REMAINING_SECTIONS_ENDPOINT = "page/mobile-sections-remaining/";
     private static final int MAX_ATTEMPTS = 3;
 
     @SuppressLint("StaticFieldLeak")
@@ -140,8 +140,8 @@ public final class SavedPagesConversionUtil {
         String baseUrl = CURRENT_PAGE.wiki().url();
         String title = CURRENT_PAGE.apiTitle();
 
-        String leadSectionUrl = UriUtil.encodeOkHttpUrl(baseUrl + REST_API_PREFIX + LEAD_SECTION_ENDPOINT, title);
-        String remainingSectionsUrl = UriUtil.encodeOkHttpUrl(baseUrl + REST_API_PREFIX + REMAINING_SECTIONS_ENDPOINT, title);
+        String leadSectionUrl = UriUtil.encodeOkHttpUrl(ServiceFactory.getRestBasePath(CURRENT_PAGE.wiki()) + LEAD_SECTION_ENDPOINT, title);
+        String remainingSectionsUrl = UriUtil.encodeOkHttpUrl(ServiceFactory.getRestBasePath(CURRENT_PAGE.wiki()) + REMAINING_SECTIONS_ENDPOINT, title);
 
         // Do the cache files exist for this page?
         File offlineCacheDir = new File(WikipediaApp.getInstance().getFilesDir(), CACHE_DIR_NAME);
@@ -215,10 +215,9 @@ public final class SavedPagesConversionUtil {
                     .replace("@@DESCRIPTION@@", StringUtils.defaultString(pageLead.getDescription()))
                     .replace("@@DESCRIPTION_SOURCE@@", StringUtils.defaultString(pageLead.getDescriptionSource()));
 
-            String baseUrl = CURRENT_PAGE.wiki().url();
             String title = CURRENT_PAGE.apiTitle();
 
-            String summaryUrl = UriUtil.encodeOkHttpUrl(baseUrl + REST_API_PREFIX + "/page/summary/", title);
+            String summaryUrl = UriUtil.encodeOkHttpUrl(ServiceFactory.getRestBasePath(CURRENT_PAGE.wiki()) + "page/summary/", title);
             String date = DateUtil.getHttpLastModifiedDate(new Date());
             try {
                 date = DateUtil.getHttpLastModifiedDate(DateUtil.iso8601DateParse(pageLead.getLastModified()));
@@ -233,9 +232,7 @@ public final class SavedPagesConversionUtil {
     }
 
     private static void storeConvertedHtml(String html) {
-        String baseUrl = CURRENT_PAGE.wiki().url();
-        String title = CURRENT_PAGE.apiTitle();
-        String mobileHtmlUrl = UriUtil.encodeOkHttpUrl(baseUrl + REST_API_PREFIX + RestService.PAGE_HTML_ENDPOINT, title);
+        String mobileHtmlUrl = UriUtil.encodeOkHttpUrl(ServiceFactory.getRestBasePath(CURRENT_PAGE.wiki()) + RestService.PAGE_HTML_ENDPOINT, CURRENT_PAGE.apiTitle());
 
         OfflineCacheInterceptor.createCacheItemFor(CURRENT_PAGE, mobileHtmlUrl, html, "text/html", DateUtil.getHttpLastModifiedDate(new Date()));
     }


### PR DESCRIPTION
Currently if we override the base REST url in developer settings, it won't actually take effect for `mobile-html` calls.