### PR TITLE
Tweak: don't let the seach bar top and bottom be cut

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/view/FeedAdapter.java
+++ b/app/src/main/java/org/wikipedia/feed/view/FeedAdapter.java
@@ -124,7 +124,7 @@ public class FeedAdapter<T extends View & FeedCardView<?>> extends DefaultRecycl
         final int bottomMargin = 8;
         layoutParams.bottomMargin = DimenUtil.roundedDpToPx(bottomMargin);
 
-        if (feedView != null && feedView.getColumns() > 1) {
+        if (DimenUtil.isLandscape(view.getContext())) {
             layoutParams.leftMargin = ((View) view.getParent()).getWidth() / 6;
             layoutParams.rightMargin = layoutParams.leftMargin;
         }

--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.java
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.java
@@ -368,6 +368,7 @@ public class HistoryFragment extends Fragment implements BackPressedHandler {
                         ? searchCardView.getWidth() / 6 + DimenUtil.roundedDpToPx(30f) : DimenUtil.roundedDpToPx(16f);
                 layoutParams.setMarginStart(horizontalMargin);
                 layoutParams.setMarginEnd(horizontalMargin);
+                layoutParams.setMargins(0, DimenUtil.roundedDpToPx(3f), 0, DimenUtil.roundedDpToPx(3f));
                 searchCardView.setLayoutParams(layoutParams);
             });
             searchCardView.setCardBackgroundColor(ResourceUtil.getThemedColor(requireContext(), R.attr.color_group_22));

--- a/app/src/main/res/layout/view_search_bar.xml
+++ b/app/src/main/res/layout/view_search_bar.xml
@@ -5,6 +5,7 @@
     android:layout_height="wrap_content"
     android:layout_marginStart="8dp"
     android:layout_marginEnd="8dp"
+    android:layout_marginVertical="3dp"
     android:clickable="true"
     android:focusable="true"
     android:transitionName="@string/transition_search_bar"


### PR DESCRIPTION
If we look closely, we'll notice that the search bar's top and bottom are being cut. It is more obvious when using the app on a tablet.

This PR also updates the logic of adjusting the view width only if the device is in landscape mode.

![螢幕擷取畫面 2020-11-16 144751](https://user-images.githubusercontent.com/2435576/99317333-bec87100-281a-11eb-8121-b4ba9fd4eeed.jpg)
