### PR TITLE
Fix JUnit-related deprecations

### DIFF
--- a/app/src/test/java/org/wikipedia/json/RequiredFieldsCheckOnReadTypeAdapterFactoryTest.java
+++ b/app/src/test/java/org/wikipedia/json/RequiredFieldsCheckOnReadTypeAdapterFactoryTest.java
@@ -15,9 +15,9 @@ import org.wikipedia.dataclient.Service;
 import org.wikipedia.json.annotations.Required;
 import org.wikipedia.model.BaseModel;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.wikipedia.json.GsonMarshaller.marshal;
 import static org.wikipedia.json.GsonUnmarshaller.unmarshal;
 

--- a/app/src/test/java/org/wikipedia/language/AppLanguageStateTests.java
+++ b/app/src/test/java/org/wikipedia/language/AppLanguageStateTests.java
@@ -1,7 +1,6 @@
 package org.wikipedia.language;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/app/src/test/java/org/wikipedia/media/StateTest.java
+++ b/app/src/test/java/org/wikipedia/media/StateTest.java
@@ -3,8 +3,8 @@ package org.wikipedia.media;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class StateTest {
     private static final String PATH_A = "http://pathA";

--- a/app/src/test/java/org/wikipedia/util/BatchUtilTest.java
+++ b/app/src/test/java/org/wikipedia/util/BatchUtilTest.java
@@ -13,8 +13,8 @@ import org.wikipedia.testlib.TestLatch;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(RobolectricTestRunner.class) public class BatchUtilTest {
     private ArrayList<PageTitle> titles;


### PR DESCRIPTION
This should not require any testing, as the old methods call the new ones internally.