### PR TITLE
Image recs : Small screen fix for onboarding image being cut-off

### DIFF
--- a/app/src/main/java/org/wikipedia/onboarding/OnboardingPageView.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/OnboardingPageView.kt
@@ -3,9 +3,11 @@ package org.wikipedia.onboarding
 import android.content.Context
 import android.text.TextUtils
 import android.util.AttributeSet
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -79,6 +81,15 @@ class OnboardingPageView constructor(context: Context, attrs: AttributeSet? = nu
                 }
             }
         }
+    }
+
+    fun removeMAinTextLayoutGravity() {
+        val params = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT
+        )
+        params.gravity = Gravity.NO_GRAVITY
+        binding.mainTextLayout?.layoutParams = params
     }
 
     fun setSwitchChecked(checked: Boolean) {

--- a/app/src/main/java/org/wikipedia/onboarding/OnboardingPageView.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/OnboardingPageView.kt
@@ -83,7 +83,7 @@ class OnboardingPageView constructor(context: Context, attrs: AttributeSet? = nu
         }
     }
 
-    fun removeMAinTextLayoutGravity() {
+    fun removeMainTextLayoutGravity() {
         val params = FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.WRAP_CONTENT,
                 FrameLayout.LayoutParams.WRAP_CONTENT

--- a/app/src/main/java/org/wikipedia/suggestededits/ImageRecsOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/ImageRecsOnboardingFragment.kt
@@ -16,6 +16,7 @@ import org.wikipedia.model.EnumCodeMap
 import org.wikipedia.onboarding.OnboardingFragment
 import org.wikipedia.onboarding.OnboardingPageView
 import org.wikipedia.settings.Prefs
+import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil.showAboutWikipedia
 import org.wikipedia.util.FeedbackUtil.showOfflineReadingAndData
 import org.wikipedia.util.FeedbackUtil.showPrivacyPolicy
@@ -63,6 +64,10 @@ class ImageRecsOnboardingFragment : OnboardingFragment(false), OnboardingPageVie
             val view = inflater.inflate(OnboardingPage.of(position).layout, container, false) as OnboardingPageView
             if (OnboardingPage.PAGE_CONSENT.code() == position) {
                 view.setSwitchChecked(Prefs.isImageRecsConsentEnabled())
+            }
+            if (DimenUtil.displayHeightPx < 1200) {
+                // Remove layout gravity of the text below on small screens to make centered image visible
+                view.removeMAinTextLayoutGravity()
             }
             view.tag = position
             view.callback = callback

--- a/app/src/main/java/org/wikipedia/suggestededits/ImageRecsOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/ImageRecsOnboardingFragment.kt
@@ -67,7 +67,7 @@ class ImageRecsOnboardingFragment : OnboardingFragment(false), OnboardingPageVie
             }
             if (DimenUtil.displayHeightPx < 1200) {
                 // Remove layout gravity of the text below on small screens to make centered image visible
-                view.removeMAinTextLayoutGravity()
+                view.removeMainTextLayoutGravity()
             }
             view.tag = position
             view.callback = callback

--- a/app/src/main/res/layout/view_onboarding_page.xml
+++ b/app/src/main/res/layout/view_onboarding_page.xml
@@ -13,6 +13,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <LinearLayout
+            android:id="@+id/mainTextLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center"


### PR DESCRIPTION
Currently onboarding image is getting cut-off on the top on small screens. This is because of the gravity of the layout below it. However if we make a general change, the layout doesnt render correctly in other places. So put in a specific change.
![cut-off](https://user-images.githubusercontent.com/9540770/115929135-1c04c600-a43c-11eb-83d4-e8b76bcad2be.png)
