### PR TITLE
Rename the long press toast method with a proper name

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
@@ -381,7 +381,7 @@ public class DescriptionEditView extends LinearLayout {
     private void init() {
         inflate(getContext(), R.layout.view_description_edit, this);
         ButterKnife.bind(this);
-        FeedbackUtil.setToolbarButtonLongPressToast(saveButton, cancelButton, helpButton);
+        FeedbackUtil.setButtonLongPressToast(saveButton, cancelButton, helpButton);
         setOrientation(VERTICAL);
     }
 

--- a/app/src/main/java/org/wikipedia/feed/searchbar/SearchCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/searchbar/SearchCardView.java
@@ -21,7 +21,7 @@ public class SearchCardView extends DefaultFeedCardView<SearchCard> {
         inflate(getContext(), R.layout.view_search_bar, this);
         setCardBackgroundColor(ResourceUtil.getThemedColor(context, R.attr.color_group_22));
         ButterKnife.bind(this);
-        FeedbackUtil.setToolbarButtonLongPressToast(findViewById(R.id.voice_search_button));
+        FeedbackUtil.setButtonLongPressToast(findViewById(R.id.voice_search_button));
     }
 
     @OnClick(R.id.search_container) void onSearchClick() {

--- a/app/src/main/java/org/wikipedia/main/MainActivity.java
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.java
@@ -106,7 +106,7 @@ public class MainActivity extends SingleFragmentActivity<MainFragment> implement
             tabCountsView.setContentDescription(getString(R.string.menu_page_show_tabs));
             tabsItem.setActionView(tabCountsView);
             tabsItem.expandActionView();
-            FeedbackUtil.setToolbarButtonLongPressToast(tabCountsView);
+            FeedbackUtil.setButtonLongPressToast(tabCountsView);
         }
         return true;
     }

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -140,7 +140,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
         viewPager.setUserInputEnabled(false);
         viewPager.setAdapter(new NavTabFragmentPagerAdapter(this));
         viewPager.registerOnPageChangeCallback(pageChangeCallback);
