### PR TITLE
Migrate to ThreeTenABP from java.util.Date and its associated classes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -205,6 +205,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.9'
     implementation 'org.jsoup:jsoup:1.12.1'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
+    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.4'
 
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterknifeVersion"
 

--- a/app/src/androidTest/java/org/wikipedia/json/TabUnmarshallerTest.java
+++ b/app/src/androidTest/java/org/wikipedia/json/TabUnmarshallerTest.java
@@ -2,13 +2,13 @@ package org.wikipedia.json;
 
 
 import org.junit.Test;
+import org.threeten.bp.Instant;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.PageBackStackItem;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.page.tabs.Tab;
 
-import java.util.Date;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
@@ -24,7 +24,7 @@ public class TabUnmarshallerTest {
 
     @Test public void testUnmarshalSingle() {
         PageTitle page = new PageTitle("text", WikiSite.forLanguageCode("test"));
-        HistoryEntry history = new HistoryEntry(page, new Date(0), HistoryEntry.SOURCE_SEARCH);
+        HistoryEntry history = new HistoryEntry(page, Instant.ofEpochMilli(0), HistoryEntry.SOURCE_SEARCH);
         Tab tab = new Tab();
         tab.getBackStack().add(new PageBackStackItem(page, history));
         List<Tab> tabs = singletonList(tab);
@@ -35,7 +35,7 @@ public class TabUnmarshallerTest {
     // T152980
     @Test(expected = RuntimeException.class) public void testUnmarshalNoPageTitleAuthority() {
         PageTitle page = new PageTitle("text", new WikiSite("", ""));
-        HistoryEntry history = new HistoryEntry(page, new Date(0), HistoryEntry.SOURCE_SEARCH);
+        HistoryEntry history = new HistoryEntry(page, Instant.ofEpochMilli(0), HistoryEntry.SOURCE_SEARCH);
         Tab tab = new Tab();
         tab.getBackStack().add(new PageBackStackItem(page, history));
         List<Tab> tabs = singletonList(tab);
@@ -47,7 +47,7 @@ public class TabUnmarshallerTest {
     @Test(expected = RuntimeException.class) public void testUnmarshalNoHistoryEntryAuthority() {
         PageTitle page = new PageTitle("text", WikiSite.forLanguageCode("test"));
         PageTitle prevPage = new PageTitle("text", new WikiSite("", ""));
-        HistoryEntry history = new HistoryEntry(prevPage, new Date(0), HistoryEntry.SOURCE_SEARCH);
+        HistoryEntry history = new HistoryEntry(prevPage, Instant.ofEpochMilli(0), HistoryEntry.SOURCE_SEARCH);
         Tab tab = new Tab();
         tab.getBackStack().add(new PageBackStackItem(page, history));
         List<Tab> tabs = singletonList(tab);

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
 
+import com.jakewharton.threetenabp.AndroidThreeTen;
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.crashes.Crashes;
 
@@ -141,6 +142,7 @@ public class WikipediaApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+        AndroidThreeTen.init(this);
 
         WikiSite.setDefaultBaseUrl(Prefs.getMediaWikiBaseUrl());
 

--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -110,7 +110,7 @@ object JavaScriptActionHandler {
         }
         val showTalkLink = !(model.page!!.title.namespace() === Namespace.TALK)
         val showMapLink = model.page!!.pageProperties.geo != null
-        val editedDaysAgo = TimeUnit.MILLISECONDS.toDays(Date().time - model.page!!.pageProperties.lastModified.time)
+        val editedDaysAgo = TimeUnit.MILLISECONDS.toDays(Date().time - model.page!!.pageProperties.lastModified.toEpochMilli())
 
         // TODO: page-library also supports showing disambiguation ("similar pages") links and
         // "page issues". We should be mindful that they exist, even if we don't want them for now.

--- a/app/src/main/java/org/wikipedia/database/column/DateColumn.java
+++ b/app/src/main/java/org/wikipedia/database/column/DateColumn.java
@@ -4,15 +4,15 @@ import android.database.Cursor;
 
 import androidx.annotation.NonNull;
 
-import java.util.Date;
+import org.threeten.bp.Instant;
 
-public class DateColumn extends Column<Date> {
+public class DateColumn extends Column<Instant> {
     public DateColumn(@NonNull String tbl, @NonNull String name, @NonNull String type) {
         super(tbl, name, type);
     }
 
     @Override
-    public Date val(@NonNull Cursor cursor) {
-        return new Date(getLong(cursor));
+    public Instant val(@NonNull Cursor cursor) {
+        return Instant.ofEpochMilli(getLong(cursor));
     }
 }

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
@@ -1,16 +1,14 @@
 package org.wikipedia.dataclient.mwapi;
 
-import android.text.TextUtils;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.collection.ArraySet;
 
+import org.apache.commons.lang3.StringUtils;
+import org.threeten.bp.Instant;
 import org.wikipedia.util.DateUtil;
 
-import java.text.ParseException;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -34,18 +32,7 @@ public class UserInfo {
     }
 
     public boolean isBlocked() {
-        if (TextUtils.isEmpty(blockexpiry)) {
-            return false;
-        }
-        try {
-            Date now = new Date();
-            Date expiry = DateUtil.iso8601DateParse(blockexpiry);
-            if (expiry.after(now)) {
-                return true;
-            }
-        } catch (ParseException e) {
-            // ignore
-        }
-        return false;
+        return StringUtils.isNotEmpty(blockexpiry)
+                && DateUtil.iso8601InstantParse(blockexpiry).isAfter(Instant.now());
     }
 }

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummary.java
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummary.java
@@ -1,13 +1,13 @@
 package org.wikipedia.edit.summaries;
 
-import java.util.Date;
+import org.threeten.bp.Instant;
 
 public class EditSummary {
     public static final EditSummaryDatabaseTable DATABASE_TABLE = new EditSummaryDatabaseTable();
     private final String summary;
-    private final Date lastUsed;
+    private final Instant lastUsed;
 
-    public EditSummary(String summary, Date lastUsed) {
+    public EditSummary(String summary, Instant lastUsed) {
         this.summary = summary;
         this.lastUsed = lastUsed;
     }
@@ -16,7 +16,7 @@ public class EditSummary {
         return summary;
     }
 
-    public Date getLastUsed() {
+    public Instant getLastUsed() {
         return lastUsed;
     }
 }

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryDatabaseTable.java
@@ -5,12 +5,11 @@ import android.database.Cursor;
 
 import androidx.annotation.NonNull;
 
+import org.threeten.bp.Instant;
 import org.wikipedia.database.DatabaseTable;
 import org.wikipedia.database.column.Column;
 import org.wikipedia.database.contract.EditHistoryContract;
 import org.wikipedia.database.contract.EditHistoryContract.Col;
-
-import java.util.Date;
 
 public class EditSummaryDatabaseTable extends DatabaseTable<EditSummary> {
     private static final int DB_VER_INTRODUCED = 2;
@@ -23,7 +22,7 @@ public class EditSummaryDatabaseTable extends DatabaseTable<EditSummary> {
     @Override
     public EditSummary fromCursor(Cursor cursor) {
         String summary = Col.SUMMARY.val(cursor);
-        Date lastUsed = Col.LAST_USED.val(cursor);
+        Instant lastUsed = Col.LAST_USED.val(cursor);
         return new EditSummary(summary, lastUsed);
     }
 
@@ -31,7 +30,7 @@ public class EditSummaryDatabaseTable extends DatabaseTable<EditSummary> {
     protected ContentValues toContentValues(EditSummary obj) {
         ContentValues contentValues = new ContentValues();
         contentValues.put(Col.SUMMARY.getName(), obj.getSummary());
-        contentValues.put(Col.LAST_USED.getName(), obj.getLastUsed().getTime());
+        contentValues.put(Col.LAST_USED.getName(), obj.getLastUsed().toEpochMilli());
         return contentValues;
     }
 

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryHandler.java
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryHandler.java
@@ -14,12 +14,11 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.cursoradapter.widget.CursorAdapter;
 
+import org.threeten.bp.Instant;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.database.contract.EditHistoryContract;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.ContentProviderClientCompat;
-
-import java.util.Date;
 
 import static org.wikipedia.util.L10nUtil.setConditionalTextDirection;
 
@@ -63,7 +62,7 @@ public class EditSummaryHandler {
 
     public void persistSummary() {
         WikipediaApp app = (WikipediaApp)container.getContext().getApplicationContext();
-        EditSummary summary = new EditSummary(summaryEdit.getText().toString(), new Date());
+        EditSummary summary = new EditSummary(summaryEdit.getText().toString(), Instant.now());
         app.getDatabaseClient(EditSummary.class).upsert(summary, EditHistoryContract.Summary.SELECTION);
     }
 

--- a/app/src/main/java/org/wikipedia/feed/announcement/Announcement.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/Announcement.java
@@ -7,13 +7,12 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.threeten.bp.Instant;
 import org.wikipedia.json.annotations.Required;
 import org.wikipedia.model.BaseModel;
 import org.wikipedia.util.DateUtil;
 
-import java.text.ParseException;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
@@ -68,20 +67,12 @@ public class Announcement extends BaseModel {
     }
 
     @Nullable
-    public Date startTime() {
-        try {
-            return DateUtil.iso8601DateParse(startTime);
-        } catch (ParseException e) {
-            return null;
-        }
+    public Instant startTime() {
+        return DateUtil.iso8601InstantParse(startTime);
     }
 
-    @Nullable Date endTime() {
-        try {
-            return DateUtil.iso8601DateParse(endTime);
-        } catch (ParseException e) {
-            return null;
-        }
+    @Nullable Instant endTime() {
+        return DateUtil.iso8601InstantParse(endTime);
     }
 
     @NonNull List<String> platforms() {

--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementClient.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementClient.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import org.threeten.bp.Instant;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.dataclient.ServiceFactory;
@@ -20,7 +21,6 @@ import org.wikipedia.util.ReleaseUtil;
 import org.wikipedia.util.log.L;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -56,9 +56,8 @@ public class AnnouncementClient implements FeedClient {
     private static List<Card> buildCards(@NonNull List<Announcement> announcements) {
         List<Card> cards = new ArrayList<>();
         String country = GeoUtil.getGeoIPCountry();
-        Date now = new Date();
         for (Announcement announcement : announcements) {
-            if (shouldShow(announcement, country, now)) {
+            if (shouldShow(announcement, country, Instant.now())) {
                 switch (announcement.type()) {
                     case Announcement.SURVEY:
                         cards.add(new SurveyCard(announcement));
@@ -79,7 +78,7 @@ public class AnnouncementClient implements FeedClient {
 
     public static boolean shouldShow(@Nullable Announcement announcement,
                               @Nullable String country,
-                              @NonNull Date date) {
+                              @NonNull Instant date) {
         return announcement != null
                 && (announcement.platforms().contains(PLATFORM_CODE) || announcement.platforms().contains(PLATFORM_CODE_NEW))
                 && matchesCountryCode(announcement, country)
@@ -99,14 +98,14 @@ public class AnnouncementClient implements FeedClient {
         return announcement.countries().contains(country);
     }
 
-    private static boolean matchesDate(@NonNull Announcement announcement, Date date) {
+    private static boolean matchesDate(@NonNull Announcement announcement, Instant date) {
         if (Prefs.ignoreDateForAnnouncements()) {
             return true;
         }
-        if (announcement.startTime() != null && announcement.startTime().after(date)) {
+        if (announcement.startTime() != null && announcement.startTime().isAfter(date)) {
             return false;
         }
-        return announcement.endTime() == null || !announcement.endTime().before(date);
+        return announcement.endTime() == null || !announcement.endTime().isBefore(date);
     }
 
     private static boolean matchesConditions(@NonNull Announcement announcement) {

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadCard.java
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadCard.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.threeten.bp.temporal.ChronoField;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.model.CardType;
@@ -52,7 +53,7 @@ public class BecauseYouReadCard extends ListCard<BecauseYouReadItemCard> {
     /** @return The last visit age in days. */
     public long daysOld() {
         long now = System.currentTimeMillis();
-        long lastVisited = entry.getTimestamp().getTime();
+        long lastVisited = entry.getTimestamp().toEpochMilli();
         return TimeUnit.MILLISECONDS.toDays(now - lastVisited);
     }
 

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadCard.java
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadCard.java
@@ -6,7 +6,8 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.threeten.bp.temporal.ChronoField;
+import org.threeten.bp.LocalDate;
+import org.threeten.bp.Period;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.model.CardType;
@@ -15,7 +16,6 @@ import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.PageTitle;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class BecauseYouReadCard extends ListCard<BecauseYouReadItemCard> {
     @NonNull private HistoryEntry entry;
@@ -52,9 +52,7 @@ public class BecauseYouReadCard extends ListCard<BecauseYouReadItemCard> {
 
     /** @return The last visit age in days. */
     public long daysOld() {
-        long now = System.currentTimeMillis();
-        long lastVisited = entry.getTimestamp().toEpochMilli();
-        return TimeUnit.MILLISECONDS.toDays(now - lastVisited);
+        return Period.between(LocalDate.now(), LocalDate.from(entry.getTimestamp())).getDays();
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/feed/model/UtcDate.java
+++ b/app/src/main/java/org/wikipedia/feed/model/UtcDate.java
@@ -1,41 +1,33 @@
 package org.wikipedia.feed.model;
 
-import androidx.annotation.NonNull;
-
-import java.util.Calendar;
-
-import static java.util.TimeZone.getTimeZone;
+import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.ZonedDateTime;
 
 public class UtcDate {
-    @NonNull private Calendar cal;
-    @NonNull private String year;
-    @NonNull private String month;
-    @NonNull private String date;
+    private final ZonedDateTime zonedDateTime;
+    private final String year;
+    private final String month;
+    private final String date;
 
     public UtcDate(int age) {
-        this.cal = Calendar.getInstance(getTimeZone("UTC"));
-        cal.add(Calendar.DATE, -age);
-        this.year = Integer.toString(cal.get(Calendar.YEAR));
-        this.month = pad(Integer.toString(cal.get(Calendar.MONTH) + 1));
-        this.date = pad(Integer.toString(cal.get(Calendar.DATE)));
+        this.zonedDateTime = ZonedDateTime.now(ZoneOffset.UTC).minusDays(age);
+        this.year = Integer.toString(zonedDateTime.getYear());
+        this.month = pad(Integer.toString(zonedDateTime.getMonthValue()));
+        this.date = pad(Integer.toString(zonedDateTime.getDayOfMonth()));
     }
 
-    @NonNull
-    public Calendar baseCalendar() {
-        return cal;
+    public ZonedDateTime baseZonedDateTime() {
+        return zonedDateTime;
     }
 
-    @NonNull
     public String year() {
         return year;
     }
 
-    @NonNull
     public String month() {
         return month;
     }
 
-    @NonNull
     public String date() {
         return date;
     }

--- a/app/src/main/java/org/wikipedia/feed/news/NewsListCard.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsListCard.java
@@ -10,7 +10,6 @@ import org.wikipedia.feed.model.UtcDate;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class NewsListCard extends ListCard<NewsItemCard> {
     @NonNull private UtcDate date;
@@ -37,6 +36,6 @@ public class NewsListCard extends ListCard<NewsItemCard> {
     }
 
     @Override protected int dismissHashCode() {
-        return (int) TimeUnit.MILLISECONDS.toDays(date.baseCalendar().getTime().getTime()) + wikiSite().hashCode();
+        return (int) date.baseZonedDateTime().toLocalDate().toEpochDay() + wikiSite().hashCode();
     }
 }

--- a/app/src/main/java/org/wikipedia/feed/news/NewsListCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsListCardView.java
@@ -33,7 +33,7 @@ public class NewsListCardView extends HorizontalScrollingListCardView<NewsListCa
 
     private void header(@NonNull NewsListCard card) {
         headerView().setTitle(R.string.view_card_news_title)
-                .setSubtitle(DateUtil.getFeedCardDateString(card.date().baseCalendar()))
+                .setSubtitle(DateUtil.getFeedCardDateString(card.date().baseZonedDateTime()))
                 .setImage(R.drawable.icon_in_the_news)
                 .setImageCircleColor(R.color.base50)
                 .setLangCode(card.wikiSite().languageCode())

--- a/app/src/main/java/org/wikipedia/history/HistoryEntry.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryEntry.java
@@ -7,9 +7,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.threeten.bp.Instant;
 import org.wikipedia.page.PageTitle;
-
-import java.util.Date;
 
 public class HistoryEntry implements Parcelable {
     public static final HistoryEntryDatabaseTable DATABASE_TABLE = new HistoryEntryDatabaseTable();
@@ -44,14 +43,14 @@ public class HistoryEntry implements Parcelable {
     public static final int SOURCE_SUGGESTED_EDITS = 30;
 
     @NonNull private final PageTitle title;
-    @NonNull private final Date timestamp;
+    @NonNull private final Instant timestamp;
     private final int source;
     private final int timeSpentSec;
 
     // Transient variable, not stored in the db, to be set when navigating back and forth between articles.
     @Nullable private String referrer;
 
-    public HistoryEntry(@NonNull PageTitle title, @NonNull Date timestamp, int source,
+    public HistoryEntry(@NonNull PageTitle title, @NonNull Instant timestamp, int source,
                         int timeSpentSec) {
         this.title = title;
         this.timestamp = timestamp;
@@ -59,19 +58,19 @@ public class HistoryEntry implements Parcelable {
         this.timeSpentSec = timeSpentSec;
     }
 
-    public HistoryEntry(@NonNull PageTitle title, @NonNull Date timestamp, int source) {
+    public HistoryEntry(@NonNull PageTitle title, @NonNull Instant timestamp, int source) {
         this(title, timestamp, source, 0);
     }
 
     public HistoryEntry(@NonNull PageTitle title, int source) {
-        this(title, new Date(), source);
+        this(title, Instant.now(), source);
     }
 
     @NonNull public PageTitle getTitle() {
         return title;
     }
 
-    @NonNull public Date getTimestamp() {
+    @NonNull public Instant getTimestamp() {
         return timestamp;
     }
 
@@ -116,7 +115,7 @@ public class HistoryEntry implements Parcelable {
         return "HistoryEntry{"
                 + "title=" + title
                 + ", source=" + source
-                + ", timestamp=" + timestamp.getTime()
+                + ", timestamp=" + timestamp.toEpochMilli()
                 + ", timeSpentSec=" + timeSpentSec
                 + '}';
     }
@@ -128,16 +127,16 @@ public class HistoryEntry implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeParcelable(getTitle(), flags);
-        dest.writeLong(getTimestamp().getTime());
-        dest.writeInt(getSource());
-        dest.writeInt(getTimeSpentSec());
+        dest.writeParcelable(title, flags);
+        dest.writeLong(timestamp.toEpochMilli());
+        dest.writeInt(source);
+        dest.writeInt(timeSpentSec);
         dest.writeString(StringUtils.defaultString(referrer));
     }
 
     private HistoryEntry(Parcel in) {
         this.title = in.readParcelable(PageTitle.class.getClassLoader());
-        this.timestamp = new Date(in.readLong());
+        this.timestamp = Instant.ofEpochMilli(in.readLong());
         this.source = in.readInt();
         this.timeSpentSec = in.readInt();
         this.referrer = in.readString();

--- a/app/src/main/java/org/wikipedia/history/HistoryEntryDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryEntryDatabaseTable.java
@@ -5,14 +5,13 @@ import android.database.Cursor;
 
 import androidx.annotation.NonNull;
 
+import org.threeten.bp.Instant;
 import org.wikipedia.database.DatabaseTable;
 import org.wikipedia.database.column.Column;
 import org.wikipedia.database.contract.PageHistoryContract;
 import org.wikipedia.database.contract.PageHistoryContract.Col;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.PageTitle;
-
-import java.util.Date;
 
 public class HistoryEntryDatabaseTable extends DatabaseTable<HistoryEntry> {
     private static final int DB_VER_NAMESPACE_ADDED = 6;
@@ -28,7 +27,7 @@ public class HistoryEntryDatabaseTable extends DatabaseTable<HistoryEntry> {
     public HistoryEntry fromCursor(Cursor cursor) {
         WikiSite wiki = new WikiSite(Col.SITE.val(cursor), Col.LANG.val(cursor));
         PageTitle title = new PageTitle(Col.NAMESPACE.val(cursor), Col.API_TITLE.val(cursor), wiki);
-        Date timestamp = Col.TIMESTAMP.val(cursor);
+        Instant timestamp = Col.TIMESTAMP.val(cursor);
         int source = Col.SOURCE.val(cursor);
         title.setDisplayText(Col.DISPLAY_TITLE.val(cursor));
         return new HistoryEntry(title, timestamp, source);
@@ -42,7 +41,7 @@ public class HistoryEntryDatabaseTable extends DatabaseTable<HistoryEntry> {
         contentValues.put(Col.API_TITLE.getName(), obj.getTitle().getText());
         contentValues.put(Col.DISPLAY_TITLE.getName(), obj.getTitle().getDisplayText());
         contentValues.put(Col.NAMESPACE.getName(), obj.getTitle().getNamespace());
-        contentValues.put(Col.TIMESTAMP.getName(), obj.getTimestamp().getTime());
+        contentValues.put(Col.TIMESTAMP.getName(), obj.getTimestamp().toEpochMilli());
         contentValues.put(Col.SOURCE.getName(), obj.getSource());
         contentValues.put(Col.TIME_SPENT.getName(), obj.getTimeSpentSec());
         return contentValues;

--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.java
@@ -30,6 +30,10 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.snackbar.Snackbar;
 
+import org.threeten.bp.Instant;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.format.FormatStyle;
 import org.wikipedia.BackPressedHandler;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -48,9 +52,7 @@ import org.wikipedia.views.PageItemView;
 import org.wikipedia.views.SearchEmptyView;
 import org.wikipedia.views.SwipeableItemTouchHelperCallback;
 
-import java.text.DateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 
@@ -361,8 +363,9 @@ public class HistoryFragment extends Fragment implements BackPressedHandler {
             adapter.clearList();
         }
 
-        private String getDateString(Date date) {
-            return DateFormat.getDateInstance().format(date);
+        private String getDateString(Instant instant) {
+            return DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+                    .withZone(ZoneId.systemDefault()).format(instant);
         }
     }
 

--- a/app/src/main/java/org/wikipedia/notifications/Notification.java
+++ b/app/src/main/java/org/wikipedia/notifications/Notification.java
@@ -8,12 +8,10 @@ import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
+import org.threeten.bp.Instant;
 import org.wikipedia.json.GsonUtil;
 import org.wikipedia.util.DateUtil;
-import org.wikipedia.util.log.L;
 
-import java.text.ParseException;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -75,8 +73,8 @@ public class Notification {
         return contents;
     }
 
-    @NonNull Date getTimestamp() {
-        return timestamp != null ? timestamp.date() : new Date();
+    @NonNull Instant getTimestamp() {
+        return timestamp != null ? timestamp.date() : Instant.now();
     }
 
     @NonNull String getUtcIso8601() {
@@ -130,13 +128,8 @@ public class Notification {
     public static class Timestamp {
         @SuppressWarnings("unused") @Nullable private String utciso8601;
 
-        public Date date() {
-            try {
-                return DateUtil.iso8601DateParse(utciso8601);
-            } catch (ParseException e) {
-                L.e(e);
-                return new Date();
-            }
+        public Instant date() {
+            return DateUtil.iso8601InstantParse(utciso8601);
         }
     }
 

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
@@ -23,6 +23,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.google.android.material.snackbar.Snackbar;
 
+import org.threeten.bp.Instant;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.BaseActivity;
@@ -49,7 +50,6 @@ import org.wikipedia.views.WikiErrorView;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -285,9 +285,9 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
                         && !n.getContents().getHeader().contains(currentSearchQuery)) {
                     continue;
                 }
-                if (millis - n.getTimestamp().getTime() > TimeUnit.DAYS.toMillis(1)) {
+                if (millis - n.getTimestamp().toEpochMilli() > TimeUnit.DAYS.toMillis(1)) {
                     notificationContainerList.add(new NotificationListItemContainer(n.getTimestamp()));
-                    millis = n.getTimestamp().getTime();
+                    millis = n.getTimestamp().toEpochMilli();
                 }
                 notificationContainerList.add(new NotificationListItemContainer(n));
 
@@ -579,8 +579,8 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
             dateView = view.findViewById(R.id.notification_date_text);
         }
 
-        void bindItem(Date date) {
-            dateView.setText(DateUtil.getFeedCardDateString(date));
+        void bindItem(Instant instant) {
+            dateView.setText(DateUtil.getFeedCardDateString(instant));
         }
     }
 
@@ -610,7 +610,7 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
         @Override
         public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int pos) {
             if (holder instanceof NotificationDateHolder) {
-                ((NotificationDateHolder) holder).bindItem(notificationContainerList.get(pos).date);
+                ((NotificationDateHolder) holder).bindItem(notificationContainerList.get(pos).instant);
             } else if (holder instanceof NotificationItemHolderSwipeable) {
                 ((NotificationItemHolderSwipeable) holder).bindItem(notificationContainerList.get(pos));
             } else if (holder instanceof NotificationItemHolder) {
@@ -695,11 +695,11 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
 
         private final int type;
         private Notification notification;
-        private Date date;
+        private Instant instant;
         private boolean selected;
 
-        NotificationListItemContainer(@NonNull Date date) {
-            this.date = date;
+        NotificationListItemContainer(@NonNull Instant instant) {
+            this.instant = instant;
             type = ITEM_DATE_HEADER;
         }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -39,6 +39,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.threeten.bp.Instant;
 import org.wikipedia.BackPressedHandler;
 import org.wikipedia.Constants;
 import org.wikipedia.Constants.InvokeSource;
@@ -1296,7 +1297,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             return;
         }
         model.setCurEntry(new HistoryEntry(model.getCurEntry().getTitle(),
-                new Date(),
+                Instant.now(),
                 model.getCurEntry().getSource(),
                 timeSpentSec));
         if (!model.getCurEntry().getTitle().getText().equals(Constants.EMPTY_PAGE_TITLE)) {

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -40,6 +40,7 @@ import com.google.gson.JsonObject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.threeten.bp.Instant;
+import org.threeten.bp.LocalDate;
 import org.wikipedia.BackPressedHandler;
 import org.wikipedia.Constants;
 import org.wikipedia.Constants.InvokeSource;
@@ -1376,7 +1377,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(list -> {
                         String country = GeoUtil.getGeoIPCountry();
-                        Instant now = Instant.now();
+                        final LocalDate now = LocalDate.now();
                         for (Announcement announcement : list.items()) {
                             if (shouldShow(announcement, country, now)
                                     && announcement.placement().equals(PLACEMENT_ARTICLE)

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -101,7 +101,6 @@ import org.wikipedia.views.WikiErrorView;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import io.reactivex.Completable;
@@ -1377,7 +1376,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(list -> {
                         String country = GeoUtil.getGeoIPCountry();
-                        Date now = new Date();
+                        Instant now = Instant.now();
                         for (Announcement announcement : list.items()) {
                             if (shouldShow(announcement, country, now)
                                     && announcement.placement().equals(PLACEMENT_ARTICLE)

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
+import org.threeten.bp.Instant;
 import org.wikipedia.BuildConfig;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -31,10 +32,8 @@ import org.wikipedia.util.DateUtil;
 import org.wikipedia.util.StringUtil;
 import org.wikipedia.util.log.L;
 
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -567,12 +566,8 @@ public class ReadingListSyncAdapter extends AbstractThreadedSyncAdapter {
         if (TextUtils.isEmpty(lastDateHeader)) {
             return lastSyncTime;
         }
-        try {
-            Date date = DateUtil.getHttpLastModifiedDate(lastDateHeader);
-            return DateUtil.iso8601DateFormat(date);
-        } catch (ParseException e) {
-            return lastSyncTime;
-        }
+        final Instant instant = DateUtil.getHttpLastModifiedInstant(lastDateHeader);
+        return DateUtil.iso8601DateFormat(instant);
     }
 
     private void createOrUpdatePage(@NonNull ReadingList listForPage,

--- a/app/src/main/java/org/wikipedia/search/RecentSearch.java
+++ b/app/src/main/java/org/wikipedia/search/RecentSearch.java
@@ -3,19 +3,19 @@ package org.wikipedia.search;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import java.util.Date;
+import org.threeten.bp.Instant;
 
 public class RecentSearch implements Parcelable {
     public static final RecentSearchDatabaseTable DATABASE_TABLE = new RecentSearchDatabaseTable();
 
     private final String text;
-    private final Date timestamp;
+    private final Instant timestamp;
 
     public RecentSearch(String text) {
-        this(text, new Date());
+        this(text, Instant.now());
     }
 
-    public RecentSearch(String text, Date timestamp) {
+    public RecentSearch(String text, Instant timestamp) {
         this.text = text;
         this.timestamp = timestamp;
     }
@@ -24,7 +24,7 @@ public class RecentSearch implements Parcelable {
         return text;
     }
 
-    public Date getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 
@@ -46,7 +46,7 @@ public class RecentSearch implements Parcelable {
     public String toString() {
         return "RecentSearch{"
                 + "text=" + text
-                + ", timestamp=" + timestamp.getTime()
+                + ", timestamp=" + timestamp.toEpochMilli()
                 + '}';
     }
 
@@ -58,12 +58,12 @@ public class RecentSearch implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(getText());
-        dest.writeLong(getTimestamp().getTime());
+        dest.writeLong(getTimestamp().toEpochMilli());
     }
 
     private RecentSearch(Parcel in) {
         this.text = in.readString();
-        this.timestamp = new Date(in.readLong());
+        this.timestamp = Instant.ofEpochMilli(in.readLong());
     }
 
     public static final Creator<RecentSearch> CREATOR

--- a/app/src/main/java/org/wikipedia/search/RecentSearchDatabaseTable.java
+++ b/app/src/main/java/org/wikipedia/search/RecentSearchDatabaseTable.java
@@ -5,12 +5,11 @@ import android.database.Cursor;
 
 import androidx.annotation.NonNull;
 
+import org.threeten.bp.Instant;
 import org.wikipedia.database.DatabaseTable;
 import org.wikipedia.database.column.Column;
 import org.wikipedia.database.contract.SearchHistoryContract;
 import org.wikipedia.database.contract.SearchHistoryContract.Col;
-
-import java.util.Date;
 
 public class RecentSearchDatabaseTable extends DatabaseTable<RecentSearch> {
     private static final int DB_VER_INTRODUCED = 5;
@@ -22,7 +21,7 @@ public class RecentSearchDatabaseTable extends DatabaseTable<RecentSearch> {
     @Override
     public RecentSearch fromCursor(Cursor cursor) {
         String title = Col.TEXT.val(cursor);
-        Date timestamp = Col.TIMESTAMP.val(cursor);
+        Instant timestamp = Col.TIMESTAMP.val(cursor);
         return new RecentSearch(title, timestamp);
     }
 
@@ -30,7 +29,7 @@ public class RecentSearchDatabaseTable extends DatabaseTable<RecentSearch> {
     protected ContentValues toContentValues(RecentSearch obj) {
         ContentValues contentValues = new ContentValues();
         contentValues.put(Col.TEXT.getName(), obj.getText());
-        contentValues.put(Col.TIMESTAMP.getName(), obj.getTimestamp().getTime());
+        contentValues.put(Col.TIMESTAMP.getName(), obj.getTimestamp().toEpochMilli());
         return contentValues;
     }
 

--- a/app/src/main/java/org/wikipedia/util/DateUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.java
@@ -11,6 +11,7 @@ import org.threeten.bp.Instant;
 import org.threeten.bp.ZoneId;
 import org.threeten.bp.ZoneOffset;
 import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.format.FormatStyle;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.model.UtcDate;
@@ -32,6 +33,10 @@ public final class DateUtil {
 
     public static synchronized String iso8601DateFormat(Instant instant) {
         return getCachedDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT, true).format(instant);
+    }
+
+    public static synchronized Instant iso8601InstantParse(String date) {
+        return Instant.from(getCachedDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT, true).parse(date));
     }
 
     public static synchronized Date iso8601DateParse(String date) throws ParseException {
@@ -62,6 +67,10 @@ public final class DateUtil {
         return getShortDateString(date.getTime());
     }
 
+    public static String getFeedCardDateString(@NonNull Instant instant) {
+        return getShortDateString(instant);
+    }
+
     public static String getFeedCardDateString(@NonNull Date date) {
         return getShortDateString(date);
     }
@@ -84,6 +93,10 @@ public final class DateUtil {
 
     private static String getExtraShortDateString(@NonNull Date date) {
         return getDateStringWithSkeletonPattern(date, "MMM d");
+    }
+
+    private static synchronized String getDateStringWithSkeletonPattern(@NonNull Instant instant, @NonNull String pattern) {
+        return getCachedDateTimeFormatter(android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault(), false).format(instant);
     }
 
     private static synchronized String getDateStringWithSkeletonPattern(@NonNull Date date, @NonNull String pattern) {
@@ -120,6 +133,11 @@ public final class DateUtil {
         return dateFormat.format(date);
     }
 
+    public static String getShortDateString(@NonNull Instant instant) {
+        return DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneOffset.UTC)
+                .format(instant);
+    }
+
     public static UtcDate getUtcRequestDateFor(int age) {
         return new UtcDate(age);
     }
@@ -141,6 +159,10 @@ public final class DateUtil {
 
     public static synchronized String getHttpLastModifiedDate(@NonNull Date date) {
         return getCachedDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH, true).format(date);
+    }
+
+    public static synchronized String getHttpLastModifiedInstant(@NonNull Instant instant) {
+        return getCachedDateTimeFormatter("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH, true).format(instant);
     }
 
     public static String getReadingListsLastSyncDateString(@NonNull String dateStr) throws ParseException {

--- a/app/src/main/java/org/wikipedia/util/DateUtil.java
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.java
@@ -12,6 +12,7 @@ import org.threeten.bp.ZoneId;
 import org.threeten.bp.ZoneOffset;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.FormatStyle;
+import org.threeten.bp.temporal.TemporalAccessor;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.feed.model.UtcDate;
@@ -56,19 +57,15 @@ public final class DateUtil {
     }
 
     public static String getFeedCardDayHeaderDate(int age) {
-        return getDateStringWithSkeletonPattern(new UtcDate(age).baseCalendar().getTime(), "EEEE MMM d");
+        return getDateStringWithSkeletonPattern(new UtcDate(age).baseZonedDateTime(), "EEEE MMM d");
     }
 
     public static String getFeedCardDateString(int age) {
-        return getFeedCardDateString(new UtcDate(age).baseCalendar());
+        return getFeedCardDateString(new UtcDate(age).baseZonedDateTime());
     }
 
-    public static String getFeedCardDateString(@NonNull Calendar date) {
-        return getShortDateString(date.getTime());
-    }
-
-    public static String getFeedCardDateString(@NonNull Instant instant) {
-        return getShortDateString(instant);
+    public static String getFeedCardDateString(@NonNull TemporalAccessor temporalAccessor) {
+        return getShortDateString(temporalAccessor);
     }
 
     public static String getFeedCardDateString(@NonNull Date date) {
@@ -95,8 +92,8 @@ public final class DateUtil {
         return getDateStringWithSkeletonPattern(date, "MMM d");
     }
 
-    private static synchronized String getDateStringWithSkeletonPattern(@NonNull Instant instant, @NonNull String pattern) {
-        return getCachedDateTimeFormatter(android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault(), false).format(instant);
+    private static synchronized String getDateStringWithSkeletonPattern(@NonNull TemporalAccessor temporalAccessor, @NonNull String pattern) {
+        return getCachedDateTimeFormatter(android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault(), false).format(temporalAccessor);
     }
 
     private static synchronized String getDateStringWithSkeletonPattern(@NonNull Date date, @NonNull String pattern) {
@@ -133,9 +130,9 @@ public final class DateUtil {
         return dateFormat.format(date);
     }
 
-    public static String getShortDateString(@NonNull Instant instant) {
+    public static String getShortDateString(@NonNull TemporalAccessor temporalAccessor) {
         return DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneOffset.UTC)
-                .format(instant);
+                .format(temporalAccessor);
     }
 
     public static UtcDate getUtcRequestDateFor(int age) {

--- a/app/src/main/java/org/wikipedia/util/SavedPagesConversionUtil.java
+++ b/app/src/main/java/org/wikipedia/util/SavedPagesConversionUtil.java
@@ -218,12 +218,7 @@ public final class SavedPagesConversionUtil {
             String title = CURRENT_PAGE.apiTitle();
 
             String summaryUrl = UriUtil.encodeOkHttpUrl(ServiceFactory.getRestBasePath(CURRENT_PAGE.wiki()) + "page/summary/", title);
-            String date = DateUtil.getHttpLastModifiedDate(new Date());
-            try {
-                date = DateUtil.getHttpLastModifiedDate(DateUtil.iso8601DateParse(pageLead.getLastModified()));
-            } catch (Exception e) {
-                //
-            }
+            String date = DateUtil.getHttpLastModifiedInstant(DateUtil.iso8601InstantParse(pageLead.getLastModified()));
 
             OfflineCacheInterceptor.createCacheItemFor(CURRENT_PAGE, summaryUrl, json, "application/json", date);
         } catch (Exception e) {

--- a/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.java
+++ b/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.java
@@ -4,13 +4,11 @@ import com.google.gson.stream.MalformedJsonException;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.Instant;
+import org.threeten.bp.LocalDate;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.wikipedia.json.GsonUnmarshaller;
 import org.wikipedia.test.MockRetrofitTest;
 import org.wikipedia.test.TestFileUtil;
-
-import java.util.Locale;
 
 import io.reactivex.Observable;
 import io.reactivex.observers.TestObserver;
@@ -29,7 +27,7 @@ public class AnnouncementClientTest extends MockRetrofitTest {
     private static final int ANNOUNCEMENT_BETA_WITH_VERSION = 6;
     private static final int ANNOUNCEMENT_FOR_OLD_VERSION = 7;
     private AnnouncementList announcementList;
-    private DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
+    private DateTimeFormatter dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE;
 
     private static final String ANNOUNCEMENT_JSON_FILE = "announce_2016_11_21.json";
 
@@ -74,25 +72,25 @@ public class AnnouncementClientTest extends MockRetrofitTest {
         assertThat(announcement.hasImageUrl(), is(true));
     }
 
-    @Test public void testShouldShowByCountry() throws Throwable {
+    @Test public void testShouldShowByCountry() {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_SURVEY_ANDROID);
-        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
+        LocalDate dateDuring = LocalDate.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), is(true));
         assertThat(AnnouncementClient.shouldShow(announcement, "FI", dateDuring), is(false));
         assertThat(AnnouncementClient.shouldShow(announcement, null, dateDuring), is(false));
     }
 
-    @Test public void testShouldShowByDate() throws Throwable {
+    @Test public void testShouldShowByDate() {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_SURVEY_ANDROID);
-        Instant dateBefore = Instant.from(dateFormatter.parse("2016-08-01"));
-        Instant dateAfter = Instant.from(dateFormatter.parse("2017-01-05"));
+        LocalDate dateBefore = LocalDate.from(dateFormatter.parse("2016-08-01"));
+        LocalDate dateAfter = LocalDate.from(dateFormatter.parse("2017-01-05"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateBefore), is(false));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateAfter), is(false));
     }
 
-    @Test public void testShouldShowByPlatform() throws Throwable {
+    @Test public void testShouldShowByPlatform() {
         Announcement announcementIOS = announcementList.items().get(ANNOUNCEMENT_IOS);
-        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
+        LocalDate dateDuring = LocalDate.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcementIOS, "US", dateDuring), is(false));
     }
 
@@ -101,23 +99,23 @@ public class AnnouncementClientTest extends MockRetrofitTest {
         assertThat(announcementList.items().get(ANNOUNCEMENT_NO_DATES), is(nullValue()));
     }
 
-    @Test public void testShouldShowForInvalidCountries() throws Throwable {
+    @Test public void testShouldShowForInvalidCountries() {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_NO_COUNTRIES);
-        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
+        LocalDate dateDuring = LocalDate.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), is(false));
         assertThat(AnnouncementClient.shouldShow(announcement, "FI", dateDuring), is(false));
         assertThat(AnnouncementClient.shouldShow(announcement, "", dateDuring), is(false));
     }
 
-    @Test public void testBetaWithVersion() throws Throwable {
+    @Test public void testBetaWithVersion() {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_BETA_WITH_VERSION);
-        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
+        LocalDate dateDuring = LocalDate.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), is(true));
     }
 
-    @Test public void testForOldVersion() throws Throwable {
+    @Test public void testForOldVersion() {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_FOR_OLD_VERSION);
-        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
+        LocalDate dateDuring = LocalDate.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), is(false));
     }
 

--- a/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.java
+++ b/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.java
@@ -4,12 +4,12 @@ import com.google.gson.stream.MalformedJsonException;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.threeten.bp.Instant;
+import org.threeten.bp.format.DateTimeFormatter;
 import org.wikipedia.json.GsonUnmarshaller;
 import org.wikipedia.test.MockRetrofitTest;
 import org.wikipedia.test.TestFileUtil;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Locale;
 
 import io.reactivex.Observable;
@@ -29,7 +29,7 @@ public class AnnouncementClientTest extends MockRetrofitTest {
     private static final int ANNOUNCEMENT_BETA_WITH_VERSION = 6;
     private static final int ANNOUNCEMENT_FOR_OLD_VERSION = 7;
     private AnnouncementList announcementList;
-    private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
+    private DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
 
     private static final String ANNOUNCEMENT_JSON_FILE = "announce_2016_11_21.json";
 
@@ -76,7 +76,7 @@ public class AnnouncementClientTest extends MockRetrofitTest {
 
     @Test public void testShouldShowByCountry() throws Throwable {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_SURVEY_ANDROID);
-        Date dateDuring = dateFormat.parse("2016-11-20");
+        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), is(true));
         assertThat(AnnouncementClient.shouldShow(announcement, "FI", dateDuring), is(false));
         assertThat(AnnouncementClient.shouldShow(announcement, null, dateDuring), is(false));
@@ -84,15 +84,15 @@ public class AnnouncementClientTest extends MockRetrofitTest {
 
     @Test public void testShouldShowByDate() throws Throwable {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_SURVEY_ANDROID);
-        Date dateBefore = dateFormat.parse("2016-08-01");
-        Date dateAfter = dateFormat.parse("2017-01-05");
+        Instant dateBefore = Instant.from(dateFormatter.parse("2016-08-01"));
+        Instant dateAfter = Instant.from(dateFormatter.parse("2017-01-05"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateBefore), is(false));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateAfter), is(false));
     }
 
     @Test public void testShouldShowByPlatform() throws Throwable {
         Announcement announcementIOS = announcementList.items().get(ANNOUNCEMENT_IOS);
-        Date dateDuring = dateFormat.parse("2016-11-20");
+        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcementIOS, "US", dateDuring), is(false));
     }
 
@@ -103,7 +103,7 @@ public class AnnouncementClientTest extends MockRetrofitTest {
 
     @Test public void testShouldShowForInvalidCountries() throws Throwable {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_NO_COUNTRIES);
-        Date dateDuring = dateFormat.parse("2016-11-20");
+        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), is(false));
         assertThat(AnnouncementClient.shouldShow(announcement, "FI", dateDuring), is(false));
         assertThat(AnnouncementClient.shouldShow(announcement, "", dateDuring), is(false));
@@ -111,13 +111,13 @@ public class AnnouncementClientTest extends MockRetrofitTest {
 
     @Test public void testBetaWithVersion() throws Throwable {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_BETA_WITH_VERSION);
-        Date dateDuring = dateFormat.parse("2016-11-20");
+        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), is(true));
     }
 
     @Test public void testForOldVersion() throws Throwable {
         Announcement announcement = announcementList.items().get(ANNOUNCEMENT_FOR_OLD_VERSION);
-        Date dateDuring = dateFormat.parse("2016-11-20");
+        Instant dateDuring = Instant.from(dateFormatter.parse("2016-11-20"));
         assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), is(false));
     }
 

--- a/app/src/test/java/org/wikipedia/util/DateUtilTest.java
+++ b/app/src/test/java/org/wikipedia/util/DateUtilTest.java
@@ -17,12 +17,7 @@ public class DateUtilTest {
     }
 
     @Test
-    public void testIso8601DateFormat() throws Throwable {
-        assertThat(DateUtil.iso8601DateFormat(DateUtil.getHttpLastModifiedDate(HTTP_DATE_HEADER)), is("2017-05-25T21:13:47Z"));
-    }
-
-    @Test
-    public void testIso8601Identity() throws Throwable {
-        assertThat(DateUtil.iso8601DateFormat(DateUtil.iso8601DateParse("2017-05-25T21:13:47Z")), is("2017-05-25T21:13:47Z"));
+    public void testIso8601DateTimeFormatter() {
+        assertThat(DateUtil.iso8601DateFormat(DateUtil.getHttpLastModifiedInstant(HTTP_DATE_HEADER)), is("2017-05-25T21:13:47Z"));
     }
 }


### PR DESCRIPTION
[ThreeTenABP ](https://github.com/JakeWharton/ThreeTenABP) is a port of [ThreeTenBP](https://www.threeten.org/threetenbp/apidocs/index.html), a backport of Java 8's Time API (JSR-310) for Java 6 and 7, for Android.

Using this library allows the Java 8 Time API to be used on Android without having to check the API level, and also makes migrating to the standard Java 8 Time API easier as it will be made available on versions of Android older than API level 26 [starting with Android Gradle plugin 4.0](https://developer.android.com/studio/preview/features#j8-desugar) (currently at beta 5).