### PR TITLE
Update DrawableItemDecoration default setting to make dividers having consistent rules

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/view/ListCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/view/ListCardView.java
@@ -68,7 +68,7 @@ public abstract class ListCardView<T extends Card> extends DefaultFeedCardView<T
         directly. */
     protected void initRecycler(@NonNull RecyclerView recyclerView) {
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
-        recyclerView.addItemDecoration(new DrawableItemDecoration(getContext(), R.attr.list_separator_drawable));
+        recyclerView.addItemDecoration(new DrawableItemDecoration(getContext(), R.attr.list_separator_drawable, true));
         recyclerView.setNestedScrollingEnabled(false);
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
@@ -125,7 +125,7 @@ public class ReadingListsFragment extends Fragment implements
         searchEmptyView.setEmptyText(R.string.search_reading_lists_no_results);
         readingListView.setLayoutManager(new LinearLayoutManager(getContext()));
         readingListView.setAdapter(adapter);
-        readingListView.addItemDecoration(new DrawableItemDecoration(requireContext(), R.attr.list_separator_drawable, false, true));
+        readingListView.addItemDecoration(new DrawableItemDecoration(requireContext(), R.attr.list_separator_drawable));
         setUpScrollListener();
         disposables.add(WikipediaApp.getInstance().getBus().subscribe(new EventBusConsumer()));
         swipeRefreshLayout.setColorSchemeResources(getThemedAttributeId(requireContext(), R.attr.colorAccent));

--- a/app/src/main/java/org/wikipedia/views/DrawableItemDecoration.kt
+++ b/app/src/main/java/org/wikipedia/views/DrawableItemDecoration.kt
@@ -13,9 +13,8 @@ import org.wikipedia.util.ResourceUtil
 
 // todo: replace with DividerItemDecoration once it supports headers and footers
 class DrawableItemDecoration @JvmOverloads constructor(context: Context, @AttrRes id: Int,
-                                                       private val drawStart: Boolean = true,
-                                                       private val drawEnd: Boolean = true,
-                                                       private val horizontalPadding: Int = -1) : ItemDecoration() {
+                                                       private val drawStart: Boolean = false,
+                                                       private val drawEnd: Boolean = true) : ItemDecoration() {
 
     private val drawable: Drawable = AppCompatResources.getDrawable(context, ResourceUtil.getThemedAttributeId(context, id))!!
 
@@ -47,8 +46,8 @@ class DrawableItemDecoration @JvmOverloads constructor(context: Context, @AttrRe
     private fun bounds(parent: RecyclerView, child: View, top: Boolean): Rect {
         val layoutManager = parent.layoutManager
         val bounds = Rect()
-        bounds.right = parent.width - if (horizontalPadding != -1) horizontalPadding else parent.paddingRight
-        bounds.left = if (horizontalPadding != -1) horizontalPadding else parent.paddingLeft
+        bounds.right = parent.width - parent.paddingRight
+        bounds.left = parent.paddingLeft
         val height = drawable.intrinsicHeight
         bounds.top = if (top) layoutManager!!.getDecoratedTop(child) else layoutManager!!.getDecoratedBottom(child) - height
         bounds.bottom = bounds.top + height


### PR DESCRIPTION
Since we remove the elevation from the action bar, it would be better if we also remove the first divider on the first item and make it as a default setting in `DrawableItemDecoration `