### PR TITLE
Fix: remove extra start-padding in preference screen

### DIFF
--- a/app/src/main/res/values-sw360dp/preference.xml
+++ b/app/src/main/res/values-sw360dp/preference.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    **TODO: Remove this when a better solution is found in androidx for removing the iconReserved space.
+-->
+
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <bool name="config_materialPreferenceIconSpaceReserved" tools:ignore="MissingDefaultResource,PrivateResource">false</bool>
+    <dimen name="preference_category_padding_start" tools:ignore="MissingDefaultResource,PrivateResource">0dp</dimen>
+</resources>


### PR DESCRIPTION
Perhaps #1871 accidentally removed it, which makes the preference screens has the extra start-padding on the list items.