### PR TITLE
Making arrow orientation in tooltip configurable

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -304,12 +304,11 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     private fun showOneTimeSequentialUserStatsTooltips() {
-        val arrowOrientation = ArrowOrientation.BOTTOM
-        val balloon = FeedbackUtil.showTooltip(requireContext(), contributionsStatsView.tooltipText, arrowOrientation)
+        val balloon = FeedbackUtil.showTooltip(requireContext(), contributionsStatsView.tooltipText, ArrowOrientation.BOTTOM)
         contributionsStatsView.description.showAlignBottom(balloon)
-        balloon.relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), editStreakStatsView.tooltipText, arrowOrientation), editStreakStatsView.description)
-                .relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), pageViewStatsView.tooltipText, arrowOrientation), pageViewStatsView.description)
-                .relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), editQualityStatsView.tooltipText, arrowOrientation), editQualityStatsView.description)
+        balloon.relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), editStreakStatsView.tooltipText, ArrowOrientation.BOTTOM), editStreakStatsView.description)
+                .relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), pageViewStatsView.tooltipText, ArrowOrientation.BOTTOM), pageViewStatsView.description)
+                .relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), editQualityStatsView.tooltipText, ArrowOrientation.BOTTOM), editQualityStatsView.description)
         Prefs.shouldShowOneTimeSequentialUserStatsTooltip(false)
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.skydoves.balloon.ArrowOrientation
 import com.skydoves.balloon.showAlignBottom
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
@@ -303,11 +304,12 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     private fun showOneTimeSequentialUserStatsTooltips() {
-        val balloon = FeedbackUtil.showTooltip(requireContext(), contributionsStatsView.tooltipText)
+        val arrowOrientation = ArrowOrientation.BOTTOM
+        val balloon = FeedbackUtil.showTooltip(requireContext(), contributionsStatsView.tooltipText, arrowOrientation)
         contributionsStatsView.description.showAlignBottom(balloon)
-        balloon.relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), editStreakStatsView.tooltipText), editStreakStatsView.description)
-                .relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), pageViewStatsView.tooltipText), pageViewStatsView.description)
-                .relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), editQualityStatsView.tooltipText), editQualityStatsView.description)
+        balloon.relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), editStreakStatsView.tooltipText, arrowOrientation), editStreakStatsView.description)
+                .relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), pageViewStatsView.tooltipText, arrowOrientation), pageViewStatsView.description)
+                .relayShowAlignBottom(FeedbackUtil.showTooltip(requireContext(), editQualityStatsView.tooltipText, arrowOrientation), editQualityStatsView.description)
         Prefs.shouldShowOneTimeSequentialUserStatsTooltip(false)
     }
 

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.java
@@ -177,11 +177,11 @@ public final class FeedbackUtil {
     }
 
     @SuppressWarnings("checkstyle:magicnumber")
-    public static Balloon showTooltip(@NonNull Context context, @NonNull CharSequence text) {
+    public static Balloon showTooltip(@NonNull Context context, @NonNull CharSequence text, ArrowOrientation arrowOrientation) {
         return new Balloon.Builder(context)
                 .setText(text)
                 .setArrowConstraints(ArrowConstraints.ALIGN_ANCHOR)
-                .setArrowOrientation(ArrowOrientation.TOP)
+                .setArrowOrientation(arrowOrientation)
                 .setPadding(16)
                 .setTextSize(14f)
                 .setTextColorResource(ResourceUtil.getThemedAttributeId(context, R.attr.paper_color))

--- a/app/src/main/java/org/wikipedia/views/ImageTitleDescriptionView.kt
+++ b/app/src/main/java/org/wikipedia/views/ImageTitleDescriptionView.kt
@@ -10,6 +10,7 @@ import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
+import com.skydoves.balloon.ArrowOrientation
 import com.skydoves.balloon.showAlignBottom
 import kotlinx.android.synthetic.main.view_image_title_description.view.*
 import org.wikipedia.R
@@ -24,7 +25,7 @@ internal class ImageTitleDescriptionView constructor(context: Context, attrs: At
         layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         setOnLongClickListener {
             if (tooltipText.isNotEmpty()) {
-                description.showAlignBottom(FeedbackUtil.showTooltip(context, tooltipText), 0, 16)
+                description.showAlignBottom(FeedbackUtil.showTooltip(context, tooltipText, ArrowOrientation.BOTTOM), 0, 16)
             }
             true
         }


### PR DESCRIPTION
Need this to be configurable for cases like https://phabricator.wikimedia.org/T259717 where the arrow needs to be show in a different orientation based on the balloon position 