### PR TITLE
Fix display of 404 errors for nonexistent articles.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -974,7 +974,9 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         hidePageContent();
         bridge.onMetadataReady();
 
-        errorView.setError(caught);
+        if (errorView.getVisibility() != View.VISIBLE) {
+            errorView.setError(caught);
+        }
         errorView.setVisibility(View.VISIBLE);
 
         View contentTopOffset = errorView.findViewById(R.id.view_wiki_error_article_content_top_offset);


### PR DESCRIPTION
When navigating to a nonexistent article (e.g. a User page that hasn't been created yet), the app will briefly flash a 404 error, but then will be overwritten by a very general "An error has occurred" message. This is because the WebView performs a `onReceivedError()` callback right after the `summary` response returns the 404 error.

This works around the issue by showing only the "first" error that was received, and ignoring any additional errors if the error view is already visible.