### PR TITLE
Fix possible crash when adding multiple image tags.

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -14,8 +14,6 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.google.android.material.chip.Chip
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
-import io.reactivex.rxjava3.core.Observable
-import io.reactivex.rxjava3.core.ObservableSource
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_suggested_edits_image_tags_item.*
 import org.wikipedia.Constants
@@ -301,11 +299,13 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
         }
 
         val acceptedLabels = ArrayList<MwQueryPage.ImageLabel>()
-        for (label in tagList) {
-            if (label.isSelected) {
-                acceptedLabels.add(label)
+        val iterator = tagList.iterator()
+        while (iterator.hasNext()) {
+            val tag = iterator.next()
+            if (tag.isSelected) {
+                acceptedLabels.add(tag)
             } else {
-                tagList.remove(label)
+                iterator.remove()
             }
         }
         if (acceptedLabels.isEmpty()) {


### PR DESCRIPTION
The crash happens because we're modifying a list while iterating it using a foreach structure. Reproducible by adding multiple tags, then unselecting all but one tag, then publishing.