### PR TITLE
Show correct license when editing descriptions in English.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -184,7 +184,7 @@ class DescriptionEditFragment : Fragment() {
     private fun shouldWriteToLocalWiki(): Boolean {
         return (action == DescriptionEditActivity.Action.ADD_DESCRIPTION ||
                 action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION) &&
-                pageTitle.wikiSite.languageCode() == "en"
+                wikiUsesLocalDescriptions(pageTitle.wikiSite.languageCode())
     }
 
     private inner class EditViewCallback : DescriptionEditView.Callback {
@@ -412,6 +412,10 @@ class DescriptionEditFragment : Fragment() {
                         ARG_ACTION to action,
                         Constants.INTENT_EXTRA_INVOKE_SOURCE to source)
             }
+        }
+
+        fun wikiUsesLocalDescriptions(lang: String): Boolean {
+            return lang == "en"
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditLicenseView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditLicenseView.kt
@@ -19,9 +19,20 @@ class DescriptionEditLicenseView constructor(context: Context, attrs: AttributeS
         buildLicenseNotice(ARG_NOTICE_DEFAULT)
     }
 
-    fun buildLicenseNotice(arg: String) {
-        binding.licenseText.text = StringUtil.fromHtml(context.getString(getLicenseTextRes(arg),
-                context.getString(R.string.terms_of_use_url), context.getString(R.string.cc_0_url)))
+    fun buildLicenseNotice(arg: String, lang: String? = null) {
+        if ((arg == ARG_NOTICE_ARTICLE_DESCRIPTION || arg == ARG_NOTICE_DEFAULT) &&
+                DescriptionEditFragment.wikiUsesLocalDescriptions(lang.orEmpty())) {
+            binding.licenseText.text = StringUtil.fromHtml(context.getString(R.string.edit_save_action_license_logged_in,
+                    context.getString(R.string.terms_of_use_url),
+                    context.getString(R.string.cc_by_sa_3_url)))
+        } else {
+            binding.licenseText.text = StringUtil.fromHtml(context.getString(when (arg) {
+                ARG_NOTICE_ARTICLE_DESCRIPTION -> R.string.suggested_edits_license_notice
+                ARG_NOTICE_IMAGE_CAPTION -> R.string.suggested_edits_image_caption_license_notice
+                else -> R.string.description_edit_license_notice
+            }, context.getString(R.string.terms_of_use_url), context.getString(R.string.cc_0_url)))
+        }
+
         RichTextUtil.removeUnderlinesFromLinks(binding.licenseText)
     }
 
@@ -32,13 +43,6 @@ class DescriptionEditLicenseView constructor(context: Context, attrs: AttributeS
         binding.licenseText.setLinkTextColor(white70)
         binding.licenseIcon.setColorFilter(white70, android.graphics.PorterDuff.Mode.SRC_IN)
     }
-
-    private fun getLicenseTextRes(arg: String): Int =
-            when (arg) {
-                ARG_NOTICE_ARTICLE_DESCRIPTION -> R.string.suggested_edits_license_notice
-                ARG_NOTICE_IMAGE_CAPTION -> R.string.suggested_edits_image_caption_license_notice
-                else -> R.string.description_edit_license_notice
-            }
 
     companion object {
         const val ARG_NOTICE_DEFAULT = "defaultNotice"

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
@@ -35,7 +35,8 @@ class DescriptionEditReviewView constructor(context: Context, attrs: AttributeSe
             binding.licenseView.buildLicenseNotice(ARG_NOTICE_IMAGE_CAPTION)
         } else {
             setDescriptionReviewView(summaryForEdit, description)
-            binding.licenseView.buildLicenseNotice(if (summaryForEdit.description.isNullOrEmpty()) ARG_NOTICE_ARTICLE_DESCRIPTION else ARG_NOTICE_DEFAULT)
+            binding.licenseView.buildLicenseNotice(if (summaryForEdit.description.isNullOrEmpty()) ARG_NOTICE_ARTICLE_DESCRIPTION else ARG_NOTICE_DEFAULT,
+                    summaryForEdit.lang)
         }
     }
 


### PR DESCRIPTION
Right now we're showing the CC0 license for all descriptions, but that's the license for Wikidata contributions. When contributing to Wikipedia, the license is CC-BY-SA 3.0.