### PR TITLE
Fix face-transformed image alignment.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/CenterCropWithFaceTransformation.kt
+++ b/app/src/main/java/org/wikipedia/util/CenterCropWithFaceTransformation.kt
@@ -63,7 +63,7 @@ class CenterCropWithFaceTransformation : BitmapTransformation() {
             }
         }
         m.setScale(scale, scale)
-        m.postTranslate(dx + half, dy + half)
+        m.postTranslate(dx, dy)
         val result = pool.getDirty(width, height, getNonNullConfig(inBitmap))
         // We don't add or remove alpha, so keep the alpha setting of the Bitmap we were given.
         TransformationUtils.setAlpha(inBitmap, result)


### PR DESCRIPTION
If you set the app to Dark mode, and look very closely at large images (e.g. lead images in articles, card images in the feed, etc), you might notice a very thin white line at the left and top of the image.

For some reason the matrix transformation logic was adding an extra 0.5 dp to the translation.  I have no idea why this was being done, so I removed it, and now the images are aligned perfectly.
