### PR TITLE
Show progressCard when requesting APIs on the Feed

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedCoordinatorBase.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedCoordinatorBase.java
@@ -7,7 +7,10 @@ import androidx.annotation.Nullable;
 
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.feed.accessibility.AccessibilityCard;
+import org.wikipedia.feed.aggregated.AggregatedFeedContentClient;
+import org.wikipedia.feed.announcement.AnnouncementClient;
 import org.wikipedia.feed.announcement.FundraisingCard;
+import org.wikipedia.feed.becauseyouread.BecauseYouReadClient;
 import org.wikipedia.feed.dataclient.FeedClient;
 import org.wikipedia.feed.dayheader.DayHeaderCard;
 import org.wikipedia.feed.featured.FeaturedArticleCard;
@@ -19,6 +22,7 @@ import org.wikipedia.feed.news.NewsListCard;
 import org.wikipedia.feed.offline.OfflineCard;
 import org.wikipedia.feed.onthisday.OnThisDayCard;
 import org.wikipedia.feed.progress.ProgressCard;
+import org.wikipedia.feed.suggestededits.SuggestedEditsFeedClient;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.DeviceUtil;
 import org.wikipedia.util.ThrowableUtil;
@@ -95,7 +99,7 @@ public abstract class FeedCoordinatorBase {
         this.wiki = wiki;
 
         if (cards.size() == 0) {
-            insertCard(progressCard, 0);
+            requestProgressCard();
         }
 
         if (DeviceUtil.isAccessibilityEnabled()) {
@@ -166,6 +170,9 @@ public abstract class FeedCoordinatorBase {
         if (!pendingClients.isEmpty()) {
             pendingClients.remove(0);
         }
+        if (!(getLastCard() instanceof ProgressCard) && shouldShowProgressCard(pendingClients.get(0))) {
+            requestProgressCard();
+        }
         requestCard(wiki);
     }
 
@@ -183,6 +190,12 @@ public abstract class FeedCoordinatorBase {
 
     private Card getLastCard() {
         return cards.size() > 1 ? cards.get(cards.size() - 1) : null;
+    }
+
+    private void requestProgressCard() {
+        if (!(getLastCard() instanceof ProgressCard)) {
+            appendCard(new ProgressCard());
+        }
     }
 
     private void removeProgressCard() {
@@ -280,5 +293,12 @@ public abstract class FeedCoordinatorBase {
                 || card instanceof MostReadListCard || card instanceof FeaturedArticleCard
                 || card instanceof FeaturedImageCard
                 || card instanceof FundraisingCard;
+    }
+
+    private boolean shouldShowProgressCard(@NonNull FeedClient pendingClient) {
+        return pendingClient instanceof SuggestedEditsFeedClient
+                || pendingClient instanceof AggregatedFeedContentClient
+                || pendingClient instanceof AnnouncementClient
+                || pendingClient instanceof BecauseYouReadClient;
     }
 }


### PR DESCRIPTION
If you keep scrolling to the bottom of the feed, you will see certain feed cards like `SuggestedEditsFeedCard` or `BecauseYouReadCard`  require a longer time on loading.