### PR TITLE
Set paper_color for the ImageView container in NewsFragment

### DIFF
--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -23,6 +23,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true"
+                android:background="?attr/paper_color"
                 app:layout_collapseMode="parallax">
 
                 <org.wikipedia.views.FaceAndColorDetectImageView


### PR DESCRIPTION
Although we applied a white background to the image, we still can see blue background during the transition animation. This PR applies `paper_color` to the image container to solve the issue.