### PR TITLE
Use ConcurrentHashMap.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,8 @@ android {
     compileSdkVersion 30
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
+
         sourceCompatibility = JAVA_VERSION
         targetCompatibility = JAVA_VERSION
     }
@@ -165,6 +167,8 @@ dependencies {
     String kotlinCoroutinesVersion = '1.3.9'
     String firebaseMessagingVersion = '21.0.1'
     String mlKitVersion = '16.1.1'
+
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -50,12 +50,11 @@ import org.wikipedia.util.ReleaseUtil;
 import org.wikipedia.util.log.L;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.internal.functions.Functions;
@@ -69,7 +68,7 @@ import static org.wikipedia.util.ReleaseUtil.getChannel;
 
 public class WikipediaApp extends Application {
     private final RemoteConfig remoteConfig = new RemoteConfig();
-    private final Map<Class<?>, DatabaseClient<?>> databaseClients = Collections.synchronizedMap(new HashMap<>());
+    private final Map<Class<?>, DatabaseClient<?>> databaseClients = new ConcurrentHashMap<>();
     private Handler mainThreadHandler;
     private AppLanguageState appLanguageState;
     private FunnelManager funnelManager;


### PR DESCRIPTION
Enabling API desugaring includes an implementation of `ConcurrentHashMap` that isn't affected by the bug on Android Lollipop in the app.