### PR TITLE
Fix crash upon destroying WebView.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.kt
+++ b/app/src/main/java/org/wikipedia/bridge/CommunicationBridge.kt
@@ -85,6 +85,7 @@ class CommunicationBridge constructor(private val communicationBridgeListener: C
         eventListeners.clear()
         incomingMessageHandler?.removeCallbacksAndMessages(null)
         incomingMessageHandler = null
+        communicationBridgeListener.webView.webViewClient = WebViewClient()
         communicationBridgeListener.webView.removeJavascriptInterface("pcsClient")
         // Explicitly load a blank page into the WebView, to stop playback of any media.
         loadBlankPage()


### PR DESCRIPTION
@cooltey  sorry, this is the real reason for the crash:
When converting the Bridge code, there was a line that resets the WebViewClient to `null`, but I forgot to put it back because Kotlin was not allowing a null value to be passed there. We will now pass an empty WebViewClient, which is the more proper thing to do anyway.