### PR TITLE
Use getWatchedInfo() to get the proper watched state of an article

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -331,7 +331,8 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     }
 
     @Nullable public WatchlistExpiry getWatchlistExpirySession() {
-        return watchlistExpirySession;
+        // TODO: use real Watchlist expiry data from API when it's ready.
+        return watchlistExpirySession == null ? model.isWatched() ? WatchlistExpiry.NEVER : null : watchlistExpirySession;
     }
 
     @Override
@@ -809,6 +810,8 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         tocHandler.setEnabled(false);
         errorState = false;
         errorView.setVisibility(View.GONE);
+
+        watchlistExpirySession = null;
 
         model.setTitle(title);
         model.setCurEntry(entry);

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.java
@@ -8,6 +8,7 @@ import androidx.core.util.Pair;
 
 import org.wikipedia.R;
 import org.wikipedia.WikipediaApp;
+import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.bridge.CommunicationBridge;
 import org.wikipedia.bridge.JavaScriptActionHandler;
 import org.wikipedia.database.contract.PageImageHistoryContract;
@@ -187,8 +188,8 @@ public class PageFragmentLoadState {
         disposables.add(Observable.zip(ServiceFactory.getRest(model.getTitle().getWikiSite())
                 .getSummaryResponse(model.getTitle().getPrefixedText(), null, model.getCacheControl().toString(),
                         model.shouldSaveOffline() ? OfflineCacheInterceptor.SAVE_HEADER_SAVE : null,
-                        model.getTitle().getWikiSite().languageCode(), UriUtil.encodeURL(model.getTitle().getPrefixedText())), ServiceFactory.get(model.getTitle().getWikiSite())
-                .getWatchedInfo(model.getTitle().getPrefixedText()), Pair::new)
+                        model.getTitle().getWikiSite().languageCode(), UriUtil.encodeURL(model.getTitle().getPrefixedText())),
+                AccountUtil.isLoggedIn() ? ServiceFactory.get(model.getTitle().getWikiSite()).getWatchedInfo(model.getTitle().getPrefixedText()) : Observable.just(new MwQueryResponse()), Pair::new)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(pair -> {

--- a/app/src/main/java/org/wikipedia/page/PageViewModel.java
+++ b/app/src/main/java/org/wikipedia/page/PageViewModel.java
@@ -16,6 +16,7 @@ public class PageViewModel {
     @Nullable private PageTitle title;
     @Nullable private HistoryEntry curEntry;
     @Nullable private ReadingListPage readingListPage;
+    private boolean watched;
 
     private boolean forceNetwork;
 
@@ -69,6 +70,14 @@ public class PageViewModel {
 
     public boolean shouldLoadAsMobileWeb() {
         return title != null && title.isMainPage();
+    }
+
+    public void setWatched(boolean isWatched) {
+        this.watched = isWatched;
+    }
+
+    public boolean isWatched() {
+        return watched;
     }
 
     public CacheControl getCacheControl() {


### PR DESCRIPTION
This PR also fixes an issue that `watchlistExpirySession` should be cleared when entering another article on the page.