### PR TITLE
Fix buttons on Announcement dialog when shown over article.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.kt
@@ -21,6 +21,7 @@ class AnnouncementCardView(context: Context) : DefaultFeedCardView<AnnouncementC
     }
 
     private val binding = ViewCardAnnouncementBinding.inflate(LayoutInflater.from(context), this, true)
+    var localCallback: Callback? = null
 
     init {
         binding.viewAnnouncementText.movementMethod = LinkMovementMethod.getInstance()
@@ -91,14 +92,14 @@ class AnnouncementCardView(context: Context) : DefaultFeedCardView<AnnouncementC
     private fun onPositiveActionClick() {
         card?.let {
             callback?.onAnnouncementPositiveAction(it, it.actionUri())
+            localCallback?.onAnnouncementPositiveAction(it, it.actionUri())
         }
     }
 
     private fun onNegativeActionClick() {
         card?.let {
             callback?.onAnnouncementNegativeAction(it)
+            localCallback?.onAnnouncementNegativeAction(it)
         }
     }
-
-    var announcementCardCallback: Callback? = null
 }

--- a/app/src/main/java/org/wikipedia/page/AnnouncementDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/AnnouncementDialog.kt
@@ -29,7 +29,7 @@ class AnnouncementDialog internal constructor(context: Context, val announcement
         val scrollView = ScrollView(context)
         val cardView = AnnouncementCardView(context)
         cardView.card = AnnouncementCard(announcement)
-        cardView.announcementCardCallback = this
+        cardView.localCallback = this
         scrollView.addView(cardView)
         scrollView.isVerticalScrollBarEnabled = true
         setView(scrollView)


### PR DESCRIPTION
Yet another bug introduced in #2401 -- when the Announcement card is shown as a dialog while browsing an article, the positive/negative buttons don't work, because the callback never gets called.