### PR TITLE
Fix: "save" on PageFragment does not work properly on PageFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/LongPressMenu.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/LongPressMenu.kt
@@ -51,7 +51,7 @@ class LongPressMenu(private val anchorView: View, private val existsInAnyList: B
     }
 
     private fun showMenu() {
-        if (!existsInAnyList) {
+        if (!existsInAnyList && listsContainingPage.isNullOrEmpty()) {
             return
         }
         listsContainingPage?.let {


### PR DESCRIPTION
Steps to reproduce:

1. Save any page on the PageFragment
2. Click on the "save" button again

The necessary check was removed by accident in #2175 