### PR TITLE
Increase peek height of main navigation overflow dialog.

### DIFF
--- a/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.java
+++ b/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.java
@@ -14,11 +14,14 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.widget.ImageViewCompat;
 
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+
 import org.wikipedia.BuildConfig;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment;
+import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.util.UriUtil;
 
@@ -68,6 +71,13 @@ public class MenuNavTabDialog extends ExtendedBottomSheetDialogFragment {
     @Override public void onDestroyView() {
         super.onDestroyView();
         callback = null;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        BottomSheetBehavior.from((View) getView().getParent()).setPeekHeight(DimenUtil
+                .roundedDpToPx(DimenUtil.getDimension(R.dimen.navTabDialogPeekHeight)));
     }
 
     public void updateState() {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -43,6 +43,7 @@
     <dimen name="themeChooserSheetPeekHeight">420dp</dimen>
     <dimen name="readingListSheetPeekHeight">360dp</dimen>
     <dimen name="imagePreviewSheetPeekHeight">280dp</dimen>
+    <dimen name="navTabDialogPeekHeight">400dp</dimen>
     <!-- Default size of images in Link Preview thumbnail gallery -->
     <dimen name="linkPreviewImageSize">112dp</dimen>
 


### PR DESCRIPTION
The current peek height makes it pop up _almost_ all the way, obscuring the last item for no reason.