### PR TITLE
Explicitly set X-Analytics header for correct accounting of pageviews.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/CommonHeaderRequestInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/CommonHeaderRequestInterceptor.kt
@@ -3,6 +3,7 @@ package org.wikipedia.dataclient.okhttp
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.wikipedia.WikipediaApp
+import org.wikipedia.dataclient.RestService
 import org.wikipedia.settings.Prefs.isEventLoggingEnabled
 import java.io.IOException
 
@@ -10,11 +11,13 @@ internal class CommonHeaderRequestInterceptor : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val app = WikipediaApp.getInstance()
-        val request = chain.request().newBuilder()
+        val builder = chain.request().newBuilder()
                 .header("User-Agent", app.userAgent)
                 .header(if (isEventLoggingEnabled()) "X-WMF-UUID" else "DNT",
                         if (isEventLoggingEnabled()) app.appInstallID else "1")
-                .build()
-        return chain.proceed(request)
+        if (chain.request().url.encodedPath.contains(RestService.PAGE_HTML_ENDPOINT)) {
+            builder.header("X-Analytics", "pageview=1")
+        }
+        return chain.proceed(builder.build())
     }
 }


### PR DESCRIPTION
We've just realized that the apps' accessing of the `mobile-html` endpoint isn't actually counting as a pageview by the Analytics backend. We need to explicitly send an `X-Analytics` header so that the pageview is counted.