### PR TITLE
Fix: view does not go back to its original position after snackbar dismissed

### DIFF
--- a/app/src/main/java/org/wikipedia/random/BottomViewBehavior.java
+++ b/app/src/main/java/org/wikipedia/random/BottomViewBehavior.java
@@ -5,24 +5,33 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.google.android.material.snackbar.Snackbar;
 
 public class BottomViewBehavior extends CoordinatorLayout.Behavior<ViewGroup> {
+
+    private static final long ANIMATION_DURATION_MILLISECONDS = 100;
+
     public BottomViewBehavior(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
     @Override
-    public boolean layoutDependsOn(CoordinatorLayout parent, ViewGroup child, View dependency) {
+    public boolean layoutDependsOn(@NonNull CoordinatorLayout parent, @NonNull ViewGroup child, @NonNull View dependency) {
         return dependency instanceof Snackbar.SnackbarLayout;
     }
 
     @Override
-    public boolean onDependentViewChanged(CoordinatorLayout parent, ViewGroup child, View dependency) {
-        float translationY = Math.min(0, dependency.getTranslationY() - dependency.getHeight());
-        child.setTranslationY(translationY);
+    public boolean onDependentViewChanged(@NonNull CoordinatorLayout parent, @NonNull ViewGroup child, @NonNull View dependency) {
+        child.animate().setDuration(ANIMATION_DURATION_MILLISECONDS).translationY(-dependency.getHeight());
         return true;
+    }
+
+    @Override
+    public void onDependentViewRemoved(@NonNull CoordinatorLayout parent, @NonNull ViewGroup child,
+                                       @NonNull View dependency) {
+        child.animate().setDuration(ANIMATION_DURATION_MILLISECONDS).translationY(0);
     }
 }


### PR DESCRIPTION
The issue can be reproduced in the Randomizer when adding an article to the reading list.