### PR TITLE
Use default dialog theme in CustomDatePicker

### DIFF
--- a/app/src/main/java/org/wikipedia/views/CustomDatePicker.java
+++ b/app/src/main/java/org/wikipedia/views/CustomDatePicker.java
@@ -54,7 +54,7 @@ public class CustomDatePicker extends DialogFragment {
         setUpMonthGrid();
         setMonthString();
         setDayString();
-        return new AlertDialog.Builder(requireActivity(), ResourceUtil.getThemedAttributeId(requireContext(), R.attr.dialogTheme))
+        return new AlertDialog.Builder(requireActivity())
                 .setView(view)
                 .setPositiveButton(R.string.custom_date_picker_dialog_ok_button_text,
                         (dialog, id) -> callback.onDatePicked(callbackDay.get(Calendar.MONTH), callbackDay.get(Calendar.DATE)))


### PR DESCRIPTION
The button color in the current production is purple, which does not align with our app theme guideline. The default theme should be better.