### PR TITLE
Be slightly more explicit about loading blank page into WebView.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -70,6 +70,10 @@ public class CommunicationBridge {
         flushMessages();
     }
 
+    public void loadBlankPage() {
+        communicationBridgeListener.getWebView().loadUrl(BLANK_PAGE);
+    }
+
     public void resetHtml(@NonNull PageTitle pageTitle) {
         isDOMReady = false;
         pendingJSMessages.clear();
@@ -87,6 +91,10 @@ public class CommunicationBridge {
             incomingMessageHandler.removeCallbacksAndMessages(null);
             incomingMessageHandler = null;
         }
+        communicationBridgeListener.getWebView().setWebViewClient(null);
+        communicationBridgeListener.getWebView().removeJavascriptInterface("pcsClient");
+        // Explicitly load a blank page into the WebView, to stop playback of any media.
+        loadBlankPage();
     }
 
     public void addListener(String type, JSEventListener listener) {

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -313,6 +313,7 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
             webview.clearAllListeners();
             ((ViewGroup) webview.getParent()).removeView(webview);
             webview = null;
+            bridge.cleanup();
         }
         super.onDestroyView();
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1159,7 +1159,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
      */
     private void hidePageContent() {
         leadImagesHandler.hide();
-        webView.loadUrl(CommunicationBridge.BLANK_PAGE);
+        bridge.loadBlankPage();
         webView.setVisibility(View.INVISIBLE);
         if (callback() != null) {
             callback().onPageHideAllContent();

--- a/app/src/main/java/org/wikipedia/views/ObservableWebView.java
+++ b/app/src/main/java/org/wikipedia/views/ObservableWebView.java
@@ -81,8 +81,6 @@ public class ObservableWebView extends WebView {
         onUpOrCancelMotionEventListeners.clear();
         onContentHeightChangedListeners.clear();
         onFastScrollListener = null;
-        // To stop the music when left the article
-        loadUrl("about:blank");
     }
 
     public interface OnClickListener {


### PR DESCRIPTION
Currently, it's not at all obvious that the `clearAllListeners()` function will _also_ load a blank page into the WebView. This PR makes this behavior more explicit, and moves more cleanup code into the Bridge.