### PR TITLE
Whoops: don't use the default ImageView ScaleType for non-transform.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.kt
@@ -41,7 +41,7 @@ class CardLargeHeaderView : ConstraintLayout {
 
     fun setImage(uri: Uri?): CardLargeHeaderView {
         binding.viewCardHeaderLargeImage.visibility = if (uri == null) GONE else VISIBLE
-        binding.viewCardHeaderLargeImage.loadImage(uri, true, ImageLoadListener())
+        binding.viewCardHeaderLargeImage.loadImage(uri, roundedCorners = true, cropped = true, listener = ImageLoadListener())
         return this
     }
 

--- a/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.kt
@@ -5,11 +5,9 @@ import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
 import androidx.annotation.ColorInt
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
-import androidx.core.util.Pair
 import androidx.palette.graphics.Palette
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp

--- a/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.kt
@@ -31,8 +31,7 @@ class CardLargeHeaderView : ConstraintLayout {
         resetBackgroundColor()
     }
 
-    val sharedElements: Array<Pair<View, String>>
-        get() = TransitionUtil.getSharedElements(context, binding.viewCardHeaderLargeImage)
+    val sharedElements = TransitionUtil.getSharedElements(context, binding.viewCardHeaderLargeImage)
 
     fun setLanguageCode(langCode: String): CardLargeHeaderView {
         L10nUtil.setConditionalLayoutDirection(this, langCode)

--- a/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.kt
+++ b/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.kt
@@ -63,7 +63,7 @@ class FaceAndColorDetectImageView constructor(context: Context, attrs: Attribute
                 }
             })
         }
-        if (scaleType == ScaleType.FIT_CENTER) {
+        if (scaleType == ScaleType.FIT_START) {
             builder = builder.transform(WhiteBackgroundTransformation())
         } else {
             builder = if (shouldDetectFace(uri)) {

--- a/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.kt
+++ b/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.kt
@@ -35,7 +35,7 @@ class FaceAndColorDetectImageView constructor(context: Context, attrs: Attribute
     }
 
     @JvmOverloads
-    fun loadImage(uri: Uri?, roundedCorners: Boolean = false, listener: OnImageLoadListener? = null) {
+    fun loadImage(uri: Uri?, roundedCorners: Boolean = false, cropped: Boolean = true, listener: OnImageLoadListener? = null) {
         val placeholder = ViewUtil.getPlaceholderDrawable(context)
         if (!Prefs.isImageDownloadEnabled() || uri == null) {
             setImageDrawable(placeholder)
@@ -63,14 +63,14 @@ class FaceAndColorDetectImageView constructor(context: Context, attrs: Attribute
                 }
             })
         }
-        if (scaleType == ScaleType.FIT_START) {
-            builder = builder.transform(WhiteBackgroundTransformation())
-        } else {
-            builder = if (shouldDetectFace(uri)) {
+        builder = if (cropped) {
+            if (shouldDetectFace(uri)) {
                 builder.transform(if (roundedCorners) FACE_DETECT_TRANSFORM_AND_ROUNDED_CORNERS else FACE_DETECT_TRANSFORM)
             } else {
                 builder.transform(if (roundedCorners) ViewUtil.CENTER_CROP_LARGE_ROUNDED_CORNERS else CENTER_CROP_WHITE_BACKGROUND)
             }
+        } else {
+            builder.transform(WhiteBackgroundTransformation())
         }
         builder.into(this)
     }


### PR DESCRIPTION
`FIT_CENTER` is the default ScaleType, and therefore should not be used for this new special case. `FIT_START` shall be the new special case if we want a `FaceAndColorDetectImageView` that fits the image without actual face detection.