### PR TITLE
Explicitly request locally overridden errors from the API.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.java
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.java
@@ -40,7 +40,7 @@ public interface Service {
     String COMMONS_URL = "https://commons.wikimedia.org/";
     String URL_FRAGMENT_FROM_COMMONS = "/wikipedia/commons/";
 
-    String MW_API_PREFIX = "w/api.php?format=json&formatversion=2&errorformat=html&";
+    String MW_API_PREFIX = "w/api.php?format=json&formatversion=2&errorformat=html&errorsuselocal=1&";
 
     int PREFERRED_THUMB_SIZE = 320;
 


### PR DESCRIPTION
This is related to https://phabricator.wikimedia.org/T276139
The API requires another obscure parameter to return MediaWiki errors that are overridden on the local wiki. This should make our displaying of errors even more accurate for each language wiki.