### PR TITLE
Translate icon should not be autoMirrored

### DIFF
--- a/app/src/main/res/drawable/ic_translate_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_translate_white_24dp.xml
@@ -1,5 +1,5 @@
 <vector xmlns:tools="http://schemas.android.com/tools"
-    android:autoMirrored="true" android:height="24dp"
+    android:height="24dp"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android"
     tools:ignore="UnusedAttribute">


### PR DESCRIPTION
The "文" character should not be auto mirrored, otherwise, it would be super weird to people who recognize it.