### PR TITLE
Set RTL support for the input field in the edit description view

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.java
@@ -217,7 +217,7 @@ public class DescriptionEditView extends LinearLayout {
                 && !TextUtils.isEmpty(sourceSummary.getPageTitle().getDescription())) {
             pageSummaryContainer.setVisibility(GONE);
         }
-        setConditionalLayoutDirection(pageSummaryContainer, isTranslationEdit ? sourceSummary.getLang() : pageTitle.getWikiSite().languageCode());
+        setConditionalLayoutDirection(this, isTranslationEdit ? sourceSummary.getLang() : pageTitle.getWikiSite().languageCode());
         setUpBottomBar();
     }
 


### PR DESCRIPTION
In the current master, we set the RTL support for the summary view only. Since the user will mostly input RTL text for the RTL articles, it would be a good idea to give the input field the RTL support.