### PR TITLE
Hide HTML tags from title in Share-a-fact

### DIFF
--- a/app/src/main/java/org/wikipedia/page/shareafact/ShareHandler.java
+++ b/app/src/main/java/org/wikipedia/page/shareafact/ShareHandler.java
@@ -111,7 +111,7 @@ public class ShareHandler {
                 .subscribe(imageLicense -> {
                     final Bitmap snippetBitmap = SnippetImage.getSnippetImage(fragment.requireContext(),
                             fragment.getLeadImageBitmap(),
-                            title.getDisplayText(),
+                            StringUtil.fromHtml(title.getDisplayText()),
                             fragment.getPage().isMainPage() ? "" : title.getDescription(),
                             selectedText,
                             imageLicense);
@@ -250,10 +250,10 @@ public class ShareHandler {
             rootView.findViewById(R.id.share_as_image_button)
                     .setOnClickListener((v) -> {
                         String introText = context.getString(R.string.snippet_share_intro,
-                                title.getDisplayText(),
+                                StringUtil.fromHtml(title.getDisplayText()),
                                 UriUtil.getUrlWithProvenance(context, title, R.string.prov_share_image));
-                        ShareUtil.shareImage(context, resultBitmap, title.getDisplayText(),
-                                title.getDisplayText(), introText);
+                        ShareUtil.shareImage(context, resultBitmap, title.getText(),
+                                StringUtil.removeHTMLTags(title.getDisplayText()), introText);
                         funnel.logShareIntent(selectedText, ShareMode.image);
                         completed = true;
                     });
@@ -274,9 +274,9 @@ public class ShareHandler {
         static void shareAsText(@NonNull Context context, @NonNull PageTitle title,
                                 @NonNull String selectedText, @Nullable ShareAFactFunnel funnel) {
             String introText = context.getString(R.string.snippet_share_intro,
-                    title.getDisplayText(),
+                    StringUtil.fromHtml(title.getDisplayText()),
                     UriUtil.getUrlWithProvenance(context, title, R.string.prov_share_text));
-            ShareUtil.shareText(context, title.getDisplayText(),
+            ShareUtil.shareText(context, StringUtil.removeHTMLTags(title.getDisplayText()),
                     constructShareText(selectedText, introText));
             if (funnel != null) {
                 funnel.logShareIntent(selectedText, ShareMode.text);

--- a/app/src/main/java/org/wikipedia/page/shareafact/SnippetImage.java
+++ b/app/src/main/java/org/wikipedia/page/shareafact/SnippetImage.java
@@ -55,7 +55,7 @@ public final class SnippetImage {
      * just use a black background.
      */
     public static Bitmap getSnippetImage(@NonNull Context context, @Nullable Bitmap leadImageBitmap,
-                                         @NonNull String title, @Nullable String description,
+                                         @NonNull CharSequence title, @Nullable String description,
                                          @NonNull CharSequence textSnippet,
                                          @NonNull ImageLicense license) {
         Bitmap resultBitmap = drawBackground(leadImageBitmap, license);
@@ -169,7 +169,7 @@ public final class SnippetImage {
         return top;
     }
 
-    private static void drawTitle(@NonNull Canvas canvas, @NonNull String title, int top,
+    private static void drawTitle(@NonNull Canvas canvas, @NonNull CharSequence title, int top,
                                   boolean isArticleRTL) {
         final int marginBottom = 0;
         final int maxHeight = 70;


### PR DESCRIPTION
Some display titles include HTML tags. This patch ensures that
(1) the visible title does not show HTML tags anymore and
(2) the file name used for sharing an image does not include HTML tags.

Bug: https://phabricator.wikimedia.org/T246847