### PR TITLE
Revert "Launch PageActivity in default mode to maintain back-stack as expected"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,7 @@
             android:windowSoftInputMode="stateAlwaysHidden|adjustPan"
             android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.Page"
+            android:launchMode="singleTask"
             android:parentActivityName=".main.MainActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"


### PR DESCRIPTION
Reverts wikimedia/apps-android-wikipedia#1586

There are very specific and extremely important reasons why `PageActivity` is set to be `singleTask`.
This would introduce much more confusion than the issue that it attempts to fix.