### PR TITLE
Fix: don't set new card if it matches the old one

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/news/NewsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsCardView.kt
@@ -47,11 +47,13 @@ class NewsCardView(context: Context) : DefaultFeedCardView<NewsCard>(context) {
 
     override var card: NewsCard? = null
         set(value) {
-            field = value
-            value?.let {
-                header(it)
-                setLayoutDirectionByWikiSite(it.wikiSite(), binding.rtlContainer)
-                setUpRecycler(it)
+            if (field != value) {
+                field = value
+                value?.let {
+                    header(it)
+                    setLayoutDirectionByWikiSite(it.wikiSite(), binding.rtlContainer)
+                    setUpRecycler(it)
+                }
             }
         }
 

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -24,10 +24,12 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
 
     override var card: SuggestedEditsCard? = null
         set(value) {
-            field = value
-            value?.let {
-                header(it)
-                updateContents(it)
+            if (field != value) {
+                field = value
+                value?.let {
+                    header(it)
+                    updateContents(it)
+                }
             }
         }
 


### PR DESCRIPTION
Also a bug from #2401.

If we click on the second news card item and then press the back button to return to the feed, the `NewsCard` view will be created again and it will push down an empty space below the news card. 

If you try many times the issue will become more obvious.