### PR TITLE
Add a test case of checking the resources in qq/strings.xml match en/strings.xml

### DIFF
--- a/app/src/test/java/org/wikipedia/language/TranslationTests.java
+++ b/app/src/test/java/org/wikipedia/language/TranslationTests.java
@@ -101,12 +101,12 @@ public class TranslationTests {
 
         StringBuilder mismatches = new StringBuilder();
 
-        List<String> baseList = findStringItemInXML(getBaseFile(), "plural");
+        List<String> baseList = findStringItemInXML(getBaseFile(), "plurals");
 
         for (File dir : getAllFiles()) {
             String lang = dir.getName().contains("-") ? dir.getName().substring(dir.getName().indexOf("-") + 1) : "en";
             File targetStringsXml = new File(dir, STRINGS_XML_NAME);
-            List<String> targetList = findStringItemInXML(targetStringsXml, "plural");
+            List<String> targetList = findStringItemInXML(targetStringsXml, "plurals");
 
             targetList.forEach(targetKey -> {
                 if (!baseList.contains(targetKey)) {

--- a/app/src/test/java/org/wikipedia/language/TranslationTests.java
+++ b/app/src/test/java/org/wikipedia/language/TranslationTests.java
@@ -189,7 +189,7 @@ public class TranslationTests {
         return false;
     }
 
-    private List<String> findStringItemInXML(@NonNull File xmlPath, String ...strings) throws Throwable {
+    private List<String> findStringItemInXML(@NonNull File xmlPath, @NonNull String ...strings) throws Throwable {
         List<String> list = new ArrayList<>();
         Document document = Jsoup.parse(xmlPath, "UTF-8");
 


### PR DESCRIPTION
Sometimes the build failed because we forgot to add newly created string items to the `qq/strings.xml`. This test case will show us a more specific error message in the Travis build log.