### PR TITLE
Follow-up to overflow menu changes: Minor renaming

### DIFF
--- a/app/src/main/res/menu/menu_tabs.xml
+++ b/app/src/main/res/menu/menu_tabs.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
     <item android:id="@+id/menu_open_a_new_tab"
-          android:title="@string/menu_page_open_a_new_tab_v2"
+          android:title="@string/menu_page_new_tab"
           app:showAsAction="never" />
     <item android:id="@+id/menu_save_all_tabs"
         android:title="@string/menu_save_all_tabs"

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -82,7 +82,7 @@
   <string name="feed_card_add_to_default_list">Menu item for adding the a card from the feed to a default reading list.</string>
   <string name="menu_page_share">Menu item text for sharing the currently active page. Uses the build-in Android sharing functionality, so translate it the same way as the operating system does.\n{{Identical|Share}}</string>
   <string name="menu_page_open_a_new_tab">Menu item text for opening a new tab.</string>
-  <string name="menu_page_open_a_new_tab_v2">Menu item text for opening a new tab.</string>
+  <string name="menu_page_new_tab">Menu item text for opening a new tab.</string>
   <string name="menu_page_reading_lists">&gt;Menu item text for opening the reading lists page.</string>
   <string name="menu_page_recently_viewed">&gt;Menu item text for opening the history page.</string>
   <string name="menu_long_press_open_page">Menu item for opening a link in the current tab.\n{{Identical|Open}}</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="feed_card_add_to_default_list">Save</string>
     <string name="menu_page_share">Share link</string>
     <string name="menu_page_open_a_new_tab">Open a new tab</string>
-    <string name="menu_page_open_a_new_tab_v2">New tab</string>
+    <string name="menu_page_new_tab">New tab</string>
     <string name="menu_page_reading_lists">Reading lists</string>
     <string name="menu_page_recently_viewed">Recently viewed</string>
 


### PR DESCRIPTION
shorter name instead of using 'v2'