### PR TITLE
Hygiene: remove unused imports, redundant code and use getDrawable() properly in Kotlin files

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
@@ -14,7 +14,6 @@ import io.reactivex.rxjava3.functions.BiFunction
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_file_page.*
 import org.apache.commons.lang3.StringUtils
-import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.analytics.ABTestSuggestedEditsSnackbarFunnel
 import org.wikipedia.dataclient.Service

--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.commons
 
-import android.app.Activity
 import android.content.Context
 import android.icu.text.ListFormatter
 import android.net.Uri
@@ -29,7 +28,6 @@ import org.wikipedia.util.ImageUrlUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
-import org.wikipedia.util.log.L
 import org.wikipedia.views.ImageDetailView
 import org.wikipedia.views.ImageZoomHelper
 import org.wikipedia.views.ViewUtil

--- a/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.Menu
-import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import com.google.android.material.bottomnavigation.BottomNavigationView

--- a/app/src/main/java/org/wikipedia/onboarding/OnboardingPageView.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/OnboardingPageView.kt
@@ -19,7 +19,6 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.onboarding.OnboardingPageView.LanguageListAdapter.OptionsViewHolder
 import org.wikipedia.page.LinkMovementMethodExt
-import org.wikipedia.page.LinkMovementMethodExt.UrlHandler
 import org.wikipedia.util.StringUtil
 import java.util.*
 
