### PR TITLE
Fix: use the same text direction in the ReferenceDialog as the article

### DIFF
--- a/app/src/main/res/layout/view_reference_pager_item.xml
+++ b/app/src/main/res/layout/view_reference_pager_item.xml
@@ -29,6 +29,7 @@
         android:textColor="?android:textColorPrimary"
         android:textIsSelectable="true"
         android:textSize="16sp"
+        android:textDirection="locale"
         tools:text="Reference text" />
 
 </LinearLayout>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T127406