### PR TITLE
Fix: reset page revision to prevent loading media-list incorrectly

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -771,8 +771,9 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
 
         updateProgressBar(true);
 
-        this.pageRefreshed = isRefresh;
+        pageRefreshed = isRefresh;
         references = null;
+        revision = 0;
 
         closePageScrollFunnel();
         pageFragmentLoadState.load(pushBackStack);


### PR DESCRIPTION
Steps to reproduce:

1. Tap on any Chinese article that has a lead image.
2. While the page is not completely loaded, click on the lead image

The reason why causes error is because the revision is still using the revision from the last page.