### PR TITLE
Follow-up: simplify and fix a bunch of things in Diff view.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
@@ -176,6 +176,7 @@ public class MwQueryPage extends BaseModel {
         @Nullable private String content;
         @Nullable private String comment;
         @Nullable private Map<String, RevisionSlot> slots;
+        private int size;
 
         @NonNull public String getComment() {
             return StringUtils.defaultString(comment);
@@ -192,6 +193,10 @@ public class MwQueryPage extends BaseModel {
         @NonNull
         public String getUser() {
             return StringUtils.defaultString(user);
+        }
+
+        public int getSize() {
+            return size;
         }
 
         @NonNull

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
@@ -176,7 +176,6 @@ public class MwQueryPage extends BaseModel {
         @Nullable private String content;
         @Nullable private String comment;
         @Nullable private Map<String, RevisionSlot> slots;
-        private int size;
 
         @NonNull public String getComment() {
             return StringUtils.defaultString(comment);
@@ -193,10 +192,6 @@ public class MwQueryPage extends BaseModel {
         @NonNull
         public String getUser() {
             return StringUtils.defaultString(user);
-        }
-
-        public int getSize() {
-            return size;
         }
 
         @NonNull

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsActivity.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsActivity.kt
@@ -9,22 +9,19 @@ class ArticleEditDetailsActivity : SingleFragmentActivity<ArticleEditDetailsFrag
     override fun createFragment(): ArticleEditDetailsFragment {
         return ArticleEditDetailsFragment.newInstance(intent.getStringExtra(EXTRA_ARTICLE_TITLE)!!,
                 intent.getLongExtra(EXTRA_EDIT_REVISION_ID, 0),
-                intent.getStringExtra(EXTRA_EDIT_LANGUAGE_CODE)!!,
-                intent.getIntExtra(EXTRA_EDIT_SIZE, 0))
+                intent.getStringExtra(EXTRA_EDIT_LANGUAGE_CODE)!!)
     }
 
     companion object {
         const val EXTRA_ARTICLE_TITLE = "articleTitle"
         const val EXTRA_EDIT_REVISION_ID = "revisionId"
         const val EXTRA_EDIT_LANGUAGE_CODE = "languageCode"
-        const val EXTRA_EDIT_SIZE = "diffSize"
 
-        fun newIntent(context: Context, articleTitle: String, revisionId: Long, languageCode: String, diffSize: Int): Intent {
+        fun newIntent(context: Context, articleTitle: String, revisionId: Long, languageCode: String): Intent {
             return Intent(context, ArticleEditDetailsActivity::class.java)
                     .putExtra(EXTRA_ARTICLE_TITLE, articleTitle)
                     .putExtra(EXTRA_EDIT_REVISION_ID, revisionId)
                     .putExtra(EXTRA_EDIT_LANGUAGE_CODE, languageCode)
-                    .putExtra(EXTRA_EDIT_SIZE, diffSize)
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -73,6 +73,15 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     private val disposables = CompositeDisposable()
     private val bottomSheetPresenter = ExclusiveBottomSheetPresenter()
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        retainInstance = true
+        revisionId = requireArguments().getLong(EXTRA_EDIT_REVISION_ID, 0)
+        languageCode = requireArguments().getString(EXTRA_EDIT_LANGUAGE_CODE, AppLanguageLookUpTable.FALLBACK_LANGUAGE_CODE)
+        articlePageTitle = PageTitle(requireArguments().getString(EXTRA_ARTICLE_TITLE, ""),
+                WikiSite.forLanguageCode(languageCode))
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -81,10 +90,6 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        revisionId = requireArguments().getLong(EXTRA_EDIT_REVISION_ID, 0)
-        languageCode = requireArguments().getString(EXTRA_EDIT_LANGUAGE_CODE, AppLanguageLookUpTable.FALLBACK_LANGUAGE_CODE)
-        articlePageTitle = PageTitle(requireArguments().getString(EXTRA_ARTICLE_TITLE, ""),
-                WikiSite.forLanguageCode(languageCode))
         setUpInitialUI()
         setUpListeners()
         getWatchedStatus()
@@ -101,12 +106,10 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
             }
         }
         newerIdButton.setOnClickListener {
-            diffSize = 0
             revisionId = newerRevisionId
             fetchEditDetails()
         }
         olderIdButton.setOnClickListener {
-            diffSize = 0
             revisionId = olderRevisionId
             fetchEditDetails()
         }
@@ -172,6 +175,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                 .subscribe({
                     val firstPage = it.query()!!.firstPage()!!
                     currentRevision = firstPage.revisions()[0]
+                    revisionId = currentRevision!!.revId
                     username = currentRevision!!.user
                     newerRevisionId = if (firstPage.revisions().size < 2) {
                         -1
@@ -186,12 +190,14 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     private fun hideOrShowViews(isLoading: Boolean) {
         if (isLoading) {
             progressBar.visibility = VISIBLE
-            userDetailsFlowView.visibility = INVISIBLE
+            usernameButton.visibility = INVISIBLE
+            thankButton.visibility = INVISIBLE
             editComment.visibility = INVISIBLE
             diffText.visibility = INVISIBLE
+            diffCharacterCountView.visibility = INVISIBLE
         } else {
-            progressBar.visibility = INVISIBLE
-            userDetailsFlowView.visibility = VISIBLE
+            usernameButton.visibility = VISIBLE
+            thankButton.visibility = VISIBLE
             editComment.visibility = VISIBLE
             diffText.visibility = VISIBLE
         }
@@ -329,15 +335,22 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
 
     private fun fetchDiffText() {
         disposables.add(ServiceFactory.getCoreRest(WikiSite.forLanguageCode(languageCode)).getDiff(olderRevisionId, revisionId)
+                .map {
+                    createSpannable(it.diffs)
+                }
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    displayDiffs(it.diffs)
+                    diffText.text = it
+                    updateDiffCharCountView(diffSize)
+                    progressBar.visibility = INVISIBLE
+                    diffCharacterCountView.visibility = VISIBLE
                 }) { t: Throwable? -> L.e(t) })
     }
 
-    private fun displayDiffs(diffs: List<DiffItem>) {
+    private fun createSpannable(diffs: List<DiffItem>): CharSequence {
         val spannableString = SpannableStringBuilder()
+        diffSize = 0
         for (diff in diffs) {
             val prefixLength = spannableString.length
             spannableString.append(if (diff.text.isNotEmpty()) diff.text else "\n")
@@ -376,8 +389,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
             }
             spannableString.append("\n")
         }
-        diffText.text = spannableString
-        updateDiffCharCountView(diffSize)
+        return spannableString
     }
 
     private fun updateDiffTextDecor(spannableText: SpannableStringBuilder, isAddition: Boolean, start: Int, end: Int) {

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
@@ -294,7 +294,7 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
             return
         }
         startActivity(ArticleEditDetailsActivity.newIntent(requireContext(), item.title,
-                item.revid, item.wiki.languageCode(), item.newlen - item.oldlen))
+                item.revid, item.wiki.languageCode()))
     }
 
     override fun onUserClick(item: MwQueryResult.WatchlistItem) {


### PR DESCRIPTION
* The character count was incorrect (off-by-one) for certain types of diffs.
* This fixes rotating the display and staying on the revision that you were looking at before rotating.
* We only need to check once if the article is Watched -- we don't need to re-check it every time we go backward and forward through the edit history.
* We no longer need to pass the diff size from the parent activity, since we're calculating the diff size ourselves.
* We can compose the actual diff (Spannable) in a background thread, and not block the UI thread while loading it.