### PR TITLE
Hygiene: use getString() instead of String.format()

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditRevertHelpView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditRevertHelpView.java
@@ -38,10 +38,10 @@ public class DescriptionEditRevertHelpView extends ScrollView {
                 .replaceAll(":revertSubtitle", getString(R.string.description_edit_revert_subtitle))
                 .replaceAll(":revertIntro", getString(R.string.description_edit_revert_intro))
                 .replaceAll(":revertHistory",
-                        String.format(getString(R.string.description_edit_revert_history), getHistoryUri(qNumber))));
+                        getContext().getString(R.string.description_edit_revert_history, getHistoryUri(qNumber))));
 
         int gapWidth = DimenUtil.roundedDpToPx(8);
-        SpannableString revertReason1 = new SpannableString(StringUtil.fromHtml(String.format(getString(R.string.description_edit_revert_reason1), getString(R.string.wikidata_description_guide_url))));
+        SpannableString revertReason1 = new SpannableString(StringUtil.fromHtml(getContext().getString(R.string.description_edit_revert_reason1, getString(R.string.wikidata_description_guide_url))));
         SpannableString revertReason2 = new SpannableString(StringUtil.fromHtml(getString(R.string.description_edit_revert_reason2)));
         revertReason1.setSpan(new BulletSpan(gapWidth), 0, revertReason1.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         revertReason2.setSpan(new BulletSpan(gapWidth), 0, revertReason2.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.java
@@ -244,9 +244,9 @@ public class EditSectionActivity extends BaseActivity {
 
     private void updateEditLicenseText() {
         TextView editLicenseText = findViewById(R.id.edit_section_license_text);
-        editLicenseText.setText(StringUtil.fromHtml(String.format(getString(AccountUtil.isLoggedIn()
+        editLicenseText.setText(StringUtil.fromHtml(getString(AccountUtil.isLoggedIn()
                         ? R.string.edit_save_action_license_logged_in
-                        : R.string.edit_save_action_license_anon),
+                        : R.string.edit_save_action_license_anon,
                 getString(R.string.terms_of_use_url),
                 getString(R.string.cc_by_sa_3_url))));
 

--- a/app/src/main/java/org/wikipedia/feed/mainpage/MainPageCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/mainpage/MainPageCardView.java
@@ -22,7 +22,7 @@ public class MainPageCardView extends StaticCardView<MainPageCard> {
     @Override public void setCard(@NonNull final MainPageCard card) {
         super.setCard(card);
         setTitle(getString(R.string.view_main_page_card_title));
-        setSubtitle(String.format(getString(R.string.view_main_page_card_subtitle),
+        setSubtitle(getContext().getString(R.string.view_main_page_card_subtitle,
                 DateFormat.getDateInstance().format(new Date())));
         setIcon(R.drawable.ic_today_24dp);
         setContainerBackground(R.color.green50);

--- a/app/src/main/java/org/wikipedia/feed/view/StaticCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/StaticCardView.java
@@ -41,7 +41,7 @@ public abstract class StaticCardView<T extends Card> extends DefaultFeedCardView
         title.setText(text);
     }
 
-    protected void setSubtitle(String text) {
+    protected void setSubtitle(CharSequence text) {
         subtitle.setText(text);
     }
 

--- a/app/src/main/java/org/wikipedia/feed/view/StaticCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/StaticCardView.java
@@ -41,7 +41,7 @@ public abstract class StaticCardView<T extends Card> extends DefaultFeedCardView
         title.setText(text);
     }
 
-    protected void setSubtitle(CharSequence text) {
+    protected void setSubtitle(String text) {
         subtitle.setText(text);
     }
 

--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.java
@@ -291,8 +291,8 @@ public class HistoryFragment extends Fragment implements BackPressedHandler {
 
     private void showDeleteItemsUndoSnackbar(final List<HistoryEntry> entries) {
         String message = entries.size() == 1
-                ? String.format(getString(R.string.history_item_deleted), entries.get(0).getTitle().getDisplayText())
-                : String.format(getString(R.string.history_items_deleted), entries.size());
+                ? getString(R.string.history_item_deleted, entries.get(0).getTitle().getDisplayText())
+                : getString(R.string.history_items_deleted, entries.size());
         Snackbar snackbar = FeedbackUtil.makeSnackbar(getActivity(), message,
                 FeedbackUtil.LENGTH_DEFAULT);
         snackbar.setAction(R.string.history_item_delete_undo, (v) -> {

--- a/app/src/main/java/org/wikipedia/main/MainDrawerView.java
+++ b/app/src/main/java/org/wikipedia/main/MainDrawerView.java
@@ -97,7 +97,7 @@ public class MainDrawerView extends ScrollView {
 
     @OnClick(R.id.main_drawer_donate_container) void onDonateClick() {
         UriUtil.visitInExternalBrowser(getContext(),
-                Uri.parse(String.format(getContext().getString(R.string.donate_url),
+                Uri.parse(getContext().getString(R.string.donate_url,
                         BuildConfig.VERSION_NAME, WikipediaApp.getInstance().language().getSystemLanguageCode())));
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -142,8 +142,8 @@ object ReadingListBehaviorsUtil {
         }
         FeedbackUtil
                 .makeSnackbar(activity,
-                        String.format(activity.getString(
-                                if (lists.size == 1) R.string.reading_list_item_deleted else R.string.reading_lists_item_deleted), page.title()),
+                        activity.getString(
+                                if (lists.size == 1) R.string.reading_list_item_deleted else R.string.reading_lists_item_deleted, page.title()),
                         FeedbackUtil.LENGTH_DEFAULT)
                 .setAction(R.string.reading_list_item_delete_undo) {
                     ReadingListDbHelper.instance().addPageToLists(lists, page, true)
@@ -157,8 +157,8 @@ object ReadingListBehaviorsUtil {
         }
         FeedbackUtil
                 .makeSnackbar(activity,
-                        String.format(activity.getString(
-                                if (pages.size == 1) R.string.reading_list_item_deleted else R.string.reading_list_items_deleted),
+                        activity.getString(
+                                if (pages.size == 1) R.string.reading_list_item_deleted else R.string.reading_list_items_deleted,
                                 if (pages.size == 1) pages[0].title() else pages.size),
                         FeedbackUtil.LENGTH_DEFAULT)
                 .setAction(R.string.reading_list_item_delete_undo) {
@@ -177,7 +177,7 @@ object ReadingListBehaviorsUtil {
             return
         }
         FeedbackUtil
-                .makeSnackbar(activity, String.format(activity.getString(R.string.reading_list_deleted), readingList.title()), FeedbackUtil.LENGTH_DEFAULT)
+                .makeSnackbar(activity, activity.getString(R.string.reading_list_deleted, readingList.title()), FeedbackUtil.LENGTH_DEFAULT)
                 .setAction(R.string.reading_list_item_delete_undo) {
                     val newList = ReadingListDbHelper.instance().createList(readingList.title(), readingList.description())
                     val newPages = ArrayList<ReadingListPage>()

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPageTable.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPageTable.java
@@ -129,7 +129,7 @@ public class ReadingListPageTable extends DatabaseTable<ReadingListPage> {
     private void renameListsWithIdenticalNameAsDefault(SQLiteDatabase db, List<ReadingList> lists) {
         for (ReadingList list : lists) {
             if (list.dbTitle().equalsIgnoreCase(WikipediaApp.getInstance().getString(R.string.default_reading_list_name))) {
-                list.title(String.format(WikipediaApp.getInstance().getString(R.string.reading_list_saved_list_rename), list.dbTitle()));
+                list.title(WikipediaApp.getInstance().getString(R.string.reading_list_saved_list_rename, list.dbTitle()));
                 ReadingListDbHelper.instance().updateList(db, list, false);
             }
         }

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -272,7 +272,7 @@ public class SearchResultsFragment extends Fragment {
     private void handleSuggestion(@Nullable String suggestion) {
         if (suggestion != null) {
             searchSuggestion.setText(StringUtil.fromHtml("<u>"
-                    + String.format(getString(R.string.search_did_you_mean), suggestion)
+                    + getString(R.string.search_did_you_mean, suggestion)
                     + "</u>"));
             searchSuggestion.setTag(suggestion);
             searchSuggestion.setVisibility(View.VISIBLE);
@@ -500,7 +500,7 @@ public class SearchResultsFragment extends Fragment {
             } else {
                 redirectText.setVisibility(View.VISIBLE);
                 redirectArrow.setVisibility(View.VISIBLE);
-                redirectText.setText(String.format(getString(R.string.search_redirect_from), result.getRedirectFrom()));
+                redirectText.setText(getString(R.string.search_redirect_from, result.getRedirectFrom()));
                 descriptionText.setVisibility(View.GONE);
             }
 

--- a/app/src/main/java/org/wikipedia/util/ShareUtil.java
+++ b/app/src/main/java/org/wikipedia/util/ShareUtil.java
@@ -124,16 +124,13 @@ public final class ShareUtil {
     }
 
     private static void displayOnCatchMessage(Throwable caught, Context context) {
-        Toast.makeText(context,
-                String.format(context.getString(R.string.gallery_share_error),
-                        caught.getLocalizedMessage()), Toast.LENGTH_SHORT).show();
+        Toast.makeText(context, context.getString(R.string.gallery_share_error,
+                caught.getLocalizedMessage()), Toast.LENGTH_SHORT).show();
     }
 
     private static void displayShareErrorMessage(Context context) {
-        Toast.makeText(context,
-                String.format(context.getString(R.string.gallery_share_error),
-                        context.getString(R.string.err_cannot_save_file)),
-                Toast.LENGTH_SHORT).show();
+        Toast.makeText(context, context.getString(R.string.gallery_share_error,
+                context.getString(R.string.err_cannot_save_file)), Toast.LENGTH_SHORT).show();
     }
 
     public static void showUnresolvableIntentMessage(Context context) {

--- a/app/src/main/java/org/wikipedia/views/NotificationWithProgressBar.java
+++ b/app/src/main/java/org/wikipedia/views/NotificationWithProgressBar.java
@@ -67,9 +67,9 @@ public class NotificationWithProgressBar {
         }
 
         builderIcon = getNotificationIcon();
-        builderTitle = String.format(context.getResources().getQuantityString(getNotificationTitle(), total), total);
+        builderTitle = context.getResources().getQuantityString(getNotificationTitle(), total, total);
         builderInfo = (int) MathUtil.percentage(progress, total) + "%";
-        builderDescription = String.format(context.getResources().getQuantityString(getNotificationDescription(), total - progress), total - progress);
+        builderDescription = context.getResources().getQuantityString(getNotificationDescription(), total - progress, total - progress);
 
         builder.setSmallIcon(builderIcon)
                 .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), builderIcon))

--- a/app/src/main/java/org/wikipedia/views/ReadingListsOverflowView.java
+++ b/app/src/main/java/org/wikipedia/views/ReadingListsOverflowView.java
@@ -56,7 +56,7 @@ public class ReadingListsOverflowView extends FrameLayout {
         lastSync.setVisibility(TextUtils.isEmpty(lastSyncTime) ? View.GONE : View.VISIBLE);
         if (!TextUtils.isEmpty(lastSyncTime)) {
             try {
-                lastSync.setText(String.format(getContext().getString(R.string.reading_list_menu_last_sync),
+                lastSync.setText(getContext().getString(R.string.reading_list_menu_last_sync,
                         DateUtil.getReadingListsLastSyncDateString(Prefs.getReadingListsLastSyncTime())));
             } catch (ParseException e) {
                 // ignore


### PR DESCRIPTION
If we can use `getString()` for setting the arguments then it is okay to remove the `String.format()`.