### PR TITLE
Fix: make sure to override the colorPrimary to prevent showing default color

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -31,6 +31,9 @@
         <item name="android:statusBarColor">@android:color/black</item>
         <item name="android:selectableItemBackground">@drawable/ripple_background</item>
         <item name="android:selectableItemBackgroundBorderless">@drawable/ripple_background_borderless</item>
+
+        <!-- TODO: remove when the components can get correct custom ?attr/colorPrimary -->
+        <item name="colorPrimary">?attr/colorPrimary</item>
     </style>
 
     <style name="AppTheme" parent="BaseAppTheme">


### PR DESCRIPTION
The default `colorPrimary` in material design is `#6200EE`, which is a purple color that we have seen in the past (e.g. view pager indicators, buttons...)

This is a temporary fix that replaces the default `colorPrimary` with our custom `?attr/colorPrimary` in the `BaseAppTheme`, and the result shows below:
![Screenshot_20201116-150710](https://user-images.githubusercontent.com/2435576/99319101-d1907500-281d-11eb-97c4-af84403031ec.jpg)

Other default colors might have the same issue, but we can hold until they really affect the app.
