### PR TITLE
Disallow touch interception on NewsCard

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.java
@@ -135,7 +135,7 @@ public class FeedFragment extends Fragment implements BackPressedHandler {
         feedAdapter = new FeedAdapter<>(coordinator, feedCallback);
         feedView.setAdapter(feedAdapter);
         feedView.addOnScrollListener(feedScrollListener);
-
+        feedView.requestDisallowInterceptTouchEvent(true);
         swipeRefreshLayout.setColorSchemeResources(ResourceUtil.getThemedAttributeId(requireContext(), R.attr.colorAccent));
         swipeRefreshLayout.setOnRefreshListener(this::refresh);
 

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -133,6 +133,7 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
         viewPager.setUserInputEnabled(false);
         viewPager.setAdapter(new NavTabFragmentPagerAdapter(this));
         viewPager.registerOnPageChangeCallback(pageChangeCallback);
+        viewPager.requestDisallowInterceptTouchEvent(true);
         FeedbackUtil.setButtonLongPressToast(moreContainer);
 
         tabLayout.setOnNavigationItemSelectedListener(item -> {


### PR DESCRIPTION
To make the news ViewPager2 scroll more smoothly, I first tried to prevent both the parent viewPager and parent Recyclerview from stealing the touch, on horizontal scrolls, by overriding the onInterceptTouchEvent. However, this did not work as ViewPager2 doesn't allow direct override, so I have tried to achieve the same with requestDisallowInterceptTouchEvent(boolean) on both. Experimental. Please test and lmk if you see any difference in scroll experience. 