### PR TITLE
Load Main Page(s) via Mobile Web instead of via API.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -20,6 +20,7 @@ import org.wikipedia.dataclient.RestService;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.json.GsonUtil;
 import org.wikipedia.page.PageTitle;
+import org.wikipedia.page.PageViewModel;
 import org.wikipedia.util.UriUtil;
 import org.wikipedia.util.log.L;
 
@@ -51,7 +52,7 @@ public class CommunicationBridge {
 
     public interface CommunicationBridgeListener {
         WebView getWebView();
-        PageTitle getPageTitle();
+        PageViewModel getModel();
         boolean isPreview();
     }
 
@@ -89,7 +90,7 @@ public class CommunicationBridge {
         isMetadataReady = false;
         pendingJSMessages.clear();
         pendingEvals.clear();
-        if (pageTitle.isMainPage()) {
+        if (communicationBridgeListener.getModel().shouldLoadAsMobileWeb()) {
             communicationBridgeListener.getWebView().loadUrl(pageTitle.getMobileUri());
         } else {
             communicationBridgeListener.getWebView().loadUrl(ServiceFactory.getRestBasePath(pageTitle.getWikiSite())
@@ -172,7 +173,7 @@ public class CommunicationBridge {
         }
     });
 
-    private class CommunicatingChrome extends WebChromeClient {
+    private static class CommunicatingChrome extends WebChromeClient {
         @Override
         public boolean onConsoleMessage(@NonNull ConsoleMessage consoleMessage) {
             L.d(consoleMessage.sourceId() + ":" + consoleMessage.lineNumber() + " - " + consoleMessage.message());
@@ -199,12 +200,12 @@ public class CommunicationBridge {
         @JavascriptInterface
         public synchronized String getSetupSettings() {
             return JavaScriptActionHandler.setUp(communicationBridgeListener.getWebView().getContext(),
-                    communicationBridgeListener.getPageTitle(), communicationBridgeListener.isPreview());
+                    communicationBridgeListener.getModel().getTitle(), communicationBridgeListener.isPreview());
         }
     }
 
     @SuppressWarnings("unused")
-    private class BridgeMessage {
+    private static class BridgeMessage {
         @Nullable private String action;
         @Nullable private JsonObject data;
 

--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.java
@@ -89,8 +89,12 @@ public class CommunicationBridge {
         isMetadataReady = false;
         pendingJSMessages.clear();
         pendingEvals.clear();
-        communicationBridgeListener.getWebView().loadUrl(ServiceFactory.getRestBasePath(pageTitle.getWikiSite())
-                + RestService.PAGE_HTML_ENDPOINT + UriUtil.encodeURL(pageTitle.getPrefixedText()));
+        if (pageTitle.isMainPage()) {
+            communicationBridgeListener.getWebView().loadUrl(pageTitle.getMobileUri());
+        } else {
+            communicationBridgeListener.getWebView().loadUrl(ServiceFactory.getRestBasePath(pageTitle.getWikiSite())
+                    + RestService.PAGE_HTML_ENDPOINT + UriUtil.encodeURL(pageTitle.getPrefixedText()));
+        }
     }
 
     public void cleanup() {
@@ -126,6 +130,10 @@ public class CommunicationBridge {
     public void evaluate(@NonNull String js, ValueCallback<String> callback) {
         pendingEvals.put(js, callback);
         flushMessages();
+    }
+
+    public void evaluateImmediate(@NonNull String js, ValueCallback<String> callback) {
+        communicationBridgeListener.getWebView().evaluateJavascript(js, callback);
     }
 
     private void flushMessages() {

--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -1,7 +1,6 @@
 package org.wikipedia.bridge
 
 import android.content.Context
-import androidx.annotation.ColorInt
 import org.wikipedia.BuildConfig
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp

--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.bridge
 
 import android.content.Context
+import androidx.annotation.ColorInt
 import org.wikipedia.BuildConfig
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -136,5 +137,14 @@ object JavaScriptActionHandler {
                 "       fragment: \"pcs-read-more\"" +
                 "   }" +
                 "})"
+    }
+
+    @JvmStatic
+    fun mainPageShim(@ColorInt backgroundColor: Int): String {
+        return "(function() { var elements = document.querySelectorAll('tr,td,div,h2,h3');" +
+                "for (var i = 0; i < elements.length; i++) {" +
+                "  elements[i].style.backgroundColor = '#${String.format("%08x", backgroundColor).substring(2)}';" +
+                "}" +
+                "})();"
     }
 }

--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -140,15 +140,11 @@ object JavaScriptActionHandler {
     }
 
     @JvmStatic
-    fun mainPageShim(@ColorInt backgroundColor: Int): String {
-        return "(function() { var i; var elements = document.querySelectorAll('tr,td,div,h2,h3');" +
-                "for (i = 0; i < elements.length; i++) {" +
-                "  elements[i].style.backgroundColor = '#${String.format("%08x", backgroundColor).substring(2)}';" +
-                "  if (elements[i].tagName === 'TD') {" +
-                "    elements[i].style.display = 'block';" +
-                "    elements[i].style.width = '100%';" +
-                "  }" +
-                "}" +
+    fun mobileWebChromeShim(): String {
+        return "(function() {" +
+                "let style = document.createElement('style');" +
+                "style.innerHTML = '.header-chrome { visibility: hidden; } #page-secondary-actions { display: none; } .mw-footer { margin-bottom: 48px; }';" +
+                "document.head.appendChild(style);" +
                 "})();"
     }
 }

--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -141,9 +141,13 @@ object JavaScriptActionHandler {
 
     @JvmStatic
     fun mainPageShim(@ColorInt backgroundColor: Int): String {
-        return "(function() { var elements = document.querySelectorAll('tr,td,div,h2,h3');" +
-                "for (var i = 0; i < elements.length; i++) {" +
+        return "(function() { var i; var elements = document.querySelectorAll('tr,td,div,h2,h3');" +
+                "for (i = 0; i < elements.length; i++) {" +
                 "  elements[i].style.backgroundColor = '#${String.format("%08x", backgroundColor).substring(2)}';" +
+                "  if (elements[i].tagName === 'TD') {" +
+                "    elements[i].style.display = 'block';" +
+                "    elements[i].style.width = '100%';" +
+                "  }" +
                 "}" +
                 "})();"
     }

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 
 import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.WikipediaApp;
+import org.wikipedia.page.LinkHandler;
 import org.wikipedia.page.PageViewModel;
 import org.wikipedia.util.UriUtil;
 import org.wikipedia.util.log.L;
@@ -45,6 +46,16 @@ public abstract class OkHttpWebViewClient extends WebViewClient {
     private static final String PCS_JS = "/data/javascript/mobile/pcs";
 
     @NonNull public abstract PageViewModel getModel();
+    @NonNull public abstract LinkHandler getLinkHandler();
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        if (getModel().getTitle() != null && getModel().getTitle().isMainPage()) {
+            getLinkHandler().onUrlClick(UriUtil.decodeURL(url), null, "");
+            return true;
+        }
+        return false;
+    }
 
     @SuppressWarnings("checkstyle:magicnumber")
     @Override public WebResourceResponse shouldInterceptRequest(WebView view,

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.java
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.java
@@ -50,7 +50,9 @@ public abstract class OkHttpWebViewClient extends WebViewClient {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
-        if (getModel().getTitle() != null && getModel().getTitle().isMainPage()) {
+        if (getModel().shouldLoadAsMobileWeb()) {
+            // If the page was loaded as Mobile Web, then pass all link clicks through
+            // to our own link handler.
             getLinkHandler().onUrlClick(UriUtil.decodeURL(url), null, "");
             return true;
         }

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -294,8 +294,8 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
     }
 
     @Override
-    public PageTitle getPageTitle() {
-        return model.getTitle();
+    public PageViewModel getModel() {
+        return model;
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -206,53 +206,7 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
         bridge.addListener("final_setup", (String messageType, JsonObject messagePayload) -> {
             // ignore
         });
-        bridge.addListener("link", new LinkHandler(requireActivity()) {
-            @Override
-            public void onPageLinkClicked(@NonNull String href, @NonNull String linkText) {
-                // TODO: also need to handle references, issues, disambig, ... in preview eventually
-            }
-
-            @Override
-            public void onInternalLinkClicked(@NonNull final PageTitle title) {
-                showLeavingEditDialogue(() -> startActivity(PageActivity.newIntentForCurrentTab(getContext(),
-                        new HistoryEntry(title, HistoryEntry.SOURCE_INTERNAL_LINK), title)));
-            }
-
-            @Override
-            public void onExternalLinkClicked(@NonNull final Uri uri) {
-                showLeavingEditDialogue(() -> handleExternalLink(getContext(), uri));
-            }
-
-            @Override
-            public void onMediaLinkClicked(@NonNull PageTitle title) {
-                // ignore
-            }
-
-            /**
-             * Shows the user a dialogue asking them if they really meant to leave the edit
-             * workflow, and warning them that their changes have not yet been saved.
-             *
-             * @param runnable The runnable that is run if the user chooses to leave.
-             */
-            private void showLeavingEditDialogue(final Runnable runnable) {
-                //Ask the user if they really meant to leave the edit workflow
-                final AlertDialog leavingEditDialog = new AlertDialog.Builder(requireActivity())
-                        .setMessage(R.string.dialog_message_leaving_edit)
-                        .setPositiveButton(R.string.dialog_message_leaving_edit_leave, (dialog, which) -> {
-                            //They meant to leave; close dialogue and run specified action
-                            dialog.dismiss();
-                            runnable.run();
-                        })
-                        .setNegativeButton(R.string.dialog_message_leaving_edit_stay, null)
-                        .create();
-                leavingEditDialog.show();
-            }
-
-            @Override
-            public WikiSite getWikiSite() {
-                return model.getTitle().getWikiSite();
-            }
-        });
+        bridge.addListener("link", linkHandler);
         bridge.addListener("image", (messageType, messagePayload) -> {
             // TODO: do something when an image is clicked in Preview.
         });

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -1,5 +1,6 @@
 package org.wikipedia.edit.preview;
 
+import android.content.Context;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -56,6 +57,7 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
 
     private PageViewModel model = new PageViewModel();
     private CommunicationBridge bridge;
+    private EditLinkHandler linkHandler;
 
     private List<EditSummaryTag> summaryTags;
     private EditSummaryTag otherTag;
@@ -70,6 +72,7 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
         previewContainer = parent.findViewById(R.id.edit_preview_container);
         ViewGroup editSummaryTagsContainer = parent.findViewById(R.id.edit_summary_tags_container);
         bridge = new CommunicationBridge(this);
+        linkHandler = new EditLinkHandler(requireActivity());
         initWebView();
 
         PageTitle pageTitle = ((EditSectionActivity)requireActivity()).getPageTitle();
@@ -181,6 +184,10 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
         webview.setWebViewClient(new OkHttpWebViewClient() {
             @NonNull @Override public PageViewModel getModel() {
                 return model;
+            }
+
+            @NonNull @Override public LinkHandler getLinkHandler() {
+                return linkHandler;
             }
 
             @Override public void onPageFinished(WebView view, String url) {
@@ -340,5 +347,57 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
     @Override
     public boolean isPreview() {
         return true;
+    }
+
+    private class EditLinkHandler extends LinkHandler {
+        EditLinkHandler(@NonNull Context context) {
+            super(context);
+        }
+
+        @Override
+        public void onPageLinkClicked(@NonNull String href, @NonNull String linkText) {
+            // TODO: also need to handle references, issues, disambig, ... in preview eventually
+        }
+
+        @Override
+        public void onInternalLinkClicked(@NonNull final PageTitle title) {
+            showLeavingEditDialogue(() -> startActivity(PageActivity.newIntentForCurrentTab(getContext(),
+                    new HistoryEntry(title, HistoryEntry.SOURCE_INTERNAL_LINK), title)));
+        }
+
+        @Override
+        public void onExternalLinkClicked(@NonNull final Uri uri) {
+            showLeavingEditDialogue(() -> handleExternalLink(getContext(), uri));
+        }
+
+        @Override
+        public void onMediaLinkClicked(@NonNull PageTitle title) {
+            // ignore
+        }
+
+        /**
+         * Shows the user a dialogue asking them if they really meant to leave the edit
+         * workflow, and warning them that their changes have not yet been saved.
+         *
+         * @param runnable The runnable that is run if the user chooses to leave.
+         */
+        private void showLeavingEditDialogue(final Runnable runnable) {
+            //Ask the user if they really meant to leave the edit workflow
+            final AlertDialog leavingEditDialog = new AlertDialog.Builder(requireActivity())
+                    .setMessage(R.string.dialog_message_leaving_edit)
+                    .setPositiveButton(R.string.dialog_message_leaving_edit_leave, (dialog, which) -> {
+                        //They meant to leave; close dialogue and run specified action
+                        dialog.dismiss();
+                        runnable.run();
+                    })
+                    .setNegativeButton(R.string.dialog_message_leaving_edit_stay, null)
+                    .create();
+            leavingEditDialog.show();
+        }
+
+        @Override
+        public WikiSite getWikiSite() {
+            return model.getTitle().getWikiSite();
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -462,10 +462,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         requireActivity().invalidateOptionsMenu();
         initPageScrollFunnel();
 
-        if (model.getPage().isMainPage()) {
-            bridge.execute(JavaScriptActionHandler.mainPageShim(ResourceUtil.getThemedColor(requireContext(), R.attr.paper_color)));
-        }
-
         if (model.getReadingListPage() != null) {
             final ReadingListPage page = model.getReadingListPage();
             final PageTitle title = model.getTitle();
@@ -492,6 +488,10 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         // handler), since the page metadata might have altered the lead image display state.
         bridge.execute(JavaScriptActionHandler.setTopMargin(leadImagesHandler.getTopMargin()));
         bridge.execute(JavaScriptActionHandler.setFooter(model));
+
+        if (model.getPage().isMainPage()) {
+            bridge.execute(JavaScriptActionHandler.mainPageShim(ResourceUtil.getThemedColor(requireContext(), R.attr.paper_color)));
+        }
     }
 
     private void handleInternalLink(@NonNull PageTitle title) {

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -978,6 +978,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         if (bookmarkTab != null) {
             ((ImageView) bookmarkTab).setImageResource(pageSaved ? R.drawable.ic_bookmark_white_24dp
                     : R.drawable.ic_bookmark_border_white_24dp);
+            bookmarkTab.setEnabled(!(model.getTitle() != null && model.getTitle().isMainPage()));
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -253,8 +253,8 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     }
 
     @Override
-    public PageTitle getPageTitle() {
-        return model.getTitle();
+    public PageViewModel getModel() {
+        return model;
     }
 
     @Override
@@ -978,7 +978,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         if (bookmarkTab != null) {
             ((ImageView) bookmarkTab).setImageResource(pageSaved ? R.drawable.ic_bookmark_white_24dp
                     : R.drawable.ic_bookmark_border_white_24dp);
-            bookmarkTab.setEnabled(!(model.getTitle() != null && model.getTitle().isMainPage()));
+            bookmarkTab.setEnabled(!model.shouldLoadAsMobileWeb());
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -490,6 +490,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         bridge.execute(JavaScriptActionHandler.setFooter(model));
 
         if (model.getPage().isMainPage()) {
+            // TODO: remove when mobile-html presents the Main Page more correctly.
             bridge.execute(JavaScriptActionHandler.mainPageShim(ResourceUtil.getThemedColor(requireContext(), R.attr.paper_color)));
         }
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -89,6 +89,7 @@ import org.wikipedia.util.ActiveTimer;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.GeoUtil;
+import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.util.ShareUtil;
 import org.wikipedia.util.ThrowableUtil;
 import org.wikipedia.util.UriUtil;
@@ -460,6 +461,10 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         refreshView.setRefreshing(false);
         requireActivity().invalidateOptionsMenu();
         initPageScrollFunnel();
+
+        if (model.getPage().isMainPage()) {
+            bridge.execute(JavaScriptActionHandler.mainPageShim(ResourceUtil.getThemedColor(requireContext(), R.attr.paper_color)));
+        }
 
         if (model.getReadingListPage() != null) {
             final ReadingListPage page = model.getReadingListPage();

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -236,7 +236,9 @@ public class PageFragmentLoadState {
             app.getSessionFunnel().noDescription();
         }
 
-        model.getTitle().setDisplayText(page.getDisplayTitle());
+        if (!model.getTitle().isMainPage()) {
+            model.getTitle().setDisplayText(page.getDisplayTitle());
+        }
 
         leadImagesHandler.loadLeadImage();
 

--- a/app/src/main/java/org/wikipedia/page/PageTitle.java
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.java
@@ -244,6 +244,10 @@ public class PageTitle implements Parcelable {
         return getUriForDomain(getWikiSite().authority());
     }
 
+    public String getMobileUri() {
+        return getUriForDomain(getWikiSite().authority().replace(".wikipedia.org", ".m.wikipedia.org"));
+    }
+
     public String getUriForAction(String action) {
         try {
             return String.format(

--- a/app/src/main/java/org/wikipedia/page/PageViewModel.java
+++ b/app/src/main/java/org/wikipedia/page/PageViewModel.java
@@ -76,6 +76,10 @@ public class PageViewModel {
         return forceNetwork;
     }
 
+    public boolean shouldLoadAsMobileWeb() {
+        return title != null && title.isMainPage();
+    }
+
     public CacheControl getCacheControl() {
         return shouldForceNetwork() ? OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK : OkHttpConnectionFactory.CACHE_CONTROL_NONE;
     }


### PR DESCRIPTION
Thanks to some ideas from @joewalsh, we shall now load the Main Page (of any language wiki) by literally loading the mobile web URL into the WebView. (this is in fact what the iOS app does.)

This has a couple of drawbacks:

* It will only appear in the Light theme (i.e. will ignore the user's theme selection).

* The Main Page of many wikis often has links to various Special and Portal pages that may also render weirdly in the app.

* The Main Page won't have the other affordances that other pages have, such as the table of contents, collapsible tables, etc.

...But at least this will allow us to present the Main Page to users who need it, making sure it's formatted correctly because we're leveraging mobile web, instead of the still-evolving parsoid `page/html` API.