### PR TITLE
Handling plurals in ReadingList messages

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/AddToReadingListDialog.java
+++ b/app/src/main/java/org/wikipedia/readinglist/AddToReadingListDialog.java
@@ -246,12 +246,13 @@ public class AddToReadingListDialog extends ExtendedBottomSheetDialogFragment {
         disposables.add(Observable.fromCallable(() -> ReadingListDbHelper.instance().addPagesToListIfNotExist(readingList, titles))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(numAdded -> {
+                .subscribe(addedTitlesList -> {
                     String message;
-                    if (numAdded == 0) {
+                    if (addedTitlesList.size() == 0) {
                         message = getString(R.string.reading_list_articles_already_exist_message, readingList.title());
                     } else {
-                        message = getString(R.string.reading_list_articles_added_to_named, numAdded, readingList.title());
+                        message = (addedTitlesList.size() == 1) ? getString(R.string.reading_list_article_added_to_named, addedTitlesList.get(0), readingList.title())
+                                : getString(R.string.reading_list_articles_added_to_named, addedTitlesList.size(), readingList.title());
                         new ReadingListsFunnel().logAddToList(readingList, readingLists.size(), invokeSource);
                     }
                     showViewListSnackBar(readingList, message);

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
@@ -217,27 +217,27 @@ public class ReadingListDbHelper {
         SavedPageSyncService.enqueue();
     }
 
-    public int addPagesToListIfNotExist(@NonNull ReadingList list, @NonNull List<PageTitle> titles) {
+    public ArrayList<String> addPagesToListIfNotExist(@NonNull ReadingList list, @NonNull List<PageTitle> titles) {
         SQLiteDatabase db = getWritableDatabase();
         db.beginTransaction();
-        int numAdded = 0;
+        ArrayList<String> addedTitles = new ArrayList<>();
         try {
             for (PageTitle title : titles) {
                 if (getPageByTitle(db, list, title) != null) {
                     continue;
                 }
                 addPageToList(db, list, title);
-                numAdded++;
+                addedTitles.add(title.getDisplayText());
             }
             db.setTransactionSuccessful();
         } finally {
             db.endTransaction();
         }
-        if (numAdded > 0) {
+        if (addedTitles.size() > 0) {
             SavedPageSyncService.enqueue();
             ReadingListSyncAdapter.manualSync();
         }
-        return numAdded;
+        return addedTitles;
     }
 
     private void addPageToList(SQLiteDatabase db, @NonNull ReadingList list, @NonNull PageTitle title) {

--- a/app/src/test/java/org/wikipedia/readinglist/database/ReadingListDbHelperTest.java
+++ b/app/src/test/java/org/wikipedia/readinglist/database/ReadingListDbHelperTest.java
@@ -135,14 +135,14 @@ public class ReadingListDbHelperTest {
         pages.add(page);
         pages.add(page2);
         pages.add(page3);
-        int numAdded = readingListDbHelper.addPagesToListIfNotExist(list, pages);
+        ArrayList<String> addedTitles = readingListDbHelper.addPagesToListIfNotExist(list, pages);
         readingListDbHelper.deleteList(list);
         List<ReadingListPage> readingListPages = new ArrayList<>();
         for (PageTitle page1 : pages) {
             readingListPages.add(new ReadingListPage(page1));
         }
         readingListDbHelper.markPagesForDeletion(list, readingListPages);
-        Assert.assertTrue(numAdded == 2);
+        Assert.assertTrue(addedTitles.size() == 2);
     }
 
     @Test


### PR DESCRIPTION
**Phab:** https://phabricator.wikimedia.org/T166462

Only one of the cases has a wrong plural message : 
Adding many articles from one list to another, where only one article did not exist in the new list. 

Previous message :  
"Added 1 articles to 'list'" 

To match with existing messages, new message : 
"Added %articleName to 'list'

![change](https://user-images.githubusercontent.com/9540770/81974935-21765100-95db-11ea-9c42-ca6fb0bd3854.png)

Details on phab ticket.
