### PR TITLE
ImgRecs: throw proper exception and provide a proper button for going to next item

### DIFF
--- a/app/src/main/java/org/wikipedia/util/ThrowableUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ThrowableUtil.kt
@@ -7,6 +7,7 @@ import org.wikipedia.createaccount.CreateAccountException
 import org.wikipedia.dataclient.mwapi.MwException
 import org.wikipedia.dataclient.okhttp.HttpStatusException
 import org.wikipedia.login.LoginClient.LoginFailedException
+import java.lang.Exception
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -75,11 +76,17 @@ object ThrowableUtil {
     }
 
     @JvmStatic
+    fun isEmptyException(caught: Throwable): Boolean {
+        return caught is EmptyException
+    }
+
+    @JvmStatic
     fun isNetworkError(e: Throwable): Boolean {
         return throwableContainsException(e, UnknownHostException::class.java) ||
                 throwableContainsException(e, TimeoutException::class.java) ||
                 throwableContainsException(e, SSLException::class.java)
     }
 
+    class EmptyException : Exception()
     class AppError(val error: String, val detail: String?)
 }

--- a/app/src/main/java/org/wikipedia/views/WikiErrorView.kt
+++ b/app/src/main/java/org/wikipedia/views/WikiErrorView.kt
@@ -11,6 +11,7 @@ import org.wikipedia.R
 import org.wikipedia.databinding.ViewWikiErrorBinding
 import org.wikipedia.dataclient.mwapi.MwException
 import org.wikipedia.util.ThrowableUtil.is404
+import org.wikipedia.util.ThrowableUtil.isEmptyException
 import org.wikipedia.util.ThrowableUtil.isOffline
 import org.wikipedia.util.ThrowableUtil.isTimeout
 
@@ -19,6 +20,7 @@ class WikiErrorView : LinearLayout {
     var binding = ViewWikiErrorBinding.inflate(LayoutInflater.from(context), this)
     var retryClickListener: OnClickListener? = null
     var backClickListener: OnClickListener? = null
+    var nextClickListener: OnClickListener? = null
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
@@ -62,6 +64,9 @@ class WikiErrorView : LinearLayout {
                 isOffline(it) -> {
                     return ErrorType.OFFLINE
                 }
+                isEmptyException(it) -> {
+                    return ErrorType.EMPTY
+                }
                 else -> { }
             }
         }
@@ -89,6 +94,12 @@ class WikiErrorView : LinearLayout {
                 R.string.offline_load_error_retry) {
             override fun buttonClickListener(errorView: WikiErrorView): OnClickListener? {
                 return errorView.retryClickListener
+            }
+        },
+        EMPTY(R.drawable.ic_error_black_24dp, R.string.error_message_generic,
+                R.string.error_next) {
+            override fun buttonClickListener(errorView: WikiErrorView): OnClickListener? {
+                return errorView.nextClickListener
             }
         },
         GENERIC(R.drawable.ic_error_black_24dp, R.string.error_message_generic,

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -58,6 +58,7 @@
   <string name="offline_load_error_retry">Text for button that retries when there is an error because of lack of internet connection.\n{{Identical|Retry}}</string>
   <string name="page_error_back_to_main">Text for the back button that goes to the last page visited when tapped.\n{{Identical|Go back}}</string>
   <string name="error_back">Text for suggesting to go back to the previous screen in case of error.\n{{Identical|Go back}}</string>
+  <string name="error_next">Text for suggesting to go to the next item in case of error.\n{{Identical|Next}}</string>
   <string name="menu_clear_all_history">Menu item text for clearing your reading history.\n{{Identical|Clear history}}</string>
   <string name="history_item_deleted">Message shown when an article is removed from the browsing history. The \"%s\" symbol is replaced with the name of the article.</string>
   <string name="history_items_deleted">Message shown when multiple articles are removed from the browsing history. The \"%d\" symbol is replaced with the number of articles removed.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="offline_load_error_retry">Retry</string>
     <string name="page_error_back_to_main">Go back</string>
     <string name="error_back">Go back</string>
+    <string name="error_next">Next</string>
     <string name="menu_clear_all_history">Clear history</string>
     <string name="history_item_deleted">%s removed from history</string>
     <string name="history_items_deleted">%d articles removed from history</string>


### PR DESCRIPTION
In order to use unclear `Exception` for the empty title, it would be better if we show the "Next" button for `ExceptionEmpty`.