### PR TITLE
Quick follow-up: remove Define item only for non-English articles.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -713,7 +713,8 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
         for (int i = 0; i < menu.size(); i++) {
             String title = menu.getItem(i).getTitle().toString();
-            if (!title.contains(getString(R.string.search_hint)) && !title.contains(getString(R.string.menu_text_select_define))) {
+            if (!title.contains(getString(R.string.search_hint))
+                    && !(title.contains(getString(R.string.menu_text_select_define)) && pageFragment.getShareHandler().shouldEnableWiktionaryDialog())) {
                 menuItemsList.add(menu.getItem(i));
             }
         }

--- a/app/src/main/java/org/wikipedia/page/shareafact/ShareHandler.java
+++ b/app/src/main/java/org/wikipedia/page/shareafact/ShareHandler.java
@@ -97,11 +97,7 @@ public class ShareHandler {
         funnel.logHighlight();
     }
 
-    private boolean shouldEnableWiktionaryDialog() {
-        return isWiktionaryDialogEnabledForArticleLanguage();
-    }
-
-    private boolean isWiktionaryDialogEnabledForArticleLanguage() {
+    public boolean shouldEnableWiktionaryDialog() {
         return Arrays.asList(WiktionaryDialog.getEnabledLanguages())
                 .contains(fragment.getTitle().getWikiSite().languageCode());
     }


### PR DESCRIPTION
Notice that we only show the Wiktionary dialog for English articles, because we don't yet have the capability of parsing non-English Wiktionary pages. Therefore, we should only remove the system-provided Define option for non-English articles.