### PR TITLE
Follow-up: Further simplify logic of performing search.

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -170,7 +170,12 @@ public class SearchResultsFragment extends Fragment {
             return;
         }
 
-        searchResultsDisplay.postDelayed(() -> doTitlePrefixSearch(term), force ? 0 : DELAY_MILLIS);
+        searchResultsDisplay.postDelayed(() -> {
+            if (!isAdded()) {
+                return;
+            }
+            doTitlePrefixSearch(term);
+        }, force ? 0 : DELAY_MILLIS);
     }
 
     private void doTitlePrefixSearch(final String searchTerm) {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -34,12 +34,14 @@ import org.wikipedia.views.WikiErrorView;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.Unbinder;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
@@ -58,7 +60,7 @@ public class SearchResultsFragment extends Fragment {
     }
 
     private static final int BATCH_SIZE = 20;
-    private static final int DELAY_MILLIS = 300;
+    private static final int DELAY_MILLIS = 500;
     private static final int MAX_CACHE_SIZE_SEARCH_RESULTS = 4;
     /**
      * Constant to ease in the conversion of timestamps from nanoseconds to milliseconds.
@@ -170,41 +172,37 @@ public class SearchResultsFragment extends Fragment {
             return;
         }
 
-        searchResultsDisplay.postDelayed(() -> {
-            if (!isAdded()) {
-                return;
-            }
-            doTitlePrefixSearch(term);
-        }, force ? 0 : DELAY_MILLIS);
+        doTitlePrefixSearch(term, force);
     }
 
-    private void doTitlePrefixSearch(final String searchTerm) {
+    private void doTitlePrefixSearch(final String searchTerm, boolean force) {
         cancelSearchTask();
         final long startTime = System.nanoTime();
         updateProgressBar(true);
 
-        disposables.add(ServiceFactory.get(WikiSite.forLanguageCode(getSearchLanguageCode())).prefixSearch(searchTerm, BATCH_SIZE, searchTerm)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .map(response -> {
-                    if (response != null && response.query() != null && response.query().pages() != null) {
-                        // noinspection ConstantConditions
-                        return new SearchResults(response.query().pages(),
-                                WikiSite.forLanguageCode(getSearchLanguageCode()), response.continuation(),
-                                response.suggestion());
-                    }
-                    // A prefix search query with no results will return the following:
-                    //
-                    // {
-                    //   "batchcomplete": true,
-                    //   "query": {
-                    //      "search": []
-                    //   }
-                    // }
-                    //
-                    // Just return an empty SearchResults() in this case.
-                    return new SearchResults();
-                })
+        disposables.add(Observable.timer(force ? 0 : DELAY_MILLIS, TimeUnit.MILLISECONDS).flatMap(timer ->
+                ServiceFactory.get(WikiSite.forLanguageCode(getSearchLanguageCode())).prefixSearch(searchTerm, BATCH_SIZE, searchTerm)
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .map(response -> {
+                            if (response != null && response.query() != null && response.query().pages() != null) {
+                                // noinspection ConstantConditions
+                                return new SearchResults(response.query().pages(),
+                                        WikiSite.forLanguageCode(getSearchLanguageCode()), response.continuation(),
+                                        response.suggestion());
+                            }
+                            // A prefix search query with no results will return the following:
+                            //
+                            // {
+                            //   "batchcomplete": true,
+                            //   "query": {
+                            //      "search": []
+                            //   }
+                            // }
+                            //
+                            // Just return an empty SearchResults() in this case.
+                            return new SearchResults();
+                        }))
                 .doAfterTerminate(() -> updateProgressBar(false))
                 .subscribe(results -> {
                     searchErrorView.setVisibility(View.GONE);


### PR DESCRIPTION
This performs the time delay using pure Rx functions, and no more `post`ing.
This also bumps the delay to 500ms. This will be imperceptible to the user, but will save a lot of unnecessary network traffic.