### PR TITLE
Remove images when parsing strings as Html.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -109,9 +109,16 @@ object StringUtil {
             // processing that fromHtml() performs.
             return sourceStr.toSpanned()
         }
-        sourceStr = sourceStr.replace("&#8206;".toRegex(), "\u200E")
-                .replace("&#8207;".toRegex(), "\u200F")
-                .replace("&amp;".toRegex(), "&")
+        sourceStr = sourceStr.replace("&#8206;", "\u200E")
+            .replace("&#8207;", "\u200F")
+            .replace("&amp;", "&")
+
+        // HACK: We don't want to display "images" in the html string, because they will just show
+        // up as a green square. Therefore, let's just disable the parsing of images by renaming
+        // <img> tags to something that the native Html parser doesn't recognize.
+        // This automatically covers both <img></img> and <img /> variations.
+        sourceStr = sourceStr.replace("<img ", "<figure ").replace("</img>", "</figure>")
+
         return sourceStr.parseAsHtml()
     }
 


### PR DESCRIPTION
When we parse html messages with "images" in them, the images appear as green boxes. (This can be seen in link previews for certain articles, as well as in certain types of error messages.)

Instead of showing a green box, let's just remove images from html strings that we parse.