### PR TITLE
Fix additional UI issues in Diff screens.

### DIFF
--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -147,13 +147,12 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     }
 
     private fun updateDiffCharCountView(diffSize: Int) {
+        diffCharacterCountView.text = String.format(if (diffSize != 0) "%+d" else "%d", diffSize)
         if (diffSize >= 0) {
             diffCharacterCountView.setTextColor(if (diffSize > 0) ContextCompat.getColor(requireContext(),
                     R.color.green50) else ResourceUtil.getThemedColor(requireContext(), R.attr.material_theme_secondary_color))
-            diffCharacterCountView.text = String.format("%+d", diffSize)
         } else {
             diffCharacterCountView.setTextColor(ContextCompat.getColor(requireContext(), R.color.red50))
-            diffCharacterCountView.text = String.format("%+d", diffSize)
         }
     }
 
@@ -207,7 +206,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         diffText.scrollTo(0, 0)
         diffText.text = ""
         usernameButton.text = currentRevision!!.user
-        editTimestamp.text = DateUtil.getDateAndTimeStringFromTimestampString(currentRevision!!.timeStamp())
+        editTimestamp.text = DateUtil.getDateAndTimeWithPipe(DateUtil.iso8601DateParse(currentRevision!!.timeStamp()))
         editComment.text = currentRevision!!.comment
         newerIdButton.isClickable = newerRevisionId != -1L
         olderIdButton.isClickable = olderRevisionId != 0L

--- a/app/src/main/java/org/wikipedia/util/DateUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.kt
@@ -90,8 +90,8 @@ object DateUtil {
         return getDateStringWithSkeletonPattern(date, "HH:mm")
     }
 
-    fun getDateAndTimeStringFromTimestampString(dateStr: String): String {
-        return getCachedDateFormat("MMM dd, yyyy | HH:mm", Locale.ROOT, false)!!.format(iso8601DateParse(dateStr))
+    fun getDateAndTimeWithPipe(date: Date): String {
+        return getCachedDateFormat("MMM dd, yyyy | HH:mm", Locale.getDefault(), false)!!.format(date)
     }
 
     @Synchronized

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistItemView.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistItemView.kt
@@ -71,7 +71,7 @@ class WatchlistItemView constructor(context: Context, attrs: AttributeSet? = nul
             containerView.isClickable = false
         } else {
             val diffByteCount = item.newlen - item.oldlen
-            setButtonTextAndIconColor(String.format("%+d", diffByteCount), R.attr.color_group_22)
+            setButtonTextAndIconColor(String.format(if (diffByteCount != 0) "%+d" else "%d", diffByteCount), R.attr.color_group_22)
             if (diffByteCount >= 0) {
                 diffText.setTextColor(if (diffByteCount > 0) ContextCompat.getColor(context, R.color.green50)
                 else ResourceUtil.getThemedColor(context, R.attr.material_theme_secondary_color))

--- a/app/src/main/res/layout/item_watchlist.xml
+++ b/app/src/main/res/layout/item_watchlist.xml
@@ -90,7 +90,7 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/diffText"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/FlatButton.Small"
             android:layout_marginTop="4dp"


### PR DESCRIPTION
* I recall discussing the `Locale.ROOT` issue that was causing incorrect "M01" dates to be shown, but it looks like this was never fixed?
* Apply correct sizing to the diff-count button.
* For zero-sized diffs, show "0" instead of "+0".

https://phabricator.wikimedia.org/T269447