### PR TITLE
Fix: should use correct color on TabCountsView

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -64,6 +64,7 @@ import org.wikipedia.util.DeviceUtil;
 import org.wikipedia.util.DimenUtil;
 import org.wikipedia.util.FeedbackUtil;
 import org.wikipedia.util.ReleaseUtil;
+import org.wikipedia.util.ResourceUtil;
 import org.wikipedia.util.ShareUtil;
 import org.wikipedia.util.ThrowableUtil;
 import org.wikipedia.views.FrameLayoutNavMenuTriggerer;
@@ -189,6 +190,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
 
         searchButton.setOnClickListener(view -> startActivity(SearchActivity.newIntent(PageActivity.this, TOOLBAR, null)));
 
+        tabsButton.setColor(ResourceUtil.getThemedColor(this, R.attr.material_theme_de_emphasised_color));
         FeedbackUtil.setButtonLongPressToast(tabsButton, overflowButton);
         tabsButton.updateTabCount();
 

--- a/app/src/main/java/org/wikipedia/views/TabCountsView.kt
+++ b/app/src/main/java/org/wikipedia/views/TabCountsView.kt
@@ -37,6 +37,11 @@ class TabCountsView constructor(context: Context, attrs: AttributeSet? = null) :
         tabsCountText.setTextSize(TypedValue.COMPLEX_UNIT_PX, DimenUtil.dpToPx(tabTextSize))
     }
 
+    fun setColor(@ColorInt color: Int) {
+        tabsCountText.setTextColor(color)
+        tabsCountText.backgroundTintList = ColorStateList.valueOf(color)
+    }
+
     companion object {
         private const val TAB_COUNT_LARGE_NUMBER = 99f
         private const val TAB_COUNT_SMALL_NUMBER = 9f

--- a/app/src/main/res/drawable/tab_counts_shape_border.xml
+++ b/app/src/main/res/drawable/tab_counts_shape_border.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="4dp" />
-    <stroke android:width="2dp" android:color="?attr/material_theme_de_emphasised_color" />
+    <stroke android:width="2dp" android:color="?attr/toolbar_icon_color" />
     <solid android:color="@android:color/transparent" />
 </shape>

--- a/app/src/main/res/layout/view_tabs_count.xml
+++ b/app/src/main/res/layout/view_tabs_count.xml
@@ -16,7 +16,7 @@
         android:textStyle="bold"
         android:gravity="center"
         android:textAlignment="center"
-        android:textColor="?attr/material_theme_de_emphasised_color"
+        android:textColor="?attr/toolbar_icon_color"
         android:textSize="12sp"
         tools:text="3" />
 </merge>


### PR DESCRIPTION
The previous PR incorrectly updates the icon and text color, which leads the inconsistency with other icons in the toolbar in most places that have the `TabCountsView`.