### PR TITLE
Follow up: add revision "null" string check

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -531,7 +531,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         app.getSessionFunnel().leadSectionFetchEnd();
 
         bridge.evaluate(JavaScriptActionHandler.getRevision(), revision -> {
-            if (!isAdded() || revision == null) {
+            if (!isAdded() || revision == null || revision.equals("null")) {
                 return;
             }
             try {


### PR DESCRIPTION
From the previous PR #1581, the revision is actually a string "null", and we should add it to the if statement. Otherwise, we will still see the error message in the log.