### PR TITLE
Hygiene: clean up unused string resources

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -833,23 +833,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Ahir</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Heu fet una contribució a la Viquipèdia fent servir Edicions suggerides. Gràcies!</item>
-    <item quantity="other">Heu fet %d contribucions a la Viquipèdia fent servir Edicions suggerides. Gràcies!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Heu editat un dia sencer. Seguiu, %2$s!</item>
-    <item quantity="other">Fins ara heu canviat cada dia durant %1$d Continueu, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Una persona ha vist les vostres modificacions durant els darrers 30 dies. Gràcies i segueix endavant!</item>
-    <item quantity="other"> %d persones han vist les vostres modificacions durant els darrers 30 dies. Gràcies i segueix endavant!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Heu fet %d contribucions a la Viquipèdia a partir d\'edicions suggerides. Gràcies!</string>
-  <string name="suggested_edits_rewards_edit_streak">Heu editat cada dia durant %1$d dies fins ara. Bon ritme, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">%d persones han vist les vostres edicions els darrers 30 dies. Gràcies i endavant!</string>
-  <string name="suggested_edits_rewards_edit_quality">Heu fet fins ara %s edicions. Endavant! Esperem les vostres contribucions.</string>
-  <string name="suggested_edits_rewards_continue_button">Continua</string>
   <string name="suggested_edits_encourage_account_creation_title">Sabíeu que tothom pot editar la Viquipèdia?</string>
   <string name="suggested_edits_encourage_account_creation_message">Les edicions suggerides és una nova forma d\'editar a la Viquipèdia en Android. Us ajuda a fer contribucions menudes, tot i que vitals, a la Viquipèdia.\nEl nostre objectiu és facilitar-ne l\'edició i fer-la més accessible per a tothom! Inicieu una sessió a la Viquipèdia per a començar.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Inicia una sessió / uniu-vos a la Viquipèdia</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -843,23 +843,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Gestern</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Sie haben mit vorgeschlagenen Bearbeitungen einen Beitrag zu Wikipedia geleistet. Vielen Dank! </item>
-    <item quantity="other"> Sie haben mit empfohlenen Bearbeitungen %d Beiträge zu Wikipedia geleistet. Danke!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Sie haben einen ganzen Tag lang bearbeitet. Halten Sie die Serie am Laufen,%2$s! </item>
-    <item quantity="other"> Sie haben bisher jeden Tag für %1$d Tage bearbeitet. Machen Sie weiter so, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Ihre Änderungen wurden in den letzten 30 Tagen von einer Person gesehen. Vielen Dank und weiter so! </item>
-    <item quantity="other"> Ihre Änderungen wurden in den letzten 30 Tagen von %d Personen gesehen. Danke fürs Weitermachen!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Sie haben %d Beiträge zu Wikipedia mit vorgeschlagenen Bearbeitungen geleistet. Danke!</string>
-  <string name="suggested_edits_rewards_edit_streak">Sie haben bisher jeden Tag für %1$d Tage bearbeitet. Machen Sie weiter so, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Ihre Änderungen wurden in den letzten 30 Tagen von %d Personen gesehen. Danke und machen Sie weiter so!</string>
-  <string name="suggested_edits_rewards_edit_quality">Ihre bisherigen Änderungen sind %s. Machen Sie weiter so! Wir freuen uns auf Ihre Beiträge.</string>
-  <string name="suggested_edits_rewards_continue_button">Weiter</string>
   <string name="suggested_edits_encourage_account_creation_title">Wussten Sie, dass jeder Wikipedia bearbeiten kann?</string>
   <string name="suggested_edits_encourage_account_creation_message">Vorgeschlagene Bearbeitungen ist eine neue Art, Wikipedia auf Android zu bearbeiten. Es hilft dir, kleine aber wichtige Beiträge zu Wikipedia zu leisten.\nUnser Ziel ist es, das Editieren einfacher und zugänglicher für alle zu machen! Logge dich ein oder schließe dich Wikipedia an, um anzufangen.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Anmelden / Wikipedia beitreten</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -835,23 +835,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">دیروز</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">شما با استفاده از ویرایش‌های پیشنهادی یک بار با ویکی‌پدیا همکاری کرده اید. متشکریم!</item>
-    <item quantity="other">شما با استفاده از ویرایش‌های پیشنهادی %d بار با ویکی‌پدیا همکاری کرده اید. متشکریم!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">%2$s، شما برای یک روز کامل در حال ویرایش بوده‌اید. این روند بی‌وقفه را ادامه دهید!</item>
-    <item quantity="other">%2$s! شما تاکنون به‌مدت %1$d روز هر روز ویرایش انجام داده‌اید. این روند بی‌وقفه را ادامه دهید!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">ویرایش‌های شما در ۳۰ روز گذشته توسط یک نفر دیده شده است. ممنون، همین روند را ادامه دهید!</item>
-    <item quantity="other">در ۳۰ روز گذشته ویرایش‌های شما توسط %d نفر دیده شده است. ممنون، همین روند را ادامه دهید!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">شما با استفاده از ویرایش‌های پیشنهادی %d بار با ویکی‌پدیا مشارکت کرده اید. متشکریم!</string>
-  <string name="suggested_edits_rewards_edit_streak">%2$s! شما تاکنون به‌مدت %1$d روز هر روز ویرایش انجام داده‌اید. این روند بی‌وقفه را ادامه دهید!</string>
-  <string name="suggested_edits_rewards_pageviews">در ۳۰ روز گذشته ویرایش های شما توسط %d نفر دیده شده است. متشکریم، ادامه دهید!</string>
-  <string name="suggested_edits_rewards_edit_quality">ویرایش های شما %s هستند. ادامه دهید! ما منتظر مشارکت‌های شما هستیم.</string>
-  <string name="suggested_edits_rewards_continue_button">ادامه</string>
   <string name="suggested_edits_encourage_account_creation_title">آیا می‌دانستید همه می‌توانند ویکی‌پدیا را ویرایش کنند؟</string>
   <string name="suggested_edits_encourage_account_creation_message">ویرایش‌های پیشنهادی راه جدیدی برای ویرایش ویکی‌پدیا در اندروید هستند. این راه به شما کمک می‌کند تا مشارکت‌های کوچک اما حیاتی در ویکی‌پدیا داشته باشید.\nهدف ما این است که ویرایش برای همه ساده‌تر در دسترس‌تر باشد! برای شروع، به حساب خود وارد شوید یا حساب جدید بسازید.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">ورود/پیوستن به ویکی پدیا</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -831,12 +831,6 @@
   <string name="suggested_edits_contribution_seen_text">Nähty %s kertaa viimeisen 30 päivän aikana.</string>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Eilen</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Olet tehnyt yhden muokkauksen Wikipediaan ehdotettujen muokkausten avulla. Kiitos!</item>
