### PR TITLE
Fix: prevent crash when clicking on search results

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.java
@@ -626,7 +626,7 @@ public class SearchResultsFragment extends Fragment {
             getView().setLongClickable(true);
             getView().setOnClickListener(view -> {
                 Callback callback = callback();
-                if (callback != null) {
+                if (callback != null && position < totalResults.size()) {
                     callback.navigateToTitle(totalResults.get(position).getPageTitle(), false, position);
                 }
             });


### PR DESCRIPTION
Forgot to add the `size()` check to the code and it causes the crash.
https://appcenter.ms/orgs/ci-apps-hockeyapp-f5mf/apps/Wikipedia/crashes/errors/3242268481u/overview

https://github.com/wikimedia/apps-android-wikipedia/commit/994cd6757f0e10b53a525c46d68ebbcdec6ad594#diff-85741b59e95afd1258918b505cc3c844L442-L443