### PR TITLE
When imageEditType is null, do not add default CTA 

### DIFF
--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
@@ -136,6 +136,9 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
     }
 
     private fun finalizeCallToAction() {
+        if (imageEditType == null) {
+            return
+        }
         when (imageEditType) {
             ImageEditType.ADD_TAGS -> pageHeaderView.setUpCallToAction(parentFragment.getString(R.string.suggested_edits_article_cta_image_tags))
             ImageEditType.ADD_CAPTION_TRANSLATION -> {


### PR DESCRIPTION
**Phab:** https://phabricator.wikimedia.org/T279851

When there is an image caption available in the only language selected, the imageEditType is null. But we were not checking for null here and hence just adding the default "Add image caption" CTA by default. This would fail during the execution of click listener.