### PR TITLE
Minor margin fix for ImageTag feed card

### DIFF
--- a/app/src/main/res/layout/view_suggested_edit_card.xml
+++ b/app/src/main/res/layout/view_suggested_edit_card.xml
@@ -36,7 +36,6 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:paddingStart="16dp"
-            android:paddingTop="11dp"
             android:paddingEnd="16dp"
             android:paddingBottom="16dp">
 
@@ -48,6 +47,7 @@
                 android:fontFamily="serif"
                 android:lineSpacingExtra="4sp"
                 android:maxLines="2"
+                android:layout_marginTop="11dp"
                 android:textColor="?attr/primary_text_color"
                 android:textSize="24sp"
                 tools:text="Lorem ipsum" />


### PR DESCRIPTION
**Phab:** https://phabricator.wikimedia.org/T244866

The margin needs to be on the title view, because, we need to hide the margin when the view is hidden, otherwise we will have an unnecessary top margin.