### PR TITLE
Remove unused language count method

### DIFF
--- a/app/src/main/java/org/wikipedia/util/L10nUtil.java
+++ b/app/src/main/java/org/wikipedia/util/L10nUtil.java
@@ -203,20 +203,6 @@ public final class L10nUtil {
         }
     }
 
-    // TODO: remove this if we can get correct language counts from server
-    public static int getUpdatedLanguageCountIfNeeded(String getLanguageCode, int originalLanguageCount) {
-
-        int updatedLanguageCount = originalLanguageCount;
-
-        if (getLanguageCode.equals(CHINESE_LANGUAGE_CODE)) {
-            updatedLanguageCount = updatedLanguageCount + 2; // for both Traditional and Simplified
-        } else if (getLanguageCode.equals(TRADITIONAL_CHINESE_LANGUAGE_CODE) || getLanguageCode.equals(SIMPLIFIED_CHINESE_LANGUAGE_CODE)) {
-            updatedLanguageCount = updatedLanguageCount + 1;
-        }
-
-        return updatedLanguageCount;
-    }
-
     private L10nUtil() {
     }
 }


### PR DESCRIPTION
Looks like we don't have to show the language count on the footer anymore.