### PR TITLE
Fix: update Watchlist overflow menu item properly

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1553,6 +1553,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
         if (watch.getUnwatched()) {
             FeedbackUtil.showMessage(this, getString(R.string.watchlist_page_removed_from_watchlist_snackbar, getTitle().getDisplayText()));
             watchlistExpirySession = null;
+            model.setWatched(false);
         } else if (watch.getWatched() && expiry != null) {
             Snackbar snackbar = FeedbackUtil.makeSnackbar(requireActivity(),
                     getString(R.string.watchlist_page_add_to_watchlist_snackbar,


### PR DESCRIPTION
If we visit a page that has already on the watchlist and then remove it, the menu item status will not be changed properly.