### PR TITLE
Possibly fix elusive saveInstanceState bug!

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.java
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.java
@@ -116,20 +116,6 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        try {
-            // TODO: remove when bug is fixed.
-            // https://appcenter.ms/orgs/ci-apps-hockeyapp-f5mf/apps/Wikipedia-Beta/crashes/errors/2836099990u/overview
-            super.onStart();
-        } catch (Exception e) {
-            String className = this.getLocalClassName();
-            RuntimeException ex = new RuntimeException("Exception in " + className + ": " + e.getMessage());
-            ex.setStackTrace(e.getStackTrace());
-            throw ex;
-        }
-    }
-
-    @Override
     protected void onStop() {
         WikipediaApp.getInstance().getSessionFunnel().persistSession();
         super.onStop();

--- a/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.Menu
+import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 
@@ -24,7 +25,7 @@ class NavTabLayout constructor(context: Context, attrs: AttributeSet) : BottomNa
             if (!AccountUtil.isLoggedIn() && NavTab.SUGGESTED_EDITS === navTab) {
                 continue
             }
-            menu.add(Menu.NONE, i, i, navTab.text()).setIcon(navTab.icon())
+            menu.add(Menu.NONE, View.generateViewId(), i, navTab.text()).setIcon(navTab.icon())
         }
         fixTextStyle()
     }


### PR DESCRIPTION
You see, when we create the bottom navigation items, the "index" that we pass into the `add()` function will actually become the `id` of the resulting View.  So, if we pass an index of 1, the view will have an id of `id/0x1`, which can conflict with the id that `ViewPager2` automatically assigns to its `RecyclerView`.

This change will start using the `View.generateViewId()` function instead, so that it's guaranteed to no longer conflict with any other View id.

Even though I haven't been able to reproduce the actual crash reliably, I'm hopeful that this is the correct fix.