### PR TITLE
Show progressbar correctly in the Suggested edits task screen

### DIFF
--- a/app/src/main/res/layout/fragment_suggested_edits_tasks.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_tasks.xml
@@ -8,166 +8,170 @@
     android:layout_height="match_parent"
     android:background="?attr/paper_color">
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/suggestedEditsScrollView"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <FrameLayout
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/suggestedEditsScrollView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusableInTouchMode="true">
+            android:layout_height="match_parent">
 
-            <ProgressBar
-                android:id="@+id/progressBar"
-                style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:indeterminate="true"
-                android:indeterminateTint="?attr/colorAccent"
-                android:progressBackgroundTint="?attr/multi_select_background_color"
-                android:layout_marginTop="-6dp" />
+                android:focusableInTouchMode="true">
 
-            <org.wikipedia.views.SuggestedEditsDisabledStatesView
-                android:id="@+id/disabledStatesView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="@dimen/activity_horizontal_margin"
-                android:paddingEnd="@dimen/activity_horizontal_margin"
-                android:visibility="gone" />
-
-            <org.wikipedia.views.WikiErrorView
-                android:id="@+id/errorView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="32dp"
-                android:layout_gravity="center"
-                android:visibility="gone" />
-
-            <LinearLayout
-                android:id="@+id/tasksContainer"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <androidx.constraintlayout.widget.ConstraintLayout
+                <org.wikipedia.views.SuggestedEditsDisabledStatesView
+                    android:id="@+id/disabledStatesView"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:clipChildren="false"
-                    android:clipToPadding="false"
                     android:paddingStart="@dimen/activity_horizontal_margin"
                     android:paddingEnd="@dimen/activity_horizontal_margin"
-                    android:background="?attr/paper_color">
+                    android:visibility="gone" />
 
-                    <org.wikipedia.views.ImageTitleDescriptionView
-                        android:id="@+id/contributionsStatsView"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:minWidth="140dp"
-                        android:layout_marginTop="16dp"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toStartOf="@id/editStreakStatsView"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <org.wikipedia.views.ImageTitleDescriptionView
-                        android:id="@+id/editStreakStatsView"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:minWidth="140dp"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toEndOf="@id/contributionsStatsView"
-                        app:layout_constraintTop_toTopOf="@id/contributionsStatsView" />
-
-                    <org.wikipedia.views.ImageTitleDescriptionView
-                        android:id="@+id/pageViewStatsView"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:minWidth="140dp"
-                        android:layout_marginTop="20dp"
-                        app:layout_constraintStart_toStartOf="@id/contributionsStatsView"
-                        app:layout_constraintTop_toBottomOf="@id/contributionsStatsView" />
-
-                    <org.wikipedia.views.ImageTitleDescriptionView
-                        android:id="@+id/editQualityStatsView"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:minWidth="140dp"
-                        app:layout_constraintStart_toStartOf="@id/editStreakStatsView"
-                        app:layout_constraintTop_toTopOf="@id/pageViewStatsView" />
-
-                    <ImageView
-                        android:id="@+id/onboardingImageView"
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/suggested_edits_top_illustration_height"
-                        android:contentDescription="@null"
-                        android:visibility="gone"
-                        android:layout_marginTop="16dp"
-                        app:layout_constraintTop_toBottomOf="@id/editQualityStatsView"
-                        app:srcCompat="@drawable/ic_suggested_edits_onboarding" />
-
-                    <TextView
-                        android:id="@+id/textViewForMessage"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/onboardingImageView"
-                        android:lineSpacingExtra="6sp"
-                        android:textAlignment="center"
-                        android:textSize="@dimen/suggested_edits_message_textview_text_size" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                <FrameLayout
-                    android:layout_width="match_parent"
+                <org.wikipedia.views.WikiErrorView
+                    android:id="@+id/errorView"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:background="?attr/paper_color">
-                    <View
-                        android:layout_width="30dp"
-                        android:layout_height="15dp"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginTop="8dp"
-                        android:background="@drawable/triangle" />
-                </FrameLayout>
+                    android:layout_marginTop="32dp"
+                    android:layout_gravity="center"
+                    android:visibility="gone" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/tasksRecyclerView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="?attr/paper_color" />
-
-                <!-- TODO: remove. -->
                 <LinearLayout
+                    android:id="@+id/tasksContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="8dp">
+                    android:orientation="vertical">
 
