### PR TITLE
Priority: fix loading of articles with slash in title.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -20,6 +20,7 @@ import org.wikipedia.dataclient.RestService;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.json.GsonUtil;
 import org.wikipedia.page.PageTitle;
+import org.wikipedia.util.UriUtil;
 import org.wikipedia.util.log.L;
 
 import java.util.ArrayList;
@@ -89,7 +90,7 @@ public class CommunicationBridge {
         pendingJSMessages.clear();
         pendingEvals.clear();
         communicationBridgeListener.getWebView().loadUrl(ServiceFactory.getRestBasePath(pageTitle.getWikiSite())
-                + RestService.PAGE_HTML_ENDPOINT + pageTitle.getPrefixedText());
+                + RestService.PAGE_HTML_ENDPOINT + UriUtil.encodeURL(pageTitle.getPrefixedText()));
     }
 
     public void cleanup() {

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -169,7 +169,7 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
         hideSoftKeyboard(requireActivity());
         ((EditSectionActivity)requireActivity()).showProgressBar(true);
 
-        String url = ServiceFactory.getRestBasePath(model.getTitle().getWikiSite()) + PAGE_HTML_PREVIEW_ENDPOINT + title.getPrefixedText();
+        String url = ServiceFactory.getRestBasePath(model.getTitle().getWikiSite()) + PAGE_HTML_PREVIEW_ENDPOINT + UriUtil.encodeURL(title.getPrefixedText());
         String postData = "wikitext=" + UriUtil.encodeURL(wikiText);
         webview.postUrl(url, postData.getBytes());
 

--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.java
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.java
@@ -291,7 +291,7 @@ public class SavedPageSyncService extends JobIntentService {
 
     private Observable<okhttp3.Response> reqMobileHTML(@NonNull PageTitle pageTitle) {
         Request request = makeUrlRequest(pageTitle.getWikiSite(), ServiceFactory.getRestBasePath(pageTitle.getWikiSite())
-                + RestService.PAGE_HTML_ENDPOINT + pageTitle.getPrefixedText(), pageTitle).build();
+                + RestService.PAGE_HTML_ENDPOINT + UriUtil.encodeURL(pageTitle.getPrefixedText()), pageTitle).build();
 
         return Observable.create(emitter -> {
             try {


### PR DESCRIPTION
When making requests to the `mobile-html` endpoint, we need to explicitly encode the title before it goes into the interceptor chain.  The new TitleEncodeInterceptor is supposed to encode the title transparently, but it operates on path segments -- but when a title contains slashes, it gets treated as multiple path segments.

This should have no additional impact on loading other articles, with any other special characters.