### PR TITLE
Filter claims by P180

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
+++ b/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
@@ -11,7 +11,7 @@ import java.util.*
 
 object ImageTagsProvider {
     fun getImageTagsObservable(pageId: Int, langCode: String): Observable<Map<String, List<String>>> {
-        return ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getClaims("M$pageId")
+        return ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getClaims("M$pageId", null)
                 .subscribeOn(Schedulers.io())
                 .onErrorReturnItem(Claims())
                 .flatMap { claims ->

--- a/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
+++ b/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
@@ -11,7 +11,7 @@ import java.util.*
 
 object ImageTagsProvider {
     fun getImageTagsObservable(pageId: Int, langCode: String): Observable<Map<String, List<String>>> {
-        return ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getClaims("M$pageId", null)
+        return ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getClaims("M$pageId", "P180")
                 .subscribeOn(Schedulers.io())
                 .onErrorReturnItem(Claims())
                 .flatMap { claims ->

--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -263,8 +263,9 @@ public interface Service {
     @NonNull Observable<Entities> getWikidataLabels(@Query("ids") @NonNull String idList,
                                                     @Query("languages") @NonNull String langList);
 
-    @GET(MW_API_PREFIX + "action=wbgetclaims&property=P180")
-    @NonNull Observable<Claims> getClaims(@Query("entity") @NonNull String entity);
+    @GET(MW_API_PREFIX + "action=wbgetclaims") @NonNull
+    Observable<Claims> getClaims(@Query("entity") @NonNull String entity,
+                                 @Query("property") @Nullable String property);
 
     @GET(MW_API_PREFIX + "action=wbgetentities&props=descriptions|labels|sitelinks")
     @NonNull Observable<Entities> getWikidataLabelsAndDescriptions(@Query("ids") @NonNull String idList);

--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -263,7 +263,7 @@ public interface Service {
     @NonNull Observable<Entities> getWikidataLabels(@Query("ids") @NonNull String idList,
                                                     @Query("languages") @NonNull String langList);
 
-    @GET(MW_API_PREFIX + "action=wbgetclaims")
+    @GET(MW_API_PREFIX + "action=wbgetclaims&property=P180")
     @NonNull Observable<Claims> getClaims(@Query("entity") @NonNull String entity);
 
     @GET(MW_API_PREFIX + "action=wbgetentities&props=descriptions|labels|sitelinks")


### PR DESCRIPTION
If image has claims other than P180, ImageTagsProvider.kt doesn't count them. Filtering them at the api call level corrects this.
Ex: https://commons.wikimedia.org/w/api.php?format=json&formatversion=2&errorformat=plaintext&action=wbgetclaims&entity=M87877968
tags count is 0.