### PR TITLE
Remove onSearchRequested() from PageActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -176,7 +176,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         boolean languageChanged = false;
         if (savedInstanceState != null) {
             if (savedInstanceState.getBoolean("isSearching")) {
-                openSearchActivity(TOOLBAR, null);
+                openSearchActivity();
             }
             String language = savedInstanceState.getString(LANGUAGE_CODE_BUNDLE_KEY);
             languageChanged = !app.getAppOrSystemLanguageCode().equals(language);
@@ -196,7 +196,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
     @OnClick(R.id.page_toolbar_button_search)
     public void onSearchButtonClicked() {
-        openSearchActivity(TOOLBAR, null);
+        openSearchActivity();
     }
 
     @OnClick(R.id.page_toolbar_button_tabs)
@@ -241,12 +241,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
             default:
                 return super.onOptionsItemSelected(item);
         }
-    }
-
-    @Override
-    public boolean onSearchRequested() {
-        openSearchActivity(TOOLBAR, null);
-        return true;
     }
 
     private void goToMainTab(@NonNull NavTab tab) {
@@ -769,8 +763,8 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
                 .show();
     }
 
-    private void openSearchActivity(@NonNull InvokeSource source, @Nullable String query) {
-        Intent intent = SearchActivity.newIntent(this, source, query);
+    private void openSearchActivity() {
+        Intent intent = SearchActivity.newIntent(this, TOOLBAR, null);
         startActivity(intent);
     }
 


### PR DESCRIPTION
Since the doesn't show `SearchView` on the `PageActivity`, it should be safe to remove the `onSearchRequested()`. This PR also updates the `openSearchActivity()` because it is always sending `TOOLBAR` for `InvokeSource` and `null` for the query.