### PR TITLE
Make text selectable again in Image Detail view.

### DIFF
--- a/app/src/main/res/layout/view_image_detail.xml
+++ b/app/src/main/res/layout/view_image_detail.xml
@@ -59,6 +59,7 @@
             android:lineSpacingExtra="8sp"
             android:textColor="?attr/primary_text_color"
             android:textSize="20sp"
+            android:textIsSelectable="true"
             tools:text="Watercolor portrait of Ada King, Countess of Lovelace (Ada Lovelace)" />
 
         <ImageView


### PR DESCRIPTION
For some reason `textIsSelectable` was removed.

https://phabricator.wikimedia.org/T281705