-    <item quantity="other">Olet tehnyt %d muokkausta Wikipediaan ehdotettujen muokkausten avulla. Kiitos!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Olet tehnyt %d muokkausta Wikipediaan ehdotettujen muokkausten avulla. Kiitos!</string>
-  <string name="suggested_edits_rewards_continue_button">Jatka</string>
   <string name="suggested_edits_encourage_account_creation_title">Tiesitkö että kaikki voivat muokata Wikipediaa?</string>
   <string name="suggested_edits_encourage_account_creation_message">Ehdotetut muokkaukset on uusi tapa muokata Wikipediaa Androidilla. Se auttaa tekemään pieniä, tärkeitä muutoksia Wikipediaan.\nTavoitteenamme on tehdä muokkaamisesta kaikille helpompaa ja helppopääsyisempää! Aloita kirjautumalla sisään tai liittymällä Wikipediaan.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Kirjaudu sisään / liity Wikipediaan</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -856,23 +856,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Hier</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Vous avez fait une contribution à Wikipédia en utilisant Modifications suggérées. Merci !</item>
-    <item quantity="other">Vous avez fait %d contributions à Wikipédia en utilisant Modifications suggérées. Merci !</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Vous avez modifié durant un jour complet. Continuez, %2$s !</item>
-    <item quantity="other">Vous avez modifié durant chacun des %1$d derniers jours jusqu’à présent. Continuez, %2$s !</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Vos modifications ont été vues par une personne dans les 30 derniers jours. Merci, et continuez !</item>
-    <item quantity="other">Vos modifications ont été vues par %d personnes dans les 30 derniers jours. Merci, et continuez !</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Vous avez fait %d contributions à Wikipédia en utilisant les Modifications suggérées. Merci !</string>
-  <string name="suggested_edits_rewards_edit_streak">Vous avez modifié tous les jours depuis %1$d jusqu’à présent. Continuez la série en cours, %2$s !</string>
-  <string name="suggested_edits_rewards_pageviews">Vos modifications ont été vues par %d personnes dans les 30 derniers jours. Merci et continuez sur votre lancée !</string>
-  <string name="suggested_edits_rewards_edit_quality">Vos modifications jusqu’à présent sont %s. Continuez ! Nous attendons vos contributions.</string>
-  <string name="suggested_edits_rewards_continue_button">Poursuivre</string>
   <string name="suggested_edits_encourage_account_creation_title">Savez-vous que chacun peut modifier Wikipédia ?</string>
   <string name="suggested_edits_encourage_account_creation_message">Les modifications suggérées sont une nouvelle façon de modifier Wikipédia sur Android. Elles vous aident à faire des contributions petites mais vitales pour Wikipédia. \nNotre but est de rendre les modifications plus faciles et plus accessibles à chacun ! Connectez-vous ou rejoignez Wikipédia pour commencer.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Se connecter / rejoindre Wikipédia</string>

--- a/app/src/main/res/values-fy/strings.xml
+++ b/app/src/main/res/values-fy/strings.xml
@@ -744,23 +744,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Juster</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Jo hawwe mei Bewurksuggestjes ien bydrage oan \'e Wikipedy levere. Tankjewol!</item>
-    <item quantity="other">Jo hawwe mei Bewurksuggestjes %d bydragen oan \'e Wikipedy levere. Tankjewol!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Jo binne ien hiele dei oan it bewurkjen west. Meitsje in moaie searje, %2$s!</item>
-    <item quantity="other">Jo hawwe oant no ta op %1$d dagen oanien bewurke. Meitsje in moaie searje, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Jo bewurkings binne yn \'e lêste 30 dagen troch immen sjoen. Tanke, en gean sa troch!</item>
-    <item quantity="other">Jo bewurkings binne yn \'e lêste 30 dagen troch %d lju sjoen. Tanke, en gean sa troch!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Jo hawwe mei Bewurksuggestjes %d bydragen oan \'e Wikipedy levere. Tankjewol!</string>
-  <string name="suggested_edits_rewards_edit_streak">Jo hawwe oant no ta op %1$d dagen oanien bewurke. Meitsje in moaie searje, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Jo bewurkings binne yn \'e lêste 30 dagen troch %d lju sjoen. Tanke, en gean sa troch!</string>
-  <string name="suggested_edits_rewards_edit_quality">Jo bewurkings binne oant no ta %s. Gean fral troch! Wy sjogge út nei jo bydragen.</string>
-  <string name="suggested_edits_rewards_continue_button">Fierder</string>
   <string name="suggested_edits_encourage_account_creation_title">Wisten jo dat elkenien de Wikipedy bewurkje kin?</string>
   <string name="suggested_edits_encourage_account_creation_message">Bewurksuggestjes binne in nije manier om \'e Wikipedy op Android te bewurkjen. Se helpe jo lytse mar wichtige bydragen oan \'e Wikipedy te leverjen.\nUs doel is it bewurkjen foar elkenien nofliker en tagonkliker te meitsjen! Meld jo oan, kom by de Wikipedy, en set útein.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Oanmelde / kom by de Wikipedy</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -832,23 +832,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Tegnap</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Eddig egyszer működtél közre a Wikipédián a Javasolt szerkesztésekkel. Köszönjük!</item>
-    <item quantity="other">Eddig %d alkalommal működtél közre a Wikipédián a Javasolt szerkesztésekkel. Köszönjük!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Eddig egy napot szerkesztettél. Ne add fel, csak így tovább, %2$s!</item>
-    <item quantity="other">Eddig minden nap szerkesztettél, összesen %1$d napot. Ne add fel, csak így tovább, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">1 ember látta a szerkesztéseidet az elmúlt 30 napban. Köszönjük, csak így tovább!</item>
-    <item quantity="other">%d ember látta a szerkesztéseidet az elmúlt 30 napban. Köszönjük, csak így tovább!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Eddig %d alkalommal működtél közre a Wikipédián a Javasolt szerkesztésekkel. Köszönjük!</string>
-  <string name="suggested_edits_rewards_edit_streak">Eddig minden nap szerkesztettél, összesen %1$d napot. Ne add fel, csak így tovább, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">%d ember látta a szerkesztéseidet az elmúlt 30 napban. Köszönjük, csak így tovább!</string>
-  <string name="suggested_edits_rewards_edit_quality">Szerkesztéseid minősége eddig: %s. Várjuk a további szerkesztéseket.</string>
-  <string name="suggested_edits_rewards_continue_button">Folytatás</string>
   <string name="suggested_edits_encourage_account_creation_title">Tudtad, hogy a Wikipédiát bárki szerkesztheti?</string>
   <string name="suggested_edits_encourage_account_creation_message">A javasolt szerkesztések egy új módja a Wikipédia tartalmának fejlesztéséhez való hozzájárulásnak. Ez egy aprónak tűnő, de fontos rész. Célunk az, hogy a szerkesztés könnyebb legyen, és elérhetőbb mindenki számára! Jelentkezz be vagy regisztrálj a Wikipédián a kezdéshez.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Bejelentkezés/regisztrálás a Wikipédiába</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -822,33 +822,12 @@
   <string name="suggested_edits_image_tag_contribution_label">Anda telah menambahkan %d tanda</string>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Kemarin</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Anda telah memberikan sebuah kontribusi ke Wikipedia menggunakan penyuntingan yang disarankan. Terima kasih!</item>
