### PR TITLE
Don't log nuisance exception in Notification receiver.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.java
@@ -87,7 +87,7 @@ public class NotificationPollBroadcastReceiver extends BroadcastReceiver {
             // There seems to be a Samsung-specific issue where it doesn't update the existing
             // alarm correctly and adds it as a new one, and eventually hits the limit of 500
             // concurrent alarms, causing a crash.
-            L.logRemoteErrorIfProd(e);
+            L.e(e);
         }
     }
 


### PR DESCRIPTION
This is contributing to a lot of noise in AppCenter, and doesn't really need to be logged anymore.