@@ -68,12 +67,11 @@ class OnboardingPageView constructor(context: Context, attrs: AttributeSet? = nu
             switchContainer.visibility = if (TextUtils.isEmpty(switchText)) View.GONE else View.VISIBLE
             switchView.text = switchText
             setUpLanguageListContainer(showListView, listDataType)
-            secondaryTextView.movementMethod = LinkMovementMethodExt(
-                    UrlHandler { url: String ->
-                        if (callback != null) {
-                            callback!!.onLinkClick(this@OnboardingPageView, url)
-                        }
-                    })
+            secondaryTextView.movementMethod = LinkMovementMethodExt { url: String ->
+                if (callback != null) {
+                    callback!!.onLinkClick(this@OnboardingPageView, url)
+                }
+            }
             addLangContainer.setOnClickListener {
                 if (callback != null) {
                     callback!!.onListActionButtonClicked(this)

--- a/app/src/main/java/org/wikipedia/page/PageActionTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActionTabLayout.kt
@@ -3,11 +3,8 @@ package org.wikipedia.page
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import android.widget.LinearLayout
-import de.mrapp.android.util.DisplayUtil
 import org.wikipedia.R
 import org.wikipedia.page.action.PageActionTab
-import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.views.ConfigurableTabLayout
 
 class PageActionTabLayout constructor(context: Context, attrs: AttributeSet? = null) : ConfigurableTabLayout(context, attrs) {

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -48,7 +48,7 @@ object ReadingListBehaviorsUtil {
     private val exceptionHandler = CoroutineExceptionHandler { _, exception -> L.w(exception) }
 
     fun getListsContainPage(readingListPage: ReadingListPage) =
-            allReadingLists.filter { list -> list.pages().asSequence().any { it.title() == readingListPage.title() } }
+            allReadingLists.filter { list -> list.pages().any { it.title() == readingListPage.title() } }
 
     fun savePagesForOffline(activity: Activity, selectedPages: List<ReadingListPage>, callback: Callback) {
         if (Prefs.isDownloadOnlyOverWiFiEnabled() && !DeviceUtil.isOnWiFi()) {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
@@ -470,7 +470,7 @@ class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsImageTagsFragment.
         private var prevPosition: Int = 0
         private var nextPageSelectedAutomatic: Boolean = false
 
-        internal fun setNextPageSelectedAutomatic() {
+        fun setNextPageSelectedAutomatic() {
             nextPageSelectedAutomatic = true
         }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagDialog.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagDialog.kt
@@ -172,7 +172,7 @@ class SuggestedEditsImageTagDialog : DialogFragment() {
         callback()?.onSearchDismiss(currentSearchTerm)
     }
 
-    private inner class ResultItemHolder internal constructor(itemView: View) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
+    private inner class ResultItemHolder constructor(itemView: View) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
         fun bindItem(item: MwQueryPage.ImageLabel) {
             itemView.findViewById<TextView>(R.id.labelName).text = item.label
             itemView.findViewById<TextView>(R.id.labelDescription).text = item.description

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTypeItemView.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTypeItemView.kt
@@ -32,13 +32,13 @@ class SuggestedEditsTypeItemView constructor(context: Context, attrs: AttributeS
     fun setEnabledStateUI() {
         title.setTextColor(ResourceUtil.getThemedColor(context, R.attr.themed_icon_color))
         ImageViewCompat.setImageTintList(image, ColorStateList.valueOf(ContextCompat.getColor(context, ResourceUtil.getThemedAttributeId(context, R.attr.themed_icon_color))))
-        this.background = context.getDrawable(R.drawable.rounded_12dp_accent90_fill)
+        this.background = ContextCompat.getDrawable(context, R.drawable.rounded_12dp_accent90_fill)
     }
 
     fun setDisabledStateUI() {
         title.setTextColor(ResourceUtil.getThemedColor(context, R.attr.secondary_text_color))
         ImageViewCompat.setImageTintList(image, ColorStateList.valueOf(ContextCompat.getColor(context, ResourceUtil.getThemedAttributeId(context, R.attr.chart_shade4))))
-        this.background = context.getDrawable(R.drawable.rounded_12dp_corner_base90_fill)
+        this.background = ContextCompat.getDrawable(context, R.drawable.rounded_12dp_corner_base90_fill)
     }
 
     fun setAttributes(title: String, imageResource: Int, editType: Int, callback: Callback) {

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -356,7 +356,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
         errorView.visibility = VISIBLE
     }
 
-    private inner class HeaderViewHolder internal constructor(itemView: ContributionsHeaderView) : DefaultViewHolder<ContributionsHeaderView?>(itemView) {
+    private inner class HeaderViewHolder constructor(itemView: ContributionsHeaderView) : DefaultViewHolder<ContributionsHeaderView?>(itemView) {
         fun bindItem() {
             view.callback = this@ContributionsFragment
             view.updateFilterViewUI(editFilterType, totalContributionCount)
@@ -364,7 +364,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
         }
     }
 
-    private class DateViewHolder internal constructor(itemView: View) : DefaultViewHolder<View?>(itemView) {
+    private class DateViewHolder constructor(itemView: View) : DefaultViewHolder<View?>(itemView) {
         init {
             itemView.setPaddingRelative(itemView.paddingStart, 0, itemView.paddingEnd, 0)
             itemView.layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, DimenUtil.roundedDpToPx(32f))
@@ -376,7 +376,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
         }
     }
 
-    private inner class ContributionItemHolder internal constructor(itemView: ContributionsItemView) : DefaultViewHolder<ContributionsItemView?>(itemView) {
+    private inner class ContributionItemHolder constructor(itemView: ContributionsItemView) : DefaultViewHolder<ContributionsItemView?>(itemView) {
         val disposables = CompositeDisposable()
         fun bindItem(contribution: Contribution) {
             view.contribution = contribution

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsItemView.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsItemView.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import kotlinx.android.synthetic.main.item_suggested_edits_contributions.view.*
 import org.wikipedia.R
@@ -27,7 +28,7 @@ class ContributionsItemView constructor(context: Context, attrs: AttributeSet? =
         View.inflate(context, R.layout.item_suggested_edits_contributions, this)
         layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         ViewCompat.setPaddingRelative(this, DimenUtil.roundedDpToPx(16f), 0, 0, 0)
-        background = getContext().getDrawable(ResourceUtil.getThemedAttributeId(getContext(), R.attr.selectableItemBackground))
+        background = ContextCompat.getDrawable(getContext(), ResourceUtil.getThemedAttributeId(getContext(), R.attr.selectableItemBackground))
         setOnClickListener {
             if (callback != null && title.text.isNotEmpty()) {
                 callback?.onClick(context, contribution!!)

--- a/app/src/main/java/org/wikipedia/views/AppTextViewWithImages.kt
+++ b/app/src/main/java/org/wikipedia/views/AppTextViewWithImages.kt
@@ -94,7 +94,7 @@ class AppTextViewWithImages constructor(context: Context, attrs: AttributeSet? =
      * but note that the problem this works around affects an ImageSpan on any line, not just the
      * last line as reported there.
      */
-    private class BaselineAlignedYTranslationImageSpan internal constructor(drawable: Drawable, private val lineSpacingMultiplier: Float) : ImageSpan(drawable, ALIGN_BASELINE) {
+    private class BaselineAlignedYTranslationImageSpan constructor(drawable: Drawable, private val lineSpacingMultiplier: Float) : ImageSpan(drawable, ALIGN_BASELINE) {
         override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int,
                           y: Int, bottom: Int, paint: Paint) {
             val drawable = drawable

--- a/app/src/main/java/org/wikipedia/views/ImageTitleDescriptionView.kt
+++ b/app/src/main/java/org/wikipedia/views/ImageTitleDescriptionView.kt
@@ -10,8 +10,6 @@ import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
-import com.skydoves.balloon.ArrowOrientation
-import com.skydoves.balloon.showAlignBottom
 import kotlinx.android.synthetic.main.view_image_title_description.view.*
 import org.wikipedia.R
 import org.wikipedia.util.DimenUtil

--- a/app/src/main/java/org/wikipedia/views/MessageCardView.kt
+++ b/app/src/main/java/org/wikipedia/views/MessageCardView.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.views
 
-import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.util.AttributeSet


### PR DESCRIPTION
Since we don't have implemented `checkstyle` plugin for Kotlin files yet, it is easy to forget to remove unused imports from Kotlin files.