-    <item quantity="other">Anda telah memberikan %d kontribusi ke Wikipedia menggunakan penyuntingan yang disarankan. Terima kasih!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Anda telah menyunting selama satu hari penuh. Pertahankan rekornya, %2$s!</item>
-    <item quantity="other">Saat ini, anda telah menyunting setiap hari untuk %1$d hari. Pertahankan rekornya, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Penyuntingan Anda telah dilihat oleh seorang dalam 30 hari terakhir. Terima kasih, dan tetaplah menyunting!</item>
-    <item quantity="other">Penyuntingan Anda telah dilihat oleh %d orang dalam 30 hari terakhir. Terima kasih, dan tetaplah menyunting!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Anda telah memberikan %d kontribusi ke Wikipedia menggunakan penyuntingan yang disarankan. Terima kasih!</string>
-  <string name="suggested_edits_rewards_edit_streak">Saat ini, anda telah menyunting setiap hari untuk %1$d hari. Pertahankan rekornya, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Penyuntingan Anda telah dilihat oleh %d orang dalam 30 hari terakhir. Terima kasih, dan tetaplah menyunting!</string>
-  <string name="suggested_edits_rewards_edit_quality">Kualitas penyuntingan Anda sejauh ini adalah %s. Tetaplah menyunting! Kami menantikan kontribusi Anda.</string>
-  <string name="suggested_edits_rewards_continue_button">Lanjut</string>
   <string name="suggested_edits_encourage_account_creation_title">Tahukah Anda bahwa semua orang bisa menyunting Wikipedia?</string>
   <string name="suggested_edits_encourage_account_creation_message">Penyuntingan yang disarankan adalah cara baru untuk mengedit Wikipedia di Android. Ini membantu Anda memberikan kontribusi kecil yang sangat berharga untuk Wikipedia.\nTujuan kami adalah membuat pengeditan lebih mudah dan lebih bisa diakses untuk semua orang! Masuk atau bergabung dengan Wikipedia untuk memulai.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Masuk log / gabung ke Wikipedia</string>
   <string name="suggested_edits_contribution_type_image_tag">Tag gambar</string>
   <string name="suggested_edits_contribution_current_revision_text">Penyuntingan anda telah diterbitkan di Wikipedia</string>
   <string name="suggested_card_more_edits">Lihat lebih banyak saranan suntingan</string>
-  <string name="suggested_edits_tags_diff_count_text">%1$s tanda</string>
-  <string name="suggested_edits_contribution_diff_count_text">%1$s karakter</string>
-  <string name="suggested_edits_removed_contribution_label">Anda telah menghapus %d karakter</string>
-  <string name="suggested_edits_added_contribution_label">Anda telah menambah %d karakter</string>
   <string name="file_page_activity_title">Halaman berkas</string>
   <string name="file_page_add_image_caption_button">Tambahkan takarir gambar</string>
   <string name="file_page_add_image_tags_button">Tambahkan tanda gambar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -849,23 +849,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Ieri</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Hai effettuato una modifica su Wikipedia utilizzando Modifiche suggerite. Grazie!</item>
-    <item quantity="other">Hai effettuato %d modifiche su Wikipedia utilizzando Modifiche suggerite. Grazie!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Hai effettuato modifiche per un intero giorno. Continua così, %2$s!</item>
-    <item quantity="other">Hai effettuato modifiche ogni giorno per %1$d giorni ad ora. Continua così, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Le tue modifiche sono state viste da una persona negli ultimi 30 giorni. Grazie, e continua così!</item>
-    <item quantity="other">Le tue modifiche sono state viste da %d persone negli ultimi 30 giorni. Grazie, e continua così!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Hai fatto %d modifiche a Wikipedia usando le modifiche suggerite. Grazie!</string>
-  <string name="suggested_edits_rewards_edit_streak">Hai effettuato modifiche ogni giorno per %1$d giorni ad ora. Continua così, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Le tue modifiche sono state viste da %d utenti negli ultimi 30 giorni. Grazie, e continua così!</string>
-  <string name="suggested_edits_rewards_edit_quality">Le tue modifiche per ora sono %s. Continua così! Aspettiamo altri contributi.</string>
-  <string name="suggested_edits_rewards_continue_button">Continua</string>
   <string name="suggested_edits_encourage_account_creation_title">Sapevi che tutti possono modificare Wikipedia?</string>
   <string name="suggested_edits_encourage_account_creation_message">Le modifiche suggerite sono un nuovo modo per modificare Wikipedia su Android. Ti aiuta a dare piccoli ma vitali contributi a Wikipedia. Il nostro obiettivo è rendere la modifica più semplice ed accessibile a tutti! Accedi o unisciti a Wikipedia per iniziare.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Entra / unisciti a Wikipedia</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -871,29 +871,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">אתמול</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">עשית תרומה אחת לוויקיפדיה באמצעות עריכות מוצעות</item>
-    <item quantity="two">עשית %d תרומות לוויקיפדיה באמצעות עריכות מוצעות</item>
-    <item quantity="many">עשית %d תרומות לוויקיפדיה באמצעות עריכות מוצעות</item>
-    <item quantity="other">עשית %d תרומות לוויקיפדיה באמצעות עריכות מוצעות</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">ערכת במשך יום. יאללה, להמשיך את הרצף, %2$s!</item>
-    <item quantity="two">ערכת יומיים רצוף. יאללה, להמשיך את הרצף, %2$s!</item>
-    <item quantity="many">ערכת רצוף כבר %1$d יום. יאללה, להמשיך את הרצף, %2$s!</item>
-    <item quantity="other">ערכת רצוף כבר %1$d ימים. יאללה, להמשיך את הרצף, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">העריכות שלך נראו על־ידי אדם אחד ב־30 הימים האחרונים. תודה, להמשיך כך!</item>
-    <item quantity="two">העריכות שלך נראו על־ידי %d אנשים ב־30 הימים האחרונים. תודה, להמשיך כך!</item>
-    <item quantity="many">העריכות שלך נראו על־ידי %d אנשים ב־30 הימים האחרונים. תודה, להמשיך כך!</item>
-    <item quantity="other">העריכות שלך נראו על־ידי %d אנשים ב־30 הימים האחרונים. תודה, להמשיך כך!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">ביצעת %d תרומות לוויקיפדיה באמצעות ’עריכות מוצעות’. תודה!</string>
-  <string name="suggested_edits_rewards_edit_streak">ערכת כל יום במהלך %1$d ימים עד כה. לא לשבור את הרצף, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">%d אנשים צפו בעריכות שלך ב־30 הימים האחרונים. תודה ויישר כוח!</string>
-  <string name="suggested_edits_rewards_edit_quality">העריכות שלך עד לשלב זה הן %s. יישר כוח! אנו מצפים לתרומות נוספות שלך.</string>
-  <string name="suggested_edits_rewards_continue_button">המשך</string>
   <string name="suggested_edits_encourage_account_creation_title">הידעת שכולם יכולים לערוך את ויקיפדיה?</string>
   <string name="suggested_edits_encourage_account_creation_message">’עריכות מוצעות’ היא דרך חדשה לערוך את ויקיפדיה באנדרואיד. היא מסייעת בביצוע תרומות קטנות, אך חיוניות, לוויקיפדיה.\nהמטרה שלנו היא להפוך את העריכה בוויקיפדיה לקלה יותר ולנגישה יותר לכולם! יש להיכנס לחשבון או להצטרף לוויקיפדיה על מנת להתחיל.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">כניסה / הצטרפות לוויקיפדיה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -842,18 +842,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">昨日</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">あなたは提案された編集を使って1件の編集をしました。ありがとうございます!</item>
