### PR TITLE
Add DEFAULT_RESTBASE_URI_FORMAT as a buildConfigField 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,6 +85,18 @@ android {
             signingConfig signingConfigs.debug
             dimension 'default'
         }
+        labsPCS {
+            versionName computeVersionName('labsPCS')
+            applicationIdSuffix 'labsPCS'
+            signingConfig signingConfigs.debug
+            dimension 'default'
+        }
+        localPCS {
+            versionName computeVersionName('labsPCS')
+            applicationIdSuffix 'labsPCS'
+            signingConfig signingConfigs.debug
+            dimension 'default'
+        }
         prod {
             versionName computeVersionName('r')
             signingConfig signingConfigs.prod
@@ -118,6 +130,16 @@ android {
             manifestPlaceholders = [customChannel:getProperty('customChannel').toString()]
             signingConfig signingConfigs.prod
             dimension 'default'
+        }
+    }
+
+    applicationVariants.all { variant ->
+        if (variant.getName().startsWith("labsPCS")) {
+            variant.buildConfigField "String", "DEFAULT_RESTBASE_URI_FORMAT", '"https://mobileapps.wmflabs.org/%2$s/v1/"'
+        } else if (variant.getName().startsWith("localPCS")) {
+            variant.buildConfigField "String", "DEFAULT_RESTBASE_URI_FORMAT", '"http://10.0.2.2:8888/%2$s/v1/"'
+        } else {
+            variant.buildConfigField "String", "DEFAULT_RESTBASE_URI_FORMAT", '"%1$s://%2$s/api/rest_v1/"'
         }
     }
 

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.reflect.TypeToken;
 
+import org.wikipedia.BuildConfig;
 import org.wikipedia.R;
 import org.wikipedia.analytics.SessionData;
 import org.wikipedia.analytics.SessionFunnel;
@@ -266,7 +267,7 @@ public final class Prefs {
     @NonNull
     public static String getRestbaseUriFormat() {
         return defaultIfBlank(getString(R.string.preference_key_restbase_uri_format, null),
-                "%1$s://%2$s/api/rest_v1/");
+                BuildConfig.DEFAULT_RESTBASE_URI_FORMAT);
     }
 
     @NonNull


### PR DESCRIPTION
This allows for `labsPCS` and `localPCS` build variants. I added it as a separate loop to avoid having to declare it for each variant. I initially implemented `labsPCS` and `localPCS` as `buildTypes` with `initWith buildTypes.debug` and an override for `DEFAULT_RESTBASE_URI_FORMAT`, but a warning was thrown on every build about overriding the value for `DEFAULT_RESTBASE_URI_FORMAT`. Open to suggestions on different ways to implement this.