### PR TITLE
Fix: apply UriUtil.resolveProtocolRelativeUrl() for externalLink in FilePage

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -169,7 +169,7 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
                 view.binding.contentText.setTextIsSelectable(false)
                 view.binding.externalLink.visibility = View.VISIBLE
                 view.binding.contentContainer.setOnClickListener {
-                    UriUtil.visitInExternalBrowser(context, Uri.parse(externalLink))
+                    UriUtil.visitInExternalBrowser(context, Uri.parse(UriUtil.resolveProtocolRelativeUrl(externalLink)))
                 }
             } else {
                 view.binding.contentText.movementMethod = movementMethod


### PR DESCRIPTION
Steps to reproduce:

1. Go to the "IMDb" article.
2. Click on the lead image.
3. Go to the second image ("screenshot of IMDb's front page as of March 31, 2021") and go to its file page.
4. Click on the "Fair use" external link in the "Licensing" section.