### PR TITLE
Don't show reply button when the topicId=-1 in TalkTopicActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -201,7 +201,7 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
     private fun updateOnSuccess() {
         binding.talkProgressBar.visibility = View.GONE
         binding.talkErrorView.visibility = View.GONE
-        if (replyActive) {
+        if (replyActive || shouldHideReplyButton()) {
             binding.talkReplyButton.hide()
         } else {
             binding.talkReplyButton.show()
@@ -232,6 +232,11 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
     }
 
     private fun isNewTopic(): Boolean {
+        return topicId == TalkTopicsActivity.NEW_TOPIC_ID
+    }
+
+    // TODO: remove when the API fixes it
+    private fun shouldHideReplyButton(): Boolean {
         return topicId == -1
     }
 
@@ -243,7 +248,7 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
             text.movementMethod = linkMovementMethod
             text.text = StringUtil.fromHtml(reply.html)
             indentArrow.visibility = if (reply.depth > 0) View.VISIBLE else View.GONE
-            bottomSpace.visibility = if (!isLast || replyActive) View.GONE else View.VISIBLE
+            bottomSpace.visibility = if (!isLast || replyActive || shouldHideReplyButton()) View.GONE else View.VISIBLE
         }
     }
 

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -69,7 +69,7 @@ class TalkTopicsActivity : BaseActivity() {
 
         binding.talkNewTopicButton.setOnClickListener {
             funnel.logNewTopicClick()
-            startActivity(TalkTopicActivity.newIntent(this@TalkTopicsActivity, pageTitle, -1, invokeSource))
+            startActivity(TalkTopicActivity.newIntent(this@TalkTopicsActivity, pageTitle, NEW_TOPIC_ID, invokeSource))
         }
 
         binding.talkRefreshView.setOnRefreshListener {
@@ -247,6 +247,7 @@ class TalkTopicsActivity : BaseActivity() {
 
     companion object {
         private const val EXTRA_PAGE_TITLE = "pageTitle"
+        const val NEW_TOPIC_ID = -2
 
         @JvmStatic
         fun newIntent(context: Context, pageTitle: PageTitle, invokeSource: Constants.InvokeSource): Intent {


### PR DESCRIPTION
As we discussed on Slack, sometimes the `id` is `-1` and we should not show the "new topic" page for it and should hide the reply button.
https://en.wikipedia.org/api/rest_v1/page/talk/Talk%3ADreamsnake