### PR TITLE
Fix: the article description contribution list does not show the article title correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -268,7 +268,7 @@ public interface Service {
                                  @Query("property") @Nullable String property);
 
     @GET(MW_API_PREFIX + "action=wbgetentities&props=descriptions|labels|sitelinks")
-    @NonNull Observable<Entities> getWikidataLabelsAndDescriptions(@Query(value = "ids", encoded = true) @NonNull String idList);
+    @NonNull Observable<Entities> getWikidataLabelsAndDescriptions(@Query("ids") @NonNull String idList);
 
     @Headers("Cache-Control: no-cache")
     @POST(MW_API_PREFIX + "action=wbsetclaim&errorlang=uselang")

--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -268,7 +268,7 @@ public interface Service {
                                  @Query("property") @Nullable String property);
 
     @GET(MW_API_PREFIX + "action=wbgetentities&props=descriptions|labels|sitelinks")
-    @NonNull Observable<Entities> getWikidataLabelsAndDescriptions(@Query("ids") @NonNull String idList);
+    @NonNull Observable<Entities> getWikidataLabelsAndDescriptions(@Query(value = "ids", encoded = true) @NonNull String idList);
 
     @Headers("Cache-Control: no-cache")
     @POST(MW_API_PREFIX + "action=wbsetclaim&errorlang=uselang")

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -196,7 +196,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                                     val entity = entities.entities()[entityKey]!!
                                     for (contribution in wikidataContributions) {
                                         var languageCode = contribution.wikiSite.languageCode()
-                                        if (languageCode.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE)) {
+                                        if (languageCode.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE) && !entity.labels().containsKey(languageCode)) {
                                             // TODO: show the article title in the correct language variant. Now it is showing its original article title.
                                             languageCode = AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE
                                         }

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -197,6 +197,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                                     for (contribution in wikidataContributions) {
                                         var languageCode = contribution.wikiSite.languageCode()
                                         if (languageCode.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE)) {
+                                            // TODO: show the article title in the correct language variant. Now it is showing its original article title.
                                             languageCode = AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE
                                         }
                                         if (contribution.qNumber == entityKey && entity.labels().containsKey(languageCode)) {

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -197,7 +197,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                                     for (contribution in wikidataContributions) {
                                         var languageCode = contribution.wikiSite.languageCode()
                                         if (languageCode.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE) && !entity.labels().containsKey(languageCode)) {
-                                            // TODO: show the article title in the correct language variant. Now it is showing its original article title.
+                                            // TODO: more proper solution - calling page/summary endpoint to get correct page title
                                             languageCode = AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE
                                         }
                                         if (contribution.qNumber == entityKey && entity.labels().containsKey(languageCode)) {

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -36,6 +36,7 @@ import org.wikipedia.userprofile.Contribution.Companion.EDIT_TYPE_IMAGE_CAPTION
 import org.wikipedia.userprofile.Contribution.Companion.EDIT_TYPE_IMAGE_TAG
 import org.wikipedia.userprofile.ContributionsItemView.Callback
 import org.wikipedia.language.AppLanguageLookUpTable
+import org.wikipedia.language.LanguageUtil
 import org.wikipedia.util.DateUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
@@ -194,8 +195,12 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                                 for (entityKey in entities.entities().keys) {
                                     val entity = entities.entities()[entityKey]!!
                                     for (contribution in wikidataContributions) {
-                                        if (contribution.qNumber == entityKey && entity.labels().containsKey(contribution.wikiSite.languageCode())) {
-                                            contribution.title = entity.labels()[contribution.wikiSite.languageCode()]!!.value()
+                                        var languageCode = contribution.wikiSite.languageCode()
+                                        if (languageCode.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE)) {
+                                            languageCode = AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE
+                                        }
+                                        if (contribution.qNumber == entityKey && entity.labels().containsKey(languageCode)) {
+                                            contribution.title = entity.labels()[languageCode]!!.value()
                                             // if we need the current description of the item:
                                             //contribution.description = entity.descriptions()[contribution.wikiSite.languageCode()]!!.value()
                                         }


### PR DESCRIPTION
It is because of some article only contains the `zh` article title in the API responses, and we should show it instead of showing the QNumber.

**Actual**
![Screenshot_20200901-162427_Wikipedia Dev](https://user-images.githubusercontent.com/2435576/91915640-f38f4800-ec6f-11ea-9ffb-c1aa675d3e77.jpg)

**Expected**
![Screenshot_20200901-162526_Wikipedia Dev](https://user-images.githubusercontent.com/2435576/91915647-f5f1a200-ec6f-11ea-8f50-b8d6819adbaa.jpg)
