### PR TITLE
Tweak: do both prefix and fulltext search for result counts

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.java
@@ -182,7 +182,7 @@ public class SearchFragment extends Fragment implements SearchResultsFragment.Ca
     public void onStart() {
         super.onStart();
         setUpLanguageScroll(Prefs.getSelectedLanguagePositionInSearch());
-        startSearch(query, false);
+        startSearch(query, langBtnClicked);
         searchView.setCloseButtonVisibility(query);
 
         if (!TextUtils.isEmpty(query)) {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -39,6 +39,7 @@ import org.wikipedia.views.ViewUtil;
 import org.wikipedia.views.WikiErrorView;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -347,6 +348,20 @@ public class SearchResultsFragment extends Fragment {
                 .doAfterTerminate(() -> updateProgressBar(false))
                 .subscribe(list -> {
                     if (!list.isEmpty()) {
+
+                        // make a singleton list if all results are empty.
+                        int sum = 0;
+                        for (int count : list) {
+                            sum += count;
+                            if (sum > 0) {
+                                break;
+                            }
+                        }
+
+                        if (sum == 0) {
+                            list = Collections.singletonList(0);
+                        }
+
                         searchResultsCountCache.put(getSearchLanguageCode() + "-" + searchTerm, list);
                         displayResultsCount(list);
                     }
@@ -539,7 +554,7 @@ public class SearchResultsFragment extends Fragment {
             resultsText.setText(resultsCount == 0 ? getString(R.string.search_results_count_zero)
                     : getResources().getQuantityString(R.plurals.search_results_count, resultsCount, resultsCount));
             resultsText.setTextColor(resultsCount == 0 ? secondaryColorStateList : accentColorStateList);
-            languageCodeText.setVisibility(WikipediaApp.getInstance().language().getAppLanguageCodes().size() == 1 ? View.GONE : View.VISIBLE);
+            languageCodeText.setVisibility(resultsCountList.size() == 1 ? View.GONE : View.VISIBLE);
             languageCodeText.setText(langCode);
             languageCodeText.setTextColor(resultsCount == 0 ? secondaryColorStateList : accentColorStateList);
             languageCodeText.setBackgroundTintList(resultsCount == 0 ? secondaryColorStateList : accentColorStateList);


### PR DESCRIPTION
https://phabricator.wikimedia.org/T260433#6469719

This also fixes an issue when "removing" languages from the Wikipedia Language screen. The search results should be refreshed.