### PR TITLE
Fix: should use apiTitle and language code when updating bookmark status

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -855,7 +855,8 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
                     return;
                 }
                 for (ReadingListPage page : ((ArticleSavedOrDeletedEvent) event).getPages()) {
-                    if (page.title().equals(pageFragment.getTitleOriginal().getDisplayText())) {
+                    if (page.apiTitle().equals(pageFragment.getTitleOriginal().getPrefixedText())
+                            && page.wiki().languageCode().equals(pageFragment.getTitleOriginal().getWikiSite().languageCode())) {
                         pageFragment.updateBookmarkAndMenuOptionsFromDao();
                     }
                 }


### PR DESCRIPTION
Related to #1695 

When adding an article that the `getDisplayText()` is not the same as the `getPrefixedText()`, the bookmark icon will not change its status correctly.

e.g. 
https://zh.wikipedia.org/wiki/核武器 in `zh-hant`

`apiTitle` => 核武器 
`displayTitle` => 核子武器