-    <item quantity="other">あなたは提案された編集を使って%d件の編集をしました。ありがとうございます!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">過去30日の間にあなたの編集が1人に見られています。これからもよろしくお願いします。</item>
-    <item quantity="other">過去30日の間にあなたの編集が%d人に見られています。これからもよろしくお願いします。</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">あなたは提案された編集を使って%d件の編集をしました。ありがとうございます!</string>
-  <string name="suggested_edits_rewards_edit_streak">%1$d日間編集し続けています。このまま頑張ってください、%2$sさん!</string>
-  <string name="suggested_edits_rewards_pageviews">あなたの編集は30日間に%d人に見られています。これからもよろしくお願いします!</string>
-  <string name="suggested_edits_rewards_continue_button">続行</string>
   <string name="suggested_edits_encourage_account_creation_title">誰でもウィキペディアを編集できることはご存知でしたか?</string>
   <string name="suggested_edits_encourage_account_creation_message">提案された編集は Android 上でウィキペディアを編集する新しい方法です。これは小さなことですがウィキペディアに不可欠なものです。私たちの目標は誰でも簡単に編集できるようにすることです。ログインをするかウィキペディアに参加して始めましょう。</string>
   <string name="suggested_edits_encourage_account_creation_login_button">ウィキペディアにログインまたは登録</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -828,23 +828,6 @@
   <string name="suggested_edits_image_tag_contribution_label">%d개의 태그를 추가했습니다</string>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">어제</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">편집 제안을 사용하여 위키백과에 한 차례 기여하셨습니다. 감사합니다!</item>
-    <item quantity="other">편집 제한을 사용하여 위키백과에 %d차례 기여하셨습니다. 감사합니다!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">하루 종일 편집하셨습니다. 계속 기여해 주세요, %2$s님!</item>
-    <item quantity="other">지금까지 %1$d일 동안 매일 편집하셨습니다. 계속 기여해 주세요, %2$s님!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">지난 30일 동안 한 분께서 당신의 편집을 보고 계십니다. 고맙습니다. 편집을 계속해 주세요!</item>
-    <item quantity="other">지난 30일 동안 %d분께서 당신의 편집을 보고 계십니다. 고맙습니다. 편집을 계속해 주세요!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">편집 제안을 통하여 %d건의 기여를 해주셨습니다. 감사드립니다!</string>
-  <string name="suggested_edits_rewards_edit_streak">%1$d 동안 하루도 거르지 않고 편집을 해주셨습니다. %2$s님, 계속 기여해주세요!</string>
-  <string name="suggested_edits_rewards_pageviews">지난 30일 동안 당신의 편집을 %d명의 사람들이 보았습니다. 감사드립니다, 계속 기여해주세요!</string>
-  <string name="suggested_edits_rewards_edit_quality">지금까지의 편집은 %s입니다. 계속해 주세요! 앞으로도 좋은 기여를 기대하겠습니다.</string>
-  <string name="suggested_edits_rewards_continue_button">계속</string>
   <string name="suggested_edits_encourage_account_creation_title">당신은 누구나 위키백과를 편집할 수 있다는 것을 알고 계셨나요?</string>
   <string name="suggested_edits_encourage_account_creation_message">편집 제안은 안드로이드에서 위키백과를 편집하는 새로운 방법입니다. 이 기능은 위키백과에 작지만 매우 중요한 기여를 하는 데 도움이 됩니다.\n우리의 목표는 모두를 위하여 편집의 난이도를 낮추고 접근성을 높이는 것입니다! 시작하려면 로그인하거나 회원가입하세요.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">위키백과에 로그인 / 가입</string>
@@ -855,12 +838,10 @@
     <item quantity="one">태그 %1$s개</item>
     <item quantity="other">태그 %1$s개</item>
   </plurals>
-  <string name="suggested_edits_contribution_diff_count_text">%1$s자</string>
   <plurals name="suggested_edits_removed_contribution_label">
     <item quantity="one">%d자를 제거했습니다</item>
     <item quantity="other">%d자를 제거했습니다</item>
   </plurals>
-  <string name="suggested_edits_added_contribution_label">글자 %d자를 추가하셨습니다</string>
   <string name="file_page_activity_title">파일 문서</string>
   <string name="file_page_add_image_caption_button">이미지 캡션 추가</string>
   <string name="file_page_add_image_tags_button">이미지 태그 추가</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -818,23 +818,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Вчера</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Имате направено дадено еден придонес на Википедија користејќи „Предложени уредувања“. Ви благодариме!</item>
-    <item quantity="other">Имате дадено %d придонеси на Википедија користејќи „Предложени уредувања“. Ви благодариме!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Уредувавте цел еден ден. Само напред, %2$s!</item>
-    <item quantity="other">Уредувавте секој ден последниве %1$d дена. Само напред, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Вашите уредувања се видени од едно лице во последниве 30 дена. Ви благодариме и само напред!</item>
-    <item quantity="other">Вашите уредувања се видени од %d лица во последниве 30 дена. Ви благодариме и само напред!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Имате %d придонеси на Википедија користејќи „Предложени уредувања“. Ви благодариме!</string>
-  <string name="suggested_edits_rewards_edit_streak">Досега уредувате %1$d последователни денови. Само така, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Вашите уредувања се видени од %d луѓе во последниве 30 дена. Ви благодариме, и само напред!</string>
-  <string name="suggested_edits_rewards_edit_quality">Засега вашите уредувања се со %s квалитет. Само така! Со нетрпение ги очекуваме вашите понатамошни придонеси.</string>
-  <string name="suggested_edits_rewards_continue_button">Продолжи</string>
   <string name="suggested_edits_encourage_account_creation_title">Дали знаевте дека Википедија може да ја уредува секој?</string>
   <string name="suggested_edits_encourage_account_creation_message">Предложените уредувања се нов начин на уредување на Википедија со Андроид. Ви помагаат да правите мали, но суштински придонеси кон Википедија.\nНаша цел е да го олесниме уредувањето и да го направиме подостапно за секого! Најавете се или придружете се на Википедија за да почнете.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Најава / придружување на Википедија</string>

