### PR TITLE
The dark background in the splash layout implies that there would be …

### DIFF
--- a/app/src/main/res/drawable/splash_bg.xml
+++ b/app/src/main/res/drawable/splash_bg.xml
@@ -2,12 +2,12 @@
 <!-- TODO: Move this to drawable folder when no longer supporting API levels < 21 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:drawable="@color/base10" />
+    <item android:drawable="@color/base100" />
 
     <item android:bottom="128dp">
         <shape android:shape="rectangle">
             <gradient android:type="radial" android:gradientRadius="100dp"
-                android:startColor="@color/base30" android:endColor="@color/base10" />
+                android:startColor="@color/base90" android:endColor="@color/base100" />
         </shape>
     </item>
 


### PR DESCRIPTION
Changing the dark background in the splash layout to white, implicitly showing a white-themed application at start.