### PR TITLE
Tweak: don't load talk page an extra time unnecessarily.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -79,7 +79,6 @@ class TalkTopicsActivity : BaseActivity() {
         funnel.logOpenTalk()
 
         talkNewTopicButton.visibility = View.GONE
-        loadTopics()
     }
 
     public override fun onDestroy() {


### PR DESCRIPTION
The `loadTopics` function, which makes the network call to load the talk page, gets called in `onResume()`, so it doesn't need to be called in `onCreate()`.