### PR TITLE
Fix: Improper revId results in 404

### DIFF
--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -334,6 +334,9 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     }
 
     private fun fetchDiffText() {
+        if (olderRevisionId == 0L) {
+            return
+        }
         disposables.add(ServiceFactory.getCoreRest(WikiSite.forLanguageCode(languageCode)).getDiff(olderRevisionId, revisionId)
                 .map {
                     createSpannable(it.diffs)

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistItemView.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistItemView.kt
@@ -67,6 +67,8 @@ class WatchlistItemView constructor(context: Context, attrs: AttributeSet? = nul
                     setButtonTextAndIconColor(context.getString(R.string.watchlist_page_deleted), R.attr.suggestions_background_color, R.drawable.ic_delete_white_24dp)
                 }
             }
+            containerView.alpha = 0.5f
+            containerView.isClickable = false
         } else {
             val diffByteCount = item.newlen - item.oldlen
             setButtonTextAndIconColor(String.format("%+d", diffByteCount), R.attr.color_group_22)
@@ -76,6 +78,8 @@ class WatchlistItemView constructor(context: Context, attrs: AttributeSet? = nul
             } else {
                 diffText.setTextColor(ContextCompat.getColor(context, R.color.red50))
             }
+            containerView.alpha = 1.0f
+            containerView.isClickable = true
         }
     }
 


### PR DESCRIPTION
**Phab: ** https://phabricator.wikimedia.org/T269447

Beginning of a page doesn't have a diff text, and the comparison results in 404. Any content associated with the initial commit is returned as a comment