### PR TITLE
Show preview dialog title in the correct language variant

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
@@ -222,13 +222,7 @@ public class LinkPreviewDialog extends ExtendedBottomSheetDialogFragment
                     funnel.setPageId(summary.getPageId());
                     pageTitle.setThumbUrl(summary.getThumbnailUrl());
                     revision = summary.getRevision();
-                    // TODO: Remove this logic once Parsoid starts supporting language variants.
-                    if (pageTitle.getWikiSite().languageCode().equals(pageTitle.getWikiSite().subdomain())) {
-                        titleText.setText(StringUtil.fromHtml(summary.getDisplayTitle()));
-                    } else {
-                        titleText.setText(StringUtil.fromHtml(pageTitle.getDisplayText()));
-                    }
-
+                    titleText.setText(StringUtil.fromHtml(summary.getDisplayTitle()));
                     // TODO: remove after the restbase endpoint supports ZH variants
                     pageTitle.setText(StringUtil.removeNamespace(summary.getApiTitle()));
                     showPreview(new LinkPreviewContents(summary, pageTitle.getWikiSite()));


### PR DESCRIPTION
Since we are fetching the summary endpoint for correct `displayTitle`, we should use it on the preview dialog. 