### PR TITLE
Make the Search tooltip not auto-dismissable.

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainActivity.java
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.java
@@ -140,7 +140,7 @@ public class MainActivity extends SingleFragmentActivity<MainFragment> implement
             controlNavTabInFragment = false;
         } else {
             if (tab.equals(NavTab.SEARCH) && Prefs.shouldShowSearchTabTooltip()) {
-                FeedbackUtil.showTooltip(getFragment().tabLayout.findViewById(NavTab.SEARCH.id()), getString(R.string.search_tab_tooltip), true, true);
+                FeedbackUtil.showTooltip(getFragment().tabLayout.findViewById(NavTab.SEARCH.id()), getString(R.string.search_tab_tooltip), true, false);
                 Prefs.setShowSearchTabTooltip(false);
             }
             wordMark.setVisibility(GONE);


### PR DESCRIPTION
This allows the user to interact with the rest of the UI while the tooltip is shown, instead of having to dismiss the tooltip first.
