### PR TITLE
Don't show the toolbar elevation if the content reaches to the top

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
+++ b/app/src/main/java/org/wikipedia/page/PageToolbarHideHandler.java
@@ -63,6 +63,7 @@ public class PageToolbarHideHandler extends ViewHideHandler {
             prevToolbarLight = isToolbarLight;
             ((PageActivity) pageFragment.requireActivity()).requestLightStatusBar(prevToolbarLight);
         }
+        pageFragment.setToolbarElevationEnabled(scrollY != 0);
     }
 
     private void updateChildIconTint(@NonNull ViewGroup viewGroup, float opacity) {


### PR DESCRIPTION
> 01) To be consistent with other areas of the app, please remove the app bar shadow on article pages with no header image.

https://phabricator.wikimedia.org/T260871