### PR TITLE
Fix encoding of quotes in ToC section titles.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -66,7 +66,7 @@ object JavaScriptActionHandler {
 
     @JvmStatic
     fun prepareToScrollTo(anchorLink: String, highlight: Boolean): String {
-        return "pcs.c1.Page.prepareForScrollToAnchor(\"${anchorLink}\", { highlight: $highlight } )"
+        return "pcs.c1.Page.prepareForScrollToAnchor(\"${anchorLink.replace("\"", "\\\"")}\", { highlight: $highlight } )"
     }
 
     @JvmStatic


### PR DESCRIPTION
Sometimes articles have section titles with quotes in them. Currently when clicking on such a section in the Table of Contents does not correctly cause the WebView to scroll to the section.
For example, in the [[Howard Dean]] article, try clicking the section `Iowa Caucus setback and the "Dean Scream" media gaffe`.