### PR TITLE
A few tweaks for User Talk pages.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -570,6 +570,11 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             return;
         }
 
+        if (title.namespace() == Namespace.USER_TALK) {
+            startActivity(TalkTopicsActivity.newIntent(requireActivity(), title.getWikiSite().languageCode(), title.getText()));
+            return;
+        }
+
         // If it's a Special page, launch it in an external browser, since mobileview
         // doesn't support the Special namespace.
         // TODO: remove when Special pages are properly returned by the server

--- a/app/src/main/java/org/wikipedia/page/PageTitle.java
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.java
@@ -143,7 +143,7 @@ public class PageTitle implements Parcelable {
         parts = text.split("#", -1);
         text = parts[0];
         if (parts.length > 1) {
-            this.fragment = decodeURL(parts[1]).replace(" ", "_");
+            this.fragment = StringUtil.addUnderscores(decodeURL(parts[1]));
         } else {
             this.fragment = null;
         }
@@ -180,7 +180,7 @@ public class PageTitle implements Parcelable {
         }
 
         // Properties has the accurate namespace but it doesn't exist. Guess based on title.
-        return Namespace.fromLegacyString(wiki, namespace);
+        return Namespace.fromLegacyString(wiki, StringUtil.removeUnderscores(namespace));
     }
 
     @NonNull public WikiSite getWikiSite() {
@@ -188,7 +188,7 @@ public class PageTitle implements Parcelable {
     }
 
     @NonNull public String getText() {
-        return text.replace(" ", "_");
+        return StringUtil.addUnderscores(text);
     }
 
     @Nullable public String getFragment() {
@@ -217,7 +217,7 @@ public class PageTitle implements Parcelable {
     }
 
     @NonNull public String getDisplayText() {
-        return displayText == null ? getPrefixedText().replace("_", " ") : displayText;
+        return displayText == null ? StringUtil.removeUnderscores(getPrefixedText()) : displayText;
     }
 
     public void setDisplayText(@Nullable String displayText) {

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
@@ -294,7 +294,9 @@ public class LinkPreviewDialog extends ExtendedBottomSheetDialogFragment
         }
         if (overlayView != null) {
             overlayView.setPrimaryButtonText(getStringForArticleLanguage(pageTitle,
-                    contents.isDisambiguation() ? R.string.button_continue_to_disambiguation : R.string.button_continue_to_article));
+                    contents.isDisambiguation() ? R.string.button_continue_to_disambiguation
+                            : pageTitle.namespace() == Namespace.TALK || pageTitle.namespace() == Namespace.USER_TALK
+                            ? R.string.button_continue_to_talk_page : R.string.button_continue_to_article));
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
@@ -33,6 +33,7 @@ import org.wikipedia.gallery.MediaList;
 import org.wikipedia.gallery.MediaListItem;
 import org.wikipedia.history.HistoryEntry;
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment;
+import org.wikipedia.page.Namespace;
 import org.wikipedia.page.PageTitle;
 import org.wikipedia.util.GeoUtil;
 import org.wikipedia.util.StringUtil;
@@ -153,7 +154,8 @@ public class LinkPreviewDialog extends ExtendedBottomSheetDialogFragment
         if (overlayView == null && containerView != null) {
             overlayView = new LinkPreviewOverlayView(getContext());
             overlayView.setCallback(new OverlayViewCallback());
-            overlayView.setPrimaryButtonText(getStringForArticleLanguage(pageTitle, R.string.button_continue_to_article));
+            overlayView.setPrimaryButtonText(getStringForArticleLanguage(pageTitle,
+                    pageTitle.namespace() == Namespace.TALK || pageTitle.namespace() == Namespace.USER_TALK ? R.string.button_continue_to_talk_page : R.string.button_continue_to_article));
             overlayView.setSecondaryButtonText(getStringForArticleLanguage(pageTitle, R.string.menu_long_press_open_in_new_tab));
             overlayView.showTertiaryButton(location != null);
             containerView.addView(overlayView);

--- a/app/src/main/java/org/wikipedia/util/StringUtil.java
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.java
@@ -16,6 +16,7 @@ import androidx.core.text.HtmlCompat;
 
 import com.google.gson.Gson;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 
 import java.text.Collator;
@@ -86,12 +87,12 @@ public final class StringUtil {
         return String.format("x%08x", i);
     }
 
-    public static String addUnderscores(@NonNull String text) {
-        return text.replace(" ", "_");
+    public static String addUnderscores(@Nullable String text) {
+        return StringUtils.defaultString(text).replace(" ", "_");
     }
 
-    public static String removeUnderscores(@NonNull String text) {
-        return text.replace("_", " ");
+    public static String removeUnderscores(@Nullable String text) {
+        return StringUtils.defaultString(text).replace("_", " ");
     }
 
     public static boolean hasSectionAnchor(@NonNull String text) {

--- a/app/src/main/res/drawable/ic_user_talk.xml
+++ b/app/src/main/res/drawable/ic_user_talk.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:viewportHeight="20"
-    android:viewportWidth="20" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#00af89" android:pathData="M18,0L2,0a2,2 0,0 0,-2 2v18l4,-4h14a2,2 0,0 0,2 -2L20,2a2,2 0,0 0,-2 -2zM14,4a1.5,1.5 0,1 1,-1.5 1.5A1.5,1.5 0,0 1,14 4zM6,4a1.5,1.5 0,1 1,-1.5 1.5A1.5,1.5 0,0 1,6 4zM10,12c-2.61,0 -4.83,-0.67 -5.65,-3h11.3c-0.82,2.33 -3.04,3 -5.65,3z"/>
+<vector android:height="24dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#00af89" android:pathData="M20,2L4,2A2,2 0,0 0,2 4v18l4,-4h14a2,2 0,0 0,2 -2L22,4A2,2 0,0 0,20 2ZM16,6A1.5,1.5 0,1 1,14.5 7.5,1.5 1.5,0 0,1 16,6ZM8,6A1.5,1.5 0,1 1,6.5 7.5,1.5 1.5,0 0,1 8,6ZM12,14C9.39,14 7.17,13.33 6.35,11h11.3c-0.82,2.33 -3.04,3 -5.65,3z"/>
 </vector>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -334,6 +334,7 @@
   <string name="address_copied">Message shown after copying a link to the system clipboard.</string>
   <string name="text_copied">Message shown after copying text to the system clipboard.</string>
   <string name="button_continue_to_article">Button to continue to the full article from the current link preview.</string>
+  <string name="button_continue_to_talk_page">Button to continue to the talk page that is currently being previewed.</string>
   <string name="button_continue_to_disambiguation">Button to continue to the disambiguation page for the selected title.</string>
   <string name="link_preview_disambiguation_description">Message shown when a selected title refers to more than one page, ending with a colon after which the disambiguations will be listed.</string>
   <string name="button_add_to_reading_list">Button text for adding the current page to a reading list.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,6 +312,7 @@
     <string name="address_copied">Address copied to clipboard.</string>
     <string name="text_copied">Text copied to clipboard.</string>
     <string name="button_continue_to_article">Read article</string>
+    <string name="button_continue_to_talk_page">Open talk page</string>
     <string name="button_continue_to_disambiguation">View similar pages</string>
     <string name="link_preview_disambiguation_description">This title relates to more than one page:</string>
     <string name="button_add_to_reading_list">Add to reading list</string>


### PR DESCRIPTION
- Adjust the Talk icon to be slightly smaller, according to the OOUI shape.
- Update link preview button text for talk pages.
- Explicitly open the User Talk activity from internal links.