### PR TITLE
Fix possible crash due to transitions on Lollipop devices.

### DIFF
--- a/app/src/main/res/layout/fragment_page.xml
+++ b/app/src/main/res/layout/fragment_page.xml
@@ -21,6 +21,13 @@
             android:layout_height="16dp"
             android:visibility="gone" />
 
+        <ImageView
+            android:id="@+id/page_image_transition_holder"
+            android:layout_width="1dp"
+            android:layout_height="1dp"
+            android:transitionName="@string/transition_page_gallery"
+            android:contentDescription="@null"/>
+
         <org.wikipedia.views.WikiErrorView
             android:id="@+id/page_error"
             android:layout_width="match_parent"


### PR DESCRIPTION
https://appcenter.ms/orgs/ci-apps-hockeyapp-f5mf/apps/Wikipedia/crashes/errors/3504266540u/overview
https://appcenter.ms/orgs/ci-apps-hockeyapp-f5mf/apps/Wikipedia/crashes/errors/367965300u/overview

Note: I believe the crash was happening because the "source" ImageView from which the transition starts gets destroyed when the user goes back to the previous activity. This change will make the source ImageView always present in the activity.