### PR TITLE
Finish "On This Day" activity on back pressed

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayActivity.java
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayActivity.java
@@ -26,6 +26,7 @@ public class OnThisDayActivity extends SingleFragmentActivity<OnThisDayFragment>
     public void onBackPressed() {
         super.onBackPressed();
         getFragment().onBackPressed();
+        finish();
     }
 
     @Override


### PR DESCRIPTION
**Background**
https://phabricator.wikimedia.org/T265226

Using a shared element transition between the feed to "On this day" page causes date text to overlay when user goes back to the feed.

**Change**
- [x] Call `finish()` when user goes back to the feed from "On this day" page, so all pending transition animations are cleared.

**Testing**
Before:
![before](https://user-images.githubusercontent.com/22717320/95816270-8988aa80-0cd3-11eb-8b1f-efe6a59f3bd7.gif)

After:
![after](https://user-images.githubusercontent.com/22717320/95816347-bb017600-0cd3-11eb-946a-78195454b804.gif)

