### PR TITLE
Design tweak: News

### DIFF
--- a/app/src/main/java/org/wikipedia/richtext/URLSpanBoldNoUnderline.java
+++ b/app/src/main/java/org/wikipedia/richtext/URLSpanBoldNoUnderline.java
@@ -26,7 +26,7 @@ public class URLSpanBoldNoUnderline extends URLSpanNoUnderline {
 
     @Override public void updateDrawState(TextPaint paint) {
         super.updateDrawState(paint);
-        paint.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        paint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
     }
 
     @Override public String toString() {


### PR DESCRIPTION
**Phab:** https://phabricator.wikimedia.org/T261672#6567557
When we bold parts of rich text, it should be bold, and not faux bolded by converting to sans-serif-medium