### PR TITLE
 Should re-select tab to prevent losing current activated tab.

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -473,6 +473,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
     }
 
     private void resetNavTabLayouts() {
+        goToTab(NavTab.of(viewPager.getCurrentItem()));
         if (Prefs.shouldShowSuggestedEditsTooltip()) {
             Prefs.setShouldShowSuggestedEditsTooltip(false);
             Prefs.setShouldShowImageTagsTooltip(false);


### PR DESCRIPTION
This issue happens when rotating the device.