--- a/app/src/main/res/values-mnw/strings.xml
+++ b/app/src/main/res/values-mnw/strings.xml
@@ -793,23 +793,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">နူကဏေအ်</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">မၞးလုပ်ကၠောန်လဝ် မွဲအလန် ပ္ဍဲဝဳကဳပဳဒဳယာ မစကာလဝ် အရာပလေဝ်ဒါန် မအာတ်မိက်။ တင်ဂုန်ရ။</item>
-    <item quantity="other">မၞးကၠောန်ဂွံ %d အလန် သွက်ဝဳကဳပဳဒဳယာ မစကာလဝ် အရာပလေဝ်ဒါန် မအာတ်မိက်။ တင်ဂုန်ရ။</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">မၞးပလေဝ်ဒါန်လဝ် မွဲ ပ္ဍဲမွဲကၠိုဟ်တ္ၚဲ။ ဆက်ကၠောန် လ္ပဒေါအ်ညိ %2$s!</item>
-    <item quantity="other">မၞးပလေဝ်ဒါန်ဂွံလဝ် ဇၟာပ်တ္ၚဲ သီုဖအိုတ်  %1$d တ္ၚဲ စဵုကဵုလၟုဟ်မ္ဂး။ ဆက်ကၠောန် လ္ပဒေါအ်ညိ %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">ပလေဝ်ဒါန်မၞးဂှ် ပ္ဍဲကဵု ၃၀ တ္ၚဲမတုဲကၠုင်ဂှ် မၞိဟ်လုပ်ဗဵုဂွံ မွဲ တၠ။ တင်ဂုန်ရ ဆက်ကၠောန်အာညိ။</item>
-    <item quantity="other">ပလေဝ်ဒါန်မၞးဂှ် မၞိဟ် %d တၠ လုပ်ဗဵုလဝ် ပ္ဍဲပွိုင် ၃၀ တ္ၚဲဂှ်။ တင်ဂုန်ရ ဆက်ကၠောန်အာညိ။</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">မၞးကၠောန်ဂွံ ပ္ဍဲဝဳကဳပဳဒဳယာ %d ကမၠောန် မစကာလဝ် အရာပလေဝ်ဒါန် မအာတ်မိက်။ တင်ဂုန်ရ။</string>
-  <string name="suggested_edits_rewards_edit_streak">မၞး ပလေဝ်ဒါန် ရိုဟ်ဒဒှ်တ္ၚဲ နူကဵု ပွိုင် %1$d တ္ၚဲဂှ်။ ဆက်ကၠောန် လ္ပဒေါအ်ညိ  %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">ပလေဝ်ဒါန်မၞးဂှ် ပ္ဍဲကဵုပွိုင် ၃၀ တ္ၚဲဂှ် မၞိဟ်လုပ်ဗဵုဂွံ  %d တၠ။ တင်ဂုန်၊ ဆက်ကၠောန်ညိ။</string>
-  <string name="suggested_edits_rewards_edit_quality">စဵုကဵုလၟုဟ်ဂှ် မၞိဟ်ပလေဝ်ဒါန်ဂွံ %s အလန်။ ဆက်ကၠောန်ညိ။ ပိုယ်စၟဳဒၟံင် ပရေင်ကမၠောန်မၞးရ။</string>
-  <string name="suggested_edits_rewards_continue_button">ဆက်</string>
   <string name="suggested_edits_encourage_account_creation_title">မၞးတီဟာ ဒဒှ်ရ ဇၟာပ်မၞိဟ် လုပ်ပလေဝ်ဒါန် ဝဳကဳပဳဒဳယာဂွံဒၟံင်ဂှ်။</string>
   <string name="suggested_edits_encourage_account_creation_message">တင်ပလေဝ်ဒါန် မအာတ်မိက်ဂှ် ဒှ်နဲကဲတၟိ သွက်ဂွံပလေဝ်ဒါန် ပ္ဍဲဝဳကဳပဳဒဳယာ နကဵု အေန်ဒရောန်။ အရာဏအ်ဂှ် မၞးမကၠောန်ကဵုညိည ဒှ်ဂုန်ဗွဲမဇၞော် သွက်ဝဳကဳပဳဒဳယာရ။ တင်ရန်တၟအ်ပိုယ်ဂှ် ဇၟာပ်မၞိဟ် ဗွဲမလောဲသွာ ညံင်ဂွံလုပ် ပလေဝ်ဒါန်ဂွံရ။ လုပ်လံက်အေန် ဟွံသေင်မ္ဂး လုပ်ပံင်တောဲ သွက်ဂွံ လုပ်စကၠောန်။</string>
   <string name="suggested_edits_encourage_account_creation_login_button">လုပ်လံက်အေန် / လုပ်ပံင်တောဲ ဝဳကဳပဳဒဳယာ</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -845,23 +845,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Ontem</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Você fez uma contribuição para a Wikipédia usando as edições sugeridas. Obrigado!</item>
-    <item quantity="other">Você fez %d contribuições à Wikipédia usando as edições sugeridas. Obrigado!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Você está editando há um dia inteiro. Mantenha a sequencia, %2$s!</item>
-    <item quantity="other">Você editou todos os dias por %1$d dias até agora. Mantenha a seqüência, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Suas edições foram vistas por uma pessoa nos últimos 30 dias. Obrigado e continue!</item>
-    <item quantity="other">Suas edições foram vistas por %d pessoas nos últimos 30 dias. Obrigado e continue!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Você fez %d contribuições para a Wikipedia usando as edições sugeridas. Obrigado!</string>
-  <string name="suggested_edits_rewards_edit_streak">Você editou todos os dias por %1$d dias até o momento. Mantenha a sequência, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Suas edições foram vistas por %d pessoas nos últimos 30 dias. Obrigado, e continue!</string>
-  <string name="suggested_edits_rewards_edit_quality">Suas edições até agora são %s. Continue! Esperamos suas contribuições.</string>
-  <string name="suggested_edits_rewards_continue_button">Continuar</string>
   <string name="suggested_edits_encourage_account_creation_title">Você sabia que todos podem editar a Wikipédia?</string>
   <string name="suggested_edits_encourage_account_creation_message">As edições sugeridas são uma nova maneira de editar a Wikipédia no Android. Ajuda você a fazer contribuições pequenas, mas vitais, para a Wikipédia.\nNosso objetivo é tornar a edição mais fácil e mais acessível para todos! Entre ou participe da Wikipédia para começar.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Entrar / Juntar na Wikipédia</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -834,23 +834,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Ontem</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Fez uma contribuição na Wikipédia usando as edições sugeridas. Obrigado!</item>
-    <item quantity="other">Fez %d contribuições na Wikipédia usando as edições sugeridas. Obrigado!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Esteve a editar durante um dia inteiro. Continue nesse ritmo, %2$s!</item>
-    <item quantity="other">Até agora, editou todos os dias durante %1$d dias. Continue nesse ritmo, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">As suas edições foram vistas por uma pessoa nos últimos 30 dias. Obrigado e continue!</item>
-    <item quantity="other">As suas edições foram vistas por %d pessoas nos últimos 30 dias. Obrigado e continue!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Fez %d contribuições para a Wikipédia usando as \"Edições sugeridas\". Obrigado!</string>
-  <string name="suggested_edits_rewards_edit_streak">Até agora, editou todos os dias durante %1$d dias. Mantenha o ritmo, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">As suas edições foram vistas por %d pessoas nos últimos 30 dias. Obrigado e continue!</string>
-  <string name="suggested_edits_rewards_edit_quality">As suas edições até agora são %s. Continue! Aguardamos as suas contribuições.</string>
-  <string name="suggested_edits_rewards_continue_button">Continuar</string>
   <string name="suggested_edits_encourage_account_creation_title">Sabia que qualquer pessoa pode editar a Wikipédia?</string>
   <string name="suggested_edits_encourage_account_creation_message">As \"Edições sugeridas\" são uma forma nova de editar a Wikipédia em Android. Ajudam a dar contribuições pequenas mas vitais para a Wikipédia.\nO nosso objetivo é tornar a edição mais fácil e mais acessível a todos! Inicie uma sessão ou registe-se na Wikipédia para começar.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Entrar ou registar-se na Wikipédia</string>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -844,35 +844,24 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">Dropdown selection for filtering different types of edits made by the user. %1$d represents the number of edits of a certain type, and %2$s represents the type of edit, which can include Descriptions, Captions, or general Contributions.</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Text for contributions date to indicate it was contributed yesterday</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Message shown about the number of contributions the user has made.</item>
