### PR TITLE
Fix: crash when destroying GalleryActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
@@ -71,11 +71,12 @@ class GalleryItemFragment : Fragment(), RequestListener<Drawable?> {
             }
             (requireActivity() as GalleryActivity).toggleControls()
         }
+        val imageScale = binding.image.scale
         binding.image.setOnMatrixChangeListener {
             if (!isAdded) {
                 return@setOnMatrixChangeListener
             }
-            (requireActivity() as GalleryActivity).setViewPagerEnabled(binding.image.scale <= 1f)
+            (requireActivity() as GalleryActivity).setViewPagerEnabled(imageScale <= 1f)
         }
         return binding.root
     }


### PR DESCRIPTION
It would cause when trying to get the `scale` from `binding.image` from a destroyed `GalleryItemFragment`, which the `_binding` is set to `null`.