### PR TITLE
Fix: reset margins to zero in the Announcement dialog on the article screen

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.java
@@ -26,6 +26,8 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+
 public class AnnouncementCardView extends DefaultFeedCardView<AnnouncementCard> {
     public interface Callback {
         void onAnnouncementPositiveAction(@NonNull Card card, @NonNull Uri uri);
@@ -101,11 +103,7 @@ public class AnnouncementCardView extends DefaultFeedCardView<AnnouncementCard> 
         }
 
         if (card.isArticlePlacement()) {
-            LinearLayout.LayoutParams layoutParams = (LinearLayout.LayoutParams) container.getLayoutParams();
-            layoutParams.setMarginStart(0);
-            layoutParams.setMarginEnd(0);
-            layoutParams.setMargins(0, 0, 0, 0);
-            container.setLayoutParams(layoutParams);
+            container.setLayoutParams(new LinearLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT));
             container.setRadius(0);
         }
     }

--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.java
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.java
@@ -104,6 +104,7 @@ public class AnnouncementCardView extends DefaultFeedCardView<AnnouncementCard> 
             LinearLayout.LayoutParams layoutParams = (LinearLayout.LayoutParams) container.getLayoutParams();
             layoutParams.setMarginStart(0);
             layoutParams.setMarginEnd(0);
+            layoutParams.setMargins(0, 0, 0, 0);
             container.setLayoutParams(layoutParams);
             container.setRadius(0);
         }


### PR DESCRIPTION
The recently change in #1771 added a bottom margin to the view, and we should reset it to zero in the dialog on the article screen.