-    <item quantity="other">Message shown about the number of contributions the user has made. The %d parameter represents the number of contrubutions.</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Message shown about the length of edit streak the user has made. The %2$s parameter represents the user name.</item>
-    <item quantity="other">Message shown about the length of edit streak the user has made. The %1$d parameter represents the length of edit streak and the %2$s parameter represents the user name.</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Message shown about the pageviews the user has earned in a period of time. The %d represents the number of pageviews.</item>
-    <item quantity="other">Message shown about the pageviews the user has earned in a period of time. The %d represents the number of pageviews.</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Message shown to a user about the number of contributions the user has made. The %d represents the number of contrubutions.</string>
-  <string name="suggested_edits_rewards_edit_streak">Message shown to a user about the length of edit streak the user has made. The %1$d represents the length of edit streak and the %2$s represents the user name.</string>
-  <string name="suggested_edits_rewards_pageviews">Message shown to a user about the pageviews the user has earned in a period of time. The %d represents the number of pageviews.</string>
-  <string name="suggested_edits_rewards_edit_quality">Message shown to the user about the quality of their edits so far. The %s represents the quality, such as Excellent, Good, Okay, Bad, etc.</string>
-  <string name="suggested_edits_rewards_continue_button">Button label to move to the next card of suggested edits.</string>
   <string name="suggested_edits_encourage_account_creation_title">Title text of the encourage account creation card.</string>
   <string name="suggested_edits_encourage_account_creation_message">Content text of the encourage account creation card.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Button text of the encourage account creation card log in button.</string>
   <string name="suggested_edits_contribution_type_image_tag">Text indicating that the user edit was an Image tag edit</string>
   <string name="suggested_edits_contribution_current_revision_text">Text indicating that the user\'s edit was the most recent one on a given image or article</string>
   <string name="suggested_card_more_edits">Label text for SE feed card footer action.</string>
-  <string name="suggested_edits_tags_diff_count_text">Label text indicating the number of tags added or removed by a user contribution. %1$s represents the number.</string>
+  <plurals name="suggested_edits_tags_diff_count_text">
+    <item quantity="one">Label text indicating the number of tags added or removed by a user contribution. %1$s represents the number.</item>
+    <item quantity="other">Label text indicating the number of tags added or removed by a user contribution. %1$s represents the number.</item>
+  </plurals>
   <plurals name="suggested_edits_contribution_diff_count_text">
     <item quantity="one">Label text indicating the number of characters added or removed by a user contribution. %1$s represents the number.</item>
     <item quantity="other">Label text indicating the number of characters added or removed by a user contribution. %1$s represents the number.</item>
   </plurals>
-  <string name="suggested_edits_removed_contribution_label">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are removed by the contribution.</string>
+  <plurals name="suggested_edits_removed_contribution_label">
+    <item quantity="one">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are removed by the contribution.</item>
+    <item quantity="other">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are removed by the contribution.</item>
+  </plurals>
   <plurals name="suggested_edits_added_contribution_label">
     <item quantity="one">Text summarizing the user\'s contribution to the article or image. %d represents the number when only one character is added.</item>
     <item quantity="other">Text summarizing the user\'s contribution to the article or image. %d represents the number when many characters are added.</item>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -831,23 +831,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Igår</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Du har gjort ett bidrag på Wikipedia med redigeringsförslag. Tack!</item>
-    <item quantity="other">Du har gjort %d bidrag på Wikipedia med redigeringsförslag. Tack!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Du har redigerat en hel dag i rad. Fortsätt med det, %2$s!</item>
-    <item quantity="other">Du har redigerat %1$d dagar i rad. Fortsätt med det, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">En person har sett dina redigeringar under de senaste 30 dagarna. Tack och fortsätt med det!</item>
-    <item quantity="other">%d personer har sett dina redigeringar under de senaste 30 dagar. Tack och fortsätt med det!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Du har gjort %d bidrag på Wikipedia med redigeringsförslag. Tack!</string>
-  <string name="suggested_edits_rewards_edit_streak">Du har redigerat varje dag %1$d dagar i rad. Fortsätt med det, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Dina redigeringar har setts av %d personer under de senaste 30 dagarna. Tack och fortsätt med det!</string>
-  <string name="suggested_edits_rewards_edit_quality">Dina redigeringar är så länge %s. Fortsätt med det! Vi ser fram emot dina bidrag.</string>
-  <string name="suggested_edits_rewards_continue_button">Fortsätt</string>
   <string name="suggested_edits_encourage_account_creation_title">Visste du att alla kan redigera på Wikipedia?</string>
   <string name="suggested_edits_encourage_account_creation_message">Redigeringsförslag är ett nytt sätt att redigera på Wikipedia på Android. Det hjälper dig att göra små men väsentliga bidrag på Wikipedia.\nVårt mål är att göra det enklare och åtkomligare att redigera för alla! Logga in eller registrera dig på Wikipedia för att komma igång.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Logga in / skapa konto på Wikipedia</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -815,23 +815,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Kahapon</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Nakapag-ambag ka sa Wikipedia gamit ng Alok na Edit. Salamat po!</item>
-    <item quantity="other">Nakapag-ambag ka sa Wikipedia nang %d (na) beses gamit ng Alok na Edit. Maraming salamat po!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Nag-eedit ka na nang isang buong araw. Kaya mo yan, %2$s!</item>
-    <item quantity="other">Nag-eedit ka na nang %1$d (na) araw sunod-sunod. Kaya mo yan, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Nakita ang edit mo ng isang tao sa nakaraang 30 araw. Salamat po, at ambag pa!</item>
-    <item quantity="other">Nakita ang edit mo ng %d (na) tao sa nakaraang 30 araw. Maraming salamat po, at ambag pa!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Nag-ambag ka na nang %d (na) beses sa Wikipedia gamit ang Alok na Edit. Maraming salamat po!</string>
-  <string name="suggested_edits_rewards_edit_streak">Araw-araw ka na\'ng nag-eedit sa loob ng %1$d (na) araw. Kaya mo yan, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Nakita ng %d (na) katao ang mga edit mo sa nakalipas na 30 araw. Salamat, at tuloy lang ang pag-edit!</string>
-  <string name="suggested_edits_rewards_edit_quality">Ang mga edit mo ay %s. Tuloy lang ang pag-edit! Umaasa kami ng mga magagandang ambag mo.</string>
-  <string name="suggested_edits_rewards_continue_button">Magpatuloy</string>
   <string name="suggested_edits_encourage_account_creation_title">Alam mo ba, kahit sino pwedeng mag-edit sa Wikipedia?</string>
   <string name="suggested_edits_encourage_account_creation_message">Bagong paraan para makapag-edit sa Wikipedia gamit ng Android ang mga Alok na Edit. Matutulungan ka nitong makapag-ambag ng kahit maliit ngunit mahalagang mga ambag sa Wikipedia.\nGinagawa naming mas madali at mas kaya ang pag-eedit sa lahat ng tao! Mag-login lamang o sumali sa Wikipedia para makapagsimula ka na.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Mag-login / Sumali sa Wikipedia</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -848,23 +848,6 @@
   <string name="suggested_edits_image_tag_contribution_label">%d etiket eklediniz</string>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Dün</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Önerilen Düzenlemeleri kullanarak Vikipedi\'ye bir katkı yaptınız. Teşekkür ederiz!</item>
