### PR TITLE
Fix: add image tags null check in FilePageView

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -29,6 +29,7 @@ import org.wikipedia.util.ImageUrlUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
+import org.wikipedia.util.log.L
 import org.wikipedia.views.ImageDetailView
 import org.wikipedia.views.ImageZoomHelper
 import org.wikipedia.views.ViewUtil
@@ -99,6 +100,10 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
     }
 
     private fun getImageTags(imageTags: Map<String, List<String>>, languageCode: String) : String? {
+        if (!imageTags.containsKey(languageCode)) {
+            return null
+        }
+
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && imageTags.isNotEmpty()) {
             ListFormatter.getInstance(Locale(languageCode)).format(imageTags[languageCode])
         } else {


### PR DESCRIPTION
It prevents showing incomplete content in the FilePage.

Steps to reproduce:
1. Find a non-English article with a lead image.
2. Go to the gallery and find images that require image tags.
3. Add image tags in English.