### PR TITLE
Fix: announcement card action buttons container visibility

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.kt
@@ -39,9 +39,9 @@ class AnnouncementCardView(context: Context) : DefaultFeedCardView<AnnouncementC
                     binding.viewAnnouncementText.text = StringUtil.fromHtml(it.extract())
                 }
                 if (!it.hasAction()) {
-                    binding.viewAnnouncementCardDialogButtonsContainer.visibility = GONE
+                    binding.viewAnnouncementCardButtonsContainer.visibility = GONE
                 } else {
-                    binding.viewAnnouncementCardDialogButtonsContainer.visibility = VISIBLE
+                    binding.viewAnnouncementCardButtonsContainer.visibility = VISIBLE
                     binding.viewAnnouncementActionPositive.text = it.actionTitle()
                     binding.viewAnnouncementDialogActionPositive.text = it.actionTitle()
                 }


### PR DESCRIPTION
It was a bug from #2401, which in a fresh install, the "customize feed" card will show four action buttons.