### PR TITLE
Follow up: display file page image when images are disabled

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -119,7 +119,7 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
 
     private fun loadImage(summaryForEdit: PageSummaryForEdit, containerWidth: Int, thumbWidth: Int, thumbHeight: Int) {
         ImageZoomHelper.setViewZoomable(imageView)
-        ViewUtil.loadImage(imageView, ImageUrlUtil.getUrlForPreferredSize(summaryForEdit.thumbnailUrl!!, PREFERRED_GALLERY_IMAGE_SIZE))
+        ViewUtil.loadImage(imageView, ImageUrlUtil.getUrlForPreferredSize(summaryForEdit.thumbnailUrl!!, PREFERRED_GALLERY_IMAGE_SIZE), false, false, true, null)
         imageViewPlaceholder.layoutParams = LayoutParams(containerWidth, ViewUtil.adjustImagePlaceholderHeight(containerWidth.toFloat(), thumbWidth.toFloat(), thumbHeight.toFloat()))
     }
 


### PR DESCRIPTION
A follow-up PR of #1898. The only way of viewing the "Picture of the day" image is on the File page, and we should still show the image if images are disabled.