### PR TITLE
Use PhotoView in the Gallery for zooming images.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -204,6 +204,7 @@ dependencies {
     implementation 'com.microsoft.appcenter:appcenter-crashes:3.1.0'
     implementation 'org.apache.commons:commons-lang3:3.9'
     implementation 'org.jsoup:jsoup:1.12.1'
+    implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterknifeVersion"
 

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -12,7 +12,6 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.Menu;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -58,7 +57,6 @@ import org.wikipedia.util.ImageUrlUtil;
 import org.wikipedia.util.ShareUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
-import org.wikipedia.views.ImageZoomHelper;
 import org.wikipedia.views.PositionAwareFragmentStateAdapter;
 import org.wikipedia.views.ViewAnimations;
 import org.wikipedia.views.WikiErrorView;
@@ -131,7 +129,6 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
 
     private boolean controlsShowing = true;
     private GalleryPageChangeListener pageChangeListener = new GalleryPageChangeListener();
-    private ImageZoomHelper imageZoomHelper;
 
     @Nullable private GalleryFunnel funnel;
 
@@ -214,7 +211,6 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         galleryPager.registerOnPageChangeCallback(pageChangeListener);
         galleryPager.setOffscreenPageLimit(2);
 
-        imageZoomHelper = new ImageZoomHelper(this);
         funnel = new GalleryFunnel(app, getIntent().getParcelableExtra(EXTRA_WIKI),
                 getIntent().getIntExtra(EXTRA_SOURCE, 0));
 
@@ -318,11 +314,6 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
             layOutGalleryDescription();
             setResult(ACTIVITY_RESULT_IMAGE_CAPTION_ADDED);
         }
-    }
-
-    @Override
-    public boolean dispatchTouchEvent(MotionEvent event) {
-        return imageZoomHelper.onDispatchTouchEvent(event) || super.dispatchTouchEvent(event);
     }
 
     @OnClick(R.id.gallery_caption_edit_button) void onEditClick(View v) {

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
@@ -37,7 +37,6 @@ import org.wikipedia.util.PermissionUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.UriUtil;
 import org.wikipedia.util.log.L;
-import org.wikipedia.views.ImageZoomHelper;
 import org.wikipedia.views.ViewUtil;
 
 import butterknife.BindView;
@@ -148,13 +147,6 @@ public class GalleryItemFragment extends Fragment {
             }
             mediaController.hide();
         }
-        ImageZoomHelper.clearViewZoomable(imageView);
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        ImageZoomHelper.setViewZoomable(imageView);
     }
 
     private void updateProgressBar(boolean visible) {

--- a/app/src/main/res/layout/fragment_gallery_item.xml
+++ b/app/src/main/res/layout/fragment_gallery_item.xml
@@ -35,7 +35,7 @@
             app:srcCompat="@drawable/ic_play_circle" />
     </FrameLayout>
 
-    <ImageView
+    <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/gallery_image"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url "https://jitpack.io" }
         google()
         mavenLocal()
     }


### PR DESCRIPTION
After the switchover to Glide, the zooming functionality in the Gallery was relying on our custom pinch-to-zoom function, which snaps the image back when the pinch is released. This is not desirable, since we want the image to remain zoomed after pinching.

This PR adds the `PhotoView` component, which is a very popular component precisely for zooming ImageViews..  We were actually going to use this component a long time ago, but it's not compatible with Fresco, which is why we couldn't use it.

P.S. After including this library, our method count is still about 42000, so we're still good for a while.