### PR TITLE
Make getting strings for custom locale more efficient.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/L10nUtil.java
+++ b/app/src/main/java/org/wikipedia/util/L10nUtil.java
@@ -140,6 +140,7 @@ public final class L10nUtil {
             for (int stringRes : strings) {
                 localizedStrings.put(stringRes, WikipediaApp.getInstance().getString(stringRes));
             }
+            return localizedStrings;
         }
         setDesiredLocale(config, targetLocale);
         SparseArray<String> localizedStrings = getTargetStrings(strings, config);


### PR DESCRIPTION
Somebody forgot a `return` statement.