### PR TITLE
Update WikiArticleCard image height to adapt new design changes

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleCardView.java
@@ -142,7 +142,7 @@ public class FeaturedArticleCardView extends DefaultFeedCardView<FeaturedArticle
             wikiArticleCardView.getImageContainer().setVisibility(GONE);
         } else {
             wikiArticleCardView.getImageContainer().setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
-                    (int) (DimenUtil.leadImageHeightForDevice(getContext()) - SUM_OF_CARD_HORIZONTAL_MARGINS)));
+                    (int) (DimenUtil.leadImageHeightForDevice(getContext()) - DimenUtil.getToolbarHeightPx(getContext()) - SUM_OF_CARD_HORIZONTAL_MARGINS)));
             wikiArticleCardView.getImageContainer().setVisibility(VISIBLE);
             wikiArticleCardView.getImageView().loadImage(uri);
             ImageZoomHelper.setViewZoomable(wikiArticleCardView.getImageView());

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -18,10 +18,8 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
-import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -674,15 +672,10 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
             Uri uri = TextUtils.isEmpty(title.getThumbUrl()) ? null : Uri.parse(title.getThumbUrl());
             if (uri == null || DimenUtil.isLandscape(this)) {
-                FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
-                layoutParams.topMargin = DimenUtil.getToolbarHeightPx(this)
-                        + DimenUtil.getStatusBarHeightPx(this)
-                        + (int) DimenUtil.dpToPx(16f);
                 wikiArticleCardView.getImageContainer().setVisibility(View.GONE);
-                wikiArticleCardView.setLayoutParams(layoutParams);
             } else {
                 wikiArticleCardView.getImageContainer().setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
-                        DimenUtil.leadImageHeightForDevice(this)));
+                        DimenUtil.leadImageHeightForDevice(this) - DimenUtil.getToolbarHeightPx(this)));
                 wikiArticleCardView.getImageContainer().setVisibility(View.VISIBLE);
                 wikiArticleCardView.getImageView().loadImage(uri);
             }

--- a/app/src/main/res/layout/activity_page.xml
+++ b/app/src/main/res/layout/activity_page.xml
@@ -16,7 +16,8 @@
         <org.wikipedia.views.WikiArticleCardView
             android:id="@+id/wiki_article_card_view"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:layout_marginTop="?attr/actionBarSize"/>
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/page_fragment"


### PR DESCRIPTION
The new design changes in #1743 resized the lead image height, and the animation should adapt that.