### PR TITLE
Fix: prevent showing a translucent cover when losing focus on searchView

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.java
@@ -377,7 +377,6 @@ public class SearchFragment extends Fragment implements SearchResultsFragment.Ca
         isSearchActive = true;
 
         searchView.setIconified(false);
-        searchView.requestFocusFromTouch();
         // if we already have a previous search query, then put it into the SearchView, and it will
         // automatically trigger the showing of the corresponding search results.
         if (isValidQuery(query)) {

--- a/app/src/main/java/org/wikipedia/views/FindInPageActionProvider.java
+++ b/app/src/main/java/org/wikipedia/views/FindInPageActionProvider.java
@@ -60,7 +60,6 @@ public class FindInPageActionProvider extends ActionProvider {
         setFindInPageChevronsEnabled(false);
         searchView.setQueryHint(context.getString(R.string.menu_page_find_in_page));
         searchView.setFocusable(true);
-        searchView.requestFocusFromTouch();
         searchView.setOnQueryTextListener(searchQueryListener);
         searchView.setIconified(false);
         searchView.setMaxWidth(Integer.MAX_VALUE);

--- a/app/src/main/java/org/wikipedia/views/SearchActionProvider.java
+++ b/app/src/main/java/org/wikipedia/views/SearchActionProvider.java
@@ -47,7 +47,6 @@ public class SearchActionProvider extends ActionProvider {
         View view = View.inflate(context, R.layout.group_search, null);
         ButterKnife.bind(this, view);
         searchView.setFocusable(true);
-        searchView.requestFocusFromTouch();
         searchView.setIconified(false);
         searchView.setMaxWidth(Integer.MAX_VALUE);
         searchView.setInputType(EditorInfo.TYPE_CLASS_TEXT);


### PR DESCRIPTION
Steps to reproduce:

Open search screen -> search something -> tap first article -> tap system "back" button -> tap system "back" button again to hide the keyboard -> see a translucent cover.