### PR TITLE
Fix: move PCS calls to onPageMetadataLoaded to prevent incomplete page loading

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -46,7 +46,20 @@ object JavaScriptActionHandler {
 
     @JvmStatic
     fun getRevision(): String {
-        return "pcs.c1.Page.getRevision();"
+        return "pcs.c1.Page.getRevision()"
+    }
+
+    @JvmStatic
+    fun getPageInformation(model: PageViewModel): String {
+        return "function pageInformation() {" +
+                "  return {" +
+                "      toc: ${getSections()}, " +
+                "      revision: ${getRevision()}, " +
+                "      protection: ${getProtection()}, " +
+                "      footer: ${setFooter(model)} " +
+                "  } " +
+                "}" +
+                "pageInformation()"
     }
 
     @JvmStatic


### PR DESCRIPTION
When loading Traditional Chinese trending articles for the first, sometimes the page will not a complete status of it. You will see the ToC and footer are gone, and the protection status is also incorrect.

This PR moves the PCS calls into one function to reduce multiple bridge calls.  