### PR TITLE
Tweak: changes to overflow menu in tabs overview screen

### DIFF
--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.java
@@ -272,12 +272,6 @@ public class TabActivity extends BaseActivity {
             case R.id.menu_explore:
                 goToMainTab(NavTab.EXPLORE);
                 return true;
-            case R.id.menu_reading_lists:
-                goToMainTab(NavTab.READING_LISTS);
-                return true;
-            case R.id.menu_search:
-                goToMainTab(NavTab.SEARCH);
-                return true;
             default:
                 break;
         }

--- a/app/src/main/res/menu/menu_tabs.xml
+++ b/app/src/main/res/menu/menu_tabs.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
     <item android:id="@+id/menu_open_a_new_tab"
-          android:title="@string/menu_page_open_a_new_tab"
+          android:title="@string/menu_page_open_a_new_tab_v2"
           app:showAsAction="never" />
     <item android:id="@+id/menu_save_all_tabs"
         android:title="@string/menu_save_all_tabs"
@@ -12,11 +12,5 @@
         app:showAsAction="never" />
     <item android:id="@+id/menu_explore"
         android:title="@string/feed"
-        app:showAsAction="never" />
-    <item android:id="@+id/menu_reading_lists"
-        android:title="@string/nav_item_reading_lists"
-        app:showAsAction="never" />
-    <item android:id="@+id/menu_search"
-        android:title="@string/nav_item_search"
         app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -82,6 +82,7 @@
   <string name="feed_card_add_to_default_list">Menu item for adding the a card from the feed to a default reading list.</string>
   <string name="menu_page_share">Menu item text for sharing the currently active page. Uses the build-in Android sharing functionality, so translate it the same way as the operating system does.\n{{Identical|Share}}</string>
   <string name="menu_page_open_a_new_tab">Menu item text for opening a new tab.</string>
+  <string name="menu_page_open_a_new_tab_v2">Menu item text for opening a new tab.</string>
   <string name="menu_page_reading_lists">&gt;Menu item text for opening the reading lists page.</string>
   <string name="menu_page_recently_viewed">&gt;Menu item text for opening the history page.</string>
   <string name="menu_long_press_open_page">Menu item for opening a link in the current tab.\n{{Identical|Open}}</string>
@@ -866,12 +867,10 @@
   <string name="suggested_edits_contribution_type_image_tag">Text indicating that the user edit was an Image tag edit</string>
   <string name="suggested_edits_contribution_current_revision_text">Text indicating that the user\'s edit was the most recent one on a given image or article</string>
   <string name="suggested_card_more_edits">Label text for SE feed card footer action.</string>
-  <string name="suggested_edits_tags_diff_count_text">Label text indicating the number of tags added or removed by a user contribution. %1$s represents the number.</string>
   <plurals name="suggested_edits_contribution_diff_count_text">
     <item quantity="one">Label text indicating the number of characters added or removed by a user contribution. %1$s represents the number.</item>
     <item quantity="other">Label text indicating the number of characters added or removed by a user contribution. %1$s represents the number.</item>
   </plurals>
-  <string name="suggested_edits_removed_contribution_label">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are removed by the contribution.</string>
   <plurals name="suggested_edits_added_contribution_label">
     <item quantity="one">Text summarizing the user\'s contribution to the article or image. %d represents the number when only one character is added.</item>
     <item quantity="other">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are added.</item>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -875,6 +875,14 @@
     <item quantity="one">Text summarizing the user\'s contribution to the article or image. %d represents the number when only one character is added.</item>
     <item quantity="other">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are added.</item>
   </plurals>
+  <plurals name="suggested_edits_tags_diff_count_text">
+    <item quantity="one">Label text indicating the number of tags added or removed by a user contribution. %1$s represents the number.</item>
+    <item quantity="other">Label text indicating the number of tags added or removed by a user contribution. %1$s represents the number.</item>
+  </plurals>
+  <plurals name="suggested_edits_removed_contribution_label">
+    <item quantity="one">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are removed by the contribution.</item>
+    <item quantity="other">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are removed by the contribution.</item>
+  </plurals>
   <string name="file_page_activity_title">Title shown at the top of the activity for the file page.</string>
   <string name="file_page_add_image_caption_button">Button label to add image caption for the file.</string>
   <string name="file_page_add_image_tags_button">Button label to add image tags for the file.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="feed_card_add_to_default_list">Save</string>
     <string name="menu_page_share">Share link</string>
     <string name="menu_page_open_a_new_tab">Open a new tab</string>
+    <string name="menu_page_open_a_new_tab_v2">New tab</string>
     <string name="menu_page_reading_lists">Reading lists</string>
     <string name="menu_page_recently_viewed">Recently viewed</string>
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T268289

This PR also fixes the incorrect `qq-string` format for `suggested_edits_tags_diff_count_text` and `suggested_edits_removed_contribution_label`