### PR TITLE
Remove toolbar_title_color and replace it with material_theme_primary_color

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
@@ -184,7 +184,7 @@ public class DescriptionEditView extends LinearLayout {
             toolbarContainer.setBackgroundResource(enabled ? android.R.color.black : ResourceUtil.getThemedAttributeId(getContext(), R.attr.paper_color));
             saveButton.setColorFilter(enabled ? whiteRes : ResourceUtil.getThemedColor(getContext(), R.attr.themed_icon_color), PorterDuff.Mode.SRC_IN);
             cancelButton.setColorFilter(enabled ? whiteRes : ResourceUtil.getThemedColor(getContext(), R.attr.toolbar_icon_color), PorterDuff.Mode.SRC_IN);
-            headerText.setTextColor(enabled ? whiteRes : ResourceUtil.getThemedColor(getContext(), R.attr.toolbar_title_color));
+            headerText.setTextColor(enabled ? whiteRes : ResourceUtil.getThemedColor(getContext(), R.attr.material_theme_primary_color));
             ((DescriptionEditActivity) activity).updateStatusBarColor(enabled ? Color.BLACK : ResourceUtil.getThemedColor(getContext(), R.attr.paper_color));
             DeviceUtil.updateStatusBarTheme(activity, null, enabled);
             ((DescriptionEditActivity) activity).updateNavigationBarColor(enabled ? Color.BLACK : ResourceUtil.getThemedColor(getContext(), R.attr.paper_color));

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayFragment.java
@@ -119,7 +119,7 @@ public class OnThisDayFragment extends Fragment implements CustomDatePicker.Call
                 }
                 updateContents(age);
                 ValueAnimator colorAnimation = ValueAnimator.ofObject(new ArgbEvaluator(), dayText.getCurrentTextColor(),
-                        ResourceUtil.getThemedColor(requireContext(), R.attr.toolbar_title_color));
+                        ResourceUtil.getThemedColor(requireContext(), R.attr.material_theme_primary_color));
                 colorAnimation.addUpdateListener(animator -> {
                     if (dayText != null) {
                         dayText.setTextColor((Integer) animator.getAnimatedValue());
@@ -128,7 +128,7 @@ public class OnThisDayFragment extends Fragment implements CustomDatePicker.Call
                 colorAnimation.start();
             }, animDelay);
         } else {
-            dayText.setTextColor(ResourceUtil.getThemedColor(requireContext(), R.attr.toolbar_title_color));
+            dayText.setTextColor(ResourceUtil.getThemedColor(requireContext(), R.attr.material_theme_primary_color));
             updateContents(age);
         }
 
@@ -177,7 +177,7 @@ public class OnThisDayFragment extends Fragment implements CustomDatePicker.Call
         getAppCompatActivity().setSupportActionBar(toolbar);
         getAppCompatActivity().getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getAppCompatActivity().getSupportActionBar().setTitle("");
-        collapsingToolbarLayout.setCollapsedTitleTextColor(ResourceUtil.getThemedColor(requireContext(), R.attr.toolbar_title_color));
+        collapsingToolbarLayout.setCollapsedTitleTextColor(ResourceUtil.getThemedColor(requireContext(), R.attr.material_theme_primary_color));
         dayText.setText(DateUtil.getMonthOnlyDateString(date.getTime()));
         indicatorLayout.setAlpha((date.get(Calendar.MONTH) == Calendar.getInstance().get(Calendar.MONTH) && date.get(Calendar.DATE) == Calendar.getInstance().get(Calendar.DATE)) ? HALF_ALPHA : 1.0f);
         indicatorDate.setText(String.format(Locale.getDefault(), "%d", Calendar.getInstance().get(Calendar.DATE)));

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,8 +16,7 @@
         android:background="?attr/paper_color"
         android:elevation="4dp"
         app:titleTextAppearance="@style/LargeTextToolbarTitleText"
-        app:titleMarginStart="28dp"
-        app:titleTextColor="?attr/toolbar_title_color">
+        app:titleMarginStart="28dp">
 
         <ImageView
             android:id="@+id/single_fragment_toolbar_wordmark"
@@ -26,7 +25,7 @@
             android:layout_marginStart="32dp"
             android:contentDescription="@null"
             app:srcCompat="@drawable/feed_header_wordmark"
-            app:tint="?attr/toolbar_title_color" />
+            app:tint="?attr/material_theme_primary_color" />
     </androidx.appcompat.widget.Toolbar>
 
     <FrameLayout

--- a/app/src/main/res/layout/date_picker_dialog.xml
+++ b/app/src/main/res/layout/date_picker_dialog.xml
@@ -25,7 +25,7 @@
             android:fontFamily="sans-serif-medium"
             android:lineSpacingExtra="4sp"
             android:text="@string/on_this_day_card_title"
-            android:textColor="?attr/toolbar_title_color"
+            android:textColor="?attr/material_theme_primary_color"
             android:textSize="16sp"
             android:textStyle="normal"
             tools:text="ON THIS DAY" />
@@ -36,7 +36,7 @@
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif-medium"
             android:text=""
-            android:textColor="?attr/toolbar_title_color"
+            android:textColor="?attr/material_theme_primary_color"
             android:textSize="34sp"
             android:textStyle="normal" />
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_contribution_diff_detail.xml
+++ b/app/src/main/res/layout/fragment_contribution_diff_detail.xml
@@ -21,7 +21,7 @@
             android:layout_height="?attr/actionBarSize"
             android:contentDescription="@null"
             android:padding="16dp"
