### PR TITLE
Fix: replace getTitleOriginal() with getTitle() to prevent failing on loading media-list

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1073,7 +1073,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             webView.setScrollY(webView.getScrollY() + diffY - webView.getHeight() / offsetFraction);
         });
         bridge.addListener("image", (String messageType, JsonObject messagePayload) -> {
-            L.d("Image clicked " + messagePayload);
             linkHandler.onUrlClick(decodeURL(messagePayload.get("href").getAsString()),
                     messagePayload.has("title") ? messagePayload.get("title").getAsString() : null, "");
         });

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1073,6 +1073,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             webView.setScrollY(webView.getScrollY() + diffY - webView.getHeight() / offsetFraction);
         });
         bridge.addListener("image", (String messageType, JsonObject messagePayload) -> {
+            L.d("Image clicked " + messagePayload);
             linkHandler.onUrlClick(decodeURL(messagePayload.get("href").getAsString()),
                     messagePayload.has("title") ? messagePayload.get("title").getAsString() : null, "");
         });
@@ -1157,7 +1158,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     private void startGalleryActivity(@NonNull String fileName) {
         if (app.isOnline()) {
             requireActivity().startActivityForResult(GalleryActivity.newIntent(requireActivity(),
-                    model.getTitleOriginal(), fileName,
+                    model.getTitle(), fileName,
                     model.getTitle().getWikiSite(), getRevision(), GalleryFunnel.SOURCE_NON_LEAD_IMAGE), ACTIVITY_REQUEST_GALLERY);
         } else {
             Snackbar snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(R.string.gallery_not_available_offline_snackbar), FeedbackUtil.LENGTH_DEFAULT);


### PR DESCRIPTION
A similar issue as #1490. Found that if we turn off the link preview, it will use the incorrect title to request endpoint when loading the Gallery sometimes. 

Steps to reproduce:
1. Turn off link preview in settings.
2. Go to https://en.wikipedia.org/wiki/List_of_countries_by_military_expenditures in Traditional Chinese
3. Click on [開發中國家] in-article link in the first paragraph. 
4. Click on the first image in article.