### PR TITLE
Fix: get fragment value properly to prevent issue when changing device orientation

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
@@ -11,22 +11,19 @@ import org.wikipedia.R
  * Boilerplate for a FragmentActivity containing a single stack of Fragments.
  */
 abstract class SingleFragmentActivity<T : Fragment> : BaseActivity() {
+    @Suppress("UNCHECKED_CAST")
+    val fragment: T?
+        get() = supportFragmentManager.findFragmentById(containerId) as T?
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(layout)
-        if (getFragment() == null) {
+        if (fragment == null) {
             supportFragmentManager.beginTransaction().add(containerId, createFragment()).commit()
         }
     }
 
     protected abstract fun createFragment(): T
-
-    /** @return The Fragment added to the stack.
-     */
-    @Suppress("UNCHECKED_CAST")
-    protected open fun getFragment(): T? {
-        return supportFragmentManager.findFragmentById(containerId) as T?
-    }
 
     /** @return The resource layout to inflate which must contain a [android.view.ViewGroup]
      * whose ID is [.getContainerId].

--- a/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
@@ -1,24 +1,32 @@
 package org.wikipedia.activity
 
 import android.os.Bundle
+import androidx.annotation.IdRes
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import org.wikipedia.R
+
 
 /**
  * Boilerplate for a FragmentActivity containing a single stack of Fragments.
  */
 abstract class SingleFragmentActivity<T : Fragment> : BaseActivity() {
-    lateinit var fragment: T
-
-    public override fun onCreate(savedInstanceState: Bundle?) {
+    override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(layout)
-        fragment = createFragment()
-        supportFragmentManager.beginTransaction().add(R.id.fragment_container, fragment).commit()
+        if (getFragment() == null) {
+            supportFragmentManager.beginTransaction().add(containerId, createFragment()).commit()
+        }
     }
 
     protected abstract fun createFragment(): T
+
+    /** @return The Fragment added to the stack.
+     */
+    @Suppress("UNCHECKED_CAST")
+    protected open fun getFragment(): T? {
+        return supportFragmentManager.findFragmentById(containerId) as T?
+    }
 
     /** @return The resource layout to inflate which must contain a [android.view.ViewGroup]
      * whose ID is [.getContainerId].
@@ -26,4 +34,10 @@ abstract class SingleFragmentActivity<T : Fragment> : BaseActivity() {
     @get:LayoutRes
     protected open val layout: Int
         get() = R.layout.activity_single_fragment
+
+    /** @return The resource identifier for the Fragment container.
+     */
+    @get:IdRes
+    protected open val containerId: Int
+        get() = R.id.fragment_container
 }

--- a/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
@@ -6,7 +6,6 @@ import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import org.wikipedia.R
 
-
 /**
  * Boilerplate for a FragmentActivity containing a single stack of Fragments.
  */


### PR DESCRIPTION
Steps to reproduce:

1. Go to Explore Feed.
2. Change device orientation to landscape.
3. Scroll down and you will see the view overlapped.