### PR TITLE
Bounce "thankyou." domain to external browser too

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -366,10 +366,12 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
             }
             // Special cases:
             // If the app was launched from an external deeplink to a "Special:" page, or if the
-            // link is to a page in the "donate." domain (e.g. a "thank you" page after having
-            // donated), then bounce it out to an external browser, since we don't have the same
-            // cookie state as the browser does.
-            if (title.isSpecial() || wiki.languageCode().toLowerCase().equals("donate")) {
+            // link is to a page in the "donate." or "thankyou." domains (e.g. a "thank you" page
+            // after having donated), then bounce it out to an external browser, since we don't have
+            // the same cookie state as the browser does.
+            String language = wiki.languageCode().toLowerCase();
+            boolean isDonationRelated = language.equals("donate") || language.equals("thankyou");
+            if (title.isSpecial() || isDonationRelated) {
                 visitInExternalBrowser(this, uri);
                 finish();
                 return;


### PR DESCRIPTION
We've recently moved the donation Thank You pages to
thankyou.wikiPedia.org so we can set cookies which are readable
across the encyclopedias.

Bug: T259312