### PR TITLE
Whoops: fix rotation of SingleFragmentActivity.

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
@@ -14,8 +14,14 @@ abstract class SingleFragmentActivity<T : Fragment> : BaseActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(layout)
-        fragment = createFragment()
-        supportFragmentManager.beginTransaction().add(R.id.fragment_container, fragment).commit()
+
+        val currentFragment: T? = supportFragmentManager.findFragmentById(R.id.fragment_container) as T?
+        if (currentFragment != null) {
+            fragment = currentFragment
+        } else {
+            fragment = createFragment()
+            supportFragmentManager.beginTransaction().add(R.id.fragment_container, fragment).commit()
+        }
     }
 
     protected abstract fun createFragment(): T


### PR DESCRIPTION
This one slipped past me:
When an Activity is rotated, it gets recreated (`onCreate` is called again) but its state is preserved, along with the fragment that's already in there, so we don't need to re-add the fragment a second time.