### PR TITLE
Fix: set PageTitle correctly to show the correct displayTitle in MOstReadItemCard

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadItemCard.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadItemCard.java
@@ -1,7 +1,6 @@
 package org.wikipedia.feed.mostread;
 
 import android.net.Uri;
-import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -39,13 +38,6 @@ public class MostReadItemCard extends Card {
     }
 
     @NonNull public PageTitle pageTitle() {
-        PageTitle title = new PageTitle(page.getApiTitle(), wiki);
-        if (page.getThumbnailUrl() != null) {
-            title.setThumbUrl(page.getThumbnailUrl());
-        }
-        if (!TextUtils.isEmpty(page.getDescription())) {
-            title.setDescription(page.getDescription());
-        }
-        return title;
+        return page.getPageTitle(wiki);
     }
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T194161

The API is fixed and now we can show the title correctly.
<img width="832" alt="Screenshot at Jul 08 09-40-22" src="https://user-images.githubusercontent.com/2435576/86946364-1af9e680-c0ff-11ea-835f-06dbda6e1a47.png">
