### PR TITLE
Only refresh feed if languages or feed configurations are changed in settings

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
@@ -2,10 +2,13 @@ package org.wikipedia.settings;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 
+import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.SingleFragmentActivity;
+import org.wikipedia.util.StringUtil;
 
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_ADD_A_LANGUAGE;
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_FEED_CONFIGURE;
@@ -13,6 +16,8 @@ import static org.wikipedia.Constants.ACTIVITY_REQUEST_FEED_CONFIGURE;
 public class SettingsActivity extends SingleFragmentActivity<SettingsFragment> {
     public static final int ACTIVITY_RESULT_LANGUAGE_CHANGED = 1;
     public static final int ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED = 2;
+    private WikipediaApp app = WikipediaApp.getInstance();
+    private String initialLanguageList;
 
     public static Intent newIntent(@NonNull Context ctx) {
         return new Intent(ctx, SettingsActivity.class);
@@ -24,9 +29,18 @@ public class SettingsActivity extends SingleFragmentActivity<SettingsFragment> {
     }
 
     @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        initialLanguageList = StringUtil.listToJsonArrayString(app.language().getAppLanguageCodes());
+    }
+
+    @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE) {
+        String finalLanguageList = StringUtil.listToJsonArrayString(app.language().getAppLanguageCodes());
+
+        if (requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE
+                && (!finalLanguageList.equals(initialLanguageList))) {
             setResult(ACTIVITY_RESULT_LANGUAGE_CHANGED);
         } else if (requestCode == ACTIVITY_REQUEST_FEED_CONFIGURE) {
             setResult(ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED);

--- a/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
@@ -10,14 +10,20 @@ import org.wikipedia.WikipediaApp;
 import org.wikipedia.activity.SingleFragmentActivity;
 import org.wikipedia.util.StringUtil;
 
+import java.util.List;
+
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_ADD_A_LANGUAGE;
 import static org.wikipedia.Constants.ACTIVITY_REQUEST_FEED_CONFIGURE;
 
 public class SettingsActivity extends SingleFragmentActivity<SettingsFragment> {
     public static final int ACTIVITY_RESULT_LANGUAGE_CHANGED = 1;
     public static final int ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED = 2;
+
     private WikipediaApp app = WikipediaApp.getInstance();
+
     private String initialLanguageList;
+    private List<Boolean> initialFeedCardsEnabled;
+    private List<Integer> initialFeedCardsOrder;
 
     public static Intent newIntent(@NonNull Context ctx) {
         return new Intent(ctx, SettingsActivity.class);
@@ -31,18 +37,26 @@ public class SettingsActivity extends SingleFragmentActivity<SettingsFragment> {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         initialLanguageList = StringUtil.listToJsonArrayString(app.language().getAppLanguageCodes());
+        initialFeedCardsEnabled = Prefs.getFeedCardsEnabled();
+        initialFeedCardsOrder = Prefs.getFeedCardsOrder();
     }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
+
         String finalLanguageList = StringUtil.listToJsonArrayString(app.language().getAppLanguageCodes());
+        List<Boolean> finalFeedCardsEnabled = Prefs.getFeedCardsEnabled();
+        List<Integer> finalFeedCardsOrder = Prefs.getFeedCardsOrder();
 
         if (requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE
                 && (!finalLanguageList.equals(initialLanguageList))) {
             setResult(ACTIVITY_RESULT_LANGUAGE_CHANGED);
-        } else if (requestCode == ACTIVITY_REQUEST_FEED_CONFIGURE) {
+        } else if (requestCode == ACTIVITY_REQUEST_FEED_CONFIGURE
+                && (!initialFeedCardsEnabled.equals(finalFeedCardsEnabled)
+                || !initialFeedCardsOrder.equals(finalFeedCardsOrder))) {
             setResult(ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED);
         }
     }

--- a/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
@@ -48,15 +48,13 @@ public class SettingsActivity extends SingleFragmentActivity<SettingsFragment> {
         super.onActivityResult(requestCode, resultCode, data);
 
         String finalLanguageList = StringUtil.listToJsonArrayString(app.language().getAppLanguageCodes());
-        List<Boolean> finalFeedCardsEnabled = Prefs.getFeedCardsEnabled();
-        List<Integer> finalFeedCardsOrder = Prefs.getFeedCardsOrder();
 
         if (requestCode == ACTIVITY_REQUEST_ADD_A_LANGUAGE
                 && (!finalLanguageList.equals(initialLanguageList))) {
             setResult(ACTIVITY_RESULT_LANGUAGE_CHANGED);
         } else if (requestCode == ACTIVITY_REQUEST_FEED_CONFIGURE
-                && (!finalFeedCardsEnabled.equals(initialFeedCardsEnabled)
-                || !finalFeedCardsOrder.equals(initialFeedCardsOrder))) {
+                && (!Prefs.getFeedCardsEnabled().equals(initialFeedCardsEnabled)
+                || !Prefs.getFeedCardsOrder().equals(initialFeedCardsOrder))) {
             setResult(ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED);
         }
     }

--- a/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
+++ b/app/src/main/java/org/wikipedia/settings/SettingsActivity.java
@@ -55,8 +55,8 @@ public class SettingsActivity extends SingleFragmentActivity<SettingsFragment> {
                 && (!finalLanguageList.equals(initialLanguageList))) {
             setResult(ACTIVITY_RESULT_LANGUAGE_CHANGED);
         } else if (requestCode == ACTIVITY_REQUEST_FEED_CONFIGURE
-                && (!initialFeedCardsEnabled.equals(finalFeedCardsEnabled)
-                || !initialFeedCardsOrder.equals(finalFeedCardsOrder))) {
+                && (!finalFeedCardsEnabled.equals(initialFeedCardsEnabled)
+                || !finalFeedCardsOrder.equals(initialFeedCardsOrder))) {
             setResult(ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED);
         }
     }


### PR DESCRIPTION
**Background**
https://phabricator.wikimedia.org/T198385

The feed automatically refreshes every time user enters language selection or feed configuration from settings even if nothing is changed.

**Change**
- [x] Save the initial and final language lists and feed card lists when entering and leaving `SettingsActivity`. Compare these lists and only set activity results if they are different.

**Testing**
- [x] Go to Settings --> add/remove/rearrange items in languages --> go back to feed and ensure it refreshes
- [x] Go to Settings --> enable/disable/rearrange items in feed configurations --> go back to feed and ensure it refreshes
- [x] Go to Settings --> click on languages/feed configurations but do not make changes --> go back to feed and ensure it **does not refresh**

\ | Before | After |
--- | --- | --- |
Languages | ![languages_before](https://user-images.githubusercontent.com/22717320/97793523-65213f00-1baa-11eb-974e-b61b5a30df55.gif) | ![languages_after](https://user-images.githubusercontent.com/22717320/97793524-694d5c80-1baa-11eb-90f1-700304e0dc14.gif) |
Feed configuration | ![feed_before](https://user-images.githubusercontent.com/22717320/97793526-736f5b00-1baa-11eb-90e9-dcd097e023f7.gif) | ![feed_after](https://user-images.githubusercontent.com/22717320/97793529-7f5b1d00-1baa-11eb-81d6-8164465b357c.gif) |