### PR TITLE
Improve Gallery zoom+pager interaction.

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.java
@@ -500,6 +500,10 @@ public class GalleryActivity extends BaseActivity implements LinkPreviewDialog.C
                 LinkPreviewDialog.newInstance(new HistoryEntry(title, HistoryEntry.SOURCE_GALLERY), null));
     }
 
+    public void setViewPagerEnabled(boolean enabled) {
+        galleryPager.setUserInputEnabled(enabled);
+    }
+
     /**
      * LinkMovementMethod for handling clicking of links in the description or metadata
      * text fields. For internal links, this activity will close, and pass the page title as

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
@@ -18,6 +18,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
+import com.github.chrisbanes.photoview.PhotoView;
+
 import org.wikipedia.Constants;
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -66,7 +68,7 @@ public class GalleryItemFragment extends Fragment {
     @BindView(R.id.gallery_video) VideoView videoView;
     @BindView(R.id.gallery_video_thumbnail) ImageView videoThumbnail;
     @BindView(R.id.gallery_video_play_button) View videoPlayButton;
-    @BindView(R.id.gallery_image) ImageView imageView;
+    @BindView(R.id.gallery_image) PhotoView imageView;
     @Nullable private Unbinder unbinder;
     private CompositeDisposable disposables = new CompositeDisposable();
 
@@ -122,6 +124,9 @@ public class GalleryItemFragment extends Fragment {
                 ((GalleryActivity) requireActivity()).toggleControls();
             }
         });
+
+        imageView.setOnMatrixChangeListener(rect -> ((GalleryActivity) requireActivity()).setViewPagerEnabled(imageView.getScale() <= 1f));
+
         return rootView;
     }
 

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.java
@@ -125,7 +125,12 @@ public class GalleryItemFragment extends Fragment {
             }
         });
 
-        imageView.setOnMatrixChangeListener(rect -> ((GalleryActivity) requireActivity()).setViewPagerEnabled(imageView.getScale() <= 1f));
+        imageView.setOnMatrixChangeListener(rect -> {
+            if (!isAdded() || imageView == null) {
+                return;
+            }
+            ((GalleryActivity) requireActivity()).setViewPagerEnabled(imageView.getScale() <= 1f);
+        });
 
         return rootView;
     }


### PR DESCRIPTION
There's an annoying thing when flipping through images in the Gallery:  if you start zooming in on an image, and then pan around the zoomed-in image, it sometimes causes the ViewPager to flip to another image instead.
This will make the ViewPager disable its scrolling while an image is zoomed in, and only reenable the ViewPager when the image is fully zoomed out.

https://phabricator.wikimedia.org/T260625