### PR TITLE
Use buffering only whilst Offline

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/DestinationEventService.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/DestinationEventService.java
@@ -15,7 +15,7 @@ import static org.wikipedia.BuildConfig.EVENTGATE_LOGGING_EXTERNAL_BASE_URI;
  * event service configured as eventgate-analytics-external. However, that will likely change in
  * the future, so flexible destination event service support is added optimistically now.
  */
-enum DestinationEventService {
+public enum DestinationEventService {
 
     @SerializedName("eventgate-analytics-external") ANALYTICS (
             "eventgate-analytics-external",

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -259,7 +259,9 @@ public final class EventPlatformClient {
                     }
                 }
                 events.removeAll(eventsList);
-                postEvent(getStreamConfig(stream), eventsList);
+                if (eventsList != null && stream != null) {
+                    postEvent(getStreamConfig(stream), eventsList);
+                }
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -243,9 +243,6 @@ public final class EventPlatformClient {
          * @param events list of events
          */
         static void send(List<Event> events) {
-            if (!ENABLED) {
-                return;
-            }
             Map<String, ArrayList<Event>> eventsByStream = new HashMap<>();
             for (Event event : events) {
                 String stream = event.getStream();

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -19,7 +19,7 @@ import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegrati
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getStoredSessionId;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getStoredStreamConfigs;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.isOnline;
-import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.postEvent;
+import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.postEvents;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.setStoredSessionId;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.setStoredStreamConfigs;
 import static org.wikipedia.analytics.eventplatform.SamplingConfig.Identifier.DEVICE;
@@ -252,7 +252,7 @@ public final class EventPlatformClient {
                 eventsByStream.get(stream).add(event);
             }
             for (String stream : eventsByStream.keySet()) {
-                postEvent(getStreamConfig(stream), eventsByStream.get(stream));
+                postEvents(getStreamConfig(stream), eventsByStream.get(stream));
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -171,9 +171,14 @@ public final class EventPlatformClient {
         private static final int WAIT_MS = 30000;
 
         /*
-         * When QUEUE.size() exceeds this value TIMER becomes non-interruptable.
+         * While coming out of offline, When QUEUE.size() exceeds this value TIMER becomes non-interruptable.
          */
-        private static final int MAX_QUEUE_SIZE = WikipediaApp.getInstance().isOnline() ? 10 : 128;
+        private static final int MAX_OFFLINE_QUEUE_SIZE = 128;
+
+        /*
+         * While online, When QUEUE.size() exceeds this value TIMER becomes non-interruptable.
+         */
+        private static final int MAX_ONLINE_QUEUE_SIZE = 10;
 
         /*
          * IMPLEMENTATION NOTE: Java Timer will provide the desired asynchronous
@@ -222,7 +227,7 @@ public final class EventPlatformClient {
             QUEUE.add(event);
 
             if (ENABLED) {
-                if (QUEUE.size() >= MAX_QUEUE_SIZE) {
+                if (QUEUE.size() >= (WikipediaApp.getInstance().isOnline() ? MAX_ONLINE_QUEUE_SIZE : MAX_OFFLINE_QUEUE_SIZE)) {
                     /*
                      * >= because while sending is disabled, any number of items
                      * could be added to QUEUE without it emptying.

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -19,7 +19,7 @@ import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegrati
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getStoredSessionId;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getStoredStreamConfigs;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.isOnline;
-import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.postEvents;
+import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.postEvent;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.setStoredSessionId;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.setStoredStreamConfigs;
 import static org.wikipedia.analytics.eventplatform.SamplingConfig.Identifier.DEVICE;
@@ -252,7 +252,7 @@ public final class EventPlatformClient {
                 eventsByStream.get(stream).add(event);
             }
             for (String stream : eventsByStream.keySet()) {
-                postEvents(getStreamConfig(stream), eventsByStream.get(stream));
+                postEvent(getStreamConfig(stream), eventsByStream.get(stream));
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -1,7 +1,5 @@
 package org.wikipedia.analytics.eventplatform;
 
-import org.wikipedia.WikipediaApp;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -171,14 +169,9 @@ public final class EventPlatformClient {
         private static final int WAIT_MS = 30000;
 
         /*
-         * While coming out of offline, When QUEUE.size() exceeds this value TIMER becomes non-interruptable.
+         * When QUEUE.size() exceeds this value TIMER becomes non-interruptable.
          */
         private static final int MAX_OFFLINE_QUEUE_SIZE = 128;
-
-        /*
-         * While online, When QUEUE.size() exceeds this value TIMER becomes non-interruptable.
-         */
-        private static final int MAX_ONLINE_QUEUE_SIZE = 10;
 
         /*
          * IMPLEMENTATION NOTE: Java Timer will provide the desired asynchronous
@@ -225,7 +218,7 @@ public final class EventPlatformClient {
             QUEUE.add(event);
 
             if (ENABLED) {
-                if (QUEUE.size() >= (WikipediaApp.getInstance().isOnline() ? MAX_ONLINE_QUEUE_SIZE : MAX_OFFLINE_QUEUE_SIZE)) {
+                if (QUEUE.size() >= MAX_OFFLINE_QUEUE_SIZE) {
                     /*
                      * >= because while sending is disabled, any number of items
                      * could be added to QUEUE without it emptying.

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -171,7 +171,7 @@ public final class EventPlatformClient {
         /*
          * When QUEUE.size() exceeds this value TIMER becomes non-interruptable.
          */
-        private static final int MAX_OFFLINE_QUEUE_SIZE = 128;
+        private static final int MAX_QUEUE_SIZE = 128;
 
         /*
          * IMPLEMENTATION NOTE: Java Timer will provide the desired asynchronous
@@ -218,7 +218,7 @@ public final class EventPlatformClient {
             QUEUE.add(event);
 
             if (ENABLED) {
-                if (QUEUE.size() >= MAX_OFFLINE_QUEUE_SIZE) {
+                if (QUEUE.size() >= MAX_QUEUE_SIZE) {
                     /*
                      * >= because while sending is disabled, any number of items
                      * could be added to QUEUE without it emptying.

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -1,5 +1,7 @@
 package org.wikipedia.analytics.eventplatform;
 
+import org.wikipedia.WikipediaApp;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -171,7 +173,7 @@ public final class EventPlatformClient {
         /*
          * When QUEUE.size() exceeds this value TIMER becomes non-interruptable.
          */
-        private static final int MAX_QUEUE_SIZE = 128;
+        private static final int MAX_QUEUE_SIZE = WikipediaApp.getInstance().isOnline() ? 10 : 128;
 
         /*
          * IMPLEMENTATION NOTE: Java Timer will provide the desired asynchronous

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegration.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegration.java
@@ -53,7 +53,7 @@ final class EventPlatformClientIntegration {
      * @param streamConfig stream config
      * @param events Events to be posted. Gson will take care of serializing to JSON.
      */
-    static void postEvent(@NonNull StreamConfig streamConfig, @NonNull List<Event> events) {
+    static void postEvents(@NonNull StreamConfig streamConfig, @NonNull List<Event> events) {
         DISPOSABLES.add(ServiceFactory.getAnalyticsRest(streamConfig).postEvents(events)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegration.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegration.java
@@ -6,7 +6,6 @@ import androidx.annotation.Nullable;
 import org.wikipedia.WikipediaApp;
 import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.WikiSite;
-import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory;
 import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.log.L;
 
@@ -18,9 +17,6 @@ import java.util.Map;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import retrofit2.Retrofit;
-import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory;
-import retrofit2.converter.gson.GsonConverterFactory;
 
 import static java.net.HttpURLConnection.HTTP_ACCEPTED;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
@@ -29,8 +25,6 @@ import static java.net.HttpURLConnection.HTTP_GATEWAY_TIMEOUT;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static org.wikipedia.BuildConfig.META_WIKI_BASE_URI;
-import static org.wikipedia.json.GsonUtil.getDefaultGson;
-import static org.wikipedia.settings.Prefs.getEventPlatformIntakeUriOverride;
 import static org.wikipedia.settings.Prefs.getEventPlatformSessionId;
 import static org.wikipedia.settings.Prefs.getStreamConfigs;
 import static org.wikipedia.settings.Prefs.setEventPlatformSessionId;
@@ -51,42 +45,6 @@ final class EventPlatformClientIntegration {
     }
 
     /**
-     * Lazily instantiate a Retrofit service instance for the destination event service specified in
-     * the provided stream configuration.
-     *
-     * @param streamConfig stream configuration
-     * @return EventService
-     */
-    @NonNull
-    static EventService getEventService(@NonNull StreamConfig streamConfig) {
-        DestinationEventService destinationEventService = streamConfig.getDestinationEventService();
-        if (destinationEventService == null) {
-            destinationEventService = DestinationEventService.ANALYTICS;
-        }
-
-        EventService service;
-        if (RETROFIT_SERVICE_CACHE.containsKey(destinationEventService.getId())) {
-            service = RETROFIT_SERVICE_CACHE.get(destinationEventService.getId());
-            if (service != null) {
-                return service;
-            }
-        }
-
-        String intakeBaseUriOverride = getEventPlatformIntakeUriOverride();
-
-        service = new Retrofit.Builder()
-                .client(OkHttpConnectionFactory.getClient().newBuilder().build())
-                .baseUrl(intakeBaseUriOverride != null ? intakeBaseUriOverride : destinationEventService.getBaseUri())
-                .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
-                .addConverterFactory(GsonConverterFactory.create(getDefaultGson()))
-                .build()
-                .create(EventService.class);
-
-        RETROFIT_SERVICE_CACHE.put(destinationEventService.getId(), service);
-        return service;
-    }
-
-    /**
      * Post events to EventGate.
      *
      * Failures are logged remotely (as well as in Logcat). The only exception is for unexpected
@@ -95,8 +53,8 @@ final class EventPlatformClientIntegration {
      * @param streamConfig stream config
      * @param events Events to be posted. Gson will take care of serializing to JSON.
      */
-    static void postEvents(@NonNull StreamConfig streamConfig, @NonNull List<Event> events) {
-        DISPOSABLES.add(getEventService(streamConfig).postEvents(events)
+    static void postEvent(@NonNull StreamConfig streamConfig, @NonNull List<Event> events) {
+        DISPOSABLES.add(ServiceFactory.getAnalyticsRest(streamConfig).postEvents(events)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> {

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegration.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegration.java
@@ -96,7 +96,7 @@ final class EventPlatformClientIntegration {
      * @param events Events to be posted. Gson will take care of serializing to JSON.
      */
     static void postEvent(@NonNull StreamConfig streamConfig, @NonNull List<Event> events) {
-        DISPOSABLES.add(getEventService(streamConfig).postEvent(events)
+        DISPOSABLES.add(getEventService(streamConfig).postEvents(events)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> {

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegration.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegration.java
@@ -95,7 +95,7 @@ final class EventPlatformClientIntegration {
      * @param streamConfig stream config
      * @param events Events to be posted. Gson will take care of serializing to JSON.
      */
-    static void postEvent(@NonNull StreamConfig streamConfig, @NonNull List<Event> events) {
+    static void postEvents(@NonNull StreamConfig streamConfig, @NonNull List<Event> events) {
         DISPOSABLES.add(getEventService(streamConfig).postEvents(events)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.java
@@ -2,8 +2,9 @@ package org.wikipedia.analytics.eventplatform;
 
 import androidx.annotation.NonNull;
 
-import io.reactivex.rxjava3.core.Observable;
+import java.util.List;
 
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Response;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
@@ -20,5 +21,5 @@ import retrofit2.http.POST;
  */
 interface EventService {
     @POST("/v1/events?hasty=true")
-    Observable<Response<EventServiceResponse>> postEvent(@NonNull @Body Event event);
+    Observable<Response<EventServiceResponse>> postEvent(@NonNull @Body List<Event> events);
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.java
@@ -21,5 +21,5 @@ import retrofit2.http.POST;
  */
 interface EventService {
     @POST("/v1/events?hasty=true")
-    Observable<Response<EventServiceResponse>> postEvent(@NonNull @Body List<Event> events);
+    Observable<Response<EventServiceResponse>> postEvents(@NonNull @Body List<Event> events);
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.java
@@ -19,7 +19,7 @@ import retrofit2.http.POST;
  * TODO: In the future, consider updating to wait for processing and handle partial-success and
  * failure responses.
  */
-interface EventService {
+public interface EventService {
     @POST("/v1/events?hasty=true")
     Observable<Response<EventServiceResponse>> postEvents(@NonNull @Body List<Event> events);
 }

--- a/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.java
+++ b/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.java
@@ -6,7 +6,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.collection.LruCache;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wikipedia.WikipediaApp;
+import org.wikipedia.analytics.eventplatform.DestinationEventService;
+import org.wikipedia.analytics.eventplatform.EventService;
+import org.wikipedia.analytics.eventplatform.StreamConfig;
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory;
 import org.wikipedia.json.GsonUtil;
 import org.wikipedia.settings.Prefs;
@@ -14,17 +18,21 @@ import org.wikipedia.settings.Prefs;
 import java.io.IOException;
 
 import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 
+import static org.wikipedia.settings.Prefs.getEventPlatformIntakeUriOverride;
+
 public final class ServiceFactory {
     private static final int SERVICE_CACHE_SIZE = 8;
     private static LruCache<Long, Service> SERVICE_CACHE = new LruCache<>(SERVICE_CACHE_SIZE);
     private static LruCache<Long, RestService> REST_SERVICE_CACHE = new LruCache<>(SERVICE_CACHE_SIZE);
     private static LruCache<Long, CoreRestService> CORE_REST_SERVICE_CACHE = new LruCache<>(SERVICE_CACHE_SIZE);
+    private static LruCache<String, EventService> ANALYTICS_REST_SERVICE_CACHE = new LruCache<>(SERVICE_CACHE_SIZE);
 
     public static Service get(@NonNull WikiSite wiki) {
         long hashCode = wiki.hashCode();
@@ -59,6 +67,28 @@ public final class ServiceFactory {
         return s;
     }
 
+    public static EventService getAnalyticsRest(@NonNull StreamConfig streamConfig) {
+        DestinationEventService destinationEventService = streamConfig.getDestinationEventService();
+        if (destinationEventService == null) {
+            destinationEventService = DestinationEventService.ANALYTICS;
+        }
+
+        EventService s;
+        if (ANALYTICS_REST_SERVICE_CACHE.get(destinationEventService.getId()) != null) {
+            s = ANALYTICS_REST_SERVICE_CACHE.get(destinationEventService.getId());
+            if (s != null) {
+                return s;
+            }
+        }
+
+        String intakeBaseUriOverride = getEventPlatformIntakeUriOverride();
+
+        Retrofit r = createRetrofit(null, StringUtils.defaultString(intakeBaseUriOverride, destinationEventService.getBaseUri()));
+        s = r.create(EventService.class);
+        ANALYTICS_REST_SERVICE_CACHE.put(destinationEventService.getId(), s);
+        return s;
+    }
+
     public static <T> T get(@NonNull WikiSite wiki, @Nullable String baseUrl, Class<T> service) {
         Retrofit r = createRetrofit(wiki, TextUtils.isEmpty(baseUrl) ? wiki.url() + "/" : baseUrl);
         return r.create(service);
@@ -78,10 +108,13 @@ public final class ServiceFactory {
         return path;
     }
 
-    private static Retrofit createRetrofit(@NonNull WikiSite wiki, @NonNull String baseUrl) {
+    private static Retrofit createRetrofit(@Nullable WikiSite wiki, @NonNull String baseUrl) {
+        OkHttpClient.Builder okHttpClientBuilder = OkHttpConnectionFactory.getClient().newBuilder();
+        if (wiki != null) {
+            okHttpClientBuilder.addInterceptor(new LanguageVariantHeaderInterceptor(wiki));
+        }
         return new Retrofit.Builder()
-                .client(OkHttpConnectionFactory.getClient().newBuilder()
-                        .addInterceptor(new LanguageVariantHeaderInterceptor(wiki)).build())
+                .client(okHttpClientBuilder.build())
                 .baseUrl(baseUrl)
                 .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
                 .addConverterFactory(GsonConverterFactory.create(GsonUtil.getDefaultGson()))

--- a/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegrationTest.java
+++ b/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegrationTest.java
@@ -3,6 +3,7 @@ package org.wikipedia.analytics.eventplatform;
 import com.google.gson.Gson;
 
 import org.junit.Test;
+import org.wikipedia.dataclient.ServiceFactory;
 import org.wikipedia.dataclient.mwapi.MwStreamConfigsResponse;
 import org.wikipedia.json.GsonMarshaller;
 import org.wikipedia.test.MockRetrofitTest;
@@ -21,7 +22,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.wikipedia.analytics.eventplatform.DestinationEventService.LOGGING;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClient.setStreamConfig;
-import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getEventService;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getIso8601Timestamp;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getStoredStreamConfigs;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.postEvents;
@@ -37,13 +37,13 @@ public class EventPlatformClientIntegrationTest extends MockRetrofitTest {
     @Test
     public void testGetEventService() {
         StreamConfig streamConfig = new StreamConfig("test", null, LOGGING);
-        assertThat(getEventService(streamConfig), is(notNullValue()));
+        assertThat(ServiceFactory.getAnalyticsRest(streamConfig), is(notNullValue()));
     }
 
     @Test
     public void testGetEventServiceDefaultDestination() {
         StreamConfig streamConfig = new StreamConfig("test");
-        assertThat(getEventService(streamConfig), is(notNullValue()));
+        assertThat(ServiceFactory.getAnalyticsRest(streamConfig), is(notNullValue()));
     }
 
     @Test

--- a/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegrationTest.java
+++ b/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegrationTest.java
@@ -9,6 +9,8 @@ import org.wikipedia.test.MockRetrofitTest;
 import org.wikipedia.test.TestFileUtil;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import okhttp3.mockwebserver.MockResponse;
@@ -52,18 +54,22 @@ public class EventPlatformClientIntegrationTest extends MockRetrofitTest {
 
     @Test
     public void testPostEventsSuccess() {
+        List<Event> events = new ArrayList<>();
         StreamConfig streamConfig = new StreamConfig("test");
         setStreamConfig(streamConfig);
         server().enqueue(new MockResponse().setResponseCode(202));
-        postEvent(streamConfig, new Event("test", "test"));
+        events.add(new Event("test", "test"));
+        postEvent(streamConfig, events);
     }
 
     @Test
     public void testDoesNotThrowOnPostEventsFailureResponse() {
+        List<Event> events = new ArrayList<>();
         StreamConfig streamConfig = new StreamConfig("test");
         setStreamConfig(streamConfig);
         server().enqueue(new MockResponse().setResponseCode(400));
-        postEvent(streamConfig, new Event("test", "test"));
+        events.add(new Event("test", "test"));
+        postEvent(streamConfig, events);
     }
 
     @Test

--- a/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegrationTest.java
+++ b/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientIntegrationTest.java
@@ -24,7 +24,7 @@ import static org.wikipedia.analytics.eventplatform.EventPlatformClient.setStrea
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getEventService;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getIso8601Timestamp;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.getStoredStreamConfigs;
-import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.postEvent;
+import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.postEvents;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClientIntegration.setStoredStreamConfigs;
 import static org.wikipedia.json.GsonUtil.getDefaultGson;
 
@@ -59,7 +59,7 @@ public class EventPlatformClientIntegrationTest extends MockRetrofitTest {
         setStreamConfig(streamConfig);
         server().enqueue(new MockResponse().setResponseCode(202));
         events.add(new Event("test", "test"));
-        postEvent(streamConfig, events);
+        postEvents(streamConfig, events);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class EventPlatformClientIntegrationTest extends MockRetrofitTest {
         setStreamConfig(streamConfig);
         server().enqueue(new MockResponse().setResponseCode(400));
         events.add(new Event("test", "test"));
-        postEvent(streamConfig, events);
+        postEvents(streamConfig, events);
     }
 
     @Test


### PR DESCRIPTION
Buffering while online creates unnecessary flurry of 128 network calls. We can limit this batching to 10 when online and 128 while offline