### PR TITLE
Update recyclerview version to 1.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:1.3.1"
     implementation "androidx.palette:palette-ktx:1.0.0"
     implementation "androidx.preference:preference-ktx:1.1.1"
-    implementation "androidx.recyclerview:recyclerview:1.1.0"
+    implementation "androidx.recyclerview:recyclerview:1.2.0"
     implementation "androidx.viewpager2:viewpager2:1.0.0"
     implementation 'com.google.android:flexbox:2.0.1'
     implementation 'com.android.installreferrer:installreferrer:2.2'


### PR DESCRIPTION
https://developer.android.com/jetpack/androidx/releases/recyclerview#recyclerview-1.2.0

I am not seeing the `getAdapterPosition` has the deprecated label on it and I think we can still continue using it for a while.