### PR TITLE
Fix page margins for Persian and other locales.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -21,7 +21,7 @@ import kotlin.math.roundToInt
 object JavaScriptActionHandler {
     @JvmStatic
     fun setTopMargin(top: Int): String {
-        return String.format("pcs.c1.Page.setMargins({ top:'%dpx', right:'%dpx', bottom:'%dpx', left:'%dpx' })", top + 16, 16, 48, 16)
+        return String.format(Locale.ROOT, "pcs.c1.Page.setMargins({ top:'%dpx', right:'%dpx', bottom:'%dpx', left:'%dpx' })", top + 16, 16, 48, 16)
     }
 
     @JvmStatic
@@ -79,7 +79,7 @@ object JavaScriptActionHandler {
             (if (DimenUtil.isLandscape(context) || !Prefs.isImageDownloadEnabled()) 0 else (leadImageHeightForDevice(context) / getDensityScalar()).roundToInt() - topActionBarHeight)
         val topMargin = topActionBarHeight + 16
 
-        return String.format("{" +
+        return String.format(Locale.ROOT, "{" +
                 "   \"platform\": \"android\"," +
                 "   \"clientVersion\": \"${BuildConfig.VERSION_NAME}\"," +
                 "   \"l10n\": {" +


### PR DESCRIPTION
When we pass the page margins into the Page Library, they get formatted as `%d`, which actually follows the current Locale of the device. And if the locale is Persian, then it will output Persian numbers, e.g. `۱۲۳px`.
Therefore we must use the `ROOT` locale when formatting strings to be passed to the WebView.

This will finally fix the issue reported by numerous Persian users about the lead image overlapping the article.