### PR TITLE
Follow-up to contributions detail screen.

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsContributionDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsContributionDetailsFragment.kt
@@ -23,6 +23,7 @@ import org.wikipedia.util.DateUtil
 import org.wikipedia.util.GradientUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.views.ViewUtil
+import kotlin.math.abs
 
 class SuggestedEditsContributionDetailsFragment : Fragment() {
     private lateinit var contribution: Contribution
@@ -78,8 +79,8 @@ class SuggestedEditsContributionDetailsFragment : Fragment() {
         when (contribution.editType) {
             EDIT_TYPE_ARTICLE_DESCRIPTION -> {
                 contributionCategory.text = getString(R.string.suggested_edits_contribution_article_label)
-                contributionDiffText.text = if (contribution.sizeDiff < 0) getString(R.string.suggested_edits_removed_contribution_label, contribution.description.length)
-                else getString(R.string.suggested_edits_added_contribution_label, contribution.description.length)
+                contributionDiffText.text = if (contribution.sizeDiff < 0) getString(R.string.suggested_edits_removed_contribution_label, abs(contribution.sizeDiff))
+                else getString(R.string.suggested_edits_added_contribution_label, contribution.sizeDiff)
                 pageViewsDetailView.setLabelAndDetail(getString(R.string.suggested_edits_contribution_views,
                         if (contribution.editType == EDIT_TYPE_ARTICLE_DESCRIPTION) getString(R.string.suggested_edits_contribution_article_label)
                         else getString(R.string.suggested_edits_contribution_image_label)), contribution.pageViews.toString(), R.drawable.ic_trending_up_black_24dp)
@@ -88,8 +89,8 @@ class SuggestedEditsContributionDetailsFragment : Fragment() {
             }
             EDIT_TYPE_IMAGE_CAPTION -> {
                 contributionCategory.text = getString(R.string.suggested_edits_contribution_image_label)
-                contributionDiffText.text = if (contribution.sizeDiff < 0) getString(R.string.suggested_edits_removed_contribution_label, contribution.description.length)
-                else getString(R.string.suggested_edits_added_contribution_label, contribution.description.length)
+                contributionDiffText.text = if (contribution.sizeDiff < 0) getString(R.string.suggested_edits_removed_contribution_label, abs(contribution.sizeDiff))
+                else getString(R.string.suggested_edits_added_contribution_label, contribution.sizeDiff)
                 pageViewsDetailView.setLabelAndDetail()
                 typeDetailView.setLabelAndDetail(getString(R.string.suggested_edits_contribution_type_label), getString(R.string.description_edit_add_caption_hint), R.drawable.ic_image_caption)
                 languageDetailView.setLabelAndDetail(getString(R.string.suggested_edits_contribution_language_label), WikipediaApp.getInstance().language().getAppLanguageCanonicalName(contribution.wikiSite.languageCode()))

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsContributionsFragment.kt
@@ -230,6 +230,7 @@ class SuggestedEditsContributionsFragment : Fragment(), SuggestedEditsContributi
                                                 qNumber = qNumberRegex.find(contribution.comment)?.value
                                                         ?: ""
                                                 editType = EDIT_TYPE_IMAGE_TAG
+                                                tagCount = 1
                                             }
                                             metaComment.contains("wbeditentity") -> {
                                                 if (matches.count() > 1 && matches.elementAt(1).value.contains(DEPICTS_META_STR)) {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsContributionsItemView.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsContributionsItemView.kt
@@ -14,7 +14,7 @@ import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.views.ViewUtil
-import kotlin.math.abs
+import java.text.DecimalFormat
 
 class SuggestedEditsContributionsItemView constructor(context: Context, attrs: AttributeSet? = null) : LinearLayout(context, attrs) {
     interface Callback {
@@ -22,6 +22,7 @@ class SuggestedEditsContributionsItemView constructor(context: Context, attrs: A
     }
 
     var callback: Callback? = null
+    private var numFormat: DecimalFormat = DecimalFormat("+0;-#")
 
     init {
         View.inflate(context, R.layout.item_suggested_edits_contributions, this)
@@ -84,7 +85,7 @@ class SuggestedEditsContributionsItemView constructor(context: Context, attrs: A
             contributionDiffCountText.visibility = GONE
         } else {
             contributionDiffCountText.visibility = VISIBLE
-            contributionDiffCountText.text = resources.getQuantityString(R.plurals.suggested_edits_contribution_diff_count_text, abs(sizeDiff), if (sizeDiff > 0) "+ " else "", sizeDiff)
+            contributionDiffCountText.text = resources.getQuantityString(R.plurals.suggested_edits_contribution_diff_count_text, sizeDiff, numFormat.format(sizeDiff))
             contributionDiffCountText.setTextColor(if (sizeDiff < 0) ResourceUtil.getThemedColor(context, R.attr.colorError)
             else ResourceUtil.getThemedColor(context, R.attr.action_mode_green_background))
         }

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -888,10 +888,10 @@
   <string name="custom_date_picker_dialog_cancel_button_text">Negative action button text in date picker pop-up dialog.\n{{Identical|Cancel}}</string>
   <string name="suggested_edits_added_contribution_label">Text summarizing the user\'s contribution to the article or image. %d represents the number of characters contributed.</string>
   <string name="suggested_edits_contribution_current_revision">Text indicating that the user\'s contribution is the most current edit on that file or article.</string>
-  <string name="suggested_edits_removed_contribution_label">Text summarizing the user\'s contribution to the article or image. %d represents the number of characters removed by the contributed.</string>
+  <string name="suggested_edits_removed_contribution_label">Text summarizing the user\'s contribution to the article or image. %d represents the number of characters removed by the contribution.</string>
   <plurals name="suggested_edits_contribution_diff_count_text">
-    <item quantity="one">Label text indicating the number of characters added or removed by a user contribution. %1$s represents the sign and %2$d represents the number</item>
-    <item quantity="other">Label text indicating the number of characters added or removed by a user contribution. %1$s represents the sign and %2$d represents the number</item>
+    <item quantity="one">Label text indicating the number of characters added or removed by a user contribution. %1$s represents the number</item>
+    <item quantity="other">Label text indicating the number of characters added or removed by a user contribution. %1$s represents the number</item>
   </plurals>
   <string name="nav_item_more">Navigation menu item label for accessing menu items.</string>
   <string name="preference_title_customize_explore_feed">Title of the preference for customizing the explore feed.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,8 +818,8 @@
     <string name="suggested_edits_contribution_current_revision">Current revision</string>
     <string name="suggested_edits_removed_contribution_label">You removed %d characters</string>
     <plurals name="suggested_edits_contribution_diff_count_text">
-        <item quantity="one">%1$s %2$d character</item>
-        <item quantity="other">%1$s %2$d characters</item>
+        <item quantity="one">%1$s character</item>
+        <item quantity="other">%1$s characters</item>
     </plurals>
     <!-- /Suggested edits -->
 


### PR DESCRIPTION
This fixes a few important details that were incorrect in the original PR:

* Old image tag contributions (made using the old single-contribution scheme) were being shown as "0 tags added".
* The incorrect number of added/removed characters was being shown for descriptions and captions.
* Improved the logic for formatting positive/negative numbers, without needing an explicit sign placeholder.