### PR TITLE
Fix: correct the regular expression of getting page title from a link

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.java
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.java
@@ -96,6 +96,9 @@ public class WikiSite implements Parcelable {
         if (languageCode.equals(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE)) {
             languageCode = LanguageUtil.getFirstSelectedChineseVariant();
         }
+
+        // TODO: should use the default language code on the authority to prevent incorrect url such as zh-tw.wikipedia.org.
+
         this.uri = new Uri.Builder()
                 .scheme(tempUri.getScheme())
                 .encodedAuthority(authority)

--- a/app/src/main/java/org/wikipedia/page/LinkHandler.java
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.java
@@ -89,12 +89,12 @@ public abstract class LinkHandler implements CommunicationBridge.JSEventListener
         // TODO: remove this after the endpoint supporting language variants
         String convertedText = UriUtil.getTitleFromUrl(href);
         if (!convertedText.equals(titleString)) {
-            titleString = convertedText;
+            titleString = convertedText;`
         }
 
         L.d("Link clicked was " + uri.toString());
         if (!TextUtils.isEmpty(uri.getPath()) && WikiSite.supportedAuthority(uri.getAuthority())
-                && (uri.getPath().matches("^" + UriUtil.getWikiRegex() + ".*"))) {
+                && (uri.getPath().matches("^" + UriUtil.WIKI_REGEX + ".*"))) {
             WikiSite site = new WikiSite(uri);
             if (site.subdomain().equals(getWikiSite().subdomain())
                     && !site.languageCode().equals(getWikiSite().languageCode())) {

--- a/app/src/main/java/org/wikipedia/page/LinkHandler.java
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.java
@@ -94,7 +94,7 @@ public abstract class LinkHandler implements CommunicationBridge.JSEventListener
 
         L.d("Link clicked was " + uri.toString());
         if (!TextUtils.isEmpty(uri.getPath()) && WikiSite.supportedAuthority(uri.getAuthority())
-                && (uri.getPath().startsWith("/wiki/") || uri.getPath().startsWith("/zh-"))) {
+                && (uri.getPath().matches("^" + UriUtil.getWikiRegex() + ".*"))) {
             WikiSite site = new WikiSite(uri);
             if (site.subdomain().equals(getWikiSite().subdomain())
                     && !site.languageCode().equals(getWikiSite().languageCode())) {

--- a/app/src/main/java/org/wikipedia/page/LinkHandler.java
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.java
@@ -89,7 +89,7 @@ public abstract class LinkHandler implements CommunicationBridge.JSEventListener
         // TODO: remove this after the endpoint supporting language variants
         String convertedText = UriUtil.getTitleFromUrl(href);
         if (!convertedText.equals(titleString)) {
-            titleString = convertedText;`
+            titleString = convertedText;
         }
 
         L.d("Link clicked was " + uri.toString());

--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -139,13 +139,13 @@ public final class UriUtil {
     /** For internal links only */
     @NonNull
     public static String removeInternalLinkPrefix(@NonNull String link) {
-        return link.replaceFirst("/wiki/|/zh.*/", "");
+        return link.replaceFirst("/(wiki|zh.*)/", "");
     }
 
     /** For links that could be internal or external links */
     @NonNull
     private static String removeLinkPrefix(@NonNull String link) {
-        return link.replaceFirst("^.*?/wiki/", "");
+        return link.replaceFirst("^.*?/(wiki|zh.*)/", "");
     }
 
     /** Removes an optional fragment portion of a URL */

--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -11,6 +11,7 @@ import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 
 import org.apache.commons.lang3.StringUtils;
+import org.intellij.lang.annotations.RegExp;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.WikiSite;
 import org.wikipedia.page.PageTitle;
@@ -25,6 +26,7 @@ public final class UriUtil {
     public static final String LOCAL_URL_LOGIN = "#login";
     public static final String LOCAL_URL_CUSTOMIZE_FEED = "#customizefeed";
     public static final String LOCAL_URL_LANGUAGES = "#languages";
+    @RegExp public static final String WIKI_REGEX = "/(wiki|[a-z]{2,3}|[a-z]{2,3}-.*)/";
 
     /**
      * Decodes a URL-encoded string into its UTF-8 equivalent. If the string cannot be decoded, the
@@ -103,7 +105,7 @@ public final class UriUtil {
         return (!TextUtils.isEmpty(uri.getAuthority())
                 && uri.getAuthority().endsWith("wikipedia.org")
                 && !TextUtils.isEmpty(uri.getPath())
-                && uri.getPath().matches("^" + getWikiRegex() + ".*"))
+                && uri.getPath().matches("^" + WIKI_REGEX + ".*"))
                 && (uri.getFragment() == null
                 || (uri.getFragment().length() > 0
                 && !uri.getFragment().startsWith("cite")));
@@ -136,21 +138,16 @@ public final class UriUtil {
         return parts.length > 1 && !parts[0].equals("wiki") ? parts[0] : "";
     }
 
-    @NonNull
-    public static String getWikiRegex() {
-        return "/(wiki|[a-z]{2,3}|[a-z]{2,3}-.*)/";
-    }
-
     /** For internal links only */
     @NonNull
     public static String removeInternalLinkPrefix(@NonNull String link) {
-        return link.replaceFirst(getWikiRegex(), "");
+        return link.replaceFirst(WIKI_REGEX, "");
     }
 
     /** For links that could be internal or external links */
     @NonNull
     public static String removeLinkPrefix(@NonNull String link) {
-        return link.replaceFirst("^.*?" + getWikiRegex(), "");
+        return link.replaceFirst("^.*?" + WIKI_REGEX, "");
     }
 
     /** Removes an optional fragment portion of a URL */

--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -103,7 +103,7 @@ public final class UriUtil {
         return (!TextUtils.isEmpty(uri.getAuthority())
                 && uri.getAuthority().endsWith("wikipedia.org")
                 && !TextUtils.isEmpty(uri.getPath())
-                && uri.getPath().startsWith("/wiki"))
+                && uri.getPath().matches("^" + getWikiRegex() + ".*"))
                 && (uri.getFragment() == null
                 || (uri.getFragment().length() > 0
                 && !uri.getFragment().startsWith("cite")));

--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -149,7 +149,7 @@ public final class UriUtil {
 
     /** For links that could be internal or external links */
     @NonNull
-    private static String removeLinkPrefix(@NonNull String link) {
+    public static String removeLinkPrefix(@NonNull String link) {
         return link.replaceFirst("^.*?" + getWikiRegex(), "");
     }
 

--- a/app/src/main/java/org/wikipedia/util/UriUtil.java
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.java
@@ -136,16 +136,21 @@ public final class UriUtil {
         return parts.length > 1 && !parts[0].equals("wiki") ? parts[0] : "";
     }
 
+    @NonNull
+    public static String getWikiRegex() {
+        return "/(wiki|[a-z]{2,3}|[a-z]{2,3}-.*)/";
+    }
+
     /** For internal links only */
     @NonNull
     public static String removeInternalLinkPrefix(@NonNull String link) {
-        return link.replaceFirst("/(wiki|zh.*)/", "");
+        return link.replaceFirst(getWikiRegex(), "");
     }
 
     /** For links that could be internal or external links */
     @NonNull
     private static String removeLinkPrefix(@NonNull String link) {
-        return link.replaceFirst("^.*?/(wiki|zh.*)/", "");
+        return link.replaceFirst("^.*?" + getWikiRegex(), "");
     }
 
     /** Removes an optional fragment portion of a URL */

--- a/app/src/test/java/org/wikipedia/util/UriUtilTest.java
+++ b/app/src/test/java/org/wikipedia/util/UriUtilTest.java
@@ -52,4 +52,27 @@ public class UriUtilTest {
         assertThat(UriUtil.decodeURL("%D0%92%D0%B8%D0%BA%D0%B8%D0%BF%D0%B5%D0%B4%D0%B8%D1%8F"), is("Википедия"));
         assertThat(UriUtil.decodeURL("Sentence%20with%20spaces"), is("Sentence with spaces"));
     }
+
+    @Test
+    public void testRemoveInternalLinkPrefix() {
+        assertThat(UriUtil.removeInternalLinkPrefix("/wiki/核武器"), is("核武器"));
+        assertThat(UriUtil.removeInternalLinkPrefix("/zh/核武器"), is("核武器"));
+        assertThat(UriUtil.removeInternalLinkPrefix("/zh-tw/核武器"), is("核武器"));
+        assertThat(UriUtil.removeInternalLinkPrefix("/zh-hant/核武器"), is("核武器"));
+        assertThat(UriUtil.removeInternalLinkPrefix("/sr-ec/Барак_Обама"), is("Барак_Обама"));
+        assertThat(UriUtil.removeInternalLinkPrefix("/sr-el/Барак_Обама"), is("Барак_Обама"));
+        assertThat(UriUtil.removeInternalLinkPrefix("/crh-cyrl/Bağçasaray"), is("Bağçasaray"));
+    }
+
+    @Test
+    public void testRemoveLinkPrefix() {
+        assertThat(UriUtil.removeLinkPrefix("https://zh.wikipedia.org/wiki/核武器"), is("核武器"));
+        assertThat(UriUtil.removeLinkPrefix("https://zh.wikipedia.org/zh/核武器"), is("核武器"));
+        assertThat(UriUtil.removeLinkPrefix("https://zh.wikipedia.org/zh-tw/核武器"), is("核武器"));
+        assertThat(UriUtil.removeLinkPrefix("https://zh.wikipedia.org/zh-hant/核武器"), is("核武器"));
+        assertThat(UriUtil.removeLinkPrefix("https://zh-tw.wikipedia.org/wiki/核武器"), is("核武器"));
+        assertThat(UriUtil.removeLinkPrefix("https://sr.wikipedia.org/sr/Барак_Обама"), is("Барак_Обама"));
+        assertThat(UriUtil.removeLinkPrefix("https://sr.wikipedia.org/sr-el/Барак_Обама"), is("Барак_Обама"));
+        assertThat(UriUtil.removeLinkPrefix("https://sr.wikipedia.org/sr-ec/Барак_Обама"), is("Барак_Обама"));
+    }
 }


### PR DESCRIPTION
When testing the PR #1695, I have noticed that some in-article links will not get the page title correctly.

Please test this PR with this `testwiki` article: https://test.wikipedia.org/wiki/Language_Variants