### PR TITLE
Fix: properly clear disposables in RandomItemFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/random/RandomItemFragment.java
+++ b/app/src/main/java/org/wikipedia/random/RandomItemFragment.java
@@ -81,9 +81,9 @@ public class RandomItemFragment extends Fragment {
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
+    public void onDestroyView() {
         disposables.clear();
+        super.onDestroyView();
     }
 
     private void getRandomPage() {


### PR DESCRIPTION
**Background**
https://phabricator.wikimedia.org/T261746

@AICT2020 reported this issue where `disposables` may request and hold several callbacks for `getRandomSummary()` when device rotates.

**Change**
- [x] Call `disposables.clear()` in `RandomItemFragment.onDestroyView()` instead of `onDestroy()`.

