### PR TITLE
Convert all remaining things to View Bindings.

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
@@ -12,7 +12,6 @@ import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.apache.commons.lang3.StringUtils
-import org.wikipedia.R
 import org.wikipedia.databinding.FragmentFilePageBinding
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
@@ -40,10 +39,12 @@ class FilePageFragment : Fragment() {
         pageTitle = arguments?.getParcelable(ARG_PAGE_TITLE)!!
         retainInstance = true
     }
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         super.onCreateView(inflater, container, savedInstanceState)
+        _binding = FragmentFilePageBinding.inflate(inflater, container, false)
         L10nUtil.setConditionalLayoutDirection(container!!, pageTitle.wikiSite.languageCode())
-        return inflater.inflate(R.layout.fragment_file_page, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
@@ -11,9 +11,9 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
-import kotlinx.android.synthetic.main.fragment_file_page.*
 import org.apache.commons.lang3.StringUtils
 import org.wikipedia.R
+import org.wikipedia.databinding.FragmentFilePageBinding
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
@@ -29,6 +29,8 @@ import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 
 class FilePageFragment : Fragment() {
+    private var _binding: FragmentFilePageBinding? = null
+    private val binding get() = _binding!!
     private lateinit var pageTitle: PageTitle
     private lateinit var pageSummaryForEdit: PageSummaryForEdit
     private val disposables = CompositeDisposable()
@@ -46,16 +48,17 @@ class FilePageFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        swipeRefreshLayout.setOnRefreshListener {
-            swipeRefreshLayout.isRefreshing = false
+        binding.swipeRefreshLayout.setOnRefreshListener {
+            binding.swipeRefreshLayout.isRefreshing = false
             loadImageInfo()
         }
-        errorView.backClickListener = View.OnClickListener { requireActivity().finish() }
+        binding.errorView.backClickListener = View.OnClickListener { requireActivity().finish() }
         loadImageInfo()
     }
 
     override fun onDestroyView() {
         disposables.clear()
+        _binding = null
         super.onDestroyView()
     }
 
@@ -69,10 +72,10 @@ class FilePageFragment : Fragment() {
     }
 
     private fun showError(caught: Throwable?) {
-        progressBar.visibility = View.GONE
-        filePageView.visibility = View.GONE
-        errorView.visibility = View.VISIBLE
-        errorView.setError(caught)
+        binding.progressBar.visibility = View.GONE
+        binding.filePageView.visibility = View.GONE
+        binding.errorView.visibility = View.VISIBLE
+        binding.errorView.setError(caught)
     }
 
     private fun loadImageInfo() {
@@ -83,9 +86,9 @@ class FilePageFragment : Fragment() {
         var thumbnailWidth = 0
         var thumbnailHeight = 0
 
-        errorView.visibility = View.GONE
-        filePageView.visibility = View.GONE
-        progressBar.visibility = View.VISIBLE
+        binding.errorView.visibility = View.GONE
+        binding.filePageView.visibility = View.GONE
+        binding.progressBar.visibility = View.VISIBLE
 
         disposables.add(Observable.zip(getImageCaptions(pageTitle.prefixedText),
                 ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(pageTitle.prefixedText, pageTitle.wikiSite.languageCode()), {
@@ -133,14 +136,14 @@ class FilePageFragment : Fragment() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .doAfterTerminate {
-                    filePageView.visibility = View.VISIBLE
-                    progressBar.visibility = View.GONE
-                    filePageView.setup(
+                    binding.filePageView.visibility = View.VISIBLE
+                    binding.progressBar.visibility = View.GONE
+                    binding.filePageView.setup(
                             this,
                             pageSummaryForEdit,
                             imageTags,
                             page,
-                            container.width,
+                            binding.container.width,
                             thumbnailWidth,
                             thumbnailHeight,
                             imageFromCommons = isFromCommons,

--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -6,19 +6,19 @@ import android.net.Uri
 import android.os.Build
 import android.util.AttributeSet
 import android.util.TypedValue
+import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnClickListener
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.view_file_page.view.*
-import kotlinx.android.synthetic.main.view_image_detail.view.*
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.Constants.PREFERRED_GALLERY_IMAGE_SIZE
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.commons.FilePageFragment.Companion.ACTIVITY_REQUEST_ADD_IMAGE_CAPTION
 import org.wikipedia.commons.FilePageFragment.Companion.ACTIVITY_REQUEST_ADD_IMAGE_TAGS
+import org.wikipedia.databinding.ViewFilePageBinding
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.descriptions.DescriptionEditActivity
 import org.wikipedia.page.LinkMovementMethodExt
@@ -35,8 +35,9 @@ import org.wikipedia.views.ViewUtil
 import java.util.*
 
 class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : LinearLayout(context, attrs) {
+    val binding = ViewFilePageBinding.inflate(LayoutInflater.from(context), this)
+
     init {
-        View.inflate(context, R.layout.view_file_page, this)
         layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
 
@@ -55,15 +56,15 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
         loadImage(summaryForEdit, containerWidth, thumbWidth, thumbHeight)
 
         if (showFilename) {
-            filenameView.visibility = View.VISIBLE
-            filenameView.titleText.text = context.getString(R.string.suggested_edits_image_preview_dialog_image)
-            filenameView.titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
-            filenameView.contentText.text = StringUtil.removeNamespace(summaryForEdit.displayTitle!!)
-            filenameView.contentText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 24f)
-            filenameView.divider.visibility = View.GONE
+            binding.filenameView.visibility = View.VISIBLE
+            binding.filenameView.binding.titleText.text = context.getString(R.string.suggested_edits_image_preview_dialog_image)
+            binding.filenameView.binding.titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
+            binding.filenameView.binding.contentText.text = StringUtil.removeNamespace(summaryForEdit.displayTitle!!)
+            binding.filenameView.binding.contentText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 24f)
+            binding.filenameView.binding.divider.visibility = View.GONE
         }
 
-        detailsContainer.removeAllViews()
+        binding.detailsContainer.removeAllViews()
 
         if (summaryForEdit.pageTitle.description.isNullOrEmpty() && summaryForEdit.description.isNullOrEmpty() && showEditButton) {
             addActionButton(context.getString(R.string.file_page_add_image_caption_button), imageCaptionOnClickListener(fragment, summaryForEdit))
@@ -118,9 +119,9 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
     }
 
     private fun loadImage(summaryForEdit: PageSummaryForEdit, containerWidth: Int, thumbWidth: Int, thumbHeight: Int) {
-        ImageZoomHelper.setViewZoomable(imageView)
-        ViewUtil.loadImage(imageView, ImageUrlUtil.getUrlForPreferredSize(summaryForEdit.thumbnailUrl!!, PREFERRED_GALLERY_IMAGE_SIZE), false, false, true, null)
-        imageViewPlaceholder.layoutParams = LayoutParams(containerWidth, ViewUtil.adjustImagePlaceholderHeight(containerWidth.toFloat(), thumbWidth.toFloat(), thumbHeight.toFloat()))
+        ImageZoomHelper.setViewZoomable(binding.imageView)
+        ViewUtil.loadImage(binding.imageView, ImageUrlUtil.getUrlForPreferredSize(summaryForEdit.thumbnailUrl!!, PREFERRED_GALLERY_IMAGE_SIZE), false, false, true, null)
+        binding.imageViewPlaceholder.layoutParams = LayoutParams(containerWidth, ViewUtil.adjustImagePlaceholderHeight(containerWidth.toFloat(), thumbWidth.toFloat(), thumbHeight.toFloat()))
     }
 
     private fun imageCaptionOnClickListener(fragment: Fragment, summaryForEdit: PageSummaryForEdit): OnClickListener {
@@ -154,38 +155,38 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
     private fun addDetail(showDivider: Boolean, titleString: String, detail: String?, externalLink: String?, listener: OnClickListener?) {
         if (!detail.isNullOrEmpty()) {
             val view = ImageDetailView(context)
-            view.titleText.text = titleString
-            view.contentText.text = StringUtil.strip(StringUtil.fromHtml(detail))
-            RichTextUtil.removeUnderlinesFromLinks(view.contentText)
+            view.binding.titleText.text = titleString
+            view.binding.contentText.text = StringUtil.strip(StringUtil.fromHtml(detail))
+            RichTextUtil.removeUnderlinesFromLinks(view.binding.contentText)
             if (!externalLink.isNullOrEmpty()) {
-                view.contentText.setTextColor(ResourceUtil.getThemedColor(context, R.attr.colorAccent))
-                view.contentText.setTextIsSelectable(false)
-                view.externalLink.visibility = View.VISIBLE
-                view.contentContainer.setOnClickListener {
+                view.binding.contentText.setTextColor(ResourceUtil.getThemedColor(context, R.attr.colorAccent))
+                view.binding.contentText.setTextIsSelectable(false)
+                view.binding.externalLink.visibility = View.VISIBLE
+                view.binding.contentContainer.setOnClickListener {
                     UriUtil.visitInExternalBrowser(context, Uri.parse(externalLink))
                 }
             } else {
-                view.contentText.movementMethod = movementMethod
+                view.binding.contentText.movementMethod = movementMethod
             }
             if (!showDivider) {
-                view.divider.visibility = View.GONE
+                view.binding.divider.visibility = View.GONE
             }
             if (listener != null) {
-                view.editButton.visibility = View.VISIBLE
-                view.editButton.setOnClickListener(listener)
+                view.binding.editButton.visibility = View.VISIBLE
+                view.binding.editButton.setOnClickListener(listener)
             }
-            detailsContainer.addView(view)
+            binding.detailsContainer.addView(view)
         }
     }
 
     private fun addActionButton(buttonText: String, listener: OnClickListener) {
         val view = ImageDetailView(context)
-        view.titleContainer.visibility = View.GONE
-        view.contentContainer.visibility = View.GONE
-        view.actionButton.visibility = View.VISIBLE
-        view.actionButton.text = buttonText
-        view.actionButton.setOnClickListener(listener)
-        detailsContainer.addView(view)
+        view.binding.titleContainer.visibility = View.GONE
+        view.binding.contentContainer.visibility = View.GONE
+        view.binding.actionButton.visibility = View.VISIBLE
+        view.binding.actionButton.text = buttonText
+        view.binding.actionButton.setOnClickListener(listener)
+        binding.detailsContainer.addView(view)
     }
 
     private val movementMethod = LinkMovementMethodExt { url: String ->

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -22,11 +22,11 @@ import com.google.android.material.button.MaterialButton
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
-import kotlinx.android.synthetic.main.fragment_article_edit_details.*
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.analytics.WatchlistFunnel
 import org.wikipedia.auth.AccountUtil
+import org.wikipedia.databinding.FragmentArticleEditDetailsBinding
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage.Revision
@@ -53,6 +53,8 @@ import org.wikipedia.watchlist.WatchlistExpiryDialog
 import java.nio.charset.StandardCharsets
 
 class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, LinkPreviewDialog.Callback {
+    private var _binding: FragmentArticleEditDetailsBinding? = null
+    private val binding get() = _binding!!
     private lateinit var articlePageTitle: PageTitle
     private lateinit var languageCode: String
     private var revisionId: Long = 0
@@ -79,10 +81,10 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                 WikiSite.forLanguageCode(languageCode))
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         super.onCreateView(inflater, container, savedInstanceState)
-        return inflater.inflate(R.layout.fragment_article_edit_details, container, false)
+        _binding = FragmentArticleEditDetailsBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -95,7 +97,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     }
 
     private fun setUpListeners() {
-        articleTitleView.setOnClickListener {
+        binding.articleTitleView.setOnClickListener {
             if (articlePageTitle.namespace() == Namespace.USER_TALK || articlePageTitle.namespace() == Namespace.TALK) {
                 startActivity(TalkTopicsActivity.newIntent(requireContext(), articlePageTitle.pageTitleForTalkPage(), InvokeSource.DIFF_ACTIVITY))
             } else {
@@ -103,57 +105,57 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                         HistoryEntry(articlePageTitle, HistoryEntry.SOURCE_EDIT_DIFF_DETAILS), null))
             }
         }
-        newerIdButton.setOnClickListener {
+        binding.newerIdButton.setOnClickListener {
             revisionId = newerRevisionId
             disposables.clear()
             fetchEditDetails()
         }
-        olderIdButton.setOnClickListener {
+        binding.olderIdButton.setOnClickListener {
             revisionId = olderRevisionId
             disposables.clear()
             fetchEditDetails()
         }
-        watchButton.setOnClickListener {
+        binding.watchButton.setOnClickListener {
             if (isWatched) {
                 watchlistFunnel.logRemoveArticle()
             } else {
                 watchlistFunnel.logAddArticle()
             }
-            watchButton.isCheckable = false
+            binding.watchButton.isCheckable = false
             watchOrUnwatchTitle(WatchlistExpiry.NEVER, isWatched)
         }
-        usernameButton.setOnClickListener {
+        binding.usernameButton.setOnClickListener {
             if (AccountUtil.isLoggedIn && username != null) {
                 startActivity(TalkTopicsActivity.newIntent(requireActivity(),
                         PageTitle(UserTalkAliasData.valueFor(languageCode),
                                 username!!, WikiSite.forLanguageCode(languageCode)), InvokeSource.DIFF_ACTIVITY))
             }
         }
-        thankButton.setOnClickListener { showThankDialog() }
-        errorView.backClickListener = OnClickListener { requireActivity().finish() }
+        binding.thankButton.setOnClickListener { showThankDialog() }
+        binding.errorView.backClickListener = OnClickListener { requireActivity().finish() }
     }
 
     private fun setErrorState(t: Throwable) {
         L.e(t)
-        errorView.setError(t)
-        errorView.visibility = VISIBLE
-        revisionDetailsView.visibility = GONE
-        progressBar.visibility = INVISIBLE
+        binding.errorView.setError(t)
+        binding.errorView.visibility = VISIBLE
+        binding.revisionDetailsView.visibility = GONE
+        binding.progressBar.visibility = INVISIBLE
     }
 
     private fun setUpInitialUI() {
-        diffText.movementMethod = ScrollingMovementMethod()
-        articleTitleView.text = articlePageTitle.displayText
+        binding.diffText.movementMethod = ScrollingMovementMethod()
+        binding.articleTitleView.text = articlePageTitle.displayText
         updateDiffCharCountView(diffSize)
     }
 
     private fun updateDiffCharCountView(diffSize: Int) {
-        diffCharacterCountView.text = String.format(if (diffSize != 0) "%+d" else "%d", diffSize)
+        binding.diffCharacterCountView.text = String.format(if (diffSize != 0) "%+d" else "%d", diffSize)
         if (diffSize >= 0) {
-            diffCharacterCountView.setTextColor(if (diffSize > 0) ContextCompat.getColor(requireContext(),
+            binding.diffCharacterCountView.setTextColor(if (diffSize > 0) ContextCompat.getColor(requireContext(),
                     R.color.green50) else ResourceUtil.getThemedColor(requireContext(), R.attr.material_theme_secondary_color))
         } else {
-            diffCharacterCountView.setTextColor(ContextCompat.getColor(requireContext(), R.color.red50))
+            binding.diffCharacterCountView.setTextColor(ContextCompat.getColor(requireContext(), R.color.red50))
         }
     }
 
@@ -188,46 +190,46 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                     if (olderRevisionId > 0L) {
                         fetchDiffText()
                     } else {
-                        progressBar.visibility = INVISIBLE
+                        binding.progressBar.visibility = INVISIBLE
                     }
                 }) { setErrorState(it!!) })
     }
 
     private fun hideOrShowViews(isLoading: Boolean) {
         if (isLoading) {
-            progressBar.visibility = VISIBLE
-            usernameButton.visibility = INVISIBLE
-            thankButton.visibility = INVISIBLE
-            editComment.visibility = INVISIBLE
-            diffText.visibility = INVISIBLE
-            diffCharacterCountView.visibility = INVISIBLE
+            binding.progressBar.visibility = VISIBLE
+            binding.usernameButton.visibility = INVISIBLE
+            binding.thankButton.visibility = INVISIBLE
+            binding.editComment.visibility = INVISIBLE
+            binding.diffText.visibility = INVISIBLE
+            binding.diffCharacterCountView.visibility = INVISIBLE
         } else {
-            usernameButton.visibility = VISIBLE
-            thankButton.visibility = VISIBLE
-            editComment.visibility = VISIBLE
-            diffText.visibility = VISIBLE
+            binding.usernameButton.visibility = VISIBLE
+            binding.thankButton.visibility = VISIBLE
+            binding.editComment.visibility = VISIBLE
+            binding.diffText.visibility = VISIBLE
         }
     }
 
     private fun updateUI() {
-        diffText.scrollTo(0, 0)
-        diffText.text = ""
-        usernameButton.text = currentRevision!!.user
-        editTimestamp.text = DateUtil.getDateAndTimeWithPipe(DateUtil.iso8601DateParse(currentRevision!!.timeStamp()))
-        editComment.text = currentRevision!!.comment
-        newerIdButton.isClickable = newerRevisionId != -1L
-        olderIdButton.isClickable = olderRevisionId != 0L
-        setEnableDisableTint(newerIdButton, newerRevisionId == -1L)
-        setEnableDisableTint(olderIdButton, olderRevisionId == 0L)
-        setButtonTextAndIconColor(thankButton, ResourceUtil.getThemedColor(requireContext(), R.attr.colorAccent))
-        thankButton.isClickable = true
+        binding.diffText.scrollTo(0, 0)
+        binding.diffText.text = ""
+        binding.usernameButton.text = currentRevision!!.user
+        binding.editTimestamp.text = DateUtil.getDateAndTimeWithPipe(DateUtil.iso8601DateParse(currentRevision!!.timeStamp()))
+        binding.editComment.text = currentRevision!!.comment
+        binding.newerIdButton.isClickable = newerRevisionId != -1L
+        binding.olderIdButton.isClickable = olderRevisionId != 0L
+        setEnableDisableTint(binding.newerIdButton, newerRevisionId == -1L)
+        setEnableDisableTint(binding.olderIdButton, olderRevisionId == 0L)
+        setButtonTextAndIconColor(binding.thankButton, ResourceUtil.getThemedColor(requireContext(), R.attr.colorAccent))
+        binding.thankButton.isClickable = true
         requireActivity().invalidateOptionsMenu()
         maybeHideThankButton()
         hideOrShowViews(false)
     }
 
     private fun maybeHideThankButton() {
-        thankButton.visibility = if (AccountUtil.userName.equals(currentRevision?.user)) GONE else VISIBLE
+        binding.thankButton.visibility = if (AccountUtil.userName.equals(currentRevision?.user)) GONE else VISIBLE
     }
 
     private fun setEnableDisableTint(view: AppCompatImageView, isDisabled: Boolean) {
@@ -273,15 +275,15 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                     }
                 }) {
                     setErrorState(it!!)
-                    watchButton.isCheckable = true
+                    binding.watchButton.isCheckable = true
                 })
     }
 
     private fun updateWatchlistButtonUI() {
-        setButtonTextAndIconColor(watchButton, ResourceUtil.getThemedColor(requireContext(),
+        setButtonTextAndIconColor(binding.watchButton, ResourceUtil.getThemedColor(requireContext(),
                 if (isWatched) R.attr.color_group_68 else R.attr.colorAccent))
-        watchButton.text = getString(if (isWatched) R.string.watchlist_details_watching_label else R.string.watchlist_details_watch_label)
-        watchButton.setIconResource(getWatchlistIcon(isWatched, hasWatchlistExpiry))
+        binding.watchButton.text = getString(if (isWatched) R.string.watchlist_details_watching_label else R.string.watchlist_details_watch_label)
+        binding.watchButton.setIconResource(getWatchlistIcon(isWatched, hasWatchlistExpiry))
     }
 
     @DrawableRes
@@ -314,7 +316,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
             }
             snackbar.show()
         }
-        watchButton.isCheckable = true
+        binding.watchButton.isCheckable = true
     }
 
     private fun showThankDialog() {
@@ -343,9 +345,9 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
                     FeedbackUtil.showMessage(requireActivity(), getString(R.string.thank_success_message, username))
-                    setButtonTextAndIconColor(thankButton, ResourceUtil.getThemedColor(requireContext(),
+                    setButtonTextAndIconColor(binding.thankButton, ResourceUtil.getThemedColor(requireContext(),
                             R.attr.material_theme_de_emphasised_color))
-                    thankButton.isClickable = false
+                    binding.thankButton.isClickable = false
                 }) { setErrorState(it!!) })
     }
 
@@ -357,10 +359,10 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    diffText.text = it
+                    binding.diffText.text = it
                     updateDiffCharCountView(diffSize)
-                    diffCharacterCountView.visibility = VISIBLE
-                    progressBar.visibility = INVISIBLE
+                    binding.diffCharacterCountView.visibility = VISIBLE
+                    binding.progressBar.visibility = INVISIBLE
                 }) {
                     setErrorState(it!!)
                 })
@@ -505,6 +507,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
 
     override fun onDestroyView() {
         disposables.clear()
+        _binding = null
         super.onDestroyView()
     }
 

--- a/app/src/main/java/org/wikipedia/feed/view/CardFooterView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/CardFooterView.kt
@@ -6,7 +6,6 @@ import android.text.Spanned
 import android.text.style.ImageSpan
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -22,7 +21,6 @@ internal class CardFooterView constructor(context: Context, attrs: AttributeSet?
     var callback: Callback? = null
 
     init {
-        View.inflate(context, R.layout.view_card_footer, this)
         binding.footerActionButton.setOnClickListener {
             callback?.onFooterClicked()
         }

--- a/app/src/main/java/org/wikipedia/feed/view/CardFooterView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/CardFooterView.kt
@@ -5,11 +5,12 @@ import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.ImageSpan
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
-import kotlinx.android.synthetic.main.view_card_footer.view.*
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
+import org.wikipedia.databinding.ViewCardFooterBinding
 import org.wikipedia.util.L10nUtil
 
 internal class CardFooterView constructor(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
@@ -17,11 +18,12 @@ internal class CardFooterView constructor(context: Context, attrs: AttributeSet?
         fun onFooterClicked()
     }
 
+    private val binding = ViewCardFooterBinding.inflate(LayoutInflater.from(context), this)
     var callback: Callback? = null
 
     init {
         View.inflate(context, R.layout.view_card_footer, this)
-        footerActionButton.setOnClickListener {
+        binding.footerActionButton.setOnClickListener {
             callback?.onFooterClicked()
         }
     }
@@ -32,6 +34,6 @@ internal class CardFooterView constructor(context: Context, attrs: AttributeSet?
         val isRTL = L10nUtil.isLangRTL(langCode ?: WikipediaApp.getInstance().language().systemLanguageCode)
         val arrowImageSpan = ImageSpan(context, if (isRTL) R.drawable.ic_baseline_arrow_left_alt_themed_24px else R.drawable.ic_baseline_arrow_right_alt_themed_24px)
         spannableStringBuilder.setSpan(arrowImageSpan, actionTextWithSpace.length - 1, actionTextWithSpace.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        footerActionButton.text = spannableStringBuilder
+        binding.footerActionButton.text = spannableStringBuilder
     }
 }

--- a/app/src/main/java/org/wikipedia/feed/view/GradientCircleNumberView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/GradientCircleNumberView.kt
@@ -6,34 +6,31 @@ import android.graphics.Shader
 import android.graphics.Shader.TileMode
 import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
-import kotlinx.android.synthetic.main.view_gradient_circle_number.view.*
 import org.wikipedia.R
+import org.wikipedia.databinding.ViewGradientCircleNumberBinding
 import org.wikipedia.util.ResourceUtil
 
 internal class GradientCircleNumberView constructor(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
+    private val binding = ViewGradientCircleNumberBinding.inflate(LayoutInflater.from(context), this)
 
     private val gradientColor1 = ResourceUtil.getThemedColor(context, R.attr.colorAccent)
     private val gradientColor2 = ContextCompat.getColor(context, R.color.green50)
 
-    init {
-        View.inflate(context, R.layout.view_gradient_circle_number, this)
-    }
-
     fun setNumber(number: Int) {
-        numberView.text = number.toString()
+        binding.numberView.text = number.toString()
         applyGradient()
     }
 
     private fun applyGradient() {
-        val textShader: Shader = LinearGradient(0f, 0f, 0f, numberView.textSize,
+        val textShader: Shader = LinearGradient(0f, 0f, 0f, binding.numberView.textSize,
                 intArrayOf(gradientColor2, gradientColor1, gradientColor2),
                 floatArrayOf(0f, 0.5f, 1f), TileMode.CLAMP)
         val gradientDrawable = GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, intArrayOf(gradientColor1, gradientColor2))
         gradientDrawable.cornerRadius = 90f
-        numberView.paint.shader = textShader
-        baseNumberView.background = gradientDrawable
+        binding.numberView.paint.shader = textShader
+        binding.baseNumberView.background = gradientDrawable
     }
 }

--- a/app/src/main/java/org/wikipedia/views/ImageDetailView.kt
+++ b/app/src/main/java/org/wikipedia/views/ImageDetailView.kt
@@ -8,8 +8,9 @@ import android.widget.LinearLayout
 import org.wikipedia.databinding.ViewImageDetailBinding
 
 class ImageDetailView constructor(context: Context, attrs: AttributeSet? = null) : LinearLayout(context, attrs) {
+    val binding = ViewImageDetailBinding.inflate(LayoutInflater.from(context), this, true)
+
     init {
-        ViewImageDetailBinding.inflate(LayoutInflater.from(context), this, true)
         layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
 }


### PR DESCRIPTION
This removes all of the remaining usages of synthetics, and switches everything to View Bindings.  After this, we will be ready to remove the `kotlin-extensions` dependency from Gradle.