### PR TITLE
Add more usages of Apache Commons Lang utility methods

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.java
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.java
@@ -64,7 +64,7 @@ public class WikiSite implements Parcelable {
     }
 
     public static void setDefaultBaseUrl(@NonNull String url) {
-        DEFAULT_BASE_URL = TextUtils.isEmpty(url) ? Service.WIKIPEDIA_URL : url;
+        DEFAULT_BASE_URL = StringUtils.defaultIfEmpty(url, Service.WIKIPEDIA_URL);
     }
 
     public static WikiSite forLanguageCode(@NonNull String languageCode) {
@@ -77,8 +77,8 @@ public class WikiSite implements Parcelable {
     public WikiSite(@NonNull Uri uri) {
         Uri tempUri = ensureScheme(uri);
         String authority = StringUtils.defaultString(tempUri.getAuthority());
-        if (("wikipedia.org".equals(authority) || "www.wikipedia.org".equals(authority))
-                && tempUri.getPath() != null && tempUri.getPath().startsWith("/wiki")) {
+        if (StringUtils.equalsAny(authority, "wikipedia.org", "www.wikipedia.org")
+                && StringUtils.startsWith(tempUri.getPath(), "/wiki")) {
             // Special case for Wikipedia only: assume English subdomain when none given.
             authority = "en.wikipedia.org";
         }
@@ -114,7 +114,7 @@ public class WikiSite implements Parcelable {
 
     @NonNull
     public String scheme() {
-        return TextUtils.isEmpty(uri.getScheme()) ? DEFAULT_SCHEME : uri.getScheme();
+        return StringUtils.defaultString(uri.getScheme(), DEFAULT_SCHEME);
     }
 
     /**

--- a/app/src/main/java/org/wikipedia/edit/EditAbuseFilterResult.java
+++ b/app/src/main/java/org/wikipedia/edit/EditAbuseFilterResult.java
@@ -5,6 +5,8 @@ import android.os.Parcelable;
 
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
+
 class EditAbuseFilterResult extends EditResult {
     static final int TYPE_WARNING = 1;
     static final int TYPE_ERROR = 2;
@@ -47,11 +49,11 @@ class EditAbuseFilterResult extends EditResult {
     }
 
     public int getType() {
-        if (code != null && code.startsWith("abusefilter-warning")) {
+        if (StringUtils.startsWith(code, "abusefilter-warning")) {
             return TYPE_WARNING;
-        } else if (code != null && code.startsWith("abusefilter-disallowed")) {
+        } else if (StringUtils.startsWith(code, "abusefilter-disallowed")) {
             return TYPE_ERROR;
-        } else if (info != null && info.startsWith("Hit AbuseFilter")) {
+        } else if (StringUtils.startsWith(code, "Hit AbuseFilter")) {
             // This case is here because, unfortunately, an admin can create an abuse filter which
             // emits an arbitrary error code over the API.
             // TODO: More properly handle the case where the AbuseFilter throws an arbitrary error.

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -467,7 +467,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
             Uri uri = Uri.parse(url);
             String authority = uri.getAuthority();
             if (authority != null && WikiSite.supportedAuthority(authority)
-                && uri.getPath() != null && uri.getPath().startsWith("/wiki/")) {
+                && StringUtils.startsWith(uri.getPath(), "/wiki/")) {
                 PageTitle title = new WikiSite(uri).titleForUri(uri);
                 showLinkPreview(title);
             } else {

--- a/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
+++ b/app/src/main/java/org/wikipedia/gallery/MediaListItem.java
@@ -6,6 +6,7 @@ import androidx.annotation.Nullable;
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.wikipedia.util.UriUtil;
 import org.wikipedia.util.log.L;
 
@@ -100,7 +101,7 @@ public class MediaListItem implements Serializable {
         }
 
         public float getScale() {
-            return scale == null ? 0 : Float.parseFloat(scale.replace("x", ""));
+            return NumberUtils.toFloat(StringUtils.remove(scale, 'x'));
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/page/LinkHandler.java
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.JsonObject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.bridge.CommunicationBridge;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.util.UriUtil;
@@ -66,7 +67,7 @@ public abstract class LinkHandler implements CommunicationBridge.JSEventListener
 
         Uri uri = Uri.parse(href);
 
-        if (!TextUtils.isEmpty(uri.getFragment()) && uri.getFragment().contains("cite")) {
+        if (StringUtils.contains(uri.getFragment(), "cite")) {
             onPageLinkClicked(uri.getFragment(), linkText);
             return;
         }
@@ -93,8 +94,8 @@ public abstract class LinkHandler implements CommunicationBridge.JSEventListener
         }
 
         L.d("Link clicked was " + uri.toString());
-        if (!TextUtils.isEmpty(uri.getPath()) && WikiSite.supportedAuthority(uri.getAuthority())
-                && (uri.getPath().startsWith("/wiki/") || uri.getPath().startsWith("/zh-"))) {
+        if (StringUtils.startsWithAny(uri.getPath(), "/wiki/", "/zh-")
+                && WikiSite.supportedAuthority(uri.getAuthority())) {
             WikiSite site = new WikiSite(uri);
             if (site.subdomain().equals(getWikiSite().subdomain())
                     && !site.languageCode().equals(getWikiSite().languageCode())) {
@@ -109,8 +110,8 @@ public abstract class LinkHandler implements CommunicationBridge.JSEventListener
             } else {
                 onInternalLinkClicked(title);
             }
-        } else if (!TextUtils.isEmpty(uri.getAuthority()) && WikiSite.supportedAuthority(uri.getAuthority())
-                && !TextUtils.isEmpty(uri.getFragment())) {
+        } else if (!StringUtils.isAnyEmpty(uri.getAuthority(), uri.getFragment())
+                && WikiSite.supportedAuthority(uri.getAuthority())) {
             onPageLinkClicked(uri.getFragment(), linkText);
         } else {
             onExternalLinkClicked(uri);

--- a/app/src/main/java/org/wikipedia/util/StringUtil.java
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.java
@@ -17,6 +17,7 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.Gson;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 
 import java.nio.charset.StandardCharsets;
@@ -84,7 +85,7 @@ public final class StringUtil {
      * @return The trimmed CharSequence.
      */
     @NonNull public static CharSequence strip(@Nullable CharSequence str) {
-        if (str == null || str.length() == 0) {
+        if (TextUtils.isEmpty(str)) {
             return "";
         }
         int len = str.length();
@@ -163,7 +164,7 @@ public final class StringUtil {
         if (source == null) {
             return new SpannedString("");
         }
-        if (!source.contains("<") && !source.contains("&")) {
+        if (StringUtils.containsNone(source, '<', '&')) {
             // If the string doesn't contain any hints of HTML entities, then skip the expensive
             // processing that fromHtml() performs.
             return new SpannedString(source);

--- a/app/src/main/java/org/wikipedia/util/StringUtil.java
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.java
@@ -85,22 +85,7 @@ public final class StringUtil {
      * @return The trimmed CharSequence.
      */
     @NonNull public static CharSequence strip(@Nullable CharSequence str) {
-        if (TextUtils.isEmpty(str)) {
-            return "";
-        }
-        int len = str.length();
-        int start = 0;
-        int end = len - 1;
-        while (start < len && Character.isWhitespace(str.charAt(start))) {
-            start++;
-        }
-        while (end > 0 && Character.isWhitespace(str.charAt(end))) {
-            end--;
-        }
-        if (end > start) {
-            return str.subSequence(start, end + 1);
-        }
-        return "";
+        return TextUtils.isEmpty(str) ? "" : StringUtils.strip(str.toString());
     }
 
     @NonNull

--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -84,8 +84,7 @@ public final class UriUtil {
 
         // also handle images like /w/extensions/ImageMap/desc-20.png?15600 on Estados Unidos
         // or like /api/rest_v1/page/graph/png/API/0/019dd76b5f4887040716e65de53802c5033cb40c.png
-        return (ret.startsWith("./") || ret.startsWith("/w/") || ret.startsWith("/wiki/"))
-                || ret.startsWith("/api/")
+        return StringUtils.startsWithAny(ret, "./", "/w/", "/wiki/", "/api/")
                 ? wiki.uri().buildUpon().appendEncodedPath(ret.replaceFirst("/", "")).build().toString()
                 : ret;
     }
@@ -102,11 +101,9 @@ public final class UriUtil {
     }
 
     public static boolean isValidPageLink(@NonNull Uri uri) {
-        return (!TextUtils.isEmpty(uri.getAuthority())
-                && uri.getAuthority().endsWith("wikipedia.org")
-                && !TextUtils.isEmpty(uri.getPath())
-                && uri.getPath().startsWith("/wiki"))
-                && (uri.getFragment() == null || !uri.getFragment().startsWith("cite"));
+        return StringUtils.endsWith(uri.getAuthority(), "wikipedia.org")
+                && StringUtils.startsWith(uri.getPath(), "/wiki")
+                && !StringUtils.startsWith(uri.getFragment(), "cite");
     }
 
     public static void handleExternalLink(final Context context, final Uri uri) {

--- a/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.java
+++ b/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.java
@@ -11,6 +11,7 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.R;
 
 import butterknife.BindView;
@@ -117,12 +118,12 @@ public class WikiTextKeyboardView extends FrameLayout {
         }
         @Nullable String title = null;
         CharSequence selection = editText.getInputConnection().getSelectedText(0);
-        if (selection != null && selection.length() > 0 && !selection.toString().contains("[[")) {
+        if (!TextUtils.isEmpty(selection) && !selection.toString().contains("[[")) {
             title = trimPunctuation(selection.toString());
         } else {
             String before;
             String after;
-            if (selection != null && selection.length() > 1) {
+            if (StringUtils.length(selection) > 1) {
                 String selectionStr = selection.toString();
                 before = selectionStr.substring(0, selectionStr.length() / 2);
                 after = selectionStr.substring(selectionStr.length() / 2);
@@ -156,7 +157,7 @@ public class WikiTextKeyboardView extends FrameLayout {
         if (editText.getSelectionStart() == editText.getSelectionEnd()) {
             CharSequence before = ic.getTextBeforeCursor(prefix.length(), 0);
             CharSequence after = ic.getTextAfterCursor(suffix.length(), 0);
-            if (before != null && before.toString().equals(prefix) && after != null && after.toString().equals(suffix)) {
+            if (StringUtils.equals(before, prefix) && StringUtils.equals(after, suffix)) {
                 // the cursor is actually inside the exact syntax, so negate it.
                 ic.deleteSurroundingText(prefix.length(), suffix.length());
             } else {
@@ -197,10 +198,10 @@ public class WikiTextKeyboardView extends FrameLayout {
     }
 
     private String trimPunctuation(@NonNull String str) {
-        while (str.startsWith(".") || str.startsWith(",") || str.startsWith(";") || str.startsWith("?") || str.startsWith("!")) {
+        while (StringUtils.startsWithAny(str, ".", ",", ";", "?", "!")) {
             str = str.substring(1);
         }
-        while (str.endsWith(".") || str.endsWith(",") || str.endsWith(";") || str.endsWith("?") || str.endsWith("!")) {
+        while (StringUtils.endsWithAny(str, ".", ",", ";", "?", "!")) {
             str = str.substring(0, str.length() - 1);
         }
         return str;

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.java
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.FragmentUtil;
@@ -143,7 +144,7 @@ public class WiktionaryDialog extends ExtendedBottomSheetDialogFragment {
         LinearLayout fullDefinitionsList = rootView.findViewById(R.id.wiktionary_definitions_by_part_of_speech);
 
         RbDefinition.Usage[] usageList = currentDefinition.getUsagesForLang("en");
-        if (usageList == null || usageList.length == 0) {
+        if (ArrayUtils.isEmpty(usageList)) {
             displayNoDefinitionsFound();
             return;
         }

--- a/app/src/test/java/org/wikipedia/util/StringUtilTest.java
+++ b/app/src/test/java/org/wikipedia/util/StringUtilTest.java
@@ -57,6 +57,9 @@ public class StringUtilTest {
 
     @Test
     public void testStrip() {
+        assertThat(StringUtil.strip(null), is(""));
+        assertThat(StringUtil.strip(""), is(""));
+        assertThat(StringUtil.strip("    "), is(""));
         assertThat(StringUtil.strip("test"), is("test"));
         assertThat(StringUtil.strip(" test  "), is("test"));
     }


### PR DESCRIPTION
Some of the code present in the project, such as `StringUtil`'s `strip` method, duplicate code that is already present in the Apache Commons Lang library, so this adds calls to utility methods in Apache Commons Lang. In addition, some null checks have been simplified using said utility methods.