### PR TITLE
Transform several strings to plurals.

### DIFF
--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.java
@@ -267,7 +267,7 @@ public class HistoryFragment extends Fragment implements BackPressedHandler {
         if (selectedCount == 0) {
             finishActionMode();
         } else if (actionMode != null) {
-            actionMode.setTitle(getString(R.string.multi_select_items_selected, selectedCount));
+            actionMode.setTitle(getResources().getQuantityString(R.plurals.multi_items_selected, selectedCount, selectedCount));
         }
         adapter.notifyDataSetChanged();
     }

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.java
@@ -363,7 +363,7 @@ public class NotificationActivity extends BaseActivity implements NotificationIt
         if (selectedCount == 0) {
             finishActionMode();
         } else if (actionMode != null) {
-            actionMode.setTitle(getString(R.string.multi_select_items_selected, selectedCount));
+            actionMode.setTitle(getResources().getQuantityString(R.plurals.multi_items_selected, selectedCount, selectedCount));
         }
         recyclerView.getAdapter().notifyDataSetChanged();
     }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -163,10 +163,8 @@ object ReadingListBehaviorsUtil {
             return
         }
         FeedbackUtil
-                .makeSnackbar(activity,
-                        activity.getString(
-                                if (pages.size == 1) R.string.reading_list_item_deleted else R.string.reading_list_items_deleted,
-                                if (pages.size == 1) pages[0].title() else pages.size),
+                .makeSnackbar(activity, if (pages.size == 1) activity.getString(R.string.reading_list_item_deleted, pages[0].title())
+                                else activity.resources.getQuantityString(R.plurals.reading_list_articles_deleted, pages.size, pages.size),
                         FeedbackUtil.LENGTH_DEFAULT)
                 .setAction(R.string.reading_list_item_delete_undo) {
                     val newPages = ArrayList<ReadingListPage>()

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.java
@@ -400,7 +400,7 @@ public class ReadingListFragment extends Fragment implements ReadingListItemActi
         if (selectedCount == 0) {
             finishActionMode();
         } else if (actionMode != null) {
-            actionMode.setTitle(getString(R.string.multi_select_items_selected, selectedCount));
+            actionMode.setTitle(getResources().getQuantityString(R.plurals.multi_items_selected, selectedCount, selectedCount));
         }
         adapter.notifyDataSetChanged();
     }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListItemView.java
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListItemView.java
@@ -215,20 +215,12 @@ public class ReadingListItemView extends ConstraintLayout {
 
     @NonNull private String buildStatisticalSummaryText(@NonNull ReadingList readingList) {
         float listSize = statsTextListSize(readingList);
-        return readingList.pages().size() == 1
-                ? getString(R.string.format_reading_list_statistical_summary_singular,
-                    listSize)
-                : getString(R.string.format_reading_list_statistical_summary_plural,
-                    readingList.pages().size(), listSize);
+        return getResources().getQuantityString(R.plurals.format_reading_list_statistical_summary, readingList.pages().size(), readingList.pages().size(), listSize);
     }
 
     @NonNull private String buildStatisticalDetailText(@NonNull ReadingList readingList) {
         float listSize = statsTextListSize(readingList);
-        return readingList.pages().size() == 1
-                ? getString(R.string.format_reading_list_statistical_detail_singular,
-                    readingList.numPagesOffline(), listSize)
-                : getString(R.string.format_reading_list_statistical_detail_plural,
-                    readingList.numPagesOffline(), readingList.pages().size(), listSize);
+        return getResources().getQuantityString(R.plurals.format_reading_list_statistical_detail, readingList.pages().size(), readingList.numPagesOffline(), readingList.pages().size(), listSize);
     }
 
     private float statsTextListSize(@NonNull ReadingList readingList) {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
@@ -350,10 +350,10 @@ class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsImageTagsFragment.
                         if (editorTaskCounts.totalEdits == Prefs.getSuggestedEditsRewardInterstitialContributionOnInitialCount()
                                 || editorTaskCounts.totalEdits % Prefs.getSuggestedEditsRewardInterstitialContributionOnCount() == 0) {
                             rewardInterstitialImage = R.attr.reward_interstitial_heart_drawable
-                            rewardInterstitialText = getString(R.string.suggested_edits_rewards_contribution, editorTaskCounts.totalEdits)
+                            rewardInterstitialText = resources.getQuantityString(R.plurals.suggested_edits_rewards_contributions, editorTaskCounts.totalEdits, editorTaskCounts.totalEdits)
                         } else if (editorTaskCounts.editStreak % Prefs.getSuggestedEditsRewardInterstitialEditStreakOnCount() == 0) {
                             rewardInterstitialImage = R.attr.reward_interstitial_calendar_drawable
-                            rewardInterstitialText = getString(R.string.suggested_edits_rewards_edit_streak, editorTaskCounts.editStreak, AccountUtil.getUserName())
+                            rewardInterstitialText = resources.getQuantityString(R.plurals.suggested_edits_rewards_edit_streaks, editorTaskCounts.editStreak, editorTaskCounts.editStreak, AccountUtil.getUserName())
                         } else if ((Prefs.getLastSuggestedEditsRewardInterstitialEditQualityShown().toInt() == 0
                                         || daysOfLastEditQualityShown == Prefs.getSuggestedEditsRewardInterstitialEditQualityOnDay())
                                 && UserContributionsStats.getRevertSeverity() <= SuggestedEditsRewardsItemFragment.EDIT_STREAK_MAX_REVERT_SEVERITY) {
@@ -392,7 +392,7 @@ class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsImageTagsFragment.
                     .subscribe({
                         if (it >= 0) {
                             rewardInterstitialImage = R.attr.reward_interstitial_view_drawable
-                            rewardInterstitialText = getString(R.string.suggested_edits_rewards_pageviews, it)
+                            rewardInterstitialText = resources.getQuantityString(R.plurals.suggested_edits_rewards_page_views, it.toInt(), it)
                             Prefs.setLastSuggestedEditsRewardInterstitialPageviewsShown(System.currentTimeMillis())
                         }
                     }, { t ->
@@ -491,11 +491,11 @@ class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsImageTagsFragment.
         when (rewardInterstitialQACount) {
             0 -> {
                 rewardInterstitialImage = R.attr.reward_interstitial_heart_drawable
-                rewardInterstitialText = getString(R.string.suggested_edits_rewards_contribution, 100)
+                rewardInterstitialText = resources.getQuantityString(R.plurals.suggested_edits_rewards_contributions, 100, 100)
             }
             1 -> {
                 rewardInterstitialImage = R.attr.reward_interstitial_calendar_drawable
-                rewardInterstitialText = getString(R.string.suggested_edits_rewards_edit_streak, 100, AccountUtil.getUserName())
+                rewardInterstitialText = resources.getQuantityString(R.plurals.suggested_edits_rewards_edit_streaks, 100, 100, AccountUtil.getUserName())
             }
             2 -> {
                 rewardInterstitialImage = R.attr.reward_interstitial_quality_perfect_drawable
@@ -515,7 +515,7 @@ class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsImageTagsFragment.
             }
             6 -> {
                 rewardInterstitialImage = R.attr.reward_interstitial_view_drawable
-                rewardInterstitialText = getString(R.string.suggested_edits_rewards_pageviews, 100)
+                rewardInterstitialText = resources.getQuantityString(R.plurals.suggested_edits_rewards_page_views, 100, 100)
             }
         }
 

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsHeaderView.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsHeaderView.kt
@@ -69,7 +69,7 @@ class ContributionsHeaderView constructor(context: Context, attrs: AttributeSet?
 
     fun updateTotalPageViews(pageViews: Long) {
         if (pageViews > 0) {
-            contributionsSeenText.text = context.getString(R.string.suggested_edits_contribution_seen_text, pageViews.toString())
+            contributionsSeenText.text = context.resources.getQuantityString(R.plurals.suggested_edits_contribution_seen_times, pageViews.toInt(), pageViews)
         }
     }
 

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -345,6 +345,10 @@
   <string name="location_permissions_enable_prompt">Message shown informing the user that if they enable the Location permission, they will be able to see places nearby.</string>
   <string name="location_permissions_enable_action">Button label for requesting to turn on location permissions.</string>
   <string name="error_webview_updating">Error informing the user that the System WebView is being updated, meaning that the app cannot be launched right now, and that the user should try again in a moment.</string>
+  <plurals name="multi_items_selected">
+    <item quantity="one">Toolbar title shown when the user is selecting multiple items in a list, and one item is currently selected.</item>
+    <item quantity="other">Toolbar title shown when the user is selecting multiple items in a list. The \"%d\" symbol is replaced with the number of items currently selected.</item>
+  </plurals>
   <string name="multi_select_items_selected">Toolbar title shown when the user is selecting multiple items in a list. The \"%d\" symbol is replaced with the number of items currently selected.</string>
   <string name="error_message_generic">Generic message informing the user that an error occurred</string>
   <string name="view_link_preview_error_button_dismiss">Button label for a button to dismiss a link preview\n{{Identical|Dismiss}}</string>
@@ -393,6 +397,14 @@
   <string name="reading_list_articles_already_exist_message">Message shown to users when they try to add already existing articles to a reading list. The \"%s\" symbol is replaced with the name of the reading list.</string>
   <string name="reading_list_added_view_button">Button label to view the reading list to which the article was just added.</string>
   <string name="reading_list_add_to_list_button">Button label to add the article to a reading list.</string>
+  <plurals name="format_reading_list_statistical_summary">
+    <item quantity="one">Summary shown for a reading list that contains one article. The %2$.2f parameter is replaced with the cache size of the article.</item>
+    <item quantity="other">Summary shown for a reading list that contains multiple articles; The %1$d parameter is the number of pages in the list, and  the %2$.2f parameter is the total number of megabytes saved to disk for offline page reading.</item>
+  </plurals>
+  <plurals name="format_reading_list_statistical_detail">
+    <item quantity="one">Detailed description shown for a reading list that contains one article; The %1$d parameter is the number pages saved to disk for offline reading (zero or one), and the %3$.2f parameter is the number of megabytes saved to disk for this list.</item>
+    <item quantity="other">Detailed description shown for a reading list that contains multiple articles; The %1$d parameter is the number of pages saved to disk for offline reading, the %2$d parameter is the number of total pages in the list, and the %3$.2f parameter is the total number of megabytes saved to disk for this list.</item>
+  </plurals>
   <string name="format_reading_list_statistical_summary_singular">Summary shown for a reading list that contains one article (singular); this string is formatted with a parameter containing the number of megabytes saved to disk for offline page reading. The %1$.2f symbol is replaced with the cache size of the article.</string>
   <string name="format_reading_list_statistical_summary_plural">Summary shown for a reading list that contains zero or multiple articles (plural); this string is formatted with two arguments: 1)(%1$d) the number of pages in the list, 2)(%2$.2f) a parameter containing the total number of megabytes saved to disk for offline page reading.</string>
   <string name="format_reading_list_statistical_detail_singular">Detailed description shown for a reading list that contains one article (singular); this string is formatted with two arguments: 1)(%1$d) the number, zero or one, of pages saved to disk for offline reading, 2)(%2$.2f) a parameter containing the number of megabytes saved to disk for offline page reading.</string>
@@ -417,6 +429,10 @@
   <string name="reading_list_name_hint">Text input hint for entering the name of this reading list.</string>
   <string name="reading_list_description_hint">Text input hint for entering a description of this reading list. Mention that the description is optional.</string>
   <string name="reading_list_item_deleted">Message shown when an article is removed from a reading list. The \"%s\" symbol is replaced with the name of the article.</string>
+  <plurals name="reading_list_articles_deleted">
+    <item quantity="one">Message shown when one article is removed from a reading list.</item>
+    <item quantity="other">Message shown when multiple articles are removed from a reading list. The \"%d\" symbol is replaced with the number of articles removed.</item>
+  </plurals>
   <string name="reading_list_items_deleted">Message shown when multiple articles are removed from a reading list. The \"%d\" symbol is replaced with the number of articles removed.</string>
   <string name="reading_lists_item_deleted">Menu item to remove an article from selected reading lists. The %s symbol is replaced with the name of the article.</string>
   <string name="reading_list_item_delete_undo">Button label to undo the operation of deleting an item from a list.\n{{Identical|Undo}}</string>
@@ -800,6 +816,10 @@
   <string name="suggested_edits_contribution_image_label">Text label that indicates that the contribution is to an image file.\n{{identical|File}}</string>
   <string name="suggested_edits_contribution_article_label">Text label that indicates that the contribution is to an article.\n{{identical|Article}}</string>
   <string name="suggested_edits_contribution_views">Text label indicating that the associated data indicates the number of views that the contribution has. %s represents the type of contribution.</string>
+  <plurals name="suggested_edits_contribution_seen_times">
+    <item quantity="one">Indicates that the contributions have been seen once in the past 30 days.</item>
+    <item quantity="other">Indicates how many times the contributions have been viewed in the past 30 days. The %s parameter is replaced by the number of views.</item>
+  </plurals>
   <string name="suggested_edits_contribution_seen_text">Contribution detail text about the pageviews. %s represented the times the contribution has been viewed in the past 30 days.</string>
   <plurals name="suggested_edits_image_tag_contribution_label">
     <item quantity="one">Text summarizing the user\'s image tag contribution. %d represents the number of tags contributed.</item>
@@ -807,6 +827,18 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">Contributions filter dropdown item text. %1$d represents the count of the edit type. %2$s is the type of the edit.</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Text for contributions date to indicate it was contributed yesterday</string>
+  <plurals name="suggested_edits_rewards_contributions">
+    <item quantity="one">Message shown about the number of contributions the user has made.</item>
+    <item quantity="other">Message shown about the number of contributions the user has made. The %d parameter represents the number of contrubutions.</item>
+  </plurals>
+  <plurals name="suggested_edits_rewards_edit_streaks">
+    <item quantity="one">Message shown about the length of edit streak the user has made. The %2$s parameter represents the user name.</item>
+    <item quantity="other">Message shown about the length of edit streak the user has made. The %1$d parameter represents the length of edit streak and the %2$s parameter represents the user name.</item>
+  </plurals>
+  <plurals name="suggested_edits_rewards_page_views">
+    <item quantity="one">Message shown about the pageviews the user has earned in a period of time. The %d represents the number of pageviews.</item>
+    <item quantity="other">Message shown about the pageviews the user has earned in a period of time. The %d represents the number of pageviews.</item>
+  </plurals>
   <string name="suggested_edits_rewards_contribution">Message shown to a user about the number of contributions the user has made. The %d represents the number of contrubutions.</string>
   <string name="suggested_edits_rewards_edit_streak">Message shown to a user about the length of edit streak the user has made. The %1$d represents the length of edit streak and the %2$s represents the user name.</string>
   <string name="suggested_edits_rewards_pageviews">Message shown to a user about the pageviews the user has earned in a period of time. The %d represents the number of pageviews.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -327,6 +327,10 @@
     <string name="location_permissions_enable_prompt">Enable location permissions to see places near you.</string>
     <string name="location_permissions_enable_action">Turn on</string>
     <string name="error_webview_updating">The Android System WebView is currently being updated. Please try again in a moment.</string>
+    <plurals name="multi_items_selected">
+        <item quantity="one">%d selected</item>
+        <item quantity="other">%d selected</item>
+    </plurals>
     <string name="multi_select_items_selected">%d selected</string>
     <string name="error_message_generic">An error occurred</string>
     <string name="view_link_preview_error_button_dismiss">Dismiss</string>
@@ -386,6 +390,14 @@
     <string name="reading_list_articles_already_exist_message">All good! %s already contains all articles.</string>
     <string name="reading_list_added_view_button">View list</string>
     <string name="reading_list_add_to_list_button">Add to list</string>
+    <plurals name="format_reading_list_statistical_summary">
+        <item quantity="one">1 article, %2$.2f MB</item>
+        <item quantity="other">%1$d articles, %2$.2f MB</item>
+    </plurals>
+    <plurals name="format_reading_list_statistical_detail">
+        <item quantity="one">%1$d of 1 article available offline, %3$.2f MB</item>
+        <item quantity="other">%1$d of %2$d articles available offline, %3$.2f MB</item>
+    </plurals>
     <string name="format_reading_list_statistical_summary_singular">1 article, %1$.2f MB</string>
     <string name="format_reading_list_statistical_summary_plural">%1$d articles, %2$.2f MB</string>
     <string name="format_reading_list_statistical_detail_singular">%1$d of 1 articles available offline, %2$.2f MB</string>
@@ -410,6 +422,10 @@
     <string name="reading_list_name_hint">Name of this list</string>
     <string name="reading_list_description_hint">Description (optional)</string>
     <string name="reading_list_item_deleted">%s removed from list</string>
+    <plurals name="reading_list_articles_deleted">
+        <item quantity="one">%d article removed from list</item>
+        <item quantity="other">%d articles removed from list</item>
+    </plurals>
     <string name="reading_list_items_deleted">%d articles removed from list</string>
     <string name="reading_lists_item_deleted">%s removed from lists</string>
     <string name="reading_list_item_delete_undo">Undo</string>
@@ -816,6 +832,10 @@
     <string name="suggested_edits_contribution_image_label">Image</string>
     <string name="suggested_edits_contribution_article_label">Article</string>
     <string name="suggested_edits_contribution_views">%s views</string>
+    <plurals name="suggested_edits_contribution_seen_times">
+        <item quantity="one">Seen once in the past 30 days.</item>
+        <item quantity="other">Seen %s times in the past 30 days.</item>
+    </plurals>
     <string name="suggested_edits_contribution_seen_text">Seen %s times in the past 30 days.</string>
     <plurals name="suggested_edits_image_tag_contribution_label">
         <item quantity="one">You added %d tag</item>
@@ -823,6 +843,18 @@
     </plurals>
     <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
     <string name="suggested_edits_contribution_date_yesterday_text">Yesterday</string>
+    <plurals name="suggested_edits_rewards_contributions">
+        <item quantity="one">You\'ve made one contribution to Wikipedia using Suggested Edits. Thank you!</item>
+        <item quantity="other">You\'ve made %d contributions to Wikipedia using Suggested Edits. Thank you!</item>
+    </plurals>
+    <plurals name="suggested_edits_rewards_edit_streaks">
+        <item quantity="one">You\'ve been editing for one whole day. Keep the streak going, %2$s!</item>
+        <item quantity="other">You\'ve edited every day for %1$d days so far. Keep the streak going, %2$s!</item>
+    </plurals>
+    <plurals name="suggested_edits_rewards_page_views">
+        <item quantity="one">Your edits have been seen by one person in the last 30 days. Thanks, and keep going!</item>
+        <item quantity="other">Your edits have been seen by %d people in the last 30 days. Thanks, and keep going!</item>
+    </plurals>
     <string name="suggested_edits_rewards_contribution">You\'ve made %d contributions to Wikipedia using Suggested edits. Thank you!</string>
     <string name="suggested_edits_rewards_edit_streak">You\'ve edited every day for %1$d days so far. Keep the streak going, %2$s!</string>
     <string name="suggested_edits_rewards_pageviews">Your edits have been seen by %d people in the last 30 days. Thanks, and keep going!</string>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T260575

Note that this leaves the old `strings` resources in place until the next TWN sync, so that there's no confusion on the TWN side with renaming and copying strings, which would break our code.