### PR TITLE
Simplify and reduce jankiness of feed-to-page transition animation.

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.java
+++ b/app/src/main/java/org/wikipedia/Constants.java
@@ -48,6 +48,7 @@ public final class Constants {
     public static final String INTENT_EXTRA_GO_TO_SE_TAB = "goToSETab";
     public static final String INTENT_EXTRA_INVOKE_SOURCE = "invokeSource";
     public static final String INTENT_EXTRA_ACTION = "intentAction";
+    public static final String INTENT_EXTRA_HAS_TRANSITION_ANIM = "hasTransitionAnim";
 
     public static final int SUGGESTION_REQUEST_ITEMS = 5;
     public static final int API_QUERY_MAX_TITLES = 50;

--- a/app/src/main/java/org/wikipedia/main/MainFragment.java
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.java
@@ -287,10 +287,12 @@ public class MainFragment extends Fragment implements BackPressedHandler, FeedFr
     }
 
     @Override public final void onFeedSelectPageWithAnimation(HistoryEntry entry, Pair<View, String>[] sharedElements) {
-        ActivityOptionsCompat options = ActivityOptionsCompat.
-                makeSceneTransitionAnimation(requireActivity(), sharedElements);
-        startActivity(PageActivity.newIntentForExistingTab(requireContext(), entry, entry.getTitle()),
-                DimenUtil.isLandscape(requireContext()) || sharedElements.length == 0 ? null : options.toBundle());
+        ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(requireActivity(), sharedElements);
+        Intent intent = PageActivity.newIntentForExistingTab(requireContext(), entry, entry.getTitle());
+        if (sharedElements.length > 0) {
+            intent.putExtra(Constants.INTENT_EXTRA_HAS_TRANSITION_ANIM, true);
+        }
+        startActivity(intent, DimenUtil.isLandscape(requireContext()) || sharedElements.length == 0 ? null : options.toBundle());
     }
 
     @Override public void onFeedAddPageToList(HistoryEntry entry, boolean addToDefault) {

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -159,6 +159,9 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         super.onCreate(savedInstanceState);
         app = (WikipediaApp) getApplicationContext();
 
+        hasTransitionAnimation = getIntent().getBooleanExtra(Constants.INTENT_EXTRA_HAS_TRANSITION_ANIM, false);
+        getWindow().getSharedElementEnterTransition().addListener(transitionListener);
+
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
 
         try {
@@ -662,12 +665,8 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         overflowView.show(anchor, overflowCallback, pageFragment.getCurrentTab());
     }
 
-    @SuppressWarnings("checkstyle:magicnumber")
     private void setTransitionViews(@NonNull PageTitle title) {
-        // Should only set the view after running the transition animation from Explore feed.
-        if (!wikiArticleCardView.isLoaded()) {
-            getWindow().getSharedElementEnterTransition().addListener(transitionListener);
-
+        if (hasTransitionAnimation) {
             pageFragmentView.setVisibility(View.GONE);
 
             Uri uri = TextUtils.isEmpty(title.getThumbUrl()) ? null : Uri.parse(title.getThumbUrl());
@@ -682,7 +681,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
             wikiArticleCardView.setTitle(title.getDisplayText());
             wikiArticleCardView.setDescription(title.getDescription());
-            wikiArticleCardView.setLoaded(true);
             L10nUtil.setConditionalLayoutDirection(wikiArticleCardView, title.getWikiSite().languageCode());
         }
     }
@@ -690,28 +688,22 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     private final Transition.TransitionListener transitionListener = new Transition.TransitionListener() {
         @Override
         public void onTransitionStart(Transition transition) {
-            toolbarContainerView.setAlpha(0);
         }
 
         @Override
         public void onTransitionEnd(Transition transition) {
-            toolbarContainerView.setAlpha(1);
-            hasTransitionAnimation = true;
         }
 
         @Override
         public void onTransitionCancel(Transition transition) {
-
         }
 
         @Override
         public void onTransitionPause(Transition transition) {
-
         }
 
         @Override
         public void onTransitionResume(Transition transition) {
-
         }
     };
 

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -523,11 +523,20 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
     @Override
     public void onPageLoadComplete() {
+        removeTransitionAnimState();
+    }
+
+    private void removeTransitionAnimState() {
         if (pageFragmentView.getVisibility() != View.VISIBLE) {
             pageFragmentView.setVisibility(View.VISIBLE);
         }
         if (wikiArticleCardView.getVisibility() != View.GONE) {
-            wikiArticleCardView.setVisibility(View.GONE);
+            final int delayMillis = 250;
+            wikiArticleCardView.postDelayed(() -> {
+                if (wikiArticleCardView != null) {
+                    wikiArticleCardView.setVisibility(View.GONE);
+                }
+            }, delayMillis);
         }
     }
 
@@ -619,6 +628,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     @Override
     public void onPageLoadError(@NonNull PageTitle title) {
         getSupportActionBar().setTitle(title.getDisplayText());
+        removeTransitionAnimState();
     }
 
     @Override

--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -11,7 +11,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
-import android.transition.Transition;
 import android.view.ActionMode;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -21,7 +20,6 @@ import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
@@ -65,7 +63,6 @@ import org.wikipedia.util.ClipboardUtil;
 import org.wikipedia.util.DeviceUtil;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
-import org.wikipedia.util.L10nUtil;
 import org.wikipedia.util.ReleaseUtil;
 import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.util.ShareUtil;
@@ -137,6 +134,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
     private PageFragment pageFragment;
     private boolean hasTransitionAnimation;
+    private boolean wasTransitionShown;
 
     private WikipediaApp app;
     private Set<ActionMode> currentActionModes = new HashSet<>();
@@ -158,9 +156,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         app = (WikipediaApp) getApplicationContext();
-
-        hasTransitionAnimation = getIntent().getBooleanExtra(Constants.INTENT_EXTRA_HAS_TRANSITION_ANIM, false);
-        getWindow().getSharedElementEnterTransition().addListener(transitionListener);
 
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
 
@@ -209,6 +204,9 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
             pageFragment.updateInsets(insets);
             return insets;
         });
