### PR TITLE
Fix: app will crash when returning from article to Explore feed

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -488,6 +488,9 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
             }
 
             public void onPageFinished(WebView view, String url) {
+                if (!isAdded()) {
+                    return;
+                }
                 bridge.evaluateImmediate("(function() { return (typeof pcs !== 'undefined'); })();", pcsExists -> {
                     if (!isAdded()) {
                         return;


### PR DESCRIPTION
Looks like the conversion to Kotlin in #1968 brings this issue up to the surface, which the `communicationBridgeListener.webView` throws the following error:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.webkit.WebView.evaluateJavascript(java.lang.String, android.webkit.ValueCallback)' on a null object reference
        at org.wikipedia.bridge.CommunicationBridge.evaluateImmediate(CommunicationBridge.kt:114)
        at org.wikipedia.page.PageFragment$2.onPageFinished(PageFragment.java:491)
        at Z80.b(chromium-TrichromeWebViewGoogle.aab-stable-432409333:2)
        at j6.handleMessage(chromium-TrichromeWebViewGoogle.aab-stable-432409333:64)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:237)
        at android.app.ActivityThread.main(ActivityThread.java:8167)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
```