### PR TITLE
Quick follow-up to reading list name dialog.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/TextInputDialog.java
+++ b/app/src/main/java/org/wikipedia/views/TextInputDialog.java
@@ -34,7 +34,7 @@ public final class TextInputDialog extends AlertDialog {
     private EditText secondaryText;
     private TextInputLayout editTextContainer;
     private TextInputLayout secondaryTextContainer;
-    private TextInputWatcher watcher = new TextInputWatcher();
+    private final TextInputWatcher watcher = new TextInputWatcher();
 
     public static TextInputDialog newInstance(@NonNull Activity activity,
                                               boolean showSecondaryText,
@@ -69,10 +69,6 @@ public final class TextInputDialog extends AlertDialog {
         }
     }
 
-    public void setText(@Nullable CharSequence text) {
-        setText(text, false);
-    }
-
     public void setSecondaryText(@Nullable CharSequence text) {
         secondaryText.setText(text);
     }
@@ -88,10 +84,6 @@ public final class TextInputDialog extends AlertDialog {
 
     public void setSecondaryHint(@StringRes int id) {
         secondaryTextContainer.setHint(getContext().getResources().getString(id));
-    }
-
-    public void selectAll() {
-        editText.selectAll();
     }
 
     public void setError(@Nullable CharSequence text) {
@@ -110,24 +102,6 @@ public final class TextInputDialog extends AlertDialog {
     @Override public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         editText.removeTextChangedListener(watcher);
-    }
-
-    public static class DefaultCallback implements Callback {
-        @Override
-        public void onShow(@NonNull TextInputDialog dialog) {
-        }
-
-        @Override
-        public void onTextChanged(@NonNull CharSequence text, @NonNull TextInputDialog dialog) {
-        }
-
-        @Override
-        public void onSuccess(@NonNull CharSequence text, @NonNull CharSequence secondaryText) {
-        }
-
-        @Override
-        public void onCancel() {
-        }
     }
 
     private TextInputDialog(@NonNull Context context) {

--- a/app/src/main/res/menu/menu_reading_lists.xml
+++ b/app/src/main/res/menu/menu_reading_lists.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<menu xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:ignore="AlwaysShowAction">
     <item
         android:id="@+id/menu_search_lists"
         android:icon="@drawable/ic_baseline_filter_list_24"
         android:title="@string/filter_hint_filter_my_lists_and_articles"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
     <item
         android:id="@+id/menu_overflow_button"
         android:icon="@drawable/ic_more_vert_themed_24dp"
         android:title="@string/menu_feed_overflow_label"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 </menu>


### PR DESCRIPTION
This does a bit of cleanup, and fixes a potential issue:
On a very small display, the "My Lists" screen will have a toolbar that will hide the "filter" and "overflow" buttons, so that the option to create a new list will be inaccessible. Therefore we're changing the buttons in that menu to be `showAsAction=always`.