### PR TITLE
Don't override inactive border for Announcement cards.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.java
@@ -91,9 +91,6 @@ public class AnnouncementCardView extends DefaultFeedCardView<AnnouncementCard> 
         if (card.hasBorder()) {
             setStrokeColor(getResources().getColor(R.color.red30));
             setStrokeWidth(10);
-            setRadius(0);
-        } else {
-            setStrokeWidth(0);
         }
     }
 


### PR DESCRIPTION
Announcement cards that don't have an explicit `border` should not override the `strokeWidth` of the card.