### PR TITLE
Dismiss login dialog to prevent showing the dialog after logged in.

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -239,7 +239,10 @@ abstract class BaseActivity : AppCompatActivity() {
                     .setCancelable(false)
                     .setTitle(R.string.logged_out_in_background_title)
                     .setMessage(R.string.logged_out_in_background_dialog)
-                    .setPositiveButton(R.string.logged_out_in_background_login) { _: DialogInterface?, _: Int -> startActivity(LoginActivity.newIntent(this@BaseActivity, LoginFunnel.SOURCE_LOGOUT_BACKGROUND)) }
+                    .setPositiveButton(R.string.logged_out_in_background_login) { dialog : DialogInterface, _: Int ->
+                        startActivity(LoginActivity.newIntent(this@BaseActivity, LoginFunnel.SOURCE_LOGOUT_BACKGROUND))
+                        dialog.dismiss()
+                    }
                     .setNegativeButton(R.string.logged_out_in_background_cancel, null)
                     .show()
         }

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -239,7 +239,7 @@ abstract class BaseActivity : AppCompatActivity() {
                     .setCancelable(false)
                     .setTitle(R.string.logged_out_in_background_title)
                     .setMessage(R.string.logged_out_in_background_dialog)
-                    .setPositiveButton(R.string.logged_out_in_background_login) { dialog : DialogInterface, _: Int ->
+                    .setPositiveButton(R.string.logged_out_in_background_login) { dialog: DialogInterface, _: Int ->
                         startActivity(LoginActivity.newIntent(this@BaseActivity, LoginFunnel.SOURCE_LOGOUT_BACKGROUND))
                         dialog.dismiss()
                     }


### PR DESCRIPTION
The dialog should be dismissed after clicking on the positive button, otherwise, users will still see the dialog after logging in.