### PR TITLE
Fix: Reading list limit message bug

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.java
@@ -399,7 +399,7 @@ public class ReadingListsFragment extends Fragment implements
     }
 
     private void maybeShowListLimitMessage() {
-        if (displayedLists.size() >= Constants.MAX_READING_LISTS_LIMIT) {
+        if (actionMode == null && displayedLists.size() >= Constants.MAX_READING_LISTS_LIMIT) {
             String message = getString(R.string.reading_lists_limit_message);
             FeedbackUtil.makeSnackbar(getActivity(), message, FeedbackUtil.LENGTH_DEFAULT).show();
         }


### PR DESCRIPTION
**Bug:** https://youtu.be/1zFVuMov5o8

When there are more than 100 search result items also, the "Can\'t create another list. You\'ve reached the limit of 100 reading lists per account" message is getting triggered. This fixes that issue.