### PR TITLE
Update isValidPageLink() to avoid showing long-press dialog on "add article description" CTA

### DIFF
--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -104,7 +104,9 @@ public final class UriUtil {
                 && uri.getAuthority().endsWith("wikipedia.org")
                 && !TextUtils.isEmpty(uri.getPath())
                 && uri.getPath().startsWith("/wiki"))
-                && (uri.getFragment() == null || !uri.getFragment().startsWith("cite"));
+                && (uri.getFragment() == null
+                || (uri.getFragment().length() > 0
+                && !uri.getFragment().startsWith("cite")));
     }
 
     public static void handleExternalLink(final Context context, final Uri uri) {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T260684