-    <item quantity="other">Önerilen Düzenlemeleri kullanarak Vikipedi\'ye %d katkı yaptınız. Teşekkür ederiz!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Bir gündür düzenleme yapıyorsunuz. Seriyi devam edin, %2$s!</item>
-    <item quantity="other">%1$d gündür düzenleme yapıyorsunuz. Seriyi devam etdin, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Yaptığınız düzenlemeler, son 30 gün içinde bir kişi tarafından görüldü. Teşekkürler ve devam edin!</item>
-    <item quantity="other">Düzenlemeleriniz son 30 gün içinde %d kişi tarafından görüldü. Teşekkürler ve devam edin!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Önerilen düzenlemeleri kullanarak Vikipedi\'ye %d katkı yaptınız. Teşekkürler!</string>
-  <string name="suggested_edits_rewards_edit_streak">Her gün %1$d gün boyunca düzenlediniz. Art ardaya devam et, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Düzenlemeleriniz son 30 gün içinde %d kişi tarafından görüldü. Teşekkürler ve devam et!</string>
-  <string name="suggested_edits_rewards_edit_quality">Şu ana kadar yaptığınız düzenlemeler %s. Devam edin! Katkılarınızı bekliyoruz.</string>
-  <string name="suggested_edits_rewards_continue_button">Devam et</string>
   <string name="suggested_edits_encourage_account_creation_title">Herkesin Vikipedi\'yi düzenleyebileceğini biliyor muydunuz?</string>
   <string name="suggested_edits_encourage_account_creation_message">Önerilen düzenlemeler, Android\'de Vikipedi\'yi düzenlemenin yeni bir yoludur. Vikipedi\'ye küçük ancak hayati katkılar yapmanıza yardımcı olur.\nAmacımız, düzenlemeyi herkes için daha kolay ve daha erişilebilir hale getirmektir! Başlamak için oturum açın veya Vikipedi\'ye katılın.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Vikipedi\'ye oturum açın / katılın</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -872,29 +872,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Вчора</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Ви зробили одне редагування у Вікіпедії завдяки пропонованим редагуванням. Дякуємо!</item>
-    <item quantity="few">Ви зробили %d редагування у Вікіпедії завдяки пропонованим редагуванням. Дякуємо!</item>
-    <item quantity="many">Ви зробили %d редагувань у Вікіпедії завдяки пропонованим редагуванням. Дякуємо!</item>
-    <item quantity="other">Ви зробили %d редагувань у Вікіпедії завдяки пропонованим редагуванням. Дякуємо!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Ви редагували уже один день. Продовжуйте серію, %2$s!</item>
-    <item quantity="few">Ви редагували щодня уже %1$d дні. Продовжуйте серію, %2$s!</item>
-    <item quantity="many">Ви редагували щодня уже %1$d днів. Продовжуйте серію, %2$s!</item>
-    <item quantity="other">Ви редагували щодня уже %1$d днів. Продовжуйте серію, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Ваші редагування побачила одна людина за минулі 30 днів. Дякуємо, продовжуйте!</item>
-    <item quantity="few">Ваші редагування побачили %d людей за минулі 30 днів. Дякуємо, продовжуйте!</item>
-    <item quantity="many">Ваші редагування побачили %d людей за минулі 30 днів. Дякуємо, продовжуйте!</item>
-    <item quantity="other">Ваші редагування побачили %d людей за минулі 30 днів. Дякуємо, продовжуйте!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Ви зробили внесок у Вікіпедію %d разів з допомогою Пропонованих редагувань. Дякуємо!</string>
-  <string name="suggested_edits_rewards_edit_streak">Ви редагували щодня упродовж %1$d днів. Тримайтеся цієї лінії, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Ваші редагування побачили %d людей за минулі 30 днів. Дякуємо, продовжуйте!</string>
-  <string name="suggested_edits_rewards_edit_quality">Наразі ваші редагування %s. Продовжуйте! Ми чекаємо на ваш внесок.</string>
-  <string name="suggested_edits_rewards_continue_button">Продовжити</string>
   <string name="suggested_edits_encourage_account_creation_title">Чи знаєте ви, що будь-хто може редагувати Вікіпедію?</string>
   <string name="suggested_edits_encourage_account_creation_message">Пропоновані редагування — це новий спосіб редагувати Вікіпедію з Android. Він допомагає робити невеликі, але життєво важливі внески у Вікіпедію.\nНаша мета — зробити редагування простішим і доступнішим на всіх! Увійдіть або зареєструйтеся у Вікіпедії, щоб розпочати.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Увійти / приєднатися до Вікіпедії</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -814,23 +814,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">Kecha</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">Siz Tavsiya etilgan tahrirlar yordamida Vikipediyaga bitta hissa qoʻshdingiz. Rahmat!</item>
-    <item quantity="other">Siz Tavsiya etilgan tahrirlar yordamida Vikipediyaga %d ta hissa qoʻshdingiz. Rahmat!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">Siz bugun kun boʻyin tahrir qildingiz. Shunday davom eting, %2$s!</item>
-    <item quantity="other">Shu kunlar mobaynida %1$d ta tahrirni amalga oshirdingiz. Shunday davom eting, %2$s!</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">Soʻnggi 30 kun ichida tahrirlarni bir kishi koʻrdi. Rahmat va davom eting!</item>
-    <item quantity="other">Soʻnggi 30 kun ichida tahrirlarni %d kishi koʻrdi. Rahmat va davom eting!</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">Siz tavsiya etilgan tahrirlar yordamida Vikipediyaga %d ta hissa qoʻshdingiz. Tashakkur!</string>
-  <string name="suggested_edits_rewards_edit_streak">Siz shu kunga qadar har kuni %1$d ta tahrir qildingiz. Shu zaylda davom eting, %2$s!</string>
-  <string name="suggested_edits_rewards_pageviews">Soʻnggi 30 kun ichida tahrirlaringizni %d kishi koʻrdi. Rahmat va shu zaylda davom eting!</string>
-  <string name="suggested_edits_rewards_edit_quality">Hozircha tahrirlaringiz %s. Yurishda davom eting! Sizning hissalaringizni kutib qolamiz.</string>
-  <string name="suggested_edits_rewards_continue_button">Davom etish</string>
   <string name="suggested_edits_encourage_account_creation_title">Vikipediyani hamma tahrirlashi mumkinligini bilasizmi?</string>
   <string name="suggested_edits_encourage_account_creation_message">Tavsiya etilgan tahrirlar - bu Android tizimida Vikipediyani tahrirlashning yangi usuli hisoblanadi. Bu sizga Vikipediyaga kichik, ammo hayotiy hissa qo\'shishda yordam beradi.\nBizning maqsadimiz tahrir qilishni hamma uchun osonroq va qulayroq qilishdir! Ishni boshlash uchun Vikipediyaga kiring yoki unga qo\'shiling.</string>
   <string name="suggested_edits_encourage_account_creation_login_button">Vikipediaga kirmoq</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -835,23 +835,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
   <string name="suggested_edits_contribution_date_yesterday_text">昨天</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="one">您已使用「建議編輯」為維基百科做出了 1 次貢獻。感謝您！</item>
