### PR TITLE
Refresh feed after updated app languages or updated feed config

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.java
@@ -231,15 +231,12 @@ public class FeedFragment extends Fragment implements BackPressedHandler {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == ACTIVITY_REQUEST_FEED_CONFIGURE
-                || requestCode == ACTIVITY_REQUEST_SETTINGS
-                || requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE) {
-            if (resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED) {
-                updateHiddenCards();
-            }
-            if (resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED
-                    || resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED) {
-                refresh();
-            }
+                && resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED) {
+            coordinator.updateHiddenCards();
+            refresh();
+        } else if ((requestCode == ACTIVITY_REQUEST_SETTINGS && resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED)
+                || (requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE && resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED)) {
+            refresh();
         } else if (requestCode == ACTIVITY_REQUEST_DESCRIPTION_EDIT) {
             SuggestedEditsFunnel.get().log();
             SuggestedEditsFunnel.reset();

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.java
@@ -231,13 +231,15 @@ public class FeedFragment extends Fragment implements BackPressedHandler {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == ACTIVITY_REQUEST_FEED_CONFIGURE
-                && resultCode == ConfigureActivity.CONFIGURATION_CHANGED_RESULT) {
-            coordinator.updateHiddenCards();
-            refresh();
-        } else if ((requestCode == ACTIVITY_REQUEST_SETTINGS
-                && resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED)
+                || requestCode == ACTIVITY_REQUEST_SETTINGS
                 || requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE) {
-            refresh();
+            if (resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED) {
+                updateHiddenCards();
+            }
+            if (resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED
+                    || resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED) {
+                refresh();
+            }
         } else if (requestCode == ACTIVITY_REQUEST_DESCRIPTION_EDIT) {
             SuggestedEditsFunnel.get().log();
             SuggestedEditsFunnel.reset();
@@ -350,6 +352,10 @@ public class FeedFragment extends Fragment implements BackPressedHandler {
         coordinator.reset();
         feedAdapter.notifyDataSetChanged();
         coordinator.more(app.getWikiSite());
+    }
+
+    public void updateHiddenCards() {
+        coordinator.updateHiddenCards();
     }
 
     @Nullable private Callback getCallback() {

--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureActivity.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureActivity.java
@@ -10,8 +10,6 @@ import org.wikipedia.activity.SingleFragmentActivity;
 import static org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE;
 
 public class ConfigureActivity extends SingleFragmentActivity<ConfigureFragment> {
-    public static final int CONFIGURATION_CHANGED_RESULT = 1;
-
     public static Intent newIntent(@NonNull Context context, int invokeSource) {
         return new Intent(context, ConfigureActivity.class)
                 .putExtra(INTENT_EXTRA_INVOKE_SOURCE, invokeSource);

--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureFragment.java
@@ -42,6 +42,7 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 import static org.wikipedia.Constants.INTENT_EXTRA_INVOKE_SOURCE;
+import static org.wikipedia.settings.SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED;
 
 public class ConfigureFragment extends Fragment implements ConfigureItemView.Callback {
     @BindView(R.id.content_types_recycler) RecyclerView recyclerView;
@@ -229,7 +230,7 @@ public class ConfigureFragment extends Fragment implements ConfigureItemView.Cal
     }
 
     private void touch() {
-        requireActivity().setResult(ConfigureActivity.CONFIGURATION_CHANGED_RESULT);
+        requireActivity().setResult(ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED);
     }
 
     private class ConfigureItemHolder extends DefaultViewHolder<ConfigureItemView> {

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -211,8 +211,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
             }
         } else if ((requestCode == Constants.ACTIVITY_REQUEST_OPEN_SEARCH_ACTIVITY && resultCode == SearchFragment.RESULT_LANG_CHANGED)
                 || (requestCode == Constants.ACTIVITY_REQUEST_SETTINGS
-                && (resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED
-                || resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED))) {
+                && (resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED || resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED))) {
             refreshContents();
             if (resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED) {
                 updateFeedHiddenCards();

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -210,8 +210,13 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
                 startActivity(PageActivity.newIntent(requireContext()));
             }
         } else if ((requestCode == Constants.ACTIVITY_REQUEST_OPEN_SEARCH_ACTIVITY && resultCode == SearchFragment.RESULT_LANG_CHANGED)
-                || (requestCode == Constants.ACTIVITY_REQUEST_SETTINGS && resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED)) {
+                || (requestCode == Constants.ACTIVITY_REQUEST_SETTINGS
+                && (resultCode == SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED
+                || resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED))) {
             refreshContents();
+            if (resultCode == SettingsActivity.ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED) {
+                updateFeedHiddenCards();
+            }
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }
@@ -473,6 +478,13 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
             ((SuggestedEditsTasksFragment) fragment).refreshContents();
         }
         resetNavTabLayouts();
+    }
+
+    private void updateFeedHiddenCards() {
+        Fragment fragment = getCurrentFragment();
+        if (fragment instanceof FeedFragment) {
+            ((FeedFragment) fragment).updateHiddenCards();
+        }
     }
 
     private void resetNavTabLayouts() {

--- a/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
@@ -8,9 +8,11 @@ import androidx.annotation.NonNull;
 import org.wikipedia.activity.SingleFragmentActivity;
 
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_ADD_A_LANGUAGE;
+import static org.wikipedia.Constants.ACTIVITY_REQUEST_FEED_CONFIGURE;
 
 public class SettingsActivity extends SingleFragmentActivity<SettingsFragment> {
     public static final int ACTIVITY_RESULT_LANGUAGE_CHANGED = 1;
+    public static final int ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED = 2;
 
     public static Intent newIntent(@NonNull Context ctx) {
         return new Intent(ctx, SettingsActivity.class);
@@ -26,6 +28,8 @@ public class SettingsActivity extends SingleFragmentActivity<SettingsFragment> {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE) {
             setResult(ACTIVITY_RESULT_LANGUAGE_CHANGED);
+        } else if (requestCode == ACTIVITY_REQUEST_FEED_CONFIGURE) {
+            setResult(ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED);
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.java
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.java
@@ -41,6 +41,7 @@ import butterknife.Unbinder;
 import static android.app.Activity.RESULT_OK;
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_ADD_A_LANGUAGE;
 import static org.wikipedia.language.LanguagesListActivity.LANGUAGE_SEARCHED;
+import static org.wikipedia.settings.SettingsActivity.ACTIVITY_RESULT_LANGUAGE_CHANGED;
 import static org.wikipedia.settings.languages.WikipediaLanguagesActivity.INVOKE_SOURCE_EXTRA;
 
 public class WikipediaLanguagesFragment extends Fragment implements WikipediaLanguagesItemView.Callback {
@@ -431,6 +432,7 @@ public class WikipediaLanguagesFragment extends Fragment implements WikipediaLan
                         .setPositiveButton(R.string.remove_language_dialog_ok_button_text, (dialog, i) -> {
                             deleteSelectedLanguages();
                             finishActionMode();
+                            requireActivity().setResult(ACTIVITY_RESULT_LANGUAGE_CHANGED);
                         })
                         .setNegativeButton(R.string.remove_language_dialog_cancel_button_text, null);
             } else {


### PR DESCRIPTION
- Should refresh the feed after we tapped on the "Customize" button on the onboarding card in the explore feed
- Should refresh the feed after we went to the Settings -> "Wikipedia languages" or "Explore feed"