-                    <TextView
-                        android:id="@+id/showIPBlockedMessage"
-                        android:layout_width="wrap_content"
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:textAllCaps="true"
-                        android:textColor="?attr/colorAccent"
-                        android:textSize="@dimen/bottom_nav_label_text_size"
-                        android:text="IPBlocked" />
+                        android:clipChildren="false"
+                        android:clipToPadding="false"
+                        android:paddingStart="@dimen/activity_horizontal_margin"
+                        android:paddingEnd="@dimen/activity_horizontal_margin"
+                        android:background="?attr/paper_color">
 
-                    <TextView
-                        android:id="@+id/showOnboardingMessage"
-                        android:layout_width="wrap_content"
+                        <org.wikipedia.views.ImageTitleDescriptionView
+                            android:id="@+id/contributionsStatsView"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minWidth="140dp"
+                            android:layout_marginTop="16dp"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/editStreakStatsView"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <org.wikipedia.views.ImageTitleDescriptionView
+                            android:id="@+id/editStreakStatsView"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minWidth="140dp"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/contributionsStatsView"
+                            app:layout_constraintTop_toTopOf="@id/contributionsStatsView" />
+
+                        <org.wikipedia.views.ImageTitleDescriptionView
+                            android:id="@+id/pageViewStatsView"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minWidth="140dp"
+                            android:layout_marginTop="20dp"
+                            app:layout_constraintStart_toStartOf="@id/contributionsStatsView"
+                            app:layout_constraintTop_toBottomOf="@id/contributionsStatsView" />
+
+                        <org.wikipedia.views.ImageTitleDescriptionView
+                            android:id="@+id/editQualityStatsView"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minWidth="140dp"
+                            app:layout_constraintStart_toStartOf="@id/editStreakStatsView"
+                            app:layout_constraintTop_toTopOf="@id/pageViewStatsView" />
+
+                        <ImageView
+                            android:id="@+id/onboardingImageView"
+                            android:layout_width="match_parent"
+                            android:layout_height="@dimen/suggested_edits_top_illustration_height"
+                            android:contentDescription="@null"
+                            android:visibility="gone"
+                            android:layout_marginTop="16dp"
+                            app:layout_constraintTop_toBottomOf="@id/editQualityStatsView"
+                            app:srcCompat="@drawable/ic_suggested_edits_onboarding" />
+
+                        <TextView
+                            android:id="@+id/textViewForMessage"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/onboardingImageView"
+                            android:lineSpacingExtra="6sp"
+                            android:textAlignment="center"
+                            android:textSize="@dimen/suggested_edits_message_textview_text_size" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <FrameLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:textAllCaps="true"
-                        android:textColor="?attr/colorAccent"
-                        android:textSize="@dimen/bottom_nav_label_text_size"
-                        android:text="Onboarding" />
+                        android:background="?attr/paper_color">
+                        <View
+                            android:layout_width="30dp"
+                            android:layout_height="15dp"
+                            android:layout_gravity="center_horizontal"
+                            android:layout_marginTop="8dp"
+                            android:background="@drawable/triangle" />
+                    </FrameLayout>
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/tasksRecyclerView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/paper_color" />
+
+                    <!-- TODO: remove. -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:padding="8dp">
+
+                        <TextView
+                            android:id="@+id/showIPBlockedMessage"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:textAllCaps="true"
+                            android:textColor="?attr/colorAccent"
+                            android:textSize="@dimen/bottom_nav_label_text_size"
+                            android:text="IPBlocked" />
+
+                        <TextView
+                            android:id="@+id/showOnboardingMessage"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:textAllCaps="true"
+                            android:textColor="?attr/colorAccent"
+                            android:textSize="@dimen/bottom_nav_label_text_size"
+                            android:text="Onboarding" />
+                    </LinearLayout>
+
                 </LinearLayout>
 
-            </LinearLayout>
+            </FrameLayout>
 
-        </FrameLayout>
+        </androidx.core.widget.NestedScrollView>
 
-    </androidx.core.widget.NestedScrollView>
-
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:indeterminateTint="?attr/colorAccent"
+            android:progressBackgroundTint="?attr/multi_select_background_color"
+            android:layout_marginTop="-6dp" />
+    </FrameLayout>
 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
The current `progressbar` should show on the top of the `NestedScrollView`, otherwise, it will be a little bit weird if the view scrolls to the top after content updated.

This PR just creates a `FrameLayout` and arranges the `NestedScrollView` and `ProgressBar`.