### PR TITLE
Fix: show proper page title in the contribution list

### DIFF
--- a/app/src/main/java/org/wikipedia/userprofile/Contribution.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/Contribution.kt
@@ -3,7 +3,7 @@ package org.wikipedia.userprofile
 import org.wikipedia.dataclient.WikiSite
 import java.util.*
 
-class Contribution internal constructor(val qNumber: String, var title: String, var description: String, val editType: Int, var imageUrl: String?,
+class Contribution internal constructor(val qNumber: String, var apiTitle: String, var displayTitle: String, var description: String, val editType: Int, var imageUrl: String?,
                                         val date: Date, val wikiSite: WikiSite, var pageViews: Long, var sizeDiff: Int, var top: Boolean, var tagCount: Int) {
 
     companion object {

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionDetailsFragment.kt
@@ -66,7 +66,7 @@ class ContributionDetailsFragment : Fragment() {
         updateTopGradient()
         contributionContainer.setOnClickListener { startTypeSpecificActivity() }
         revisionLayout.visibility = if (contribution.top) VISIBLE else GONE
-        contributionTitle.text = StringUtil.removeNamespace(contribution.title)
+        contributionTitle.text = StringUtil.removeNamespace(contribution.displayTitle)
         contributionDiffDetailText.text = contribution.description
         if (contribution.imageUrl.isNullOrEmpty() || contribution.imageUrl == "null") contributionImage.visibility = GONE else ViewUtil.loadImageWithRoundedCorners(contributionImage, contribution.imageUrl)
         dateTimeDetailView.setLabelAndDetail(getString(R.string.suggested_edits_contribution_date_time_label), DateUtil.getFeedCardDateString(contribution.date) + " / " + DateUtil.get24HrFormatTimeOnlyString(contribution.date), -1)
@@ -80,11 +80,11 @@ class ContributionDetailsFragment : Fragment() {
             EDIT_TYPE_IMAGE_TAG -> UserContributionFunnel.get().logNavigateTag()
             else -> UserContributionFunnel.get().logNavigateMisc()
         }
+        val pageTitle = PageTitle(contribution.apiTitle, contribution.wikiSite, contribution.imageUrl, contribution.description, contribution.displayTitle)
         if (contribution.editType == EDIT_TYPE_ARTICLE_DESCRIPTION) {
-            startActivity(PageActivity.newIntentForNewTab(requireActivity(), HistoryEntry(PageTitle(contribution.title, contribution.wikiSite), HistoryEntry.SOURCE_SUGGESTED_EDITS),
-                    PageTitle(contribution.title, contribution.wikiSite)))
+            startActivity(PageActivity.newIntentForNewTab(requireActivity(), HistoryEntry(pageTitle, HistoryEntry.SOURCE_SUGGESTED_EDITS), pageTitle))
         } else {
-            startActivity(FilePageActivity.newIntent(requireContext(), PageTitle(contribution.title, contribution.wikiSite)))
+            startActivity(FilePageActivity.newIntent(requireContext(), pageTitle))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -196,6 +196,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                                         val dbName = WikiSite.forLanguageCode(contribution.wikiSite.languageCode()).dbName()
                                         if (contribution.qNumber == entityKey && entity.sitelinks().containsKey(dbName)) {
                                             contribution.apiTitle = entity.sitelinks()[dbName]!!.title
+                                            contribution.displayTitle = entity.sitelinks()[dbName]!!.title
                                         }
                                     }
                                 }


### PR DESCRIPTION
The previous PR (#1588) does not fix the page title correctly for some articles.

For example, https://www.wikidata.org/wiki/Q24284283
The `label` is `花木兰`, but when we opening a page it will open an incorrect page because the page title matches the `label`.
The correct page title should be `花木兰 (2020年电影)`,  which is in the `sitelinks`.

Also, since we already have called the `getSummary()`, we can update the page title with the correct one.

This PR also updates the `Contribution` class to have both `apiTitle` and `displayTitle` to prevent possible language variant issues.