### PR TITLE
Fix search order when searching History.

### DIFF
--- a/app/src/main/java/org/wikipedia/history/HistoryDbHelper.kt
+++ b/app/src/main/java/org/wikipedia/history/HistoryDbHelper.kt
@@ -14,7 +14,7 @@ object HistoryDbHelper {
 
     fun findHistoryItem(searchQuery: String): SearchResults {
         val db = WikipediaApp.getInstance().database.readableDatabase
-        val titleCol = PageHistoryContract.PageWithImage.API_TITLE.qualifiedName()
+        val titleCol = PageHistoryContract.PageWithImage.DISPLAY_TITLE.qualifiedName()
         var selection: String? = null
         var selectionArgs: Array<String>? = null
         var searchStr = searchQuery
@@ -26,7 +26,7 @@ object HistoryDbHelper {
         db.query(PageHistoryContract.PageWithImage.TABLES, null,
                 selection,
                 selectionArgs,
-                null, null, null).use { cursor ->
+                null, null, PageHistoryContract.PageWithImage.ORDER_MRU).use { cursor ->
             if (cursor.moveToFirst()) {
                 val indexedEntry = IndexedHistoryEntry(cursor)
                 val pageTitle: PageTitle = indexedEntry.entry.title

--- a/app/src/main/java/org/wikipedia/history/HistoryDbHelper.kt
+++ b/app/src/main/java/org/wikipedia/history/HistoryDbHelper.kt
@@ -23,7 +23,7 @@ object HistoryDbHelper {
             selection = "UPPER($titleCol) LIKE UPPER(?) ESCAPE '\\'"
             selectionArgs = arrayOf("%$searchStr%")
         }
-        db.query(PageHistoryContract.PageWithImage.TABLES, null,
+        db.query(PageHistoryContract.PageWithImage.TABLES, PageHistoryContract.PageWithImage.PROJECTION,
                 selection,
                 selectionArgs,
                 null, null, PageHistoryContract.PageWithImage.ORDER_MRU).use { cursor ->


### PR DESCRIPTION
Searching through History should be ordered by Descending order (most recently read).
This also makes the search by Display title, not Api title.

And also this should fix a bug when searching for a single letter, as mentioned in https://phabricator.wikimedia.org/T259717#6462779
