### PR TITLE
Fix: make sure list items are clickable in NewsFragment and MostReadFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/mostread/MostReadFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/mostread/MostReadFragment.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityOptionsCompat;
 import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -24,6 +25,7 @@ import org.wikipedia.page.PageActivity;
 import org.wikipedia.readinglist.AddToReadingListDialog;
 import org.wikipedia.readinglist.MoveToReadingListDialog;
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil;
+import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.ShareUtil;
 import org.wikipedia.views.DefaultRecyclerAdapter;
@@ -121,7 +123,10 @@ public class MostReadFragment extends Fragment {
 
         @Override
         public void onSelectPage(@NonNull Card card, @NonNull HistoryEntry entry, @NonNull Pair<View, String>[] sharedElements) {
-            // ignore
+            ActivityOptionsCompat options = ActivityOptionsCompat.
+                    makeSceneTransitionAnimation(requireActivity(), sharedElements);
+            startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()),
+                    DimenUtil.isLandscape(requireContext()) || sharedElements.length == 0 ? null : options.toBundle());
         }
 
         @Override

--- a/app/src/main/java/org/wikipedia/feed/news/NewsFragment.java
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsFragment.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.app.ActivityOptionsCompat;
 import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -34,6 +35,7 @@ import org.wikipedia.readinglist.AddToReadingListDialog;
 import org.wikipedia.readinglist.MoveToReadingListDialog;
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil;
 import org.wikipedia.util.DeviceUtil;
+import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.GradientUtil;
 import org.wikipedia.util.ResourceUtil;
@@ -165,7 +167,10 @@ public class NewsFragment extends Fragment {
 
         @Override
         public void onSelectPage(@NonNull Card card, @NonNull HistoryEntry entry, @NonNull Pair<View, String>[] sharedElements) {
-            // ignore
+            ActivityOptionsCompat options = ActivityOptionsCompat.
+                    makeSceneTransitionAnimation(requireActivity(), sharedElements);
+            startActivity(PageActivity.newIntentForCurrentTab(requireContext(), entry, entry.getTitle()),
+                    DimenUtil.isLandscape(requireContext()) || sharedElements.length == 0 ? null : options.toBundle());
         }
 
         @Override

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -290,7 +290,8 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
     @Override public final void onFeedSelectPageWithAnimation(HistoryEntry entry, Pair<View, String>[] sharedElements) {
         ActivityOptionsCompat options = ActivityOptionsCompat.
                 makeSceneTransitionAnimation(requireActivity(), sharedElements);
-        startActivity(PageActivity.newIntentForExistingTab(requireContext(), entry, entry.getTitle()), DimenUtil.isLandscape(requireContext()) ? null : options.toBundle());
+        startActivity(PageActivity.newIntentForExistingTab(requireContext(), entry, entry.getTitle()),
+                DimenUtil.isLandscape(requireContext()) || sharedElements.length == 0 ? null : options.toBundle());
     }
 
     @Override public void onFeedAddPageToList(HistoryEntry entry, boolean addToDefault) {


### PR DESCRIPTION
Since we implement the transition animation as default in `ListCardItemView`, we should not ignore the `onSelectPage` method.

This PR also optimizes the animation which if there is nothing to be transited between screens, it should be disabled.