### PR TITLE
Correctly wire up tracking of invokeSource for Image Tags.

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -137,7 +137,7 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
 
     private fun imageTagsOnClickListener(fragment: Fragment, page: MwQueryPage): OnClickListener {
         return OnClickListener {
-            fragment.startActivityForResult(SuggestedEditsImageTagEditActivity.newIntent(context, page),
+            fragment.startActivityForResult(SuggestedEditsImageTagEditActivity.newIntent(context, page, InvokeSource.FILE_PAGE_ACTIVITY),
                     ACTIVITY_REQUEST_ADD_IMAGE_TAGS)
         }
     }

--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -307,7 +307,7 @@ public interface Service {
     @Headers("Cache-Control: no-cache")
     @POST(MW_API_PREFIX + "action=wbeditentity&errorlang=uselang")
     @FormUrlEncoded
-    Observable<MwPostResponse> postEditEntity(@NonNull @Field("id") String id,
+    Observable<EntityPostResponse> postEditEntity(@NonNull @Field("id") String id,
                                               @NonNull @Field("token") String token,
                                               @Nullable @Field("data") String data,
                                               @Nullable @Field("summary") String summary,

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwPostResponse.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwPostResponse.java
@@ -2,12 +2,9 @@ package org.wikipedia.dataclient.mwapi;
 
 import androidx.annotation.Nullable;
 
-import org.wikipedia.dataclient.wikidata.Entities;
-
 @SuppressWarnings("unused")
 public class MwPostResponse extends MwResponse {
     @Nullable private MwQueryPage pageinfo;
-    @Nullable private Entities.Entity entity;
     @Nullable private String options;
     private int success;
 
@@ -25,10 +22,6 @@ public class MwPostResponse extends MwResponse {
 
     @Nullable public MwQueryPage getPageInfo() {
         return pageinfo;
-    }
-
-    @Nullable public Entities.Entity getEntity() {
-        return entity;
     }
 }
 

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwPostResponse.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwPostResponse.java
@@ -2,9 +2,12 @@ package org.wikipedia.dataclient.mwapi;
 
 import androidx.annotation.Nullable;
 
+import org.wikipedia.dataclient.wikidata.Entities;
+
 @SuppressWarnings("unused")
 public class MwPostResponse extends MwResponse {
     @Nullable private MwQueryPage pageinfo;
+    @Nullable private Entities.Entity entity;
     @Nullable private String options;
     private int success;
 
@@ -22,6 +25,10 @@ public class MwPostResponse extends MwResponse {
 
     @Nullable public MwQueryPage getPageInfo() {
         return pageinfo;
+    }
+
+    @Nullable public Entities.Entity getEntity() {
+        return entity;
     }
 }
 

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.java
@@ -283,7 +283,7 @@ public class FeedFragment extends Fragment implements BackPressedHandler {
         }
         DescriptionEditActivity.Action action = suggestedEditsCardView.getCard().getAction();
         if (action == ADD_IMAGE_TAGS) {
-            startActivityForResult(SuggestedEditsImageTagEditActivity.newIntent(requireActivity(), suggestedEditsCardView.getCard().getPage()), ACTIVITY_REQUEST_DESCRIPTION_EDIT);
+            startActivityForResult(SuggestedEditsImageTagEditActivity.newIntent(requireActivity(), suggestedEditsCardView.getCard().getPage(), FEED), ACTIVITY_REQUEST_DESCRIPTION_EDIT);
             return;
         }
         PageTitle pageTitle = (action == TRANSLATE_DESCRIPTION || action == TRANSLATE_CAPTION)

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -399,7 +399,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     }
 
     private void startTagsEdit(GalleryItemFragment item) {
-        startActivityForResult(SuggestedEditsImageTagEditActivity.newIntent(this, item.getMediaPage()), ACTIVITY_REQUEST_ADD_IMAGE_TAGS);
+        startActivityForResult(SuggestedEditsImageTagEditActivity.newIntent(this, item.getMediaPage(), GALLERY_ACTIVITY), ACTIVITY_REQUEST_ADD_IMAGE_TAGS);
     }
 
     private void startCaptionTranslation(GalleryItemFragment item) {

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -230,7 +230,7 @@ public class LeadImagesHandler {
             @Override
             public void onCallToActionClicked() {
                 if (imageEditType == ImageEditType.ADD_TAGS) {
-                    getActivity().startActivityForResult(SuggestedEditsImageTagEditActivity.Companion.newIntent(getActivity(), imagePage), ACTIVITY_REQUEST_IMAGE_TAGS_EDIT);
+                    getActivity().startActivityForResult(SuggestedEditsImageTagEditActivity.Companion.newIntent(getActivity(), imagePage, LEAD_IMAGE), ACTIVITY_REQUEST_IMAGE_TAGS_EDIT);
                     return;
                 }
                 if (imageEditType == ImageEditType.ADD_CAPTION_TRANSLATION ? (callToActionTargetSummary != null && callToActionSourceSummary != null) : callToActionSourceSummary != null) {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagEditActivity.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagEditActivity.kt
@@ -9,6 +9,7 @@ import android.view.View.VISIBLE
 import androidx.fragment.app.Fragment
 import com.google.gson.Gson
 import kotlinx.android.synthetic.main.activity_suggested_edits_feed_card_image_tags.*
+import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.BaseActivity
@@ -32,7 +33,10 @@ class SuggestedEditsImageTagEditActivity : BaseActivity(), SuggestedEditsImageTa
         supportActionBar!!.title = getString(R.string.suggested_edits_tag_images)
         imageZoomHelper = ImageZoomHelper(this)
         setContentView(R.layout.activity_suggested_edits_feed_card_image_tags)
+
         suggestedEditsImageTagsFragment = supportFragmentManager.findFragmentById(R.id.imageTagFragment) as SuggestedEditsImageTagsFragment?
+        suggestedEditsImageTagsFragment?.invokeSource = intent.getSerializableExtra(ARG_INVOKE_SOURCE) as Constants.InvokeSource
+
         addContributionButton.setOnClickListener { suggestedEditsImageTagsFragment!!.publish() }
         addContributionLandscapeImage.setOnClickListener { suggestedEditsImageTagsFragment!!.publish() }
         maybeShowOnboarding()
@@ -87,10 +91,13 @@ class SuggestedEditsImageTagEditActivity : BaseActivity(), SuggestedEditsImageTa
 
     companion object {
         private const val ARG_PAGE = "imageTagPage"
+        private const val ARG_INVOKE_SOURCE = "invokeSource"
 
         @JvmStatic
-        fun newIntent(context: Context, page: MwQueryPage): Intent {
-            return Intent(context, SuggestedEditsImageTagEditActivity::class.java).putExtra(ARG_PAGE, GsonMarshaller.marshal(page))
+        fun newIntent(context: Context, page: MwQueryPage, invokeSource: Constants.InvokeSource): Intent {
+            return Intent(context, SuggestedEditsImageTagEditActivity::class.java)
+                    .putExtra(ARG_PAGE, GsonMarshaller.marshal(page))
+                    .putExtra(ARG_INVOKE_SOURCE, invokeSource)
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -17,6 +17,7 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_suggested_edits_image_tags_item.*
 import org.wikipedia.Constants
+import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
@@ -57,6 +58,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
     private val tagList: MutableList<MwQueryPage.ImageLabel> = ArrayList()
     private var wasCaptionLongClicked: Boolean = false
     private var lastSearchTerm: String = ""
+    var invokeSource: InvokeSource = InvokeSource.SUGGESTED_EDITS
     private var funnel: EditFunnel? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -364,8 +366,8 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
                             publishing = false
                         }
                         .subscribe({
-                            if (it.pageInfo != null) {
-                                funnel?.logSaved(it.pageInfo!!.lastRevId, commentStr)
+                            if (it.entity != null) {
+                                funnel?.logSaved(it.entity!!.lastRevId, invokeSource.getName())
                             }
                             publishSuccess = true
                             onSuccess()


### PR DESCRIPTION
Currently we're not tracking the `invokeSource` for the Image Tags activity.  This will help us do analytics on the sources from which the user reaches the Image Tags screen.
We were also incorrectly trying to get the last revision-id from the response structure.