### PR TITLE
Prevent showing empty ImageView on featured article card

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCardView.java
@@ -43,6 +43,7 @@ public class FeaturedArticleCardView extends DefaultFeedCardView<FeaturedArticle
 
     @BindView(R.id.view_featured_article_card_header) CardHeaderView headerView;
     @BindView(R.id.view_featured_article_card_footer) ActionFooterView footerView;
+    @BindView(R.id.view_featured_article_card_image_container) View imageContainerView;
     @BindView(R.id.view_featured_article_card_image) FaceAndColorDetectImageView imageView;
     @BindView(R.id.view_featured_article_card_article_title) TextView articleTitleView;
     @BindView(R.id.view_featured_article_card_article_subtitle) GoneIfEmptyTextView articleSubtitleView;
@@ -153,9 +154,9 @@ public class FeaturedArticleCardView extends DefaultFeedCardView<FeaturedArticle
 
     private void image(@Nullable Uri uri) {
         if (uri == null) {
-            imageView.setVisibility(GONE);
+            imageContainerView.setVisibility(GONE);
         } else {
-            imageView.setVisibility(VISIBLE);
+            imageContainerView.setVisibility(VISIBLE);
             imageView.loadImage(uri);
         }
     }

--- a/app/src/main/res/layout/view_card_featured_article.xml
+++ b/app/src/main/res/layout/view_card_featured_article.xml
@@ -22,7 +22,7 @@
             android:id="@+id/view_featured_article_card_image"
             style="@style/ImageViewDefault"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="192dp"
             android:contentDescription="@null"/>
 
         <View

--- a/app/src/main/res/layout/view_card_featured_article.xml
+++ b/app/src/main/res/layout/view_card_featured_article.xml
@@ -11,10 +11,11 @@
         android:layout_height="@dimen/view_card_header_height"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <FrameLayout
-        android:id="@+id/viewArticleImagePlaceholder"
+    <LinearLayout
+        android:id="@+id/view_featured_article_card_image_container"
         android:layout_width="match_parent"
-        android:layout_height="192dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
         app:layout_constraintTop_toBottomOf="@id/view_featured_article_card_header">
 
         <org.wikipedia.views.FaceAndColorDetectImageView
@@ -22,16 +23,13 @@
             style="@style/ImageViewDefault"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:contentDescription="@null" />
+            android:contentDescription="@null"/>
 
-    </FrameLayout>
-
-    <View
-        android:id="@+id/view_featured_article_card_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?attr/material_theme_border_color"
-        app:layout_constraintTop_toBottomOf="@id/viewArticleImagePlaceholder" />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?attr/material_theme_border_color" />
+    </LinearLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/view_featured_article_card_text_container"
@@ -41,7 +39,7 @@
         android:clickable="true"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
-        app:layout_constraintTop_toBottomOf="@id/view_featured_article_card_divider">
+        app:layout_constraintTop_toBottomOf="@id/view_featured_article_card_image_container">
 
         <TextView
             android:id="@+id/view_featured_article_card_article_title"


### PR DESCRIPTION
Today's (2020/04/08) featured article card shows an empty `ImageView`, which is also reproducible on the production app, and we should fix it.