### PR TITLE
Adjust date picker dialog width to prevent being cut off

### DIFF
--- a/app/src/main/res/layout/date_picker_dialog.xml
+++ b/app/src/main/res/layout/date_picker_dialog.xml
@@ -2,8 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="320dp"
+    android:layout_width="wrap_content"
     android:layout_height="432dp"
+    android:minWidth="320dp"
     android:background="?attr/paper_color"
     android:orientation="vertical">
 


### PR DESCRIPTION
The right-most day items in the date picker dialog touch to the edge and the blue circles are cut off. 