### PR TITLE
Hygiene: optimize progress bar method

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -170,7 +170,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
         disposables.add(app.getBus().subscribe(new EventBusConsumer()));
 
-        updateProgressBar(false, true, 0);
+        updateProgressBar(false);
 
         pageFragment = (PageFragment) getSupportFragmentManager().findFragmentById(R.id.page_fragment);
 
@@ -392,18 +392,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         }
     }
 
-    /**
-     * Update the state of the main progress bar that is shown inside the ActionBar of the activity.
-     * @param visible Whether the progress bar is visible.
-     * @param indeterminate Whether the progress bar is indeterminate.
-     * @param value Value of the progress bar (may be between 0 and 10000). Ignored if the
-     *              progress bar is indeterminate.
-     */
-    public void updateProgressBar(boolean visible, boolean indeterminate, int value) {
-        progressBar.setIndeterminate(indeterminate);
-        if (!indeterminate) {
-            progressBar.setProgress(value);
-        }
+    public void updateProgressBar(boolean visible) {
         progressBar.setVisibility(visible ? View.VISIBLE : View.GONE);
     }
 
@@ -527,8 +516,8 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     }
 
     @Override
-    public void onPageUpdateProgressBar(boolean visible, boolean indeterminate, int value) {
-        updateProgressBar(visible, indeterminate, value);
+    public void onPageUpdateProgressBar(boolean visible) {
+        updateProgressBar(visible);
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -513,8 +513,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         // handler), since the page metadata might have altered the lead image display state.
         bridge.execute(JavaScriptActionHandler.setTopMargin(leadImagesHandler.getTopMargin()));
         bridge.execute(JavaScriptActionHandler.setFooter(model));
-
-        updateProgressBar(false);
     }
 
     private void onPageSetupEvent() {
@@ -522,6 +520,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             return;
         }
 
+        updateProgressBar(false);
         webView.setVisibility(View.VISIBLE);
         app.getSessionFunnel().leadSectionFetchEnd();
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -137,7 +137,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         void onPageInitWebView(@NonNull ObservableWebView v);
         void onPageShowLinkPreview(@NonNull HistoryEntry entry);
         void onPageLoadMainPageInForegroundTab();
-        void onPageUpdateProgressBar(boolean visible, boolean indeterminate, int value);
+        void onPageUpdateProgressBar(boolean visible);
         void onPageShowThemeChooser();
         void onPageStartSupportActionMode(@NonNull ActionMode.Callback callback);
         void onPageHideSoftKeyboard();
@@ -513,6 +513,8 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         // handler), since the page metadata might have altered the lead image display state.
         bridge.execute(JavaScriptActionHandler.setTopMargin(leadImagesHandler.getTopMargin()));
         bridge.execute(JavaScriptActionHandler.setFooter(model));
+
+        updateProgressBar(false);
     }
 
     private void onPageSetupEvent() {
@@ -520,7 +522,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             return;
         }
 
-        updateProgressBar(false, true, 0);
         webView.setVisibility(View.VISIBLE);
         app.getSessionFunnel().leadSectionFetchEnd();
 
@@ -766,7 +767,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
 
         tabLayout.enableAllTabs();
 
-        updateProgressBar(true, true, 0);
+        updateProgressBar(true);
 
         this.pageRefreshed = isRefresh;
         references = null;
@@ -928,7 +929,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         if (!isAdded()) {
             return;
         }
-        updateProgressBar(false, true, 0);
+        updateProgressBar(false);
         refreshView.setRefreshing(false);
 
         if (pageRefreshed) {
@@ -1085,10 +1086,10 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
                 avCallback = new AvCallback();
             }
             if (!avPlayer.isPlaying() && messagePayload.has("url")) {
-                updateProgressBar(true, true, 0);
+                updateProgressBar(true);
                 avPlayer.play(UriUtil.resolveProtocolRelativeUrl(messagePayload.get("url").getAsString()), avCallback, avCallback);
             } else {
-                updateProgressBar(false, true, 0);
+                updateProgressBar(false);
                 avPlayer.stop();
             }
         });
@@ -1249,10 +1250,10 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         }
     }
 
-    private void updateProgressBar(boolean visible, boolean indeterminate, int value) {
+    private void updateProgressBar(boolean visible) {
         Callback callback = callback();
         if (callback != null) {
-            callback.onPageUpdateProgressBar(visible, indeterminate, value);
+            callback.onPageUpdateProgressBar(visible);
         }
     }
 
@@ -1351,14 +1352,14 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         public void onSuccess() {
             if (avPlayer != null) {
                 avPlayer.stop();
-                updateProgressBar(false, true, 0);
+                updateProgressBar(false);
             }
         }
         @Override
         public void onError() {
             if (avPlayer != null) {
                 avPlayer.stop();
-                updateProgressBar(false, true, 0);
+                updateProgressBar(false);
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -177,7 +177,7 @@ public class PageFragmentLoadState {
         }
         fragment.requireActivity().invalidateOptionsMenu();
         if (fragment.callback() != null) {
-            fragment.callback().onPageUpdateProgressBar(true, true, 0);
+            fragment.callback().onPageUpdateProgressBar(true);
         }
 
         app.getSessionFunnel().leadSectionFetchStart();

--- a/app/src/main/res/layout/activity_page.xml
+++ b/app/src/main/res/layout/activity_page.xml
@@ -80,7 +80,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="top"
                 android:layout_marginTop="-7dp"
-                android:max="10000" />
+                android:indeterminate="true" />
 
         </FrameLayout>
 


### PR DESCRIPTION
- The `ProgressBar` is always `indeterminate=true`.
- When loading page that requires more time to load (e.g. Chinese article - [2019冠状病毒病疫情](https://zh.wikipedia.org/wiki/2019%E5%86%A0%E7%8A%B6%E7%97%85%E6%AF%92%E7%97%85%E7%96%AB%E6%83%85)), the progress bar should disappear after the metadata is loaded.