### PR TITLE
Fix: make sure image in the image caption review screen shows the entire image

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
@@ -12,6 +12,7 @@ import org.wikipedia.descriptions.DescriptionEditLicenseView.Companion.ARG_NOTIC
 import org.wikipedia.suggestededits.SuggestedEditsSummary
 import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.StringUtil
+import org.wikipedia.views.ViewUtil
 
 class DescriptionEditReviewView constructor(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
 
@@ -66,7 +67,8 @@ class DescriptionEditReviewView constructor(context: Context, attrs: AttributeSe
             galleryImage.visibility = GONE
         } else {
             galleryImage.visibility = VISIBLE
-            galleryImage.loadImage(Uri.parse(summary.getPreferredSizeThumbnailUrl()))
+            ViewUtil.loadImageWithWhiteBackground(galleryImage, summary.getPreferredSizeThumbnailUrl())
+
         }
         licenseView.darkLicenseView()
     }

--- a/app/src/main/res/layout/view_description_edit_review.xml
+++ b/app/src/main/res/layout/view_description_edit_review.xml
@@ -94,7 +94,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <org.wikipedia.views.FaceAndColorDetectImageView
+        <ImageView
             android:id="@+id/galleryImage"
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION
If you try to review the image caption in the "review image caption" screen, the image will be cropped in the first time of visiting the review screen.