### PR TITLE
Fix: prevent using incorrect page title to fetch media-list

### DIFF
--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -221,7 +221,7 @@ public class LeadImagesHandler {
                 String filename = "File:" + imageName;
                 WikiSite wiki = language == null ? getTitle().getWikiSite() : WikiSite.forLanguageCode(language);
                 getActivity().startActivityForResult(GalleryActivity.newIntent(getActivity(),
-                        parentFragment.getTitleOriginal(), filename, wiki, parentFragment.getRevision(),
+                        parentFragment.getTitle(), filename, wiki, parentFragment.getRevision(),
                         GalleryFunnel.SOURCE_LEAD_IMAGE),
                         Constants.ACTIVITY_REQUEST_GALLERY);
             }


### PR DESCRIPTION
Not sure why we are using the `getTitleOriginal()` here, but it causes a language variant issue.

Steps to reproduce:
1. Open https://en.wikipedia.org/wiki/Permanent_members_of_the_United_Nations_Security_Council in `Traditional Chinese`
2. Click on [聯合國安全理事會](https://zh.wikipedia.org/wiki/%E8%81%94%E5%90%88%E5%9B%BD%E5%AE%89%E5%85%A8%E7%90%86%E4%BA%8B%E4%BC%9A) in the first paragraph
3. Click on the lead image and will see the error message