-        FeedbackUtil.setToolbarButtonLongPressToast(moreContainer);
+        FeedbackUtil.setButtonLongPressToast(moreContainer);
 
         tabLayout.setOnNavigationItemSelectedListener(item -> {
             if (!navTabAutoSelect && getCurrentFragment() instanceof FeedFragment && item.getOrder() == 0) {

--- a/app/src/main/java/org/wikipedia/page/PageActionTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActionTabLayout.kt
@@ -25,7 +25,7 @@ class PageActionTabLayout constructor(context: Context, attrs: AttributeSet? = n
                     }
                 }
             }
-            FeedbackUtil.setToolbarButtonLongPressToast(tab)
+            FeedbackUtil.setButtonLongPressToast(tab)
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -181,7 +181,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         clearActionBarTitle();
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        FeedbackUtil.setToolbarButtonLongPressToast(searchButton, tabsButton, overflowButton);
+        FeedbackUtil.setButtonLongPressToast(searchButton, tabsButton, overflowButton);
 
         toolbarHideHandler = new PageToolbarHideHandler(pageFragment, toolbarContainerView, toolbar, tabsButton);
 

--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
@@ -135,7 +135,7 @@ public class TabActivity extends BaseActivity {
         tabCountsView.updateTabCount();
         launchedFromPageActivity = getIntent().hasExtra(LAUNCHED_FROM_PAGE_ACTIVITY);
 
-        FeedbackUtil.setToolbarButtonLongPressToast(tabCountsView);
+        FeedbackUtil.setButtonLongPressToast(tabCountsView);
 
         setStatusBarColor(ResourceUtil.getThemedColor(this, android.R.attr.colorBackground));
         setNavigationBarColor(ResourceUtil.getThemedColor(this, android.R.attr.colorBackground));

--- a/app/src/main/java/org/wikipedia/random/RandomFragment.java
+++ b/app/src/main/java/org/wikipedia/random/RandomFragment.java
@@ -71,7 +71,7 @@ public class RandomFragment extends Fragment {
         super.onCreateView(inflater, container, savedInstanceState);
         View view = inflater.inflate(R.layout.fragment_random, container, false);
         unbinder = ButterKnife.bind(this, view);
-        FeedbackUtil.setToolbarButtonLongPressToast(nextButton, saveButton);
+        FeedbackUtil.setButtonLongPressToast(nextButton, saveButton);
 
         randomPager.setOffscreenPageLimit(2);
         randomPager.setAdapter(new RandomItemAdapter(this));

--- a/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.java
+++ b/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.java
@@ -63,7 +63,7 @@ public class RecentSearchesFragment extends Fragment implements LoaderManager.Lo
                                 Completable.fromAction(() -> WikipediaApp.getInstance().getDatabaseClient(RecentSearch.class).deleteAll()).subscribeOn(Schedulers.io()).subscribe())
                         .setNegativeButton(getString(R.string.clear_recent_searches_confirm_no), null)
                         .create().show());
-        FeedbackUtil.setToolbarButtonLongPressToast(deleteButton);
+        FeedbackUtil.setButtonLongPressToast(deleteButton);
 
         return rootView;
     }

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.java
@@ -440,7 +440,7 @@ public class SearchFragment extends Fragment implements SearchResultsFragment.Ca
     private void initLangButton() {
         langButton.setText(app.language().getAppLanguageCode().toUpperCase(Locale.ENGLISH));
         ViewUtil.formatLangButton(langButton, app.language().getAppLanguageCode().toUpperCase(Locale.ENGLISH), LANG_BUTTON_TEXT_SIZE_SMALLER, LANG_BUTTON_TEXT_SIZE_LARGER);
-        FeedbackUtil.setToolbarButtonLongPressToast(langButtonContainer);
+        FeedbackUtil.setButtonLongPressToast(langButtonContainer);
     }
 
     private boolean isValidQuery(String queryText) {

--- a/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.java
+++ b/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.java
@@ -75,7 +75,7 @@ public class ThemeChooserDialog extends ExtendedBottomSheetDialogFragment {
         unbinder = ButterKnife.bind(this, rootView);
         buttonDecreaseTextSize.setOnClickListener(new FontSizeButtonListener(FontSizeAction.DECREASE));
         buttonIncreaseTextSize.setOnClickListener(new FontSizeButtonListener(FontSizeAction.INCREASE));
-        FeedbackUtil.setToolbarButtonLongPressToast(buttonDecreaseTextSize, buttonIncreaseTextSize);
+        FeedbackUtil.setButtonLongPressToast(buttonDecreaseTextSize, buttonIncreaseTextSize);
         buttonThemeLight.setOnClickListener(new ThemeButtonListener(Theme.LIGHT));
         buttonThemeDark.setOnClickListener(new ThemeButtonListener(Theme.DARK));
         buttonThemeBlack.setOnClickListener(new ThemeButtonListener(Theme.BLACK));

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
@@ -128,7 +128,7 @@ public final class FeedbackUtil {
         showMessage(activity, message);
     }
 
-    public static void setToolbarButtonLongPressToast(View... views) {
+    public static void setButtonLongPressToast(View... views) {
         for (View v : views) {
             v.setOnLongClickListener(TOOLBAR_LONG_CLICK_LISTENER);
         }

--- a/app/src/main/java/org/wikipedia/views/CabSearchView.java
+++ b/app/src/main/java/org/wikipedia/views/CabSearchView.java
@@ -48,7 +48,7 @@ public class CabSearchView extends SearchView {
         searchCloseBtn = findViewById(R.id.search_close_btn);
         searchCloseBtn.setVisibility(GONE);
         searchCloseBtn.setColorFilter(themedIconColor);
-        FeedbackUtil.setToolbarButtonLongPressToast(searchCloseBtn);
+        FeedbackUtil.setButtonLongPressToast(searchCloseBtn);
         addFilter(searchSrcTextView, new PlainTextInputFilter());
     }
 

--- a/app/src/main/java/org/wikipedia/views/PageActionOverflowView.java
+++ b/app/src/main/java/org/wikipedia/views/PageActionOverflowView.java
@@ -84,6 +84,6 @@ public class PageActionOverflowView extends FrameLayout {
     private void init() {
         inflate(getContext(), R.layout.view_page_action_overflow, this);
         ButterKnife.bind(this);
-        FeedbackUtil.setToolbarButtonLongPressToast(forwardButton);
+        FeedbackUtil.setButtonLongPressToast(forwardButton);
     }
 }

--- a/app/src/main/java/org/wikipedia/views/PageItemView.java
+++ b/app/src/main/java/org/wikipedia/views/PageItemView.java
@@ -201,7 +201,7 @@ public class PageItemView<T> extends ConstraintLayout {
         setBackground(AppCompatResources.getDrawable(getContext(), ResourceUtil.getThemedAttributeId(getContext(), R.attr.selectableItemBackground)));
         setFocusable(true);
         DeviceUtil.setContextClickAsLongClick(this);
-        FeedbackUtil.setToolbarButtonLongPressToast(secondaryActionView);
+        FeedbackUtil.setButtonLongPressToast(secondaryActionView);
     }
 
     private void updateSelectedState() {

--- a/app/src/main/java/org/wikipedia/views/WikitextKeyboardButtonView.java
+++ b/app/src/main/java/org/wikipedia/views/WikitextKeyboardButtonView.java
@@ -74,7 +74,7 @@ public class WikitextKeyboardButtonView extends FrameLayout {
 
             if (!TextUtils.isEmpty(buttonHint)) {
                 setContentDescription(buttonHint);
-                FeedbackUtil.setToolbarButtonLongPressToast(this);
+                FeedbackUtil.setButtonLongPressToast(this);
             }
             array.recycle();
         }


### PR DESCRIPTION
Since the `setToolbarButtonLongPressToast()` is not only used on toolbar buttons, we may need to update it to a more generic name.