### PR TITLE
Handle transition animation properly when the image download is disabled

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -671,7 +671,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
             pageFragmentView.setVisibility(View.GONE);
 
             Uri uri = TextUtils.isEmpty(title.getThumbUrl()) ? null : Uri.parse(title.getThumbUrl());
-            if (uri == null || DimenUtil.isLandscape(this)) {
+            if (uri == null || DimenUtil.isLandscape(this) || !Prefs.isImageDownloadEnabled()) {
                 wikiArticleCardView.getImageContainer().setVisibility(View.GONE);
             } else {
                 wikiArticleCardView.getImageContainer().setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,

--- a/app/src/main/java/org/wikipedia/util/TransitionUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/TransitionUtil.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.util.Pair
+import org.wikipedia.settings.Prefs
 
 object TransitionUtil {
     @JvmStatic
@@ -15,7 +16,9 @@ object TransitionUtil {
             if (it is TextView && it.text.isNotEmpty()) {
                 shareElements.add(Pair(it, it.transitionName))
             }
-            if (it is ImageView && it.visibility == View.VISIBLE && !DimenUtil.isLandscape(context)) {
+            if (it is ImageView && it.visibility == View.VISIBLE
+                    && !DimenUtil.isLandscape(context)
+                    && Prefs.isImageDownloadEnabled()) {
                 shareElements.add(Pair(it, it.transitionName))
             }
         }


### PR DESCRIPTION
By hiding the image container in `WikiArticleCardView` and not sending the shareElement.