### PR TITLE
Store wikitext section into SharedPreferences temporarily to prevent a crash

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
@@ -233,12 +233,6 @@ public class EditSectionActivity extends BaseActivity {
     }
 
     @Override
-    public void onPause() {
-        super.onPause();
-        Prefs.storeTemporaryWikitext(sectionWikitext);
-    }
-
-    @Override
     public void onDestroy() {
         disposables.clear();
         captchaHandler.dispose();
@@ -619,6 +613,7 @@ public class EditSectionActivity extends BaseActivity {
         outState.putBoolean("hasTemporaryWikitextStored", true);
         outState.putParcelable("abusefilter", abusefilterEditResult);
         outState.putBoolean("sectionTextModified", sectionTextModified);
+        Prefs.storeTemporaryWikitext(sectionWikitext);
         captchaHandler.saveState(outState);
     }
 

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
@@ -613,8 +613,8 @@ public class EditSectionActivity extends BaseActivity {
         outState.putBoolean("hasTemporaryWikitextStored", true);
         outState.putParcelable("abusefilter", abusefilterEditResult);
         outState.putBoolean("sectionTextModified", sectionTextModified);
-        Prefs.storeTemporaryWikitext(sectionWikitext);
         captchaHandler.saveState(outState);
+        Prefs.storeTemporaryWikitext(sectionWikitext);
     }
 
     private void updateTextSize() {

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
@@ -180,8 +180,8 @@ public class EditSectionActivity extends BaseActivity {
             funnel.logStart();
         }
 
-        if (savedInstanceState != null && savedInstanceState.containsKey("sectionWikitext")) {
-            sectionWikitext = savedInstanceState.getString("sectionWikitext");
+        if (savedInstanceState != null && savedInstanceState.containsKey("hasTemporaryWikitextStored")) {
+            sectionWikitext = Prefs.getTemporaryWikitext();
         }
 
         captchaHandler.restoreState(savedInstanceState);
@@ -230,6 +230,12 @@ public class EditSectionActivity extends BaseActivity {
         showProgressBar(false);
         editClient.cancel();
         super.onStop();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        Prefs.storeTemporaryWikitext(sectionWikitext);
     }
 
     @Override
@@ -610,7 +616,7 @@ public class EditSectionActivity extends BaseActivity {
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString("sectionWikitext", sectionWikitext);
+        outState.putBoolean("hasTemporaryWikitextStored", true);
         outState.putParcelable("abusefilter", abusefilterEditResult);
         outState.putBoolean("sectionTextModified", sectionTextModified);
         captchaHandler.saveState(outState);

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -660,6 +660,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     protected void onResume() {
         super.onResume();
         app.resetWikiSite();
+        Prefs.storeTemporaryWikitext(null);
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -903,5 +903,13 @@ public final class Prefs {
         setBoolean(R.string.preference_key_suggested_edits_reactivation_pass_stage_one, pass);
     }
 
+    public static void storeTemporaryWikitext(@Nullable String wikitext) {
+        setString(R.string.preference_key_temporary_wikitext_storage, wikitext);
+    }
+
+    public static String getTemporaryWikitext() {
+        return getString(R.string.preference_key_temporary_wikitext_storage, "");
+    }
+
     private Prefs() { }
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -117,4 +117,5 @@
     <string name="preference_key_pcs_to_mobilehtml_conversion_complete">pcsToMobileHtmlConversionComplete</string>
     <string name="preference_key_image_tags_onboarding_shown">imageTagsOnboardingShown</string>
     <string name="preference_key_install_referrer_attempts">installReferrerAttempts</string>
+    <string name="preference_key_temporary_wikitext_storage">temporaryWikitextStorage</string>
 </resources>


### PR DESCRIPTION
This may fix the issue here: https://phabricator.wikimedia.org/T242449#6073882

For a really long wikitext section, the app will crash when using the app switcher and going back to the app. If we want to keep the edit states, saving them into the `SharedPreferences` might be a way to solve the `TransactionTooLargeException` error.