### PR TITLE
Remove usages of ContextCompat.getDrawable().

### DIFF
--- a/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.java
+++ b/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.java
@@ -12,7 +12,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.core.widget.ImageViewCompat;
 
 import org.wikipedia.BuildConfig;
@@ -71,7 +70,7 @@ public class MenuNavTabDialog extends ExtendedBottomSheetDialogFragment {
 
     public void updateState() {
         if (AccountUtil.isLoggedIn()) {
-            accountAvatar.setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.ic_baseline_person_24));
+            accountAvatar.setImageDrawable(requireContext().getDrawable(R.drawable.ic_baseline_person_24));
             ImageViewCompat.setImageTintList(accountAvatar, ColorStateList.valueOf(ResourceUtil.getThemedColor(requireContext(), R.attr.material_theme_secondary_color)));
             accountNameView.setText(AccountUtil.getUserName());
             accountNameView.setVisibility(VISIBLE);
@@ -80,7 +79,7 @@ public class MenuNavTabDialog extends ExtendedBottomSheetDialogFragment {
             loginLogoutButton.setTextColor(ResourceUtil.getThemedColor(requireContext(), R.attr.colorError));
             notificationsContainer.setVisibility(VISIBLE);
         } else {
-            accountAvatar.setImageDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.ic_login_24px));
+            accountAvatar.setImageDrawable(requireContext().getDrawable(R.drawable.ic_login_24px));
         ImageViewCompat.setImageTintList(accountAvatar, ColorStateList.valueOf(ResourceUtil.getThemedColor(requireContext(), R.attr.colorAccent)));
             accountNameView.setVisibility(GONE);
             loginLogoutButton.setTextAlignment(TEXT_ALIGNMENT_TEXT_START);

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTypeItem.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTypeItem.kt
@@ -32,13 +32,13 @@ class SuggestedEditsTypeItem constructor(context: Context, attrs: AttributeSet? 
     fun setEnabledStateUI() {
         title.setTextColor(ResourceUtil.getThemedColor(context, R.attr.themed_icon_color))
         ImageViewCompat.setImageTintList(image, ColorStateList.valueOf(ContextCompat.getColor(context, ResourceUtil.getThemedAttributeId(context, R.attr.themed_icon_color))))
-        this.background = ContextCompat.getDrawable(context, R.drawable.rounded_12dp_accent90_fill)
+        this.background = context.getDrawable(R.drawable.rounded_12dp_accent90_fill)
     }
 
     fun setDisabledStateUI() {
         title.setTextColor(ResourceUtil.getThemedColor(context, R.attr.secondary_text_color))
         ImageViewCompat.setImageTintList(image, ColorStateList.valueOf(ContextCompat.getColor(context, ResourceUtil.getThemedAttributeId(context, R.attr.chart_shade4))))
-        this.background = ContextCompat.getDrawable(context, R.drawable.rounded_12dp_corner_base90_fill)
+        this.background = context.getDrawable(R.drawable.rounded_12dp_corner_base90_fill)
     }
 
     fun setAttributes(title: String, imageResource: Int, editType: Int, callback: Callback) {


### PR DESCRIPTION
Replace uses of `ContextCompat.getDrawable()` with `Context.getDrawable()`, as the minimum API level (Lollipop) supports the method.