### PR TITLE
Fix RTL alignment of Search card in Feed.

### DIFF
--- a/app/src/main/res/layout/view_search_bar.xml
+++ b/app/src/main/res/layout/view_search_bar.xml
@@ -21,13 +21,13 @@
         app:tint="?attr/material_theme_de_emphasised_color" />
 
     <TextView
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:layout_marginStart="48dp"
+        android:layout_marginEnd="48dp"
         android:text="@string/search_hint"
-        android:textColor="?attr/material_theme_secondary_color"
-        android:fontFamily="sans-serif"/>
+        android:textColor="?attr/material_theme_secondary_color"/>
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/voice_search_button"


### PR DESCRIPTION
When the system language is RTL (e.g. Farsi) the text in the Search field is misaligned.
