### PR TITLE
Add news list background color to prevent incorrect transition animation

### DIFF
--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -59,7 +59,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fitsSystemWindows="true"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:background="?attr/paper_color">
 
             <org.wikipedia.views.AppTextView
                 android:id="@+id/view_news_fullscreen_story_text"


### PR DESCRIPTION
If we don't apply a background color to the list explicitly, we will see the divider color after returning to the Explore feed from the news list screen.