+
+        hasTransitionAnimation = getIntent().getBooleanExtra(Constants.INTENT_EXTRA_HAS_TRANSITION_ANIM, false);
+        wikiArticleCardView.setVisibility(hasTransitionAnimation ? View.VISIBLE : View.GONE);
 
         boolean languageChanged = false;
         if (savedInstanceState != null) {
@@ -438,7 +436,11 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
             return;
         }
 
-        setTransitionViews(title);
+        if (hasTransitionAnimation && !wasTransitionShown) {
+            pageFragmentView.setVisibility(View.GONE);
+            wikiArticleCardView.prepareForTransition(title);
+            wasTransitionShown = true;
+        }
 
         if (entry.getSource() != HistoryEntry.SOURCE_INTERNAL_LINK || !isLinkPreviewEnabled()) {
             new LinkPreviewFunnel(app, entry.getSource()).logNavigate();
@@ -519,8 +521,14 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         bottomSheetPresenter.showMoveToListDialog(getSupportFragmentManager(), sourceReadingListId, title, source, showDefaultList, listDialogDismissListener);
     }
 
-    public void showPageFragmentView() {
-        pageFragmentView.setVisibility(View.VISIBLE);
+    @Override
+    public void onPageLoadComplete() {
+        if (pageFragmentView.getVisibility() != View.VISIBLE) {
+            pageFragmentView.setVisibility(View.VISIBLE);
+        }
+        if (wikiArticleCardView.getVisibility() != View.GONE) {
+            wikiArticleCardView.setVisibility(View.GONE);
+        }
     }
 
     // Note: back button first handled in {@link #onOptionsItemSelected()};
@@ -541,6 +549,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         if (DimenUtil.isLandscape(this) || !hasTransitionAnimation) {
             wikiArticleCardView.setVisibility(View.GONE);
         } else {
+            wikiArticleCardView.setVisibility(View.VISIBLE);
             pageFragmentView.setVisibility(View.GONE);
         }
         super.onBackPressed();
@@ -664,48 +673,6 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         PageActionOverflowView overflowView = new PageActionOverflowView(this);
         overflowView.show(anchor, overflowCallback, pageFragment.getCurrentTab());
     }
-
-    private void setTransitionViews(@NonNull PageTitle title) {
-        if (hasTransitionAnimation) {
-            pageFragmentView.setVisibility(View.GONE);
-
-            Uri uri = TextUtils.isEmpty(title.getThumbUrl()) ? null : Uri.parse(title.getThumbUrl());
-            if (uri == null || DimenUtil.isLandscape(this) || !Prefs.isImageDownloadEnabled()) {
-                wikiArticleCardView.getImageContainer().setVisibility(View.GONE);
-            } else {
-                wikiArticleCardView.getImageContainer().setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
-                        DimenUtil.leadImageHeightForDevice(this) - DimenUtil.getToolbarHeightPx(this)));
-                wikiArticleCardView.getImageContainer().setVisibility(View.VISIBLE);
-                wikiArticleCardView.getImageView().loadImage(uri);
-            }
-
-            wikiArticleCardView.setTitle(title.getDisplayText());
-            wikiArticleCardView.setDescription(title.getDescription());
-            L10nUtil.setConditionalLayoutDirection(wikiArticleCardView, title.getWikiSite().languageCode());
-        }
-    }
-
-    private final Transition.TransitionListener transitionListener = new Transition.TransitionListener() {
-        @Override
-        public void onTransitionStart(Transition transition) {
-        }
-
-        @Override
-        public void onTransitionEnd(Transition transition) {
-        }
-
-        @Override
-        public void onTransitionCancel(Transition transition) {
-        }
-
-        @Override
-        public void onTransitionPause(Transition transition) {
-        }
-
-        @Override
-        public void onTransitionResume(Transition transition) {
-        }
-    };
 
     private class OverflowCallback implements PageActionOverflowView.Callback {
         @Override

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -143,6 +143,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         ThemeChooserDialog.Callback, ReferenceDialog.Callback, WiktionaryDialog.Callback {
     public interface Callback {
         void onPageDismissBottomSheet();
+        void onPageLoadComplete();
         void onPageLoadPage(@NonNull PageTitle title, @NonNull HistoryEntry entry);
         void onPageInitWebView(@NonNull ObservableWebView v);
         void onPageShowLinkPreview(@NonNull HistoryEntry entry);
@@ -491,8 +492,6 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
                         bridge.execute(JavaScriptActionHandler.mobileWebChromeShim());
                     }
                 });
