### PR TITLE
Update short description capitalization guidance for English.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -286,8 +286,8 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
                 LanguageUtil.startsWithArticle(text, pageTitle.wikiSite.languageCode())) {
             setWarning(context.getString(R.string.description_starts_with_article))
         } else if ((action == DescriptionEditActivity.Action.ADD_DESCRIPTION || action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION) &&
-                pageTitle.wikiSite.languageCode() == "en" && Character.isUpperCase(binding.viewDescriptionEditText.text.toString()[0])) {
-            setWarning(context.getString(R.string.description_starts_with_uppercase))
+                pageTitle.wikiSite.languageCode() == "en" && Character.isLowerCase(binding.viewDescriptionEditText.text.toString()[0])) {
+            setWarning(context.getString(R.string.description_starts_with_lowercase))
         } else if (isLanguageWrong) {
             setWarning(context.getString(R.string.description_is_in_different_language,
                     WikipediaApp.getInstance().language().getAppLanguageLocalizedName(pageSummaryForEdit.lang)))

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -693,6 +693,7 @@
   <string name="description_ends_with_punctuation">Error text shown when a description ends with punctuation.</string>
   <string name="description_starts_with_article">{{Optional}}\n\nWarning text shown when a description starts with a definite or indefinite article. Currently implemented in English, German, Spanish, and French. Doesn\'t need translation to other languages. When translating, use the articles in the language and don\'t copy the English ones.</string>
   <string name="description_starts_with_uppercase">Warning text shown when a description starts with an uppercase character.</string>
+  <string name="description_starts_with_lowercase">Warning text shown when a description starts with a lowercase character.</string>
   <string name="description_is_in_different_language">Warning message shown to users when their editing language is different form their keyboard language.%s represents the expected language.</string>
   <string name="description_edit_success_saved">Message that the article description the user just added was saved.</string>
   <string name="description_edit_success_saved_snackbar">Message shown on a snackbar that the article description the user just added was saved.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -695,6 +695,7 @@
     <string name="description_ends_with_punctuation">The text must not end with punctuation.</string>
     <string name="description_starts_with_article">Avoid starting with articles like “a” or “the”.</string>
     <string name="description_starts_with_uppercase">Start with a lowercase letter unless the first word is a proper noun.</string>
+    <string name="description_starts_with_lowercase">Avoid starting with a lowercase letter.</string>
     <string name="description_is_in_different_language">The text appears to be in an unexpected language. The language should be %s.</string>
     <!-- /Description editing -->
 


### PR DESCRIPTION
We were actually only performing capitalization checking in the case of English anyway. This simply changes the capitalization requirement from lower to upper.

https://phabricator.wikimedia.org/T279702