### PR TITLE
Fix: crash when referenceGroup is null when opening ReferenceDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -1331,6 +1331,7 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     }
 
     @Override
+    @Nullable
     public List<PageReferences.Reference> getReferencesGroup() {
         return references != null ? references.getReferencesGroup() : null;
     }

--- a/app/src/main/java/org/wikipedia/page/references/ReferenceDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/references/ReferenceDialog.kt
@@ -24,7 +24,7 @@ import java.util.*
 class ReferenceDialog : ExtendedBottomSheetDialogFragment() {
     interface Callback {
         val linkHandler: LinkHandler
-        val referencesGroup: List<PageReferences.Reference>
+        val referencesGroup: List<PageReferences.Reference>?
         val selectedReferenceIndex: Int
     }
 
@@ -34,12 +34,14 @@ class ReferenceDialog : ExtendedBottomSheetDialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentReferencesPagerBinding.inflate(inflater, container, false)
         callback()?.let {
-            binding.referenceTitleText.text = requireContext().getString(R.string.reference_title, "")
-            binding.referencePager.offscreenPageLimit = 2
-            binding.referencePager.adapter = ReferencesAdapter(it.referencesGroup)
-            TabLayoutMediator(binding.pageIndicatorView, binding.referencePager) { _, _ -> }.attach()
-            binding.referencePager.setCurrentItem(it.selectedReferenceIndex, true)
-            L10nUtil.setConditionalLayoutDirection(binding.root, it.linkHandler.wikiSite.languageCode())
+            it.referencesGroup?.run {
+                binding.referenceTitleText.text = requireContext().getString(R.string.reference_title, "")
+                binding.referencePager.offscreenPageLimit = 2
+                binding.referencePager.adapter = ReferencesAdapter(this)
+                TabLayoutMediator(binding.pageIndicatorView, binding.referencePager) { _, _ -> }.attach()
+                binding.referencePager.setCurrentItem(it.selectedReferenceIndex, true)
+                L10nUtil.setConditionalLayoutDirection(binding.root, it.linkHandler.wikiSite.languageCode())
+            } ?: return@let null
         } ?: run {
             dismiss()
         }
@@ -88,7 +90,7 @@ class ReferenceDialog : ExtendedBottomSheetDialogFragment() {
 
     private inner class ViewHolder constructor(val binding: ViewReferencePagerItemBinding) : RecyclerView.ViewHolder(binding.root) {
         init {
-            binding.referenceText.movementMethod = LinkMovementMethodExt(callback()!!.linkHandler)
+            binding.referenceText.movementMethod = LinkMovementMethodExt(callback()?.linkHandler)
         }
 
         fun bindItem(idText: CharSequence?, contents: CharSequence?) {
@@ -112,7 +114,7 @@ class ReferenceDialog : ExtendedBottomSheetDialogFragment() {
         }
     }
 
-    fun callback(): Callback? {
+    private fun callback(): Callback? {
         return getCallback(this, Callback::class.java)
     }
 }


### PR DESCRIPTION
https://appcenter.ms/orgs/ci-apps-hockeyapp-f5mf/apps/Wikipedia-Beta/crashes/errors/3207428379u/overview

Didn't notice that the `referenceGroup` can be null sometimes.
https://github.com/wikimedia/apps-android-wikipedia/pull/2246/files#diff-1bbfb3f068c1a476373b73366e53dec2cf716e99f7d31c0f01338808ddf75308L57-L59