### PR TITLE
Fix logic of when to show Reading List sync snackbar.

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.java
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.java
@@ -313,7 +313,7 @@ public abstract class BaseActivity extends AppCompatActivity {
             } else if (event instanceof LoggedOutInBackgroundEvent) {
                 maybeShowLoggedOutInBackgroundDialog();
             } else if (event instanceof ReadingListSyncEvent) {
-                if (!Prefs.isSuggestedEditsHighestPriorityEnabled()) {
+                if (((ReadingListSyncEvent)event).showMessage() && !Prefs.isSuggestedEditsHighestPriorityEnabled()) {
                     FeedbackUtil.makeSnackbar(BaseActivity.this,
                             getString(R.string.reading_list_toast_last_sync), FeedbackUtil.LENGTH_DEFAULT).show();
                 }

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
@@ -15,7 +15,6 @@ import org.wikipedia.database.contract.ReadingListPageContract;
 import org.wikipedia.events.ArticleSavedOrDeletedEvent;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.readinglist.sync.ReadingListSyncAdapter;
-import org.wikipedia.readinglist.sync.ReadingListSyncEvent;
 import org.wikipedia.savedpages.SavedPageSyncService;
 import org.wikipedia.util.log.L;
 
@@ -277,7 +276,7 @@ public class ReadingListDbHelper {
                 addPageToList(db, destList, title);
             }
             markPagesForDeletion(sourceList, Collections.singletonList(sourceReadingListPage));
-            WikipediaApp.getInstance().getBus().post(new ReadingListSyncEvent());
+            ReadingListSyncAdapter.manualSync();
         }
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
@@ -277,6 +277,7 @@ public class ReadingListDbHelper {
             }
             markPagesForDeletion(sourceList, Collections.singletonList(sourceReadingListPage));
             ReadingListSyncAdapter.manualSync();
+            SavedPageSyncService.sendSyncEvent();
         }
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
@@ -532,7 +532,7 @@ public class ReadingListSyncAdapter extends AbstractThreadedSyncAdapter {
             readingListSyncNotification.cancelNotification(getContext());
 
             if (shouldSendSyncEvent) {
-                SavedPageSyncService.sendSyncEvent();
+                SavedPageSyncService.sendSyncEvent(extras.containsKey(SYNC_EXTRAS_REFRESHING));
             }
             if ((shouldRetry || shouldRetryWithForce) && !extras.containsKey(SYNC_EXTRAS_RETRYING)) {
                 Bundle b = new Bundle();

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncEvent.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncEvent.java
@@ -1,4 +1,13 @@
 package org.wikipedia.readinglist.sync;
 
 public class ReadingListSyncEvent {
+    private boolean showMessage;
+
+    public ReadingListSyncEvent(boolean showMessage) {
+        this.showMessage = showMessage;
+    }
+
+    public boolean showMessage() {
+        return showMessage;
+    }
 }

--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.java
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.java
@@ -132,9 +132,13 @@ public class SavedPageSyncService extends JobIntentService {
     }
 
     public static void sendSyncEvent() {
+        sendSyncEvent(false);
+    }
+
+    public static void sendSyncEvent(boolean showMessage) {
         // Note: this method posts from a background thread but subscribers expect events to be
         // received on the main thread.
-        WikipediaApp.getInstance().getBus().post(new ReadingListSyncEvent());
+        WikipediaApp.getInstance().getBus().post(new ReadingListSyncEvent(showMessage));
     }
 
     @SuppressLint("CheckResult")


### PR DESCRIPTION
The updates in #1397 totally changed the behavior of when the snackbar is shown -- it's now being shown for every page added to a list.  The snackbar should only be shown when the user explicitly refreshes the lists.