### PR TITLE
Tweak: set up "more on this day" background correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/news/NewsListCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsListCardView.java
@@ -21,7 +21,6 @@ public class NewsListCardView extends HorizontalScrollingListCardView<NewsListCa
 
     public NewsListCardView(@NonNull Context context) {
         super(context);
-        setAllowOverflow(true);
     }
 
     @Override public void setCard(@NonNull NewsListCard card) {

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.java
@@ -58,7 +58,6 @@ public class OnThisDayCardView extends DefaultFeedCardView<OnThisDayCard> implem
     @BindView(R.id.years_text_background) ImageView yearsInfoBackground;
     @BindView(R.id.years_text) TextView yearsInfoTextView;
     @BindView(R.id.year_layout) LinearLayout yearLayout;
-    @BindView(R.id.more_events_layout) LinearLayout moreEventsLayout;
     @BindView(R.id.pages_recycler) RecyclerView pagesRecycler;
     @BindView(R.id.gradient_layout) View gradientLayout;
     @BindView(R.id.radio_image_view) View radio;

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.java
@@ -69,7 +69,6 @@ public class OnThisDayCardView extends DefaultFeedCardView<OnThisDayCard> implem
 
     public OnThisDayCardView(@NonNull Context context) {
         super(context);
-        setAllowOverflow(true);
         inflate(getContext(), R.layout.view_card_on_this_day, this);
         ButterKnife.bind(this);
         initRecycler();

--- a/app/src/main/java/org/wikipedia/feed/view/DefaultFeedCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/DefaultFeedCardView.java
@@ -32,10 +32,6 @@ public abstract class DefaultFeedCardView<T extends Card> extends WikiCardView i
         this.callback = callback;
     }
 
-    protected void setAllowOverflow(boolean enabled) {
-        setClipChildren(!enabled);
-    }
-
     @Nullable protected FeedAdapter.Callback getCallback() {
         return callback;
     }

--- a/app/src/main/java/org/wikipedia/feed/view/DefaultFeedCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/DefaultFeedCardView.java
@@ -34,7 +34,6 @@ public abstract class DefaultFeedCardView<T extends Card> extends WikiCardView i
 
     protected void setAllowOverflow(boolean enabled) {
         setClipChildren(!enabled);
-        setClipToOutline(!enabled);
     }
 
     @Nullable protected FeedAdapter.Callback getCallback() {

--- a/app/src/main/res/layout/view_card_on_this_day.xml
+++ b/app/src/main/res/layout/view_card_on_this_day.xml
@@ -94,13 +94,12 @@
         <TextView
             android:id="@+id/next_event_years"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="13dp"
             android:layout_marginTop="2dp"
             android:maxLines="1"
             android:paddingStart="6dp"
             android:paddingTop="1dp"
             android:paddingEnd="6dp"
-            android:paddingBottom="3dp"
             android:textColor="?attr/chart_shade7"
             android:textSize="12sp"
             app:layout_constraintStart_toStartOf="@id/day"
@@ -110,7 +109,6 @@
         <View
             android:layout_width="0dp"
             android:layout_height="0.5dp"
-            android:layout_marginBottom="6dp"
             android:background="?attr/material_theme_border_color"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -122,14 +120,11 @@
         android:id="@+id/more_events_layout"
         android:layout_width="match_parent"
         android:layout_height="48dp"
-        android:layout_marginTop="-6dp"
-        android:background="?attr/paper_color"
+        android:background="?android:attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:foreground="?attr/selectableItemBackground"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        app:layout_constraintTop_toBottomOf="@id/view_list_card_list">
+        android:paddingEnd="16dp">
 
         <ImageView
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/view_card_on_this_day.xml
+++ b/app/src/main/res/layout/view_card_on_this_day.xml
@@ -94,12 +94,13 @@
         <TextView
             android:id="@+id/next_event_years"
             android:layout_width="wrap_content"
-            android:layout_height="13dp"
+            android:layout_height="wrap_content"
             android:layout_marginTop="2dp"
             android:maxLines="1"
             android:paddingStart="6dp"
             android:paddingTop="1dp"
             android:paddingEnd="6dp"
+            android:paddingBottom="3dp"
             android:textColor="?attr/chart_shade7"
             android:textSize="12sp"
             app:layout_constraintStart_toStartOf="@id/day"
@@ -109,6 +110,7 @@
         <View
             android:layout_width="0dp"
             android:layout_height="0.5dp"
+            android:layout_marginBottom="6dp"
             android:background="?attr/material_theme_border_color"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -120,9 +122,11 @@
         android:id="@+id/more_events_layout"
         android:layout_width="match_parent"
         android:layout_height="48dp"
-        android:background="?android:attr/selectableItemBackground"
+        android:layout_marginTop="-6dp"
+        android:background="?attr/paper_color"
         android:clickable="true"
         android:focusable="true"
+        android:foreground="?attr/selectableItemBackground"
         android:paddingStart="16dp"
         android:paddingEnd="16dp">
 


### PR DESCRIPTION
If you watch closely, the "more on this day" bottom action layout has `paper_color` background and makes the rounded border has a rectangle background. This PR fixes it but still has a minor issue: the ripple animation is still in a square shape. 

Please advise if any suggestions.