### PR TITLE
Fix: return to the original position after editing image caption/tags from Gallery

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.java
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.java
@@ -751,7 +751,7 @@ public class PageActivity extends BaseActivity implements PageFragment.Callback,
         } else if (newArticleLanguageSelected(requestCode, resultCode) || galleryPageSelected(requestCode, resultCode)) {
             toolbarContainerView.post(() -> handleIntent(data));
         } else if (galleryImageEdited(requestCode, resultCode)) {
-            pageFragment.refreshPage();
+            pageFragment.reloadFromBackstack();
         } else if (requestCode == Constants.ACTIVITY_REQUEST_BROWSE_TABS) {
             if (app.getTabCount() == 0 && resultCode != TabActivity.RESULT_NEW_TAB) {
                 // They browsed the tabs and cleared all of them, without wanting to open a new tab.


### PR DESCRIPTION
https://phabricator.wikimedia.org/T282765