### PR TITLE
Use local variables and hide edit pencil if protected in FilePage and ImagePreviewDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -31,11 +31,7 @@ import org.wikipedia.util.log.L
 class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.OnDismissListener {
 
     private lateinit var suggestedEditsSummary: SuggestedEditsSummary
-    private lateinit var imageTags: Map<String, List<String>>
     private lateinit var action: Action
-    private var isFromCommons: Boolean = false
-    private var thumbnailWidth: Int = 0
-    private var thumbnailHeight: Int = 0
     private val disposables = CompositeDisposable()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -77,6 +73,11 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
     }
 
     private fun loadImageInfo() {
+        lateinit var imageTags: Map<String, List<String>>
+        var isFromCommons: Boolean = false
+        var thumbnailWidth: Int = 0
+        var thumbnailHeight: Int = 0
+
         disposables.add(ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(suggestedEditsSummary.title, suggestedEditsSummary.lang)
                 .subscribeOn(Schedulers.io())
                 .flatMap {


### PR DESCRIPTION
If the file is protected, then we should not show the edit pencil in the file page. This PR also makes the global `private` variables to local variables.