### PR TITLE
Fix possible confusion in account creation errors.

### DIFF
--- a/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.java
+++ b/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.java
@@ -386,9 +386,10 @@ public class CreateAccountActivity extends BaseActivity {
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(response -> {
                         ListUserResponse user = response.query().getUserResponse(userName);
-                        if (user.canCreate()) {
-                            usernameInput.setErrorEnabled(false);
-                        } else {
+                        usernameInput.setErrorEnabled(false);
+                        if (user.isBlocked()) {
+                            handleAccountCreationError(user.getError());
+                        } else if (!user.canCreate()) {
                             usernameInput.setError(getString(R.string.create_account_name_unavailable, userName));
                         }
                     }, L::e));

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/ListUserResponse.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/ListUserResponse.java
@@ -17,28 +17,27 @@ public class ListUserResponse {
     @SerializedName("name") @Nullable private String name;
     private long userid;
     @Nullable private List<String> groups;
+    private boolean missing;
     private boolean cancreate;
-    @Nullable private List<UserResponseCreateError> cancreateerror;
+    @Nullable private List<MwServiceError> cancreateerror;
 
-    @Nullable public String name() {
-        return name;
+    @NonNull public String name() {
+        return StringUtils.defaultString(name);
     }
 
     public boolean canCreate() {
         return cancreate;
     }
 
-    @NonNull public Set<String> getGroups() {
-        return groups != null ? new ArraySet<>(groups) : Collections.emptySet();
+    public boolean isBlocked() {
+        return getError().contains("block");
     }
 
-    public static class UserResponseCreateError {
-        @Nullable private String message;
-        @Nullable private String code;
-        @Nullable private String type;
+    @NonNull public String getError() {
+        return cancreateerror != null && !cancreateerror.isEmpty() ? cancreateerror.get(0).getTitle() : "";
+    }
 
-        @NonNull public String message() {
-            return StringUtils.defaultString(message);
-        }
+    @NonNull public Set<String> getGroups() {
+        return groups != null ? new ArraySet<>(groups) : Collections.emptySet();
     }
 }


### PR DESCRIPTION
When the user types their username to create an account, we automatically check if that username is available or taken, and we show the message as the user is typing.  However, if the user's IP address is blocked, then we still show a message of "this username is not available," instead of properly saying "your IP address is blocked".  This can surely cause confusion while the user keeps trying to type their new username.
