### PR TITLE
Fix: should hide all nav menus when searching history

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -12,7 +12,7 @@ import android.speech.RecognizerIntent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.FrameLayout;
+import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -93,7 +93,7 @@ import static org.wikipedia.Constants.InvokeSource.VOICE;
 public class MainFragment extends Fragment implements BackPressedHandler, FeedFragment.Callback,
         HistoryFragment.Callback, LinkPreviewDialog.Callback {
     @BindView(R.id.fragment_main_view_pager) ViewPager2 viewPager;
-    @BindView(R.id.fragment_main_nav_tab_container) FrameLayout navTabContainer;
+    @BindView(R.id.fragment_main_nav_tab_container) LinearLayout navTabContainer;
     @BindView(R.id.fragment_main_nav_tab_layout) NavTabLayout tabLayout;
     @BindView(R.id.fragment_main_nav_tab_overlay_layout) NavTabOverlayLayout tabOverlayLayout;
     @BindView(R.id.nav_more_container) View moreContainer;

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -20,17 +20,17 @@
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <LinearLayout
+        android:id="@+id/fragment_main_nav_tab_container"
         android:elevation="6dp"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="?attr/actionBarSize"
         android:baselineAligned="false"
         android:orientation="horizontal"
         android:background="?attr/nav_tab_background_color">
 
         <FrameLayout
-            android:id="@+id/fragment_main_nav_tab_container"
             android:layout_width="0dp"
-            android:layout_height="?attr/actionBarSize"
+            android:layout_height="match_parent"
             android:layout_gravity="bottom"
             android:layout_weight="0.8">
 


### PR DESCRIPTION
If we search the history, you will see the "more" menu is still visible, which is incorrect.