### PR TITLE
Fix possible out-of-memory conditions when loading large images.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.java
+++ b/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.java
@@ -73,7 +73,7 @@ public class FaceAndColorDetectImageView extends AppCompatImageView {
                 .load(uri)
                 .placeholder(placeholder)
                 .error(placeholder)
-                .downsample(DownsampleStrategy.CENTER_OUTSIDE)
+                .downsample(DownsampleStrategy.CENTER_INSIDE)
                 .transform(FACE_DETECT_TRANSFORM)
                 .into(this);
     }

--- a/app/src/main/java/org/wikipedia/views/ViewUtil.java
+++ b/app/src/main/java/org/wikipedia/views/ViewUtil.java
@@ -46,6 +46,7 @@ public final class ViewUtil {
         RequestBuilder<Drawable> builder = Glide.with(view)
                 .load((isImageDownloadEnabled() || force) && !TextUtils.isEmpty(url) ? Uri.parse(url) : null)
                 .placeholder(placeholder)
+                .downsample(DownsampleStrategy.CENTER_INSIDE)
                 .error(placeholder);
         if (roundedCorners) {
             builder = builder.transform(CENTER_CROP_ROUNDED_CORNERS);

--- a/app/src/main/java/org/wikipedia/views/ViewUtil.java
+++ b/app/src/main/java/org/wikipedia/views/ViewUtil.java
@@ -18,6 +18,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.MultiTransformation;
 import com.bumptech.glide.load.resource.bitmap.CenterCrop;
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 
 import org.wikipedia.R;
@@ -58,6 +59,7 @@ public final class ViewUtil {
                 .load(!TextUtils.isEmpty(url) ? Uri.parse(url) : null)
                 .placeholder(placeholder)
                 .error(placeholder)
+                .downsample(DownsampleStrategy.CENTER_INSIDE)
                 .transform(new WhiteBackgroundTransformation())
                 .into(view);
     }


### PR DESCRIPTION
Images loaded in the Gallery must be properly downsampled. Otherwise, certain images (especially ones with a highly eccentric aspect ratio) will be upscaled beyond the memory limits of the VM.

https://appcenter.ms/orgs/ci-apps-hockeyapp-f5mf/apps/Wikipedia/crashes/errors/3506720188u/overview
