### PR TITLE
Fix: prevent doing doFullTextSearch() infinitely in the SearchResultsFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -516,7 +516,7 @@ public class SearchResultsFragment extends Fragment {
                 if (lastFullTextResults == null) {
                     // the first full text search
                     doFullTextSearch(currentSearchTerm, null, false);
-                } else if (lastFullTextResults.getContinuation() != null) {
+                } else if (lastFullTextResults.getContinuation() != null && !lastFullTextResults.getContinuation().isEmpty()) {
                     // subsequent full text searches
                     doFullTextSearch(currentSearchTerm, lastFullTextResults.getContinuation(), false);
                 }


### PR DESCRIPTION
If the search results is less than 20 items and the last item is visible, the app will keep calling `doFullTextSearch()`.