### PR TITLE
ImgRecs: prevent having null value in the langWikis list in ImageRecsFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/ImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/ImageRecsFragment.kt
@@ -399,10 +399,10 @@ class ImageRecsFragment : SuggestedEditsItemFragment(), ImageRecsDialog.Callback
 
     private fun getSuggestionReason(): String {
         val hasWikidata = recommendation!!.foundOnWikis.contains("wd")
-        val langWikis = recommendation!!.foundOnWikis.filter { it != "wd" && it != "com" }
+        val langWikis = recommendation!!.foundOnWikis
                 .sortedBy { WikipediaApp.getInstance().language().getLanguageCodeIndex(it) }
                 .take(3)
-                .map { getCanonicalName(it) }
+                .mapNotNull { getCanonicalName(it) }
 
         if (langWikis.isNotEmpty()) {
             return getString(R.string.image_recommendations_task_suggestion_reason,

--- a/app/src/main/java/org/wikipedia/suggestededits/ImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/ImageRecsFragment.kt
@@ -422,7 +422,7 @@ class ImageRecsFragment : SuggestedEditsItemFragment(), ImageRecsDialog.Callback
 
     private fun getFunnelReason(): String {
         val hasWikidata = recommendation!!.foundOnWikis.contains("wd")
-        val langWikis = recommendation!!.foundOnWikis.filter { it != "wd" && it != "com" }
+        val langWikis = recommendation!!.foundOnWikis.filter { it != "wd" && it != "com" && it != "species" }
         return when {
             langWikis.isNotEmpty() -> {
                 "wikipedia"


### PR DESCRIPTION
Sometimes the `langWikis` list will contains a `null` value, which will cause an error in `ImageRecsFragment`.

We should filter out `species`, or we can just use `mapNotNull`.