### PR TITLE
ImgRecs: prevent onboarding text being cut off on small screen devices

### DIFF
--- a/app/src/main/res/layout/view_onboarding_page.xml
+++ b/app/src/main/res/layout/view_onboarding_page.xml
@@ -8,7 +8,7 @@
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/bottomOffset">
 


### PR DESCRIPTION
Parts of the onboarding text are cut off on small screen devices.
<img src="https://user-images.githubusercontent.com/2435576/113943143-e95d9b00-97b6-11eb-94cb-89dbdcd0bb81.png" width="300px" /> 
How it looks on Nexus S emulator in `imageRecs_design`

Please note that the image is also cut off but I believe @sharvaniharan will have another PR(https://phabricator.wikimedia.org/T278526)  to fix it. 