### PR TITLE
Replace the theme color button with plain circular buttons

### DIFF
--- a/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.java
+++ b/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.java
@@ -17,6 +17,7 @@ import androidx.appcompat.widget.SwitchCompat;
 import androidx.core.content.ContextCompat;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.button.MaterialButton;
 
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
@@ -43,14 +44,10 @@ public class ThemeChooserDialog extends ExtendedBottomSheetDialogFragment {
     @BindView(R.id.buttonIncreaseTextSize) TextView buttonIncreaseTextSize;
     @BindView(R.id.text_size_percent) TextView textSizePercent;
     @BindView(R.id.text_size_seek_bar) DiscreteSeekBar textSizeSeekBar;
-    @BindView(R.id.button_theme_light) TextView buttonThemeLight;
-    @BindView(R.id.button_theme_dark) TextView buttonThemeDark;
-    @BindView(R.id.button_theme_black) TextView buttonThemeBlack;
-    @BindView(R.id.button_theme_sepia) TextView buttonThemeSepia;
-    @BindView(R.id.button_theme_light_highlight) View buttonThemeLightHighlight;
-    @BindView(R.id.button_theme_dark_highlight) View buttonThemeDarkHighlight;
-    @BindView(R.id.button_theme_black_highlight) View buttonThemeBlackHighlight;
-    @BindView(R.id.button_theme_sepia_highlight) View buttonThemeSepiaHighlight;
+    @BindView(R.id.button_theme_light) MaterialButton buttonThemeLight;
+    @BindView(R.id.button_theme_dark) MaterialButton buttonThemeDark;
+    @BindView(R.id.button_theme_black) MaterialButton buttonThemeBlack;
+    @BindView(R.id.button_theme_sepia) MaterialButton buttonThemeSepia;
     @BindView(R.id.theme_chooser_dark_mode_dim_images_switch) SwitchCompat dimImagesSwitch;
     @BindView(R.id.theme_chooser_match_system_theme_switch) SwitchCompat matchSystemThemeSwitch;
     @BindView(R.id.font_change_progress_bar) ProgressBar fontChangeProgressBar;
@@ -238,14 +235,16 @@ public class ThemeChooserDialog extends ExtendedBottomSheetDialogFragment {
     }
 
     private void updateThemeButtons() {
-        buttonThemeLightHighlight.setVisibility(app.getCurrentTheme() == Theme.LIGHT ? View.VISIBLE : View.GONE);
-        buttonThemeLight.setClickable(app.getCurrentTheme() != Theme.LIGHT);
-        buttonThemeSepiaHighlight.setVisibility(app.getCurrentTheme() == Theme.SEPIA ? View.VISIBLE : View.GONE);
-        buttonThemeSepia.setClickable(app.getCurrentTheme() != Theme.SEPIA);
-        buttonThemeDarkHighlight.setVisibility(app.getCurrentTheme() == Theme.DARK ? View.VISIBLE : View.GONE);
-        buttonThemeDark.setClickable(app.getCurrentTheme() != Theme.DARK);
-        buttonThemeBlackHighlight.setVisibility(app.getCurrentTheme() == Theme.BLACK ? View.VISIBLE : View.GONE);
-        buttonThemeBlack.setClickable(app.getCurrentTheme() != Theme.BLACK);
+        updateThemeButtonStroke(buttonThemeLight, app.getCurrentTheme() == Theme.LIGHT);
+        updateThemeButtonStroke(buttonThemeSepia, app.getCurrentTheme() == Theme.SEPIA);
+        updateThemeButtonStroke(buttonThemeDark, app.getCurrentTheme() == Theme.DARK);
+        updateThemeButtonStroke(buttonThemeBlack, app.getCurrentTheme() == Theme.BLACK);
+    }
+
+    @SuppressWarnings("checkstyle:magicnumbers")
+    private void updateThemeButtonStroke(@NonNull MaterialButton button, boolean selected) {
+        button.setStrokeWidth(selected ? 10 : 0);
+        button.setClickable(!selected);
     }
 
     private void updateDimImagesSwitch() {

--- a/app/src/main/res/drawable/button_shape_border_light.xml
+++ b/app/src/main/res/drawable/button_shape_border_light.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <corners android:radius="@dimen/corner_radius_smaller" />
-    <solid android:color="@android:color/transparent"/>
-    <stroke android:width="1.5dp" android:color="@color/accent50"/>
-</shape>

--- a/app/src/main/res/layout/dialog_theme_chooser.xml
+++ b/app/src/main/res/layout/dialog_theme_chooser.xml
@@ -129,26 +129,30 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/button_theme_light"
-                style="@style/App.Button.Circle"
+                style="@style/ThemeColorCircularButton"
                 android:layout_margin="5dp"
+                android:textColor="@color/base10"
                 android:backgroundTint="@color/color_state_white"/>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/button_theme_sepia"
-                style="@style/App.Button.Circle"
+                style="@style/ThemeColorCircularButton"
                 android:layout_margin="5dp"
+                android:textColor="@color/base10"
                 android:backgroundTint="@color/papyrus"/>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/button_theme_dark"
-                style="@style/App.Button.Circle"
+                style="@style/ThemeColorCircularButton"
                 android:layout_margin="5dp"
+                android:textColor="@color/base90"
                 android:backgroundTint="@color/color_state_gray" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/button_theme_black"
-                style="@style/App.Button.Circle"
+                style="@style/ThemeColorCircularButton"
                 android:layout_margin="5dp"
+                android:textColor="@color/base90"
                 android:backgroundTint="@color/color_state_black" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/dialog_theme_chooser.xml
+++ b/app/src/main/res/layout/dialog_theme_chooser.xml
@@ -122,124 +122,34 @@
             android:textColor="?attr/primary_text_color" />
 
         <LinearLayout
-            android:layout_width="300dp"
-            android:layout_height="56dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginStart="-4dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="-4dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
             android:clipChildren="false">
 
-            <FrameLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_theme_light"
+                style="@style/App.Button.Circle"
+                android:layout_margin="5dp"
+                android:backgroundTint="@color/color_state_white"/>
 
-                <Button
-                    android:id="@+id/button_theme_light"
-                    style="@style/App.Button.White"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:text="@string/color_theme_light" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_theme_sepia"
+                style="@style/App.Button.Circle"
+                android:layout_margin="5dp"
+                android:backgroundTint="@color/papyrus"/>
 
-                <View
-                    android:id="@+id/button_theme_light_highlight"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="4dp"
-                    android:layout_marginTop="6dp"
-                    android:layout_marginEnd="4dp"
-                    android:layout_marginBottom="6dp"
-                    android:background="?attr/button_highlight_border_shape"
-                    android:elevation="4dp" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_theme_dark"
+                style="@style/App.Button.Circle"
+                android:layout_margin="5dp"
+                android:backgroundTint="@color/color_state_gray" />
 
-            </FrameLayout>
-
-            <FrameLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1">
-
-                <Button
-                    android:id="@+id/button_theme_sepia"
-                    style="@style/App.Button.White"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:text="@string/color_theme_sepia"
-                    android:backgroundTint="@color/papyrus"/>
-
-                <View
-                    android:id="@+id/button_theme_sepia_highlight"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="4dp"
-                    android:layout_marginTop="6dp"
-                    android:layout_marginEnd="4dp"
-                    android:layout_marginBottom="6dp"
-                    android:background="?attr/button_highlight_border_shape"
-                    android:elevation="4dp" />
-
-            </FrameLayout>
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="300dp"
-            android:layout_height="56dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginStart="-4dp"
-            android:layout_marginEnd="-4dp"
-            android:layout_marginBottom="16dp"
-            android:clipChildren="false">
-
-            <FrameLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1">
-
-                <Button
-                    android:id="@+id/button_theme_dark"
-                    style="@style/App.Button.Gray"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:text="@string/color_theme_dark" />
-
-                <View
-                    android:id="@+id/button_theme_dark_highlight"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="4dp"
-                    android:layout_marginTop="6dp"
-                    android:layout_marginEnd="4dp"
-                    android:layout_marginBottom="6dp"
-                    android:background="?attr/button_highlight_border_shape"
-                    android:elevation="4dp" />
-
-            </FrameLayout>
-
-            <FrameLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1">
-
-                <Button
-                    android:id="@+id/button_theme_black"
-                    style="@style/App.Button.Black"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:text="@string/color_theme_black" />
-
-                <View
-                    android:id="@+id/button_theme_black_highlight"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="4dp"
-                    android:layout_marginTop="6dp"
-                    android:layout_marginEnd="4dp"
-                    android:layout_marginBottom="6dp"
-                    android:background="?attr/button_highlight_border_shape"
-                    android:elevation="4dp" />
-
-            </FrameLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_theme_black"
+                style="@style/App.Button.Circle"
+                android:layout_margin="5dp"
+                android:backgroundTint="@color/color_state_black" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -248,6 +248,7 @@
         <item name="android:insetRight">0dp</item>
         <item name="android:padding">0dp</item>
         <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:letterSpacing">0</item>
         <item name="android:textSize">16sp</item>
         <item name="android:text">Aa</item>
         <item name="android:textAllCaps">false</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -239,13 +239,18 @@
         <item name="android:textColor">@color/base30</item>
     </style>
 
-    <style name="App.Button.Circle" parent="@style/Widget.MaterialComponents.Button.Icon">
+    <style name="ThemeColorCircularButton" parent="@style/Widget.MaterialComponents.Button.Icon">
         <item name="android:layout_width">40dp</item>
         <item name="android:layout_height">40dp</item>
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
         <item name="android:insetLeft">0dp</item>
         <item name="android:insetRight">0dp</item>
+        <item name="android:padding">0dp</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:text">Aa</item>
+        <item name="android:textAllCaps">false</item>
         <item name="cornerRadius">30dp</item>
         <item name="strokeColor">@color/accent50</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -239,6 +239,17 @@
         <item name="android:textColor">@color/base30</item>
     </style>
 
+    <style name="App.Button.Circle" parent="@style/Widget.MaterialComponents.Button.Icon">
+        <item name="android:layout_width">40dp</item>
+        <item name="android:layout_height">40dp</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="android:insetLeft">0dp</item>
+        <item name="android:insetRight">0dp</item>
+        <item name="cornerRadius">30dp</item>
+        <item name="strokeColor">@color/accent50</item>
+    </style>
+
     <style name="FlatButton" parent="@style/Widget.MaterialComponents.Button.UnelevatedButton">
         <item name="backgroundTint">?attr/color_group_22</item>
         <item name="android:textColor">?attr/colorAccent</item>

--- a/app/src/main/res/values/styles_dark.xml
+++ b/app/src/main/res/values/styles_dark.xml
@@ -38,7 +38,6 @@
         <item name="lead_image_drawable">@drawable/lead_default_dark</item>
         <item name="list_separator_drawable">@drawable/divider_dark</item>
         <item name="list_separator_drawable_bottom_content">@drawable/divider_bottom_content_dark</item>
-        <item name="button_highlight_border_shape">@drawable/button_shape_border_light</item>
 
         <!-- Overrides of our own custom color attributes -->
         <item name="toolbar_icon_color">@android:color/white</item>

--- a/app/src/main/res/values/styles_light.xml
+++ b/app/src/main/res/values/styles_light.xml
@@ -38,7 +38,6 @@
         <item name="lead_image_drawable">@drawable/lead_default</item>
         <item name="list_separator_drawable">@drawable/divider_light</item>
         <item name="list_separator_drawable_bottom_content">@drawable/divider_bottom_content_light</item>
-        <item name="button_highlight_border_shape">@drawable/button_shape_border_light</item>
 
         <!-- Overrides of our own custom color attributes -->
         <item name="toolbar_icon_color">@color/base30</item>


### PR DESCRIPTION
We have to resize (re-style) the theme color buttons in order to add font-family buttons to the theme dialog.
https://phabricator.wikimedia.org/T264445