### PR TITLE
Fix: URL fragment should be encoded before navigating to other articles in PageFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageTitle.java
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.java
@@ -353,7 +353,7 @@ public class PageTitle implements Parcelable {
                     domain,
                     domain.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE) ? getWikiSite().languageCode() : "wiki",
                     URLEncoder.encode(getPrefixedText(), "utf-8"),
-                    (this.fragment != null && this.fragment.length() > 0) ? ("#" + this.fragment) : ""
+                    (this.fragment != null && this.fragment.length() > 0) ? ("#" + URLEncoder.encode(this.fragment, "utf-8")) : ""
             );
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Steps to reproduce:

1. Go to https://en.wikipedia.org/wiki/Joey_Santiago
2. Change article language to `zh-hant`
3. Click the first in-article link `菲律賓裔美國`
4. On the `菲律賓裔美國` page, click any in-article links and will see an error message.