### PR TITLE
MEP: Send events immediately for testing

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -9,6 +9,7 @@ import org.wikipedia.settings.Prefs;
 import org.wikipedia.util.log.L;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,11 +72,22 @@ public final class EventPlatformClient {
      * @param event event
      */
     public static synchronized void submit(Event event) {
+        StreamConfig streamConfig = STREAM_CONFIGS.get(event.getStream());
+        if (streamConfig == null) {
+            return;
+        }
         if (!SamplingController.isInSample(event)) {
             return;
         }
         addEventMetadata(event);
-        OutputBuffer.schedule(event);
+        //
+        // Temporarily send events immediately in order to investigate discrepancies in
+        // the numbers of events submitted in this system vs. legacy eventlogging.
+        //
+        // https://phabricator.wikimedia.org/T281001
+        //
+        // OutputBuffer.schedule(event);
+        OutputBuffer.sendEventsForStream(streamConfig, Collections.singletonList(event));
     }
 
     /**

--- a/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.java
+++ b/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.java
@@ -3,6 +3,7 @@ package org.wikipedia.analytics.eventplatform;
 import com.google.gson.Gson;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
@@ -75,6 +76,7 @@ public class EventPlatformClientTest {
         assertThat(serialized.contains("app_install_id"), is(true));
     }
 
+    @Ignore("Disabled for testing: https://phabricator.wikimedia.org/T281001")
     @Test
     public void testOutputBufferEnqueuesEventOnSubmit() {
         Event event = new Event("test", "test");

--- a/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.java
+++ b/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.java
@@ -28,10 +28,8 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.wikipedia.analytics.eventplatform.DestinationEventService.LOGGING;
-import static org.wikipedia.analytics.eventplatform.EventPlatformClient.JS_REGEXP_PATTERN;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClient.STREAM_CONFIGS;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClient.addEventMetadata;
-import static org.wikipedia.analytics.eventplatform.EventPlatformClient.getStreamConfig;
 import static org.wikipedia.analytics.eventplatform.EventPlatformClient.setStreamConfig;
 import static org.wikipedia.analytics.eventplatform.SamplingConfig.Identifier.DEVICE;
 import static org.wikipedia.analytics.eventplatform.SamplingConfig.Identifier.PAGEVIEW;
@@ -63,16 +61,8 @@ public class EventPlatformClientTest {
     @Test
     public void testGetStream() {
         setStreamConfig(new StreamConfig("test", null, null));
-        setStreamConfig(new StreamConfig("/^f[a-z]{2}$/", null, null));
-        setStreamConfig(new StreamConfig("/^mediawiki\\.job\\..+/", null, null));
-        setStreamConfig(new StreamConfig("/^swift\\.(.+\\.)?upload-complete$/", null, null));
-
-        assertThat(getStreamConfig("test"), is(notNullValue()));
-        assertThat(getStreamConfig("foo"), is(notNullValue()));
-        assertThat(getStreamConfig("mediawiki.job.foo"), is(notNullValue()));
-        assertThat(getStreamConfig("swift.foo.upload-complete"), is(notNullValue()));
-
-        assertThat(getStreamConfig("key.does.not.exist"), is(nullValue()));
+        assertThat(STREAM_CONFIGS.get("test"), is(notNullValue()));
+        assertThat(STREAM_CONFIGS.get("key.does.not.exist"), is(nullValue()));
     }
 
     @Test
@@ -165,19 +155,6 @@ public class EventPlatformClientTest {
         assertThat(EventPlatformClient.SamplingController.getSamplingId(DEVICE), is(notNullValue()));
         assertThat(EventPlatformClient.SamplingController.getSamplingId(PAGEVIEW), is(notNullValue()));
         assertThat(EventPlatformClient.SamplingController.getSamplingId(SESSION), is(notNullValue()));
-    }
-
-    @Test
-    public void testJavascriptRegExpPatternMatching() {
-        assertThat("/foo/".matches(JS_REGEXP_PATTERN), is(true));
-        assertThat("/foo/i".matches(JS_REGEXP_PATTERN), is(true));
-        assertThat("/foo/suygm".matches(JS_REGEXP_PATTERN), is(true));
-        assertThat("/^mediawiki\\.job\\..+/".matches(JS_REGEXP_PATTERN), is(true));
-        assertThat("/^swift\\.(.+\\.)?upload-complete$/".matches(JS_REGEXP_PATTERN), is(true));
-
-        assertThat("foo".matches(JS_REGEXP_PATTERN), is(false));
-        assertThat("".matches(JS_REGEXP_PATTERN), is(false));
-        assertThat("/foo/z".matches(JS_REGEXP_PATTERN), is(false));
     }
 
     @Test


### PR DESCRIPTION
Sends events immediately upon submission to the MEP client to match the legacy eventlogging behavior. We'll compare the resulting events with those sent via the legacy system in order to determine conclusively whether events are being leaked in the queueing process.

This PR also contains an incidental change to drop support for looking up stream names by regular expression matching. This feature is only used in practice by job-queue-related stream configurations, and the app need not support it.

Phab: https://phabricator.wikimedia.org/T281001