### PR TITLE
Update hostname of Releases server.

### DIFF
--- a/upload-all.sh
+++ b/upload-all.sh
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-scp ./releases/wikipedia-*-beta*apk releases1001.eqiad.wmnet:/srv/org/wikimedia/releases/mobile/android/wikipedia/betas/
-scp ./releases/wikipedia-*-r*apk releases1001.eqiad.wmnet:/srv/org/wikimedia/releases/mobile/android/wikipedia/stable/
+scp ./releases/wikipedia-*-beta*apk releases1002.eqiad.wmnet:/srv/org/wikimedia/releases/mobile/android/wikipedia/betas/
+scp ./releases/wikipedia-*-r*apk releases1002.eqiad.wmnet:/srv/org/wikimedia/releases/mobile/android/wikipedia/stable/


### PR DESCRIPTION
The Releases server was recently moved from `releases1001` to `releases1002`.