### PR TITLE
Indicate if a file originates from Wikimedia Commons.

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -57,7 +57,7 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
 
         if (showFilename) {
             binding.filenameView.visibility = View.VISIBLE
-            binding.filenameView.binding.titleText.text = context.getString(R.string.suggested_edits_image_preview_dialog_image)
+            binding.filenameView.binding.titleText.text = context.getString(if (imageFromCommons) R.string.suggested_edits_image_preview_dialog_file_commons else R.string.suggested_edits_image_preview_dialog_image)
             binding.filenameView.binding.titleText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
             binding.filenameView.binding.contentText.text = StringUtil.removeNamespace(summaryForEdit.displayTitle!!)
             binding.filenameView.binding.contentText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 24f)

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -751,6 +751,7 @@
   <string name="suggested_edits_image_preview_dialog_caption_in_language_title">Label for image caption detail on image details screen. The %s is replaced by the language that the caption is used.</string>
   <string name="suggested_edits_image_preview_dialog_description_in_language_title">Label for image description detail on image details screen. The %s is replaced by the language that the description is used.</string>
   <string name="suggested_edits_image_preview_dialog_image">Label for image file name on image details screen.</string>
+  <string name="suggested_edits_image_preview_dialog_file_commons">Label for a file that originates from Wikimedia Commons.</string>
   <string name="suggested_edits_image_preview_dialog_artist">Label for image artist detail on image details screen.</string>
   <string name="suggested_edits_image_preview_dialog_tags">Label for image tags detail on image details screen.</string>
   <string name="suggested_edits_image_preview_dialog_date">Label for image date detail on image details screen.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -762,6 +762,7 @@
     <string name="suggested_edits_image_preview_dialog_caption_in_language_title">Image caption (%s)</string>
     <string name="suggested_edits_image_preview_dialog_description_in_language_title">Image description (%s)</string>
     <string name="suggested_edits_image_preview_dialog_image">Image</string>
+    <string name="suggested_edits_image_preview_dialog_file_commons">File from Wikimedia Commons</string>
     <string name="suggested_edits_image_preview_dialog_artist">Artist</string>
     <string name="suggested_edits_image_preview_dialog_tags">Tags</string>
     <string name="suggested_edits_image_preview_dialog_date">Date</string>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T278561

IMO this is low-risk enough that it can be merged before design review.