### PR TITLE
Fix: update bookmark status correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.java
@@ -83,7 +83,6 @@ public class EditPreviewFragment extends Fragment implements CommunicationBridge
 
         PageTitle pageTitle = ((EditSectionActivity)requireActivity()).getPageTitle();
         model.setTitle(pageTitle);
-        model.setTitleOriginal(pageTitle);
         model.setCurEntry(new HistoryEntry(pageTitle, HistoryEntry.SOURCE_INTERNAL_LINK));
         funnel = WikipediaApp.getInstance().getFunnelManager().getEditFunnel(pageTitle);
 

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -853,12 +853,12 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
                 if (((ArticleSavedOrDeletedEvent) event).isAdded()) {
                     Prefs.shouldShowBookmarkToolTip(false);
                 }
-                if (pageFragment == null || !pageFragment.isAdded() || pageFragment.getTitleOriginal() == null) {
+                if (pageFragment == null || !pageFragment.isAdded() || pageFragment.getTitle() == null) {
                     return;
                 }
                 for (ReadingListPage page : ((ArticleSavedOrDeletedEvent) event).getPages()) {
-                    if (page.apiTitle().equals(pageFragment.getTitleOriginal().getPrefixedText())
-                            && page.wiki().languageCode().equals(pageFragment.getTitleOriginal().getWikiSite().languageCode())) {
+                    if (page.apiTitle().equals(pageFragment.getTitle().getPrefixedText())
+                            && page.wiki().languageCode().equals(pageFragment.getTitle().getWikiSite().languageCode())) {
                         pageFragment.updateBookmarkAndMenuOptionsFromDao();
                     }
                 }

--- a/app/src/main/java/org/wikipedia/page/PageContainerLongPressHandler.java
+++ b/app/src/main/java/org/wikipedia/page/PageContainerLongPressHandler.java
@@ -50,7 +50,7 @@ public class PageContainerLongPressHandler implements LongPressHandler.OverflowM
     @NonNull
     @Override
     public WikiSite getWikiSite() {
-        return fragment.getTitleOriginal().getWikiSite();
+        return fragment.getTitle().getWikiSite();
     }
 
     @Nullable

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -276,10 +276,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         return model.getTitle();
     }
 
-    @Nullable public PageTitle getTitleOriginal() {
-        return model.getTitleOriginal();
-    }
-
     @NonNull public ShareHandler getShareHandler() {
         return shareHandler;
     }
@@ -776,7 +772,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         errorView.setVisibility(View.GONE);
 
         model.setTitle(title);
-        model.setTitleOriginal(title);
         model.setCurEntry(entry);
         model.setReadingListPage(null);
         model.setForceNetwork(isRefresh);
@@ -839,7 +834,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
                 && resultCode == EditHandler.RESULT_REFRESH_PAGE) {
             FeedbackUtil.showMessage(requireActivity(), R.string.edit_saved_successfully);
             // and reload the page...
-            loadPage(model.getTitleOriginal(), model.getCurEntry(), false, false);
+            loadPage(model.getTitle(), model.getCurEntry(), false, false);
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -78,7 +78,7 @@ public class PageFragmentLoadState {
         if (pushBackStack) {
             // update the topmost entry in the backstack, before we start overwriting things.
             updateCurrentBackStackItem();
-            currentTab.pushBackStackItem(new PageBackStackItem(model.getTitleOriginal(), model.getCurEntry()));
+            currentTab.pushBackStackItem(new PageBackStackItem(model.getTitle(), model.getCurEntry()));
         }
         pageLoadCheckReadingLists();
     }
@@ -260,6 +260,5 @@ public class PageFragmentLoadState {
         Completable.fromAction(() -> app.getDatabaseClient(PageImage.class).upsert(pageImage, PageImageHistoryContract.Image.SELECTION)).subscribeOn(Schedulers.io()).subscribe();
 
         model.getTitle().setThumbUrl(pageImage.getImageName());
-        model.getTitleOriginal().setThumbUrl(pageImage.getImageName());
     }
 }

--- a/app/src/main/java/org/wikipedia/page/PageViewModel.java
+++ b/app/src/main/java/org/wikipedia/page/PageViewModel.java
@@ -14,7 +14,6 @@ import okhttp3.CacheControl;
 public class PageViewModel {
     @Nullable private Page page;
     @Nullable private PageTitle title;
-    @Nullable private PageTitle titleOriginal;
     @Nullable private HistoryEntry curEntry;
     @Nullable private ReadingListPage readingListPage;
 
@@ -34,14 +33,6 @@ public class PageViewModel {
 
     public void setTitle(@Nullable PageTitle title) {
         this.title = title;
-    }
-
-    @Nullable public PageTitle getTitleOriginal() {
-        return titleOriginal;
-    }
-
-    public void setTitleOriginal(@Nullable PageTitle titleOriginal) {
-        this.titleOriginal = titleOriginal;
     }
 
     @Nullable public HistoryEntry getCurEntry() {


### PR DESCRIPTION
Sometimes the `getTitleOriginal().getPrefixedText()` is not the same as `getTitle().getPrefixedText()`, which will affect the process of updating bookmark status.

This PR removes `getTitleOriginal()` related variables and objects and use `getTitle()` instead.

**Steps to reproduce:**
1. Go to [Henry_Clifford,_10th_Baron_Clifford](https://en.wikipedia.org/wiki/Henry_Clifford,_10th_Baron_Clifford).
2. Click on [English nobleman](https://en.wikipedia.org/wiki/English_peerage) in the first sentence.
3. Click on "Save" to save the article.

**Expected:**
Should see the bookmark icon turns into a filled icon.