### PR TITLE
Update enable poll notification value to true on XML

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/NotificationSettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/NotificationSettingsActivity.kt
@@ -2,7 +2,6 @@ package org.wikipedia.settings
 
 import android.app.Activity
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.widget.CheckBox
 import android.widget.TextView
@@ -39,8 +38,7 @@ class NotificationSettingsActivity : SingleFragmentActivity<NotificationSettings
                     .setCancelable(false)
                     .setTitle(R.string.notifications_poll_enable_title)
                     .setView(view)
-                    .setPositiveButton(R.string.notifications_poll_enable_positive
-                    ) { _: DialogInterface?, _: Int -> Prefs.setNotificationPollEnabled(true) }
+                    .setPositiveButton(R.string.notifications_poll_enable_positive) { _, _ -> Prefs.setNotificationPollEnabled(true) }
                     .setNegativeButton(R.string.notifications_poll_enable_negative, null)
                     .setOnDismissListener { Prefs.setNotificationPollReminderEnabled(!checkbox.isChecked) }
                     .show()

--- a/app/src/main/res/xml/preferences_notifications.xml
+++ b/app/src/main/res/xml/preferences_notifications.xml
@@ -5,7 +5,7 @@
 
     <org.wikipedia.settings.SwitchPreferenceMultiLine
         android:key="@string/preference_key_notification_poll_enable"
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:title="@string/preference_title_notification_poll"
         android:summary="@string/preference_summary_notification_poll" />
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T281414

Noticed that in `preferences_notifications.xml`, the default value of `preference_key_notification_poll_enable` is `false`.
but the `Prefs.notificationPollEnabled()`, the default value is `true`.

Not sure but it would be better if the default values are consistent. 

Steps to reproduce:
1. Fresh install app. (`preference_key_notification_poll_enable` = `true`)
2. Log in.
3. Go to `NotificatonSettings`, and  `preference_key_notification_poll_enable` will become `false` automatically.