### PR TITLE
Set default status bar color to black for < API 23 devices

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -28,6 +28,7 @@
         <item name="materialButtonStyle">@style/Widget.MaterialComponents.Button.TextButton</item>
         <item name="maxActionInlineWidth">@dimen/snackbar_action_inline_max_dimen</item>
         <item name="textInputStyle">@style/TextInputLayoutStyle</item>
+        <item name="android:statusBarColor">@android:color/black</item>
     </style>
 
     <style name="AppTheme" parent="BaseAppTheme">


### PR DESCRIPTION
It shows a purple color as the status bar background and it looks really weird.

The emulator runs API 21:
![Screenshot_1592865283](https://user-images.githubusercontent.com/2435576/85341845-0af6cb80-b49e-11ea-8952-5a151ac21441.png)
