### PR TITLE
Fix XML preference tags

### DIFF
--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen
+<PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/preferences_developer_feature_testing_heading">
@@ -399,4 +399,4 @@
 
     </PreferenceCategory>
 
-</androidx.preference.PreferenceScreen>
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -3,7 +3,7 @@
     //TODO: Remove the override of the private attributes in values/sw360dp/v13/preference.xml
      when a better solution is found in androidx for removing the iconReserved space.
 -->
-<androidx.preference.PreferenceScreen
+<PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory android:title="@string/preferences_general_heading">
         <org.wikipedia.settings.PreferenceMultiLine
@@ -71,4 +71,4 @@
             android:title="@string/preference_title_auto_upload_crash_reports"
             android:summary="@string/preference_summary_auto_upload_crash_reports" />
     </PreferenceCategory>
-</androidx.preference.PreferenceScreen>
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences_about.xml
+++ b/app/src/main/res/xml/preferences_about.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen
+<PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/about_activity_title">
@@ -29,4 +29,4 @@
         </org.wikipedia.settings.PreferenceMultiLine>
     </PreferenceCategory>
 
-</androidx.preference.PreferenceScreen>
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences_experimental.xml
+++ b/app/src/main/res/xml/preferences_experimental.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen
+<PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/preferences_heading_experimental">
 
     </PreferenceCategory>
 
-</androidx.preference.PreferenceScreen>
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences_notifications.xml
+++ b/app/src/main/res/xml/preferences_notifications.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.preference.PreferenceScreen
+<PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <org.wikipedia.settings.SwitchPreferenceMultiLine
@@ -56,4 +56,4 @@
 
     </PreferenceCategory>
 
-</androidx.preference.PreferenceScreen>
+</PreferenceScreen>


### PR DESCRIPTION
This simply corrects the XML preference tags (the androidx.preference prefix is not supposed to be used in XML; it is used [automatically](https://developer.android.com/guide/topics/ui/settings)).
