### PR TITLE
Set Robolectric SDK property to 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: android
 jdk:
-- oraclejdk8
-dist: trusty
+- oraclejdk9
+dist: xenial
 android:
   components:
   - platform-tools
   - tools
-  - build-tools-28.0.3
   - build-tools-29.0.2
   - android-29
 before_script:

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,2 +1,2 @@
 # suppress inspection "UnusedProperty" for whole file
-sdk=24
+sdk=29


### PR DESCRIPTION
Previously, the SDK property used was 24 (Nougat), which meant that SDK features introduced in later versions of Android were not being used. This change makes Robolectric test against Android SDK 29 (Q), as it is the latest version currently available.