### PR TITLE
Follow-up to language detection.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -196,7 +196,7 @@ dependencies {
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation "com.github.skydoves:balloon:1.2.1"
 
-    //ML kit for language detection during editing implementation 'com.google.mlkit:language-id:16.1.1'
+    // For language detection during editing
     prodImplementation "com.google.mlkit:language-id:$mlKitVersion"
     betaImplementation "com.google.mlkit:language-id:$mlKitVersion"
     alphaImplementation "com.google.mlkit:language-id:$mlKitVersion"

--- a/app/src/extra/java/org/wikipedia/mlkit/MlKitLanguageDetector.kt
+++ b/app/src/extra/java/org/wikipedia/mlkit/MlKitLanguageDetector.kt
@@ -9,10 +9,11 @@ class MlKitLanguageDetector {
     }
 
     var callback: Callback? = null
+    private val languageIdentifier = LanguageIdentification.getClient(LanguageIdentificationOptions.Builder()
+            .setConfidenceThreshold(0.65f)
+            .build())
+
     fun detectLanguageFromText(text: String) {
-        val languageIdentifier = LanguageIdentification.getClient(LanguageIdentificationOptions.Builder()
-                .setConfidenceThreshold(0.65f)
-                .build())
         languageIdentifier.identifyLanguage(text)
                 .addOnSuccessListener { languageCode: String ->
                     if (languageCode != "und") {

--- a/app/src/fdroid/java/org/wikipedia/mlkit/MlKitLanguageDetector.kt
+++ b/app/src/fdroid/java/org/wikipedia/mlkit/MlKitLanguageDetector.kt
@@ -2,6 +2,7 @@ package org.wikipedia.mlkit
 
 class MlKitLanguageDetector {
     interface Callback {
+        fun onLanguageDetectionSuccess(languageCode: String)
     }
 
     var callback: Callback? = null


### PR DESCRIPTION
A quick follow-up to the excellent new language detection feature:

* Keep a single instance of the identifier object for the lifetime of the `DescriptionEditView`.
* Show the language warning in order of priority, relative to the other warnings (too short, punctuation, etc).
* A bit of additional cleanup.