### PR TITLE
Fix: use correct language code for source caption/tags

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -395,7 +395,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
     private void startCaptionTranslation(GalleryItemFragment item) {
         PageTitle sourceTitle = new PageTitle(item.getImageTitle().getPrefixedText(), new WikiSite(Service.COMMONS_URL, sourceWiki.languageCode()));
         PageTitle targetTitle = new PageTitle(item.getImageTitle().getPrefixedText(), new WikiSite(Service.COMMONS_URL, StringUtils.defaultString(targetLanguageCode, app.language().getAppLanguageCodes().get(1))));
-        String currentCaption = item.getMediaInfo().getCaptions().get(app.getAppOrSystemLanguageCode());
+        String currentCaption = item.getMediaInfo().getCaptions().get(sourceWiki.languageCode());
         if (TextUtils.isEmpty(currentCaption)) {
             currentCaption = StringUtil.fromHtml(item.getMediaInfo().getMetadata().imageDescription()).toString();
         }
@@ -652,7 +652,7 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
         disposeImageCaptionDisposable();
         imageCaptionDisposable = Observable.zip(MediaHelper.INSTANCE.getImageCaptions(item.getImageTitle().getPrefixedText()),
                 ServiceFactory.get(new WikiSite(Service.COMMONS_URL)).getProtectionInfo(item.getImageTitle().getPrefixedText()),
-                ImageTagsProvider.getImageTagsObservable(getCurrentItem().getMediaPage().pageId(), WikipediaApp.getInstance().getAppOrSystemLanguageCode()), (captions, protectionInfoRsp, imageTags) -> {
+                ImageTagsProvider.getImageTagsObservable(getCurrentItem().getMediaPage().pageId(), sourceWiki.languageCode()), (captions, protectionInfoRsp, imageTags) -> {
                     item.getMediaInfo().setCaptions(captions);
                     return new Pair<>(protectionInfoRsp.query().isEditProtected(), imageTags.size());
                 })


### PR DESCRIPTION
Not sure why we are using `getAppOrSystemLanguageCode()` for finding caption from the `getCaptions()` and also getting image tags.

There's an issue when translating caption in the Gallery, here are the steps of reproducing:

1. Have two app languages setup. e.g. `Traditional Chinese` and `English`.
2. Go to the gallery and find an image that does not have the image captions in both languages.
3. Add an image caption for `Traditional Chinese`.
4. Now you'll see "ADD IMAGE CAPTION (ENGLISH)`, and click on the button to add the translation.
5. In the  `Image caption(繁體中文)` summary field, it shows the original image description of the image.

**Expected:**
We should see the `Traditional Chinese` image caption we just added in `Image caption(繁體中文)` summary field