### PR TITLE
Temporary fix of not showing images in the image preview dialog

### DIFF
--- a/app/src/main/res/layout/dialog_image_preview.xml
+++ b/app/src/main/res/layout/dialog_image_preview.xml
@@ -59,7 +59,7 @@
             <ImageView
                 android:id="@+id/galleryImage"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="300dp"
                 android:contentDescription="@null"
                 android:scaleType="fitCenter" />
 


### PR DESCRIPTION
This is a temporary fix and a better optimization is in #1157.