### PR TITLE
Harden bridge handlers against deserialization errors.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -132,9 +132,14 @@ public class CommunicationBridge {
                 L.e("No such message type registered: " + message.getAction());
                 return false;
             }
-            List<JSEventListener> listeners = eventListeners.get(message.getAction());
-            for (JSEventListener listener : listeners) {
-                listener.onMessage(message.getAction(), message.getData());
+            try {
+                List<JSEventListener> listeners = eventListeners.get(message.getAction());
+                for (JSEventListener listener : listeners) {
+                    listener.onMessage(message.getAction(), message.getData());
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                L.logRemoteErrorIfProd(e);
             }
             return false;
         }


### PR DESCRIPTION
The messages passed to us by mobile-html are bound to change in the future in unexpected ways, which can cause our bridge handlers to crash.  Instead of crashing in production, let's just log the exceptions remotely.