### PR TITLE
Remove 'title' parameter from footer call.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -119,7 +119,6 @@ object JavaScriptActionHandler {
         return "pcs.c1.Footer.add({" +
                 "   platform: \"android\"," +
                 "   clientVersion: \"${BuildConfig.VERSION_NAME}\"," +
-                "   title: \"${model.title!!.prefixedText}\"," +
                 "   menu: {" +
                 "       items: [" +
                                 "pcs.c1.Footer.MenuItemType.lastEdited, " +


### PR DESCRIPTION
Mobile-html has been updated to no longer require the `title` parameter when building the Footer structure.
https://phabricator.wikimedia.org/T255579