### PR TITLE
Fix: make sure buttons in WikiErrorView are clickable in Gallery

### DIFF
--- a/app/src/main/res/layout/activity_gallery.xml
+++ b/app/src/main/res/layout/activity_gallery.xml
@@ -8,15 +8,6 @@
     android:layout_height="match_parent"
     android:background="@android:color/black">
 
-    <org.wikipedia.views.WikiErrorView
-        android:id="@+id/view_gallery_error"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:background="@android:color/black"
-        android:orientation="vertical"
-        android:visibility="gone" />
-
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/gallery_item_pager"
         android:layout_width="match_parent"
@@ -206,4 +197,13 @@
                 tools:text="Credits" />
         </LinearLayout>
     </LinearLayout>
+
+    <org.wikipedia.views.WikiErrorView
+        android:id="@+id/view_gallery_error"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:background="@android:color/black"
+        android:orientation="vertical"
+        android:visibility="gone" />
 </FrameLayout>


### PR DESCRIPTION
If we see the `WikiErrorView` in the Gallery, we will not be able to click the "back" button.