### PR TITLE
MEP: Stop incorrectly expecting response for hasty requests.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -213,7 +213,7 @@ public final class EventPlatformClient {
                                 );
                                 break;
                         }
-                    });
+                    }, L::w);
         }
 
     }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.java
@@ -183,7 +183,7 @@ public final class EventPlatformClient {
         }
 
         private static void sendEventsForStream(@NonNull StreamConfig streamConfig, @NonNull List<Event> events) {
-            ServiceFactory.getAnalyticsRest(streamConfig).postEvents(events)
+            ServiceFactory.getAnalyticsRest(streamConfig).postEventsHasty(events)
                     .subscribeOn(Schedulers.io())
                     .subscribe(response -> {
                         switch (response.code()) {

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.kt
@@ -17,5 +17,8 @@ import retrofit2.http.POST
  */
 interface EventService {
     @POST("/v1/events?hasty=true")
-    fun postEvents(@Body events: @JvmSuppressWildcards Any): Observable<Response<Unit>>
+    fun postEventsHasty(@Body events: @JvmSuppressWildcards Any): Observable<Response<Unit>>
+
+    @POST("/v1/events")
+    fun postEvents(@Body events: @JvmSuppressWildcards Any): Observable<Response<EventServiceResponse>>
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.kt
@@ -17,5 +17,5 @@ import retrofit2.http.POST
  */
 interface EventService {
     @POST("/v1/events?hasty=true")
-    fun postEvents(@Body events: @JvmSuppressWildcards Any): Observable<Response<EventServiceResponse?>?>?
+    fun postEvents(@Body events: @JvmSuppressWildcards Any): Observable<Response<Unit>>
 }


### PR DESCRIPTION
In our network call to the MEP service, we expect a response in the form of a `EventServiceResponse` object.  However, since we're sending the events "hastily", the server doesn't actually give us any response (it's a zero-length body). This causes an exception to be thrown in RxJava, and we're simply not handling it now.

This is OK for the current release, since we're not doing anything with those responses one way or another. But this PR simply cleans up that logic and no longer expects a response body for hasty requests, and no exceptions are thrown anymore.