### PR TITLE
Should disable the SE highest priority when manually refreshing the reading list

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.java
@@ -100,6 +100,7 @@ public class ReadingListSyncAdapter extends AbstractThreadedSyncAdapter {
     }
 
     public static void manualSyncWithRefresh() {
+        Prefs.setSuggestedEditsHighestPriorityEnabled(false);
         Bundle extras = new Bundle();
         extras.putBoolean(SYNC_EXTRAS_REFRESHING, true);
         manualSync(extras);


### PR DESCRIPTION
Otherwise, the snackbar will not appear.