-            android:tint="?attr/toolbar_title_color"
+            android:tint="?attr/material_theme_primary_color"
             app:srcCompat="@drawable/ic_arrow_back_themed_24dp" />
 
         <LinearLayout

--- a/app/src/main/res/layout/fragment_on_this_day.xml
+++ b/app/src/main/res/layout/fragment_on_this_day.xml
@@ -52,7 +52,7 @@
                             android:layout_marginEnd="8dp"
                             android:layout_marginBottom="4dp"
                             android:fontFamily="serif"
-                            android:textColor="?attr/toolbar_title_color"
+                            android:textColor="?attr/material_theme_primary_color"
                             android:textSize="24sp"
                             android:textStyle="normal"
                             android:transitionName="@string/transition_on_this_day"
@@ -74,7 +74,7 @@
                         android:alpha="0.5"
                         android:text="@string/on_this_day_card_title"
                         android:textAllCaps="true"
-                        android:textColor="?attr/toolbar_title_color"
+                        android:textColor="?attr/material_theme_primary_color"
                         android:textSize="14sp" />
 
                     <TextView
@@ -83,7 +83,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="2dp"
                         android:alpha="0.5"
-                        android:textColor="?attr/toolbar_title_color"
+                        android:textColor="?attr/material_theme_primary_color"
                         android:textSize="14sp" />
 
                 </LinearLayout>
@@ -125,7 +125,7 @@
                         android:gravity="center_vertical"
                         android:letterSpacing="0.01"
                         android:lineSpacingExtra="8sp"
-                        android:textColor="?attr/toolbar_title_color"
+                        android:textColor="?attr/material_theme_primary_color"
                         android:textSize="20sp"
                         android:textStyle="normal"
                         tools:text="January 1" />
@@ -162,7 +162,7 @@
                         android:layout_height="10dp"
                         android:layout_marginStart="6dp"
                         android:layout_marginTop="8dp"
-                        android:textColor="?attr/toolbar_title_color"
+                        android:textColor="?attr/material_theme_primary_color"
                         android:textSize="8sp"
                         tools:text="12" />
                 </FrameLayout>

--- a/app/src/main/res/layout/view_description_edit.xml
+++ b/app/src/main/res/layout/view_description_edit.xml
@@ -41,7 +41,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:maxLines="1"
                 android:text="@string/description_edit_edit_description"
-                android:textColor="?attr/toolbar_title_color"
+                android:textColor="?attr/material_theme_primary_color"
                 android:textSize="20sp"
                 android:padding="16dp" />
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <attr name="toolbar_title_color" format="reference"/>
     <attr name="toolbar_icon_color" format="reference"/>
     <attr name="themed_icon_color" format="reference"/>
     <attr name="edit_improve_tag_selected_drawable" format="reference" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -157,7 +157,7 @@
     </style>
 
     <style name="ToolBarTitleText" parent="@style/TextAppearance.AppCompat.Widget.ActionBar.Title">
-        <item name="android:textColor">?attr/toolbar_title_color</item>
+        <item name="android:textColor">?attr/material_theme_primary_color</item>
     </style>
 
     <style name="PageToolbarTitleText" parent="@style/TextAppearance.AppCompat.Widget.ActionBar.Title">
@@ -165,7 +165,6 @@
     </style>
 
     <style name="LargeTextToolbarTitleText" parent="@style/TextAppearance.AppCompat.Widget.ActionBar.Title">
-        <item name="android:textColor">?attr/material_theme_primary_color</item>
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">24sp</item>
         <item name="android:textStyle">bold</item>
@@ -191,11 +190,11 @@
     </style>
 
     <style name="ActionModeTitleStyle" parent="@style/TextAppearance.AppCompat.Widget.ActionMode.Title">
-        <item name="android:textColor">?attr/toolbar_title_color</item>
+        <item name="android:textColor">?attr/material_theme_primary_color</item>
     </style>
 
     <style name="ActionModeSubtitleStyle" parent="@style/TextAppearance.AppCompat.Widget.ActionMode.Subtitle">
-        <item name="android:textColor">?attr/toolbar_title_color</item>
+        <item name="android:textColor">?attr/material_theme_primary_color</item>
     </style>
 
     <style name="PageActionModeTitleStyle" parent="@style/TextAppearance.AppCompat.Widget.ActionMode.Title">

--- a/app/src/main/res/values/styles_dark.xml
+++ b/app/src/main/res/values/styles_dark.xml
@@ -40,7 +40,6 @@
         <item name="button_highlight_border_shape">@drawable/button_shape_border_light</item>
 
         <!-- Overrides of our own custom color attributes -->
-        <item name="toolbar_title_color">@android:color/white</item>
         <item name="toolbar_icon_color">@android:color/white</item>
         <item name="themed_icon_color">@android:color/white</item>
         <item name="nav_tab_background_color">@color/base18</item>

--- a/app/src/main/res/values/styles_light.xml
+++ b/app/src/main/res/values/styles_light.xml
@@ -40,7 +40,6 @@
         <item name="button_highlight_border_shape">@drawable/button_shape_border_light</item>
 
         <!-- Overrides of our own custom color attributes -->
-        <item name="toolbar_title_color">@color/black87</item>
         <item name="toolbar_icon_color">@color/base30</item>
         <item name="themed_icon_color">@color/accent50</item>
         <item name="nav_tab_background_color">@color/base100</item>


### PR DESCRIPTION
Just noticed that the `toolbar_title_color` has the same color set as `material_theme_primary_color`, and we can remove it.