### PR TITLE
Use actual image width and height for the lead image transition animation

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.java
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.java
@@ -52,7 +52,7 @@ public class PageSummary {
         this.titles = new Titles(displayTitle, prefixTitle);
         this.description = description;
         this.extract = extract;
-        this.thumbnail = new Thumbnail(thumbnail);
+        this.thumbnail = new Thumbnail(thumbnail, 0, 0);
         this.lang = lang;
     }
 
@@ -104,6 +104,14 @@ public class PageSummary {
         return thumbnail == null ? null : thumbnail.getUrl();
     }
 
+    public int getThumbnailWidth() {
+        return thumbnail == null ? 0 : thumbnail.getWidth();
+    }
+
+    public int getThumbnailHeight() {
+        return thumbnail == null ? 0 : thumbnail.getHeight();
+    }
+
     public void setDescription(@Nullable String description) {
         this.description = description;
     }
@@ -138,14 +146,26 @@ public class PageSummary {
     }
 
     private static class Thumbnail {
-        private String source;
+        private final String source;
+        private final int width;
+        private final int height;
 
-        Thumbnail(@Nullable String source) {
+        Thumbnail(@Nullable String source, int width, int height) {
             this.source = source;
+            this.width = width;
+            this.height = height;
         }
 
         public String getUrl() {
             return source;
+        }
+
+        public int getWidth() {
+            return width;
+        }
+
+        public int getHeight() {
+            return height;
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageProperties.java
+++ b/app/src/main/java/org/wikipedia/page/PageProperties.java
@@ -19,6 +19,7 @@ import org.wikipedia.util.log.L;
 
 import java.text.ParseException;
 import java.util.Date;
+import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.wikipedia.util.DateUtil.iso8601DateParse;
@@ -35,8 +36,10 @@ public class PageProperties implements Parcelable {
     private String editProtectionStatus;
     private final boolean isMainPage;
     /** Nullable URL with no scheme. For example, foo.bar.com/ instead of http://foo.bar.com/. */
-    @Nullable private String leadImageUrl;
-    @Nullable private String leadImageName;
+    @Nullable private final String leadImageUrl;
+    @Nullable private final String leadImageName;
+    private final int leadImageWidth;
+    private final int leadImageHeight;
     @Nullable private final Location geo;
     @Nullable private final String wikiBaseItem;
     @Nullable private final String descriptionSource;
@@ -62,6 +65,8 @@ public class PageProperties implements Parcelable {
         leadImageName = UriUtil.decodeURL(StringUtils.defaultString(pageSummary.getLeadImageName()));
         leadImageUrl = pageSummary.getThumbnailUrl() != null
                 ? UriUtil.resolveProtocolRelativeUrl(ImageUrlUtil.getUrlForPreferredSize(pageSummary.getThumbnailUrl(), DimenUtil.calculateLeadImageWidth())) : null;
+        leadImageWidth = pageSummary.getThumbnailWidth();
+        leadImageHeight = pageSummary.getThumbnailHeight();
         String lastModifiedText = pageSummary.getTimestamp();
         if (lastModifiedText != null) {
             try {
@@ -91,6 +96,8 @@ public class PageProperties implements Parcelable {
         editProtectionStatus = "";
         leadImageUrl = null;
         leadImageName = "";
+        leadImageWidth = 0;
+        leadImageHeight = 0;
         lastModified = new Date();
         canEdit = false;
         this.isMainPage = isMainPage;
@@ -149,6 +156,14 @@ public class PageProperties implements Parcelable {
         return leadImageName;
     }
 
+    public int getLeadImageWidth() {
+        return leadImageWidth;
+    }
+
+    public int getLeadImageHeight() {
+        return leadImageHeight;
+    }
+
     @Nullable
     public String getWikiBaseItem() {
         return wikiBaseItem;
@@ -187,6 +202,8 @@ public class PageProperties implements Parcelable {
         parcel.writeInt(isMainPage ? 1 : 0);
         parcel.writeString(leadImageUrl);
         parcel.writeString(leadImageName);
+        parcel.writeInt(leadImageWidth);
+        parcel.writeInt(leadImageHeight);
         parcel.writeString(wikiBaseItem);
         parcel.writeString(descriptionSource);
     }
@@ -203,6 +220,8 @@ public class PageProperties implements Parcelable {
         isMainPage = in.readInt() == 1;
         leadImageUrl = in.readString();
         leadImageName = in.readString();
+        leadImageWidth = in.readInt();
+        leadImageHeight = in.readInt();
         wikiBaseItem = in.readString();
         descriptionSource = in.readString();
     }
@@ -236,12 +255,14 @@ public class PageProperties implements Parcelable {
                 && revisionId == that.revisionId
                 && lastModified.equals(that.lastModified)
                 && displayTitleText.equals(that.displayTitleText)
-                && (geo == that.geo || geo != null && geo.equals(that.geo))
+                && Objects.equals(geo, that.geo)
                 && canEdit == that.canEdit
                 && isMainPage == that.isMainPage
                 && TextUtils.equals(editProtectionStatus, that.editProtectionStatus)
                 && TextUtils.equals(leadImageUrl, that.leadImageUrl)
                 && TextUtils.equals(leadImageName, that.leadImageName)
+                && leadImageWidth == that.leadImageWidth
+                && leadImageHeight == that.leadImageHeight
                 && TextUtils.equals(wikiBaseItem, that.wikiBaseItem);
     }
 
@@ -254,6 +275,8 @@ public class PageProperties implements Parcelable {
         result = 31 * result + (isMainPage ? 1 : 0);
         result = 31 * result + (leadImageUrl != null ? leadImageUrl.hashCode() : 0);
         result = 31 * result + (leadImageName != null ? leadImageName.hashCode() : 0);
+        result = 31 * result + leadImageWidth;
+        result = 31 * result + leadImageHeight;
         result = 31 * result + (wikiBaseItem != null ? wikiBaseItem.hashCode() : 0);
         result = 31 * result + (canEdit ? 1 : 0);
         result = 31 * result + pageId;

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.java
@@ -192,6 +192,14 @@ public class LeadImagesHandler {
         }
     }
 
+    private int getLeadImageWidth() {
+        return getPage() == null ? pageHeaderView.image.getWidth() : getPage().getPageProperties().getLeadImageWidth();
+    }
+
+    private int getLeadImageHeight() {
+        return getPage() == null ? pageHeaderView.image.getHeight() : getPage().getPageProperties().getLeadImageHeight();
+    }
+
     @Nullable private String getLeadImageUrl() {
         String url = getPage() == null ? null : getPage().getPageProperties().getLeadImageUrl();
         if (url == null) {
@@ -248,7 +256,7 @@ public class LeadImagesHandler {
                 WikiSite wiki = language == null ? getTitle().getWikiSite() : WikiSite.forLanguageCode(language);
 
                 JavaScriptActionHandler.ImageHitInfo hitInfo = new JavaScriptActionHandler.ImageHitInfo(pageHeaderView.image.getLeft(),
-                        pageHeaderView.image.getTop(), pageHeaderView.image.getWidth(), pageHeaderView.image.getHeight(),
+                        pageHeaderView.image.getTop(), getLeadImageWidth(), getLeadImageHeight(),
                         getLeadImageUrl(), true);
 
                 GalleryActivity.setTransitionInfo(hitInfo);


### PR DESCRIPTION
For the current implementation, we will see the center cropped image in the Gallery before the actual image is loaded. If the cropped image contains a human, it will look not that good while loading.