-
-                ((PageActivity) requireActivity()).showPageFragmentView();
             }
 
             @Override
@@ -1078,6 +1077,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
                 return;
             }
             bridge.onPcsReady();
+            callback().onPageLoadComplete();
         });
         bridge.addListener("reference", (String messageType, JsonObject messagePayload) -> {
             if (!isAdded()) {

--- a/app/src/main/java/org/wikipedia/views/WikiArticleCardView.kt
+++ b/app/src/main/java/org/wikipedia/views/WikiArticleCardView.kt
@@ -13,9 +13,6 @@ import org.wikipedia.util.StringUtil
 import org.wikipedia.util.TransitionUtil
 
 class WikiArticleCardView constructor(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
-
-    var isLoaded: Boolean = false
-
     init {
         View.inflate(context, R.layout.view_wiki_article_card, this)
     }

--- a/app/src/main/java/org/wikipedia/views/WikiArticleCardView.kt
+++ b/app/src/main/java/org/wikipedia/views/WikiArticleCardView.kt
@@ -1,14 +1,19 @@
 package org.wikipedia.views
 
 import android.content.Context
+import android.net.Uri
+import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import androidx.core.util.Pair
 import kotlinx.android.synthetic.main.view_wiki_article_card.view.*
-import kotlinx.android.synthetic.main.view_wiki_article_card.view.articleExtract
-import kotlinx.android.synthetic.main.view_wiki_article_card.view.articleTitle
 import org.wikipedia.R
+import org.wikipedia.page.PageTitle
+import org.wikipedia.settings.Prefs
+import org.wikipedia.util.DimenUtil
+import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.TransitionUtil
 
@@ -39,5 +44,21 @@ class WikiArticleCardView constructor(context: Context, attrs: AttributeSet? = n
 
     fun getSharedElements(): Array<Pair<View, String>> {
         return TransitionUtil.getSharedElements(context, articleTitle, articleDescription, articleImage, articleDivider)
+    }
+
+    fun prepareForTransition(title: PageTitle) {
+        val uri = if (TextUtils.isEmpty(title.thumbUrl)) null else Uri.parse(title.thumbUrl)
+        if (uri == null || DimenUtil.isLandscape(context) || !Prefs.isImageDownloadEnabled()) {
+            articleImageContainer.visibility = GONE
+        } else {
+            articleImageContainer.layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
+                    DimenUtil.leadImageHeightForDevice(context) - DimenUtil.getToolbarHeightPx(context))
+            articleImageContainer.visibility = VISIBLE
+            articleImage.loadImage(uri)
+        }
+
+        setTitle(title.displayText)
+        setDescription(title.description)
+        L10nUtil.setConditionalLayoutDirection(this, title.wikiSite.languageCode())
     }
 }

--- a/app/src/main/res/layout/activity_page.xml
+++ b/app/src/main/res/layout/activity_page.xml
@@ -89,7 +89,7 @@
         <org.wikipedia.views.WikiArticleCardView
             android:id="@+id/wiki_article_card_view"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_marginTop="?attr/actionBarSize"/>
 
     </org.wikipedia.views.FrameLayoutNavMenuTriggerer>

--- a/app/src/main/res/layout/activity_page.xml
+++ b/app/src/main/res/layout/activity_page.xml
@@ -13,12 +13,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <org.wikipedia.views.WikiArticleCardView
-            android:id="@+id/wiki_article_card_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="?attr/actionBarSize"/>
-
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/page_fragment"
             android:name="org.wikipedia.page.PageFragment"
@@ -91,6 +85,12 @@
                 android:indeterminate="true" />
 
         </FrameLayout>
+
+        <org.wikipedia.views.WikiArticleCardView
+            android:id="@+id/wiki_article_card_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="?attr/actionBarSize"/>
 
     </org.wikipedia.views.FrameLayoutNavMenuTriggerer>
 


### PR DESCRIPTION
The new "wikiArticleCardView" in the PageActivity is being shown at inappropriate times, and is causing unnecessary jankiness and flashing when loading articles.
