### PR TITLE
Move the logic of showing protection status message to FeedbackUtil

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
@@ -661,20 +661,8 @@ public class EditSectionActivity extends BaseActivity {
         ViewAnimations.crossFade(progressBar, sectionContainer);
         scrollToHighlight(textToHighlight);
 
-        if (pageProps != null && !TextUtils.isEmpty(pageProps.getEditProtectionStatus())) {
-            String message;
-            switch (pageProps.getEditProtectionStatus()) {
-                case "sysop":
-                    message = getString(R.string.page_protected_sysop);
-                    break;
-                case "autoconfirmed":
-                    message = getString(R.string.page_protected_autoconfirmed);
-                    break;
-                default:
-                    message = getString(R.string.page_protected_other, pageProps.getEditProtectionStatus());
-                    break;
-            }
-            FeedbackUtil.showMessage(this, message);
+        if (pageProps != null) {
+            FeedbackUtil.showProtectionStatusMessage(this, pageProps.getEditProtectionStatus());
         }
     }
 

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
@@ -3,6 +3,7 @@ package org.wikipedia.util;
 import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -102,6 +103,26 @@ public final class FeedbackUtil {
     public static void showAndroidAppEditingFAQ(Context context, @StringRes int urlStr) {
         SuggestedEditsFunnel.get().helpOpened();
         visitInExternalBrowser(context, Uri.parse(context.getString(urlStr)));
+    }
+
+    public static boolean showProtectionStatusMessage(@NonNull Activity activity, @Nullable String status) {
+        if (TextUtils.isEmpty(status)) {
+            return false;
+        }
+        String message;
+        switch (status) {
+            case "sysop":
+                message = activity.getString(R.string.page_protected_sysop);
+                break;
+            case "autoconfirmed":
+                message = activity.getString(R.string.page_protected_autoconfirmed);
+                break;
+            default:
+                message = activity.getString(R.string.page_protected_other, status);
+                break;
+        }
+        showMessage(activity, message);
+        return true;
     }
 
     public static void setToolbarButtonLongPressToast(View... views) {


### PR DESCRIPTION
Related ticket: https://phabricator.wikimedia.org/T235028

Since the message and status are the same, we should share the logic. The `boolean` value of the method will be used when getting the response from #1216 and update the edit pencil in `GalleryActivity` and suggested edits CTA in the lead image.