-    <item quantity="other">您已使用「建議編輯」為維基百科做出了 %d 次貢獻。感謝您！</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">您今天有做出編輯，請繼續加油，%2$s！</item>
-    <item quantity="other">您在 %1$d 天裡每天都有做出編輯，請挑戰讓紀錄繼續延續下去，%2$s！</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="one">您的編輯在過去 30 天裡有被 1 個人看到。感謝您，請繼續加油！</item>
-    <item quantity="other">您的編輯在過去 30 天裡有被 %d 個人看到。感謝您，請繼續加油！</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">您在維基百科上使用建議編輯做出了 %d 次貢獻。感謝您！</string>
-  <string name="suggested_edits_rewards_edit_streak">到目前為止，您有連續 %1$d 天每日做出編輯的紀錄。請挑戰讓紀錄繼續延續下去，%2$s！</string>
-  <string name="suggested_edits_rewards_pageviews">您的編輯內容在過去 30 天裡已被 %d 個人觀看過。感謝您，並請繼續加油！</string>
-  <string name="suggested_edits_rewards_edit_quality">您的編輯到目前為止是%s。請繼續加油！我們期待您之後的貢獻。</string>
-  <string name="suggested_edits_rewards_continue_button">繼續</string>
   <string name="suggested_edits_encourage_account_creation_title">您知道維基百科是每個人都可編輯的嗎？</string>
   <string name="suggested_edits_encourage_account_creation_message">建議編輯是在 Android 上編輯維基百科的新方式。這能讓您做出微小；但對於維基百科是至關重要的貢獻。\n我們的目標是讓所有人能夠更輕鬆地編輯！請登入或加入維基百科來開始。</string>
   <string name="suggested_edits_encourage_account_creation_login_button">登入/加入維基百科</string>
@@ -862,7 +845,6 @@
     <item quantity="one">%1$s 個標籤</item>
     <item quantity="other">%1$s 個標籤</item>
   </plurals>
-  <string name="suggested_edits_contribution_diff_count_text">%1$s個字元</string>
   <plurals name="suggested_edits_removed_contribution_label">
     <item quantity="one">您已移除 %d 個字元</item>
     <item quantity="other">您已移除 %d 個字元</item>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -836,21 +836,6 @@
   </plurals>
   <string name="suggested_edits_contribution_type_title">%2$s（%1$d 件）</string>
   <string name="suggested_edits_contribution_date_yesterday_text">昨天</string>
-  <plurals name="suggested_edits_rewards_contributions">
-    <item quantity="other">您利用建议编辑为维基百科做了 %d 次贡献。谢谢您！</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_edit_streaks">
-    <item quantity="one">%2$s，您今天做过了编辑，请继续保持！</item>
-    <item quantity="other">%2$s，您已经连续 %1$d 天做出过编辑！加油保持每日编辑！</item>
-  </plurals>
-  <plurals name="suggested_edits_rewards_page_views">
-    <item quantity="other">您的编辑在过去 30 天已被 %d 个人查看！感谢您，请继续加油！</item>
-  </plurals>
-  <string name="suggested_edits_rewards_contribution">您利用建议编辑为维基百科做了 %d 次贡献。感谢！</string>
-  <string name="suggested_edits_rewards_edit_streak">%2$s，您已经连续 %1$d 天做出过编辑！加油保持每日编辑！</string>
-  <string name="suggested_edits_rewards_pageviews">您的编辑在过去 30 天已被 %d 个人查看！感谢您，请继续加油！</string>
-  <string name="suggested_edits_rewards_edit_quality">您的编辑目前为止评价为%s。继续加油！我们期待您今后的贡献。</string>
-  <string name="suggested_edits_rewards_continue_button">继续</string>
   <string name="suggested_edits_encourage_account_creation_title">你知道所有人都可以编辑Wikipedia吗？</string>
   <string name="suggested_edits_encourage_account_creation_message">建议编辑是在 Android 设备上编辑维基百科的全新途径。利用它，您就可以为维基百科做出微小却不可或缺的贡献。\n我们的目标是让所有人都能更轻松、更无障碍地编辑维基百科。请登录或者注册维基百科来开始。</string>
   <string name="suggested_edits_encourage_account_creation_login_button">登录/加入维基百科</string>
@@ -859,7 +844,6 @@
   <plurals name="suggested_edits_tags_diff_count_text">
     <item quantity="other">%1$s 个标签</item>
   </plurals>
-  <string name="suggested_edits_contribution_diff_count_text">%1$s个字符</string>
   <plurals name="suggested_edits_removed_contribution_label">
     <item quantity="other">您移除了 %d 个字符</item>
   </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -857,23 +857,6 @@
     </plurals>
     <string name="suggested_edits_contribution_type_title">%1$d %2$s</string>
     <string name="suggested_edits_contribution_date_yesterday_text">Yesterday</string>
-    <plurals name="suggested_edits_rewards_contributions">
-        <item quantity="one">You\'ve made one contribution to Wikipedia using Suggested Edits. Thank you!</item>
-        <item quantity="other">You\'ve made %d contributions to Wikipedia using Suggested Edits. Thank you!</item>
-    </plurals>
-    <plurals name="suggested_edits_rewards_edit_streaks">
-        <item quantity="one">You\'ve been editing for one whole day. Keep the streak going, %2$s!</item>
-        <item quantity="other">You\'ve edited every day for %1$d days so far. Keep the streak going, %2$s!</item>
-    </plurals>
-    <plurals name="suggested_edits_rewards_page_views">
-        <item quantity="one">Your edits have been seen by one person in the last 30 days. Thanks, and keep going!</item>
-        <item quantity="other">Your edits have been seen by %d people in the last 30 days. Thanks, and keep going!</item>
-    </plurals>
-    <string name="suggested_edits_rewards_contribution">You\'ve made %d contributions to Wikipedia using Suggested edits. Thank you!</string>
-    <string name="suggested_edits_rewards_edit_streak">You\'ve edited every day for %1$d days so far. Keep the streak going, %2$s!</string>
-    <string name="suggested_edits_rewards_pageviews">Your edits have been seen by %d people in the last 30 days. Thanks, and keep going!</string>
-    <string name="suggested_edits_rewards_edit_quality">Your edits so far are %s. Keep going! We look forward to your contributions.</string>
-    <string name="suggested_edits_rewards_continue_button">Continue</string>
     <string name="suggested_edits_encourage_account_creation_title">Did you know that everyone can edit Wikipedia?</string>
     <string name="suggested_edits_encourage_account_creation_message">Suggested edits is a new way to edit Wikipedia on Android. It helps you make small but vital contributions to Wikipedia.\nOur goal is to make editing easier and more accessible for everyone! Log in or join Wikipedia to get started.</string>
     <string name="suggested_edits_encourage_account_creation_login_button">Log in / join Wikipedia</string>


### PR DESCRIPTION
This PR also corrects the `suggested_edits_tags_diff_count_text` and `suggested_edits_removed_contribution_label` in `qq/strings.xml` that should be `plurals` items.