### PR TITLE
Fix: set description from recommendation api for enwiki

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.java
@@ -93,6 +93,10 @@ public class PageSummary {
         return thumbnail == null ? null : thumbnail.getUrl();
     }
 
+    public void setDescription(@Nullable String description) {
+        this.description = description;
+    }
+
     @Nullable
     public String getDescription() {
         return description;

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
@@ -130,7 +130,7 @@ class SuggestedEditsFeedClient(private var action: DescriptionEditActivity.Actio
         disposables.add(EditingSuggestionsProvider
                 .getNextArticleWithMissingDescription(WikiSite.forLanguageCode(langFromCode), langToCode, true, MAX_RETRY_LIMIT)
                 .map {
-                    if (it.second.description.isNullOrEmpty()) {
+                    if (it.first.description.isNullOrEmpty()) {
                         throw EditingSuggestionsProvider.ListEmptyException()
                     }
                     it
@@ -139,8 +139,8 @@ class SuggestedEditsFeedClient(private var action: DescriptionEditActivity.Actio
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ pair ->
-                    val source = pair.second
-                    val target = pair.first
+                    val source = pair.first
+                    val target = pair.second
 
                     val sourceSummary = PageSummaryForEdit(
                             source.apiTitle,

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -73,7 +73,7 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
             TRANSLATE_DESCRIPTION -> {
                 disposables.add(EditingSuggestionsProvider.getNextArticleWithMissingDescription(WikiSite.forLanguageCode(parent().langFromCode), parent().langToCode, true)
                         .map {
-                            if (it.second.description.isNullOrEmpty()) {
+                            if (it.first.description.isNullOrEmpty()) {
                                 throw EditingSuggestionsProvider.ListEmptyException()
                             }
                             it
@@ -82,8 +82,8 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe({ pair ->
-                            val source = pair.second
-                            val target = pair.first
+                            val source = pair.first
+                            val target = pair.second
 
                             sourceSummaryForEdit = PageSummaryForEdit(
                                     source.apiTitle,

--- a/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
@@ -108,7 +108,7 @@ object EditingSuggestionsProvider {
                             t is ListEmptyException
                         }
             }
-        }.flatMap { it -> getSummary(it) }
+        }.flatMap { getSummary(it) }
                 .doFinally { mutex.release() }
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
@@ -80,7 +80,7 @@ object EditingSuggestionsProvider {
             } else {
                 ServiceFactory.getRest(WikiSite(Service.WIKIDATA_URL)).getArticlesWithTranslatableDescriptions(WikiSite.normalizeLanguageCode(sourceWiki.languageCode()), WikiSite.normalizeLanguageCode(targetLang))
                         .map { pages ->
-                            var sourceAndTargetPageTitles: Pair<PageTitle, PageTitle>? = null
+                            var targetAndSourcePageTitles: Pair<PageTitle, PageTitle>? = null
                             articlesWithTranslatableDescriptionCacheFromLang = sourceWiki.languageCode()
                             articlesWithTranslatableDescriptionCacheToLang = targetLang
                             for (page in pages) {
@@ -92,28 +92,34 @@ object EditingSuggestionsProvider {
                                         || !entity.sitelinks().containsKey(targetWiki.dbName())) {
                                     continue
                                 }
-                                articlesWithTranslatableDescriptionCache.push(PageTitle(entity.sitelinks()[targetWiki.dbName()]!!.title, targetWiki)
-                                        to PageTitle(entity.sitelinks()[sourceWiki.dbName()]!!.title, sourceWiki))
+                                val sourceTitle = PageTitle(entity.sitelinks()[sourceWiki.dbName()]!!.title, sourceWiki)
+                                sourceTitle.description = entity.descriptions()[sourceWiki.languageCode()]?.value()
+                                articlesWithTranslatableDescriptionCache.push(PageTitle(entity.sitelinks()[targetWiki.dbName()]!!.title, targetWiki) to sourceTitle)
                             }
                             if (!articlesWithTranslatableDescriptionCache.empty()) {
-                                sourceAndTargetPageTitles = articlesWithTranslatableDescriptionCache.pop()
+                                targetAndSourcePageTitles = articlesWithTranslatableDescriptionCache.pop()
                             }
-                            if (sourceAndTargetPageTitles == null) {
+                            if (targetAndSourcePageTitles == null) {
                                 throw ListEmptyException()
                             }
-                            sourceAndTargetPageTitles
+                            targetAndSourcePageTitles
                         }
                         .retry(retryLimit) { t: Throwable ->
                             t is ListEmptyException
                         }
             }
-        }.flatMap { sourceAndTargetPageTitles: Pair<PageTitle, PageTitle> -> getSummary(sourceAndTargetPageTitles) }
+        }.flatMap { it -> getSummary(it) }
                 .doFinally { mutex.release() }
     }
 
-    private fun getSummary(titles: Pair<PageTitle, PageTitle>): Observable<Pair<PageSummary, PageSummary>> {
-        return Observable.zip(ServiceFactory.getRest(titles.first.wikiSite).getSummary(null, titles.first.prefixedText),
-                ServiceFactory.getRest(titles.second.wikiSite).getSummary(null, titles.second.prefixedText), { source, target -> Pair(source, target) })
+    private fun getSummary(targetAndSourcePageTitles: Pair<PageTitle, PageTitle>): Observable<Pair<PageSummary, PageSummary>> {
+        return Observable.zip(ServiceFactory.getRest(targetAndSourcePageTitles.first.wikiSite).getSummary(null, targetAndSourcePageTitles.first.prefixedText),
+                ServiceFactory.getRest(targetAndSourcePageTitles.second.wikiSite).getSummary(null, targetAndSourcePageTitles.second.prefixedText), { target, source ->
+            if (target.description.isNullOrEmpty()) {
+                target.description = targetAndSourcePageTitles.first.description
+            }
+            Pair(source, target)
+        })
     }
 
     fun getNextImageWithMissingCaption(lang: String, retryLimit: Long = MAX_RETRY_LIMIT): Observable<String> {


### PR DESCRIPTION
As discussed, this PR set the description from `recommendation` API in the `PageSummary`.

This PR also rename the variables to reduce confusion, because the `articlesWithTranslatableDescriptionCache` is `<TargetPageTitle, SourcePageTitle>`