### PR TITLE
Removed "successfully" from several messages

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
     <string name="menu_login">Log in</string>
     <string name="login_activity_title">Log in to Wikipedia</string>
     <string name="login_in_progress_dialog_message">Logging you in…</string>
-    <string name="login_success_toast">Logged in successfully!</string>
+    <string name="login_success_toast">Logged in!</string>
     <string name="reset_password_title">Set your password</string>
     <string name="reset_password_description">You logged in with a temporary password. To finish logging in, please set your new password here.</string>
     <string name="reset_password_hint">New password</string>
@@ -272,7 +272,7 @@
     <string name="gallery_menu_share">Share</string>
     <string name="gallery_share_error">Could not share image: %s</string>
     <string name="gallery_save_progress">Downloading file…</string>
-    <string name="gallery_save_success">File saved successfully.</string>
+    <string name="gallery_save_success">File saved.</string>
     <string name="gallery_error_video_failed">Could not play the video.</string>
     <string name="gallery_save_image_write_permission_rationale">Permission to write to storage on your device is required for saving images.</string>
     <string name="gallery_add_image_caption_button">Add image caption</string>
@@ -344,7 +344,7 @@
     <string name="page_footer_license_text">Content is available under $1 unless otherwise noted</string>
     <string name="empty_tab_title">New tab</string>
     <string name="menu_save_all_tabs">Save all tabs</string>
-    <string name="save_all_tabs_success_message">Successfully added all articles in open tabs to %s.</string>
+    <string name="save_all_tabs_success_message">Added all articles in open tabs to %s.</string>
     <string name="save_all_tabs_articles_already_exist_message">All good! %s already contains all articles in open tabs.</string>
 
     <!-- Crash reporter -->
@@ -476,7 +476,7 @@
         <item quantity="one">This article will no longer be available offline.</item>
         <item quantity="other">These articles will no longer be available offline.</item>
     </plurals>
-    <string name="reading_list_toast_last_sync">Reading lists synced successfully</string>
+    <string name="reading_list_toast_last_sync">Reading lists synced</string>
     <string name="reading_list_menu_last_sync">Last sync: %s</string>
     <string name="reading_list_remove_list_dialog_ok_button_text">OK</string>
     <string name="reading_list_delete_dialog_ok_button_text">OK</string>


### PR DESCRIPTION
This word is usually unnecessary. See
https://www.mediawiki.org/wiki/Localisation#Avoid_jargon_and_slang