### PR TITLE
Prevent possible crash when searching for image tag labels.

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagDialog.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagDialog.kt
@@ -49,7 +49,9 @@ class SuggestedEditsImageTagDialog : DialogFragment() {
     private val disposables = CompositeDisposable()
 
     private val searchRunnable = Runnable {
-        requestResults(currentSearchTerm)
+        if (isAdded) {
+            requestResults(currentSearchTerm)
+        }
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -106,6 +108,7 @@ class SuggestedEditsImageTagDialog : DialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         imageTagsSearchText.removeTextChangedListener(textWatcher)
+        imageTagsSearchText.removeCallbacks(searchRunnable)
         disposables.clear()
     }
 


### PR DESCRIPTION
https://appcenter.ms/orgs/ci-apps-hockeyapp-f5mf/apps/Wikipedia/crashes/errors/3007784083u/overview
