### PR TITLE
Simplify the way of trim() text in Kotlin

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListTitleDialog.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListTitleDialog.kt
@@ -25,7 +25,7 @@ object ReadingListTitleDialog {
                 }
 
                 override fun onTextChanged(text: CharSequence, dialog: TextInputDialog) {
-                    text.toString().trim { it <= ' ' }.let {
+                    text.toString().trim().let {
                         when {
                             it.isEmpty() -> {
                                 dialog.setError(null)
@@ -44,7 +44,7 @@ object ReadingListTitleDialog {
                 }
 
                 override fun onSuccess(text: CharSequence, secondaryText: CharSequence) {
-                    callback?.onSuccess(text.toString().trim { it <= ' ' }, secondaryText.toString().trim { it <= ' ' })
+                    callback?.onSuccess(text.toString().trim(), secondaryText.toString().trim())
                 }
 
                 override fun onCancel() {}

--- a/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.kt
+++ b/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.kt
@@ -88,7 +88,7 @@ class WikiTextKeyboardView : FrameLayout {
                         val i1 = lastIndexOf(before, "[[")
                         val i2 = after.indexOf("]]") + before.length
                         if (i1 >= 0 && i2 > 0 && i2 > i1) {
-                            str = str.substring(i1 + 2, i2).trim { it <= ' ' }
+                            str = str.substring(i1 + 2, i2).trim()
                             if (str.isNotEmpty()) {
                                 if (str.contains("|")) {
                                     str = str.split("\\|".toRegex()).toTypedArray()[0]

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
@@ -69,7 +69,7 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
     }
 
     private fun loadDefinitions() {
-        if (selectedText.trim { it <= ' ' }.isEmpty()) {
+        if (selectedText.trim().isEmpty()) {
             displayNoDefinitionsFound()
             return
         }


### PR DESCRIPTION
As we discussed, it should be fine to use `trim()` instead of the addition `trim { it <= ' ' }` logic.