### PR TITLE
Fix possible crash from tab removal conditions.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1257,8 +1257,8 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         }
         // if the current tab can no longer go back, then close the tab before exiting
         if (!app.getTabList().isEmpty()) {
-            int tabIndex = app.getTabList().size() - 1;
-            app.getTabList().remove(tabIndex);
+            app.getTabList().remove(app.getTabList().size() - 1);
+            app.commitTabState();
         }
         return false;
     }


### PR DESCRIPTION
This fixes a necessary precondition that I believe could lead to this weird crash.

https://appcenter.ms/orgs/ci-apps-hockeyapp-f5mf/apps/Wikipedia-Beta/crashes/errors/466475843u/overview