### PR TITLE
Fix scroll transition for "On This Day" fragment

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayFragment.java
@@ -60,6 +60,7 @@ public class OnThisDayFragment extends Fragment implements CustomDatePicker.Call
     @BindView(R.id.day_info_text_view) TextView dayInfoTextView;
     @BindView(R.id.events_recycler) RecyclerView eventsRecycler;
     @BindView(R.id.on_this_day_progress) ProgressBar progressBar;
+    @BindView(R.id.header_frame_layout) FrameLayout headerFrameLayout;
     @BindView(R.id.toolbar) Toolbar toolbar;
     @BindView(R.id.app_bar) AppBarLayout appBarLayout;
     @BindView(R.id.on_this_day_error_view) WikiErrorView errorView;
@@ -177,6 +178,7 @@ public class OnThisDayFragment extends Fragment implements CustomDatePicker.Call
         indicatorLayout.setAlpha((date.get(Calendar.MONTH) == Calendar.getInstance().get(Calendar.MONTH) && date.get(Calendar.DATE) == Calendar.getInstance().get(Calendar.DATE)) ? HALF_ALPHA : 1.0f);
         indicatorDate.setText(String.format(Locale.getDefault(), "%d", Calendar.getInstance().get(Calendar.DATE)));
         appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            headerFrameLayout.setAlpha(1.0f - Math.abs(verticalOffset / (float) appBarLayout.getTotalScrollRange()));
             if (verticalOffset > -appBarLayout.getTotalScrollRange()) {
                 toolbarDropDown.setVisibility(View.GONE);
             } else if (verticalOffset <= -appBarLayout.getTotalScrollRange()) {

--- a/app/src/main/res/layout/fragment_on_this_day.xml
+++ b/app/src/main/res/layout/fragment_on_this_day.xml
@@ -22,6 +22,7 @@
             app:statusBarScrim="?attr/paper_color">
 
             <FrameLayout
+                android:id="@+id/header_frame_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom"


### PR DESCRIPTION
**Background**
https://phabricator.wikimedia.org/T182195

**Change**
- [x] Reset alpha (opacity) value for the header section on "On This Day" page as user scrolls. When the header is fully expanded its alpha = 1 (i.e. fully visible); when it's fully collapsed its alpha = 0 (i.e. invisible).

**Result**
Before:
![before](https://user-images.githubusercontent.com/22717320/95033951-cec63000-0674-11eb-86d6-1b5c426b1d2e.gif)

After:
![after](https://user-images.githubusercontent.com/22717320/95033741-16988780-0674-11eb-8eb9-4988b07ff807.gif)
