### PR TITLE
Fix: should not scroll the feed to top if not manually tap on the nav item

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -104,6 +104,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
     private Snackbar suggestedEditsNavTabSnackbar;
     private PageChangeCallback pageChangeCallback = new PageChangeCallback();
     private CompositeDisposable disposables = new CompositeDisposable();
+    private boolean navTabAutoSelect;
 
     // The permissions request API doesn't take a callback, so in the event we have to
     // ask for permission to download a featured image from the feed, we'll have to hold
@@ -135,7 +136,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
         FeedbackUtil.setToolbarButtonLongPressToast(moreContainer);
 
         tabLayout.setOnNavigationItemSelectedListener(item -> {
-            if (getCurrentFragment() instanceof FeedFragment && item.getOrder() == 0) {
+            if (!navTabAutoSelect && getCurrentFragment() instanceof FeedFragment && item.getOrder() == 0) {
                 ((FeedFragment) getCurrentFragment()).scrollToTop();
             }
             viewPager.setCurrentItem(item.getOrder(), false);
@@ -166,7 +167,9 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
         downloadReceiver.setCallback(downloadReceiverCallback);
         // reset the last-page-viewed timer
         Prefs.pageLastShown(0);
+        navTabAutoSelect = true;
         resetNavTabLayouts();
+        navTabAutoSelect = false;
     }
 
     @Override public void onDestroyView() {


### PR DESCRIPTION
This code was removed accidentally in the #1297.