### PR TITLE
Correctly remove Wikipedia from any Sharing intents.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/ShareUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ShareUtil.kt
@@ -4,7 +4,6 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.LabeledIntent
-import android.content.pm.ResolveInfo
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
@@ -32,7 +31,8 @@ object ShareUtil {
         shareIntent.putExtra(Intent.EXTRA_SUBJECT, subject)
         shareIntent.putExtra(Intent.EXTRA_TEXT, text)
         shareIntent.type = "text/plain"
-        val chooserIntent = Intent.createChooser(shareIntent, context.getString(R.string.share_via))
+
+        val chooserIntent = getIntentChooser(context, shareIntent, context.getString(R.string.share_via))
         if (chooserIntent == null) {
             showUnresolvableIntentMessage(context)
         } else {
@@ -75,9 +75,9 @@ object ShareUtil {
     }
 
     private fun buildImageShareChooserIntent(context: Context, subject: String,
-                                             text: String, uri: Uri): Intent {
+                                             text: String, uri: Uri): Intent? {
         val shareIntent = createImageShareIntent(subject, text, uri)
-        return Intent.createChooser(shareIntent,
+        return getIntentChooser(context, shareIntent,
                 context.resources.getString(R.string.image_share_via))
     }
 
@@ -152,108 +152,50 @@ object ShareUtil {
         return fileNameStr
     }
 
-    @JvmStatic
-    fun createChooserIntent(targetIntent: Intent, context: Context): Intent {
-        val chooser = Intent.createChooser(targetIntent, null)
-
-
-        //val componentName = ComponentName(activityInfo.packageName, activityInfo.name)
-
-        //chooser.putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, )
-
-
-        var intents = queryIntents(context, targetIntent, false)
-        if (intents.isEmpty()) {
-            // This implies that the Wikipedia app itself has been chosen as the default handler
-            // for our links, so we need to explicitly build a chooser that contains other activities.
-            intents = queryIntents(context, targetIntent, true)
-            if (intents.isNotEmpty()) {
-                chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, intents.toTypedArray<Parcelable>())
-            }
-        }
-        return chooser
-    }
-
     fun getIntentChooser(context: Context, intent: Intent, chooserTitle: CharSequence? = null): Intent? {
-        val resolveInfos = context.packageManager.queryIntentActivities(intent, 0)
-        val excludedComponentNames = HashSet<ComponentName>()
-        resolveInfos.forEach {
+        val infoList = context.packageManager.queryIntentActivities(intent, 0)
+        val excludedComponents = HashSet<ComponentName>()
+        infoList.forEach {
             val activityInfo = it.activityInfo
             val componentName = ComponentName(activityInfo.packageName, activityInfo.name)
             if (isSelfComponentName(componentName))
-                excludedComponentNames.add(componentName)
+                excludedComponents.add(componentName)
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            return Intent.createChooser(intent, chooserTitle).putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludedComponentNames.toTypedArray())
+            return Intent.createChooser(intent, chooserTitle)
+                    .putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludedComponents.toTypedArray())
         }
-        if (resolveInfos.isNotEmpty()) {
-            val targetIntents: MutableList<Intent> = ArrayList()
-            for (resolveInfo in resolveInfos) {
-                val activityInfo = resolveInfo.activityInfo
-                if (excludedComponentNames.contains(ComponentName(activityInfo.packageName, activityInfo.name)))
-                    continue
-                val targetIntent = Intent(intent)
-                targetIntent.setPackage(activityInfo.packageName)
-                targetIntent.component = ComponentName(activityInfo.packageName, activityInfo.name)
-                val labeledIntent = LabeledIntent(targetIntent, activityInfo.packageName, resolveInfo.labelRes, resolveInfo.icon)
-                // add filtered intent to a list
-                targetIntents.add(labeledIntent)
-            }
-            val chooserIntent: Intent?
-            chooserIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                Intent.createChooser(Intent(), chooserTitle)
-            } else {
-                Intent.createChooser(targetIntents.removeAt(0), chooserTitle)
-            }
-            if (chooserIntent == null) {
-                return null
-            }
-            // add initial intents
-            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetIntents.toTypedArray<Parcelable>())
-            return chooserIntent
+        if (infoList.isEmpty()) {
+            return null
         }
-        return null
-    }
-
-
-
-
-
-    private fun queryIntents(context: Context, targetIntent: Intent, replaceUri: Boolean): List<Intent> {
-        val intents: MutableList<Intent> = ArrayList()
-        var queryIntent = targetIntent
-        if (replaceUri) {
-            queryIntent = Intent(targetIntent)
-            queryIntent.data = Uri.parse("https://example.com/")
+        val targetIntents = ArrayList<Intent>()
+        for (info in infoList) {
+            val activityInfo = info.activityInfo
+            if (excludedComponents.contains(ComponentName(activityInfo.packageName, activityInfo.name)))
+                continue
+            val targetIntent = Intent(intent)
+                    .setPackage(activityInfo.packageName)
+                    .setComponent(ComponentName(activityInfo.packageName, activityInfo.name))
+            targetIntents.add(LabeledIntent(targetIntent, activityInfo.packageName, info.labelRes, info.icon))
         }
+        val chooserIntent = (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Intent.createChooser(Intent(), chooserTitle)
+        } else {
+            Intent.createChooser(targetIntents.removeAt(0), chooserTitle)
+        }) ?: return null
 
-        intents.addAll(context.packageManager.queryIntentActivities(queryIntent, 0)
-                //.filter { !isIntentActivityBlacklisted(it) }
-                .map { buildLabeledIntent(targetIntent, it) })
-
-        return intents
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetIntents.toTypedArray<Parcelable>())
+        return chooserIntent
     }
 
     @JvmStatic
     fun canOpenUrlInApp(context: Context, url: String): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
         return context.packageManager.queryIntentActivities(intent, 0)
-                .any { getPackageName(it).matches(APP_PACKAGE_REGEX.toRegex()) }
+                .any { it.activityInfo.packageName.matches(APP_PACKAGE_REGEX.toRegex()) }
     }
 
     private fun isSelfComponentName(componentName: ComponentName): Boolean {
         return componentName.packageName.matches(APP_PACKAGE_REGEX.toRegex())
-    }
-
-    private fun buildLabeledIntent(intent: Intent, intentActivity: ResolveInfo): LabeledIntent {
-        val labeledIntent = LabeledIntent(intent, intentActivity.resolvePackageName,
-                intentActivity.labelRes, intentActivity.iconResource)
-        labeledIntent.setPackage(getPackageName(intentActivity))
-        labeledIntent.setClassName(getPackageName(intentActivity), intentActivity.activityInfo.name)
-        return labeledIntent
-    }
-
-    private fun getPackageName(intentActivity: ResolveInfo): String {
-        return intentActivity.activityInfo.packageName
     }
 }

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.util
 
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -50,11 +49,12 @@ object UriUtil {
 
     @JvmStatic
     fun visitInExternalBrowser(context: Context, uri: Uri) {
-        val chooserIntent = ShareUtil.createChooserIntent(Intent(Intent.ACTION_VIEW, uri), context)
+        //val chooserIntent = ShareUtil.createChooserIntent(Intent(Intent.ACTION_VIEW, uri), context)
+        val chooserIntent = ShareUtil.getIntentChooser(context, Intent(Intent.ACTION_VIEW, uri))
         try {
-            chooserIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            chooserIntent!!.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             context.startActivity(chooserIntent)
-        } catch (e: ActivityNotFoundException) {
+        } catch (e: Exception) {
             // This means that there was no way to handle this link.
             // We will just show a toast now. FIXME: Make this more visible?
             ShareUtil.showUnresolvableIntentMessage(context)

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -49,7 +49,6 @@ object UriUtil {
 
     @JvmStatic
     fun visitInExternalBrowser(context: Context, uri: Uri) {
-        //val chooserIntent = ShareUtil.createChooserIntent(Intent(Intent.ACTION_VIEW, uri), context)
         val chooserIntent = ShareUtil.getIntentChooser(context, Intent(Intent.ACTION_VIEW, uri))
         try {
             chooserIntent!!.flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -62,8 +61,7 @@ object UriUtil {
     }
 
     @JvmStatic
-    fun resolveProtocolRelativeUrl(wiki: WikiSite,
-                                   url: String): String {
+    fun resolveProtocolRelativeUrl(wiki: WikiSite, url: String): String {
         val ret = resolveProtocolRelativeUrl(url)
 
         // also handle images like /w/extensions/ImageMap/desc-20.png?15600 on Estados Unidos


### PR DESCRIPTION
https://phabricator.wikimedia.org/T120315

This finally solves the long-standing issue of removing the Wikipedia app from the list of apps when sharing content, or when navigating to external links (if the external link is also on Wiki).