### PR TITLE
Fix loss of namespace when showing redirected title in Link Preview.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
@@ -219,6 +219,7 @@ public class LinkPreviewDialog extends ExtendedBottomSheetDialogFragment
                     revision = summary.getRevision();
 
                     // Rebuild our PageTitle, since it may have been redirected or normalized.
+                    String oldFragment = pageTitle.getFragment();
                     pageTitle = new PageTitle(summary.getApiTitle(), pageTitle.getWikiSite(), summary.getThumbnailUrl(),
                             summary.getDescription(), summary.getDisplayTitle());
 
@@ -226,6 +227,8 @@ public class LinkPreviewDialog extends ExtendedBottomSheetDialogFragment
                     // to a specific section in the target article.
                     if (!TextUtils.isEmpty(response.raw().request().url().fragment())) {
                         pageTitle.setFragment(response.raw().request().url().fragment());
+                    } else if (!TextUtils.isEmpty(oldFragment)) {
+                        pageTitle.setFragment(oldFragment);
                     }
 
                     titleText.setText(StringUtil.fromHtml(summary.getDisplayTitle()));

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.java
@@ -215,17 +215,20 @@ public class LinkPreviewDialog extends ExtendedBottomSheetDialogFragment
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response -> {
                     PageSummary summary = response.body();
+                    funnel.setPageId(summary.getPageId());
+                    revision = summary.getRevision();
+
+                    // Rebuild our PageTitle, since it may have been redirected or normalized.
+                    pageTitle = new PageTitle(summary.getApiTitle(), pageTitle.getWikiSite(), summary.getThumbnailUrl(),
+                            summary.getDescription(), summary.getDisplayTitle());
+
                     // check if our URL was redirected, which might include a URL fragment that leads
                     // to a specific section in the target article.
-                    funnel.setPageId(summary.getPageId());
-                    pageTitle.setThumbUrl(summary.getThumbnailUrl());
-                    revision = summary.getRevision();
-                    titleText.setText(StringUtil.fromHtml(summary.getDisplayTitle()));
-                    // TODO: remove after the restbase endpoint supports ZH variants
-                    pageTitle.setText(StringUtil.removeNamespace(summary.getApiTitle()));
                     if (!TextUtils.isEmpty(response.raw().request().url().fragment())) {
                         pageTitle.setFragment(response.raw().request().url().fragment());
                     }
+
+                    titleText.setText(StringUtil.fromHtml(summary.getDisplayTitle()));
                     showPreview(new LinkPreviewContents(summary, pageTitle.getWikiSite()));
                 }, caught -> {
                     L.e(caught);


### PR DESCRIPTION
We were stripping away the namespace when applying the proper title from the Summary response, but this is incorrect when the response is a redirect to a page in a different namespace.
It's better to reconstruct the PageTitle altogether, with the information received from the Summary response.