### PR TITLE
Rewrite ReadingListBehaviorsUtil.getListsContainPage() using standard Kotlin functions.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -40,18 +40,8 @@ object ReadingListBehaviorsUtil {
     private val scope = CoroutineScope(Dispatchers.Main)
     private val exceptionHandler = CoroutineExceptionHandler { _, exception -> L.w(exception) }
 
-    fun getListsContainPage(readingListPage: ReadingListPage): List<ReadingList> {
-        val lists = mutableListOf<ReadingList>()
-        allReadingLists.forEach { list ->
-            list.pages().forEach addToList@{ page ->
-                if (page.title() == readingListPage.title()) {
-                    lists.add(list)
-                    return@addToList
-                }
-            }
-        }
-        return lists
-    }
+    fun getListsContainPage(readingListPage: ReadingListPage) =
+            allReadingLists.filter { list -> list.pages().asSequence().any { it.title() == readingListPage.title() } }
 
     fun savePagesForOffline(activity: Activity, selectedPages: List<ReadingListPage>, callback: Callback) {
         if (Prefs.isDownloadOnlyOverWiFiEnabled() && !DeviceUtil.isOnWiFi()) {


### PR DESCRIPTION
Use Kotlin's `filter` and `any` functions to simplify the filtering operation in getListsContainPage().

This makes the code more idiomatic and allows the function to be declared as a single expression function.