### PR TITLE
Change TabLayout background to prevent incorrect color in certain devices

### DIFF
--- a/app/src/main/res/layout/fragment_onboarding_pager.xml
+++ b/app/src/main/res/layout/fragment_onboarding_pager.xml
@@ -42,6 +42,7 @@
                 android:layout_gravity="center"
                 android:background="?attr/paper_color"
                 app:tabIndicator="@null"
+                app:tabRippleColor="?attr/color_group_59"
                 app:tabPaddingStart="8dp"
                 app:tabPaddingEnd="8dp"
                 app:tabBackground="@drawable/shape_tab_dot"

--- a/app/src/main/res/layout/fragment_onboarding_pager.xml
+++ b/app/src/main/res/layout/fragment_onboarding_pager.xml
@@ -40,7 +40,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:background="@android:color/transparent"
+                android:background="?attr/paper_color"
                 app:tabIndicator="@null"
                 app:tabPaddingStart="8dp"
                 app:tabPaddingEnd="8dp"

--- a/app/src/main/res/layout/fragment_references_pager.xml
+++ b/app/src/main/res/layout/fragment_references_pager.xml
@@ -54,7 +54,7 @@
             android:layout_width="wrap_content"
             android:layout_height="48dp"
             android:layout_gravity="center"
-            android:background="@android:color/transparent"
+            android:background="?paper_color"
             app:tabIndicator="@null"
             app:tabPaddingStart="8dp"
             app:tabPaddingEnd="8dp"

--- a/app/src/main/res/layout/fragment_references_pager.xml
+++ b/app/src/main/res/layout/fragment_references_pager.xml
@@ -54,7 +54,7 @@
             android:layout_width="wrap_content"
             android:layout_height="48dp"
             android:layout_gravity="center"
-            android:background="?paper_color"
+            android:background="?attr/paper_color"
             app:tabIndicator="@null"
             app:tabPaddingStart="8dp"
             app:tabPaddingEnd="8dp"

--- a/app/src/main/res/layout/fragment_references_pager.xml
+++ b/app/src/main/res/layout/fragment_references_pager.xml
@@ -56,6 +56,7 @@
             android:layout_gravity="center"
             android:background="?attr/paper_color"
             app:tabIndicator="@null"
+            app:tabRippleColor="?attr/color_group_59"
             app:tabPaddingStart="8dp"
             app:tabPaddingEnd="8dp"
             app:tabBackground="@drawable/shape_tab_dot"


### PR DESCRIPTION
https://phabricator.wikimedia.org/T259892

This also applies the correct ripple color to the `TabLayout`. If you re-tap on the selected indicator in `ReferenceDialog`, you'll see the purple ripple color, which is incorrect.