### PR TITLE
Using correct wikisite for network calls in Gallery

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -101,6 +101,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     public static final String EXTRA_SOURCE = "source";
     public static final String EXTRA_FEATURED_IMAGE = "featuredImage";
     public static final String EXTRA_FEATURED_IMAGE_AGE = "featuredImageAge";
+    public static final String EXTRA_IS_COMMONS = "isCommons";
 
     @NonNull private WikipediaApp app = WikipediaApp.getInstance();
     @NonNull private ExclusiveBottomSheetPresenter bottomSheetPresenter = new ExclusiveBottomSheetPresenter();
@@ -149,22 +150,24 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     private MediaDownloadReceiver downloadReceiver = new MediaDownloadReceiver();
     private MediaDownloadReceiverCallback downloadReceiverCallback = new MediaDownloadReceiverCallback();
     @Nullable private String targetLanguageCode;
+     private boolean isCommonsFile;
 
     @NonNull
     public static Intent newIntent(@NonNull Context context, int age, @NonNull String filename,
                                    @NonNull FeaturedImage image, @NonNull WikiSite wiki, int source) {
-        return newIntent(context, null, filename, wiki, 0, source)
+        return newIntent(context, null, true, filename, wiki, 0, source)
                 .putExtra(EXTRA_FEATURED_IMAGE, GsonMarshaller.marshal(image))
                 .putExtra(EXTRA_FEATURED_IMAGE_AGE, age);
     }
 
     @NonNull
     public static Intent newIntent(@NonNull Context context, @Nullable PageTitle pageTitle,
-                                   @NonNull String filename, @NonNull WikiSite wiki, long revision, int source) {
+                                   boolean isCommonsFile, @NonNull String filename, @NonNull WikiSite wiki, long revision, int source) {
         Intent intent = new Intent()
                 .setClass(context, GalleryActivity.class)
                 .putExtra(EXTRA_FILENAME, filename)
                 .putExtra(EXTRA_WIKI, wiki)
+                .putExtra(EXTRA_IS_COMMONS, isCommonsFile)
                 .putExtra(EXTRA_REVISION, revision)
                 .putExtra(EXTRA_SOURCE, source);
         if (pageTitle != null) {
@@ -204,6 +207,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         if (getIntent().hasExtra(EXTRA_PAGETITLE)) {
             pageTitle = getIntent().getParcelableExtra(EXTRA_PAGETITLE);
         }
+        isCommonsFile = getIntent().getBooleanExtra(EXTRA_IS_COMMONS, false);
         initialFilename = getIntent().getStringExtra(EXTRA_FILENAME);
         revision = getIntent().getLongExtra(EXTRA_REVISION, 0);
         sourceWiki = getIntent().getParcelableExtra(EXTRA_WIKI);
@@ -399,6 +403,10 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         if (imageCaptionDisposable != null && !imageCaptionDisposable.isDisposed()) {
             imageCaptionDisposable.dispose();
         }
+    }
+
+    public boolean isCommonsFile() {
+        return isCommonsFile;
     }
 
     private class GalleryPageChangeListener extends ViewPager2.OnPageChangeCallback {

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
@@ -232,7 +232,7 @@ public class GalleryItemFragment extends Fragment {
         if (FileUtil.isVideo(mediaListItem.getType())) {
             return ServiceFactory.get(pageTitle.getWikiSite()).getVideoInfo(title, lang);
         } else {
-            return ServiceFactory.get(pageTitle.getWikiSite()).getImageInfo(title, lang);
+            return ServiceFactory.get(((GalleryActivity) requireActivity()).isCommonsFile() ? new WikiSite(Service.COMMONS_URL) : pageTitle.getWikiSite()).getImageInfo(title, lang);
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1156,7 +1156,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     private void startGalleryActivity(@NonNull String fileName) {
         if (app.isOnline()) {
             requireActivity().startActivityForResult(GalleryActivity.newIntent(requireActivity(),
-                    model.getTitleOriginal(), fileName,
+                    model.getTitleOriginal(), false, fileName,
                     model.getTitle().getWikiSite(), getRevision(), GalleryFunnel.SOURCE_NON_LEAD_IMAGE), ACTIVITY_REQUEST_GALLERY);
         } else {
             Snackbar snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(R.string.gallery_not_available_offline_snackbar), FeedbackUtil.LENGTH_DEFAULT);

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -221,7 +221,7 @@ public class LeadImagesHandler {
                 String filename = "File:" + imageName;
                 WikiSite wiki = language == null ? getTitle().getWikiSite() : WikiSite.forLanguageCode(language);
                 getActivity().startActivityForResult(GalleryActivity.newIntent(getActivity(),
-                        parentFragment.getTitleOriginal(), filename, wiki, parentFragment.getRevision(),
+                        parentFragment.getTitleOriginal(), getLeadImageUrl().contains(Service.URL_FRAGMENT_FROM_COMMONS), filename, wiki, parentFragment.getRevision(),
                         GalleryFunnel.SOURCE_LEAD_IMAGE),
                         Constants.ACTIVITY_REQUEST_GALLERY);
             }

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
@@ -328,7 +328,7 @@ public class LinkPreviewDialog extends ExtendedBottomSheetDialogFragment
             = new GalleryThumbnailScrollView.GalleryViewListener() {
         @Override
         public void onGalleryItemClicked(String imageName) {
-            startActivityForResult(GalleryActivity.newIntent(requireContext(), pageTitle, imageName,
+            startActivityForResult(GalleryActivity.newIntent(requireContext(), pageTitle, false, imageName,
                     pageTitle.getWikiSite(), revision, GalleryFunnel.SOURCE_LINK_PREVIEW),
                     Constants.ACTIVITY_REQUEST_GALLERY);
         }


### PR DESCRIPTION
When we click on an image in the article, we pass the page title to the gallery. GalleryActivity uses this to get the media-list. Here, the wikisite related to the page is needed. However, when we populate each image item of the list, we need to make calls using the correct wikisite, based on whether the image resides on commons or a wiki. Sending that information while starting the GalleryActivity helps us do this.