### PR TITLE
Fix: properly retry the request when getting empty source description

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -8,6 +8,7 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_suggested_edits_cards_item.*
 import kotlinx.android.synthetic.main.view_image_detail_horizontal.view.*
@@ -71,6 +72,13 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
         when (parent().action) {
             TRANSLATE_DESCRIPTION -> {
                 disposables.add(EditingSuggestionsProvider.getNextArticleWithMissingDescription(WikiSite.forLanguageCode(parent().langFromCode), parent().langToCode, true)
+                        .map {
+                            if (it.second.description.isNullOrEmpty()) {
+                                throw EditingSuggestionsProvider.ListEmptyException()
+                            }
+                            it
+                        }
+                        .retry { t: Throwable -> t is EditingSuggestionsProvider.ListEmptyException }
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe({ pair ->


### PR DESCRIPTION
This is a proper fix of #1719, since it also fixes the broken views in the SE feed of translate description in `enwiki`.