### PR TITLE
Fix potential crashes when getting the section list from Page

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditHandler.java
+++ b/app/src/main/java/org/wikipedia/edit/EditHandler.java
@@ -36,7 +36,10 @@ public class EditHandler implements CommunicationBridge.JSEventListener {
         bridge.addListener("add_title_description", this);
     }
 
-    public void setPage(Page page) {
+    public void setPage(@Nullable Page page) {
+        if (page == null) {
+            return;
+        }
         this.currentPage = page;
         this.funnel = new ProtectedEditAttemptFunnel(WikipediaApp.getInstance(), page.getTitle().getWikiSite());
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -450,6 +450,9 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     }
 
     public void onPageMetadataLoaded() {
+        if (model.getPage() == null) {
+            return;
+        }
         editHandler.setPage(model.getPage());
         refreshView.setEnabled(true);
         refreshView.setRefreshing(false);
@@ -982,24 +985,26 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             });
 
             bridge.evaluate(JavaScriptActionHandler.getSections(), value -> {
+                if (model.getPage() == null) {
+                    return;
+                }
                 Section[] secArray = GsonUtil.getDefaultGson().fromJson(value, Section[].class);
                 if (secArray != null) {
                     sections = new ArrayList<>(Arrays.asList(secArray));
                     sections.add(0, new Section(0, 0, model.getTitle().getDisplayText(), model.getTitle().getDisplayText(), ""));
-                    if (model.getPage() != null) {
-                        model.getPage().setSections(sections);
-                    }
+                    model.getPage().setSections(sections);
                 }
                 tocHandler.setupToC(model.getPage(), model.getTitle().getWikiSite(), pageFragmentLoadState.isFirstPage());
                 tocHandler.setEnabled(true);
             });
 
             bridge.evaluate(JavaScriptActionHandler.getProtection(), value -> {
-                Protection protection = GsonUtil.getDefaultGson().fromJson(value, Protection.class);
-                if (model.getPage() != null) {
-                    model.getPage().getPageProperties().setProtection(protection);
-                    bridge.execute(JavaScriptActionHandler.setUpEditButtons(true, !model.getPage().getPageProperties().canEdit()));
+                if (model.getPage() == null) {
+                    return;
                 }
+                Protection protection = GsonUtil.getDefaultGson().fromJson(value, Protection.class);
+                model.getPage().getPageProperties().setProtection(protection);
+                bridge.execute(JavaScriptActionHandler.setUpEditButtons(true, !model.getPage().getPageProperties().canEdit()));
             });
 
         });

--- a/app/src/main/java/org/wikipedia/page/ToCHandler.java
+++ b/app/src/main/java/org/wikipedia/page/ToCHandler.java
@@ -130,7 +130,10 @@ public class ToCHandler implements ObservableWebView.OnClickListener,
     }
 
     @SuppressLint("RtlHardcoded")
-    void setupToC(@NonNull Page page, @NonNull WikiSite wiki, boolean firstPage) {
+    void setupToC(@Nullable Page page, @NonNull WikiSite wiki, boolean firstPage) {
+        if (page == null) {
+            return;
+        }
         adapter.setPage(page);
         rtl = L10nUtil.isLangRTL(wiki.languageCode());
         showOnboading = Prefs.isTocTutorialEnabled() && !page.isMainPage() && !firstPage;


### PR DESCRIPTION
If you exiting an article while loading and then enter another article so quickly, you will get a chance to see a crash. 

```
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err: java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.List org.wikipedia.page.Page.getSections()' on a null object reference
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at org.wikipedia.page.ToCHandler$ToCAdapter.setPage(ToCHandler.java:233)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at org.wikipedia.page.ToCHandler.setupToC(ToCHandler.java:134)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at org.wikipedia.page.PageFragment.lambda$null$10$PageFragment(PageFragment.java:991)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at org.wikipedia.page.-$$Lambda$PageFragment$ONfORjp8FWFZ60HUcHwmwOHaI4U.onReceiveValue(Unknown Source:4)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at u2.a(PG:1)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at org.chromium.android_webview.AwContents.a(PG:210)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at Ql.run(Unknown Source:4)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at android.os.MessageQueue.nativePollOnce(Native Method)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at android.os.MessageQueue.next(MessageQueue.java:336)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at android.os.Looper.loop(Looper.java:174)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at android.app.ActivityThread.main(ActivityThread.java:7356)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at java.lang.reflect.Method.invoke(Native Method)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
2020-03-31 14:08:13.840 31057-31057/org.wikipedia.dev W/System.err:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```