### PR TITLE
Fix updating of reading list metadata for articles in multiple lists.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -538,7 +538,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             disposables.add(Completable.fromAction(() -> {
                 if (!TextUtils.equals(page.thumbUrl(), title.getThumbUrl())
                         || !TextUtils.equals(page.description(), title.getDescription())) {
-                    ReadingListDbHelper.instance().updateMetadataByTitle(page.apiTitle(), page.lang(),
+                    ReadingListDbHelper.instance().updateMetadataByTitle(page,
                             title.getDescription(), title.getThumbUrl());
                 }
             }).subscribeOn(Schedulers.io()).subscribe());

--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -538,9 +538,8 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             disposables.add(Completable.fromAction(() -> {
                 if (!TextUtils.equals(page.thumbUrl(), title.getThumbUrl())
                         || !TextUtils.equals(page.description(), title.getDescription())) {
-                    page.thumbUrl(title.getThumbUrl());
-                    page.description(title.getDescription());
-                    ReadingListDbHelper.instance().updatePage(page);
+                    ReadingListDbHelper.instance().updateMetadataByTitle(page.apiTitle(), page.lang(),
+                            title.getDescription(), title.getThumbUrl());
                 }
             }).subscribeOn(Schedulers.io()).subscribe());
         }

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
@@ -391,8 +391,8 @@ public class ReadingListDbHelper {
         }
     }
 
-    public void updateMetadataByTitle(@NonNull String title, @NonNull String lang,
-                                      @Nullable String description, @Nullable String thumbUrl) {
+    public void updateMetadataByTitle(@NonNull ReadingListPage pageProto, @Nullable String description,
+                                      @Nullable String thumbUrl) {
         SQLiteDatabase db = getWritableDatabase();
         db.beginTransaction();
         try {
@@ -401,10 +401,11 @@ public class ReadingListDbHelper {
             contentValues.put(ReadingListPageContract.Col.DESCRIPTION.getName(), description);
             int result = db.update(ReadingListPageContract.TABLE, contentValues,
                     ReadingListPageContract.Col.API_TITLE.getName() + " = ? AND "
+                            + ReadingListPageContract.Col.DISPLAY_TITLE.getName() + " = ? AND "
                             + ReadingListPageContract.Col.LANG.getName() + " = ?",
-                    new String[]{title, lang});
+                    new String[]{pageProto.apiTitle(), pageProto.title(), pageProto.lang()});
             if (result != 1) {
-                L.w("Failed to update db entry for page " + title);
+                L.w("Failed to update db entry for page " + pageProto.title());
             }
             db.setTransactionSuccessful();
         } finally {

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListDbHelper.java
@@ -391,6 +391,27 @@ public class ReadingListDbHelper {
         }
     }
 
+    public void updateMetadataByTitle(@NonNull String title, @NonNull String lang,
+                                      @Nullable String description, @Nullable String thumbUrl) {
+        SQLiteDatabase db = getWritableDatabase();
+        db.beginTransaction();
+        try {
+            ContentValues contentValues = new ContentValues();
+            contentValues.put(ReadingListPageContract.Col.THUMBNAIL_URL.getName(), thumbUrl);
+            contentValues.put(ReadingListPageContract.Col.DESCRIPTION.getName(), description);
+            int result = db.update(ReadingListPageContract.TABLE, contentValues,
+                    ReadingListPageContract.Col.API_TITLE.getName() + " = ? AND "
+                            + ReadingListPageContract.Col.LANG.getName() + " = ?",
+                    new String[]{title, lang});
+            if (result != 1) {
+                L.w("Failed to update db entry for page " + title);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+    }
+
     private void insertPageInDb(SQLiteDatabase db, @NonNull ReadingList list, @NonNull ReadingListPage page) {
         page.listId(list.id());
         long id = db.insertOrThrow(ReadingListPageContract.TABLE, null,


### PR DESCRIPTION
A rather obscure issue, but worth fixing:
* Add an article to more than one reading list, and make sure the lists are synced to your account.
* Uninstall the app, then reinstall it and login to get your lists back, but cancel downloading of the articles as soon as it starts.
* Go to your reading lists and navigate to the article that you added (pick from one of the lists).
* Wait for the article to load, so that its description and lead image are loaded.
* Go back to your lists, and observe that the description and thumbnail for that page are not updated, or updated only for one instance, instead of all of them.