### PR TITLE
Prevent showing error page if latestcontrib is empty in SE task screen

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
@@ -41,10 +41,12 @@ public class UserInfo {
 
     @NonNull public Date getLatestContrib() {
         Date date = new Date(0);
-        try {
-            date = DateUtil.iso8601DateParse(latestcontrib);
-        } catch (ParseException e) {
-            // ignore
+        if (!TextUtils.isEmpty(latestcontrib)) {
+            try {
+                date = DateUtil.iso8601DateParse(latestcontrib);
+            } catch (ParseException e) {
+                // ignore
+            }
         }
         return date;
     }


### PR DESCRIPTION
It will show the error message below if it is a newly created account:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
        at java.text.SimpleDateFormat.parseInternal(SimpleDateFormat.java:1739)
        at java.text.SimpleDateFormat.parse(SimpleDateFormat.java:1726)
        at java.text.DateFormat.parse(DateFormat.java:360)
        at org.wikipedia.util.DateUtil.iso8601DateParse(DateUtil.java:34)
        at org.wikipedia.dataclient.mwapi.UserInfo.getLatestContrib(UserInfo.java:45)
        at org.wikipedia.suggestededits.SuggestedEditsTasksFragment$fetchUserContributions$1.apply(SuggestedEditsTasksFragment.kt:157)
        at org.wikipedia.suggestededits.SuggestedEditsTasksFragment$fetchUserContributions$1.apply(SuggestedEditsTasksFragment.kt:43)
```