### PR TITLE
Fix: set webview to null to prevent crash when EditPreviewFragment got destroyed

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -289,8 +289,8 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
         if (webview != null) {
             webview.clearAllListeners();
             ((ViewGroup) webview.getParent()).removeView(webview);
-            webview = null;
             bridge.cleanup();
+            webview = null;
         }
         super.onDestroyView();
     }


### PR DESCRIPTION
Steps to reproduce:

Edit article -> preview the changes -> go back to edit screen -> cancel edit