### PR TITLE
Add rounded top border with background color in PlainPasteEditText

### DIFF
--- a/app/src/main/java/org/wikipedia/views/PlainPasteEditText.java
+++ b/app/src/main/java/org/wikipedia/views/PlainPasteEditText.java
@@ -3,18 +3,21 @@ package org.wikipedia.views;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.SystemClock;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 
+import androidx.annotation.AttrRes;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.android.material.textfield.TextInputEditText;
 
+import org.wikipedia.R;
 import org.wikipedia.edit.richtext.SpanExtents;
 import org.wikipedia.edit.richtext.SyntaxHighlighter;
 import org.wikipedia.util.ClipboardUtil;
@@ -38,14 +41,29 @@ public class PlainPasteEditText extends TextInputEditText {
 
     public PlainPasteEditText(Context context) {
         super(context);
+        init(null, 0);
     }
 
     public PlainPasteEditText(Context context, AttributeSet attrs) {
         super(context, attrs);
+        init(attrs, 0);
     }
 
     public PlainPasteEditText(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        init(attrs, defStyle);
+    }
+
+    private void init(@Nullable AttributeSet attrs, @AttrRes int defStyleAttr) {
+        if (attrs != null) {
+            TypedArray array = getContext().obtainStyledAttributes(attrs,
+                    R.styleable.PlainPasteEditText, defStyleAttr, 0);
+            boolean hasRoundedTopWithBorder = array.getBoolean(R.styleable.PlainPasteEditText_roundedTopWithBorder, true);
+            if (hasRoundedTopWithBorder) {
+                setBackgroundResource(R.drawable.text_input_bg_with_rounded_top);
+            }
+            array.recycle();
+        }
     }
 
     @Override

--- a/app/src/main/res/drawable/text_input_bg_with_rounded_top.xml
+++ b/app/src/main/res/drawable/text_input_bg_with_rounded_top.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?attr/color_group_22" />
+    <stroke
+        android:width="1dp"
+        android:color="?attr/color_group_60" />
+    <corners android:topLeftRadius="4dp" android:topRightRadius="4dp"
+        android:bottomLeftRadius="0dp" android:bottomRightRadius="0dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_edit_section.xml
+++ b/app/src/main/res/layout/activity_edit_section.xml
@@ -32,7 +32,8 @@
                 android:inputType="textMultiLine"
                 android:scrollbars="vertical"
                 android:textColor="?attr/primary_text_color"
-                android:textColorHighlight="#FF9632" />
+                android:textColorHighlight="#FF9632"
+                app:roundedTopWithBorder="false"/>
         </ScrollView>
 
         <HorizontalScrollView

--- a/app/src/main/res/layout/dialog_image_tag_select.xml
+++ b/app/src/main/res/layout/dialog_image_tag_select.xml
@@ -21,7 +21,8 @@
             android:textSize="14sp"
             android:textColor="?attr/material_theme_primary_color"
             android:background="@null"
-            android:maxLines="1">
+            android:maxLines="1"
+            app:roundedTopWithBorder="false">
             <requestFocus />
         </org.wikipedia.views.PlainPasteEditText>
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -112,4 +112,8 @@
         <attr name="title" format="string" />
         <attr name="detail" format="string" />
     </declare-styleable>
+
+    <declare-styleable name="PlainPasteEditText">
+        <attr name="roundedTopWithBorder" format="boolean" />
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T246897

We can set `foreground` drawable if we don't show the helper text or error text; However we have to show the helper text in most cases, the border will contain the helper text and it looks weird.

This PR adds a custom attribute to the `PlainPasteEditText` to set the background.