### PR TITLE
Fix: make "Share link" working properly on Special: pages

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.java
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.java
@@ -877,8 +877,8 @@ public class PageFragment extends Fragment implements BackPressedHandler, Commun
     }
 
     public void sharePageLink() {
-        if (getPage() != null) {
-            ShareUtil.shareText(requireActivity(), getPage().getTitle());
+        if (model.getTitle() != null) {
+            ShareUtil.shareText(requireActivity(), model.getTitle());
         }
     }
 


### PR DESCRIPTION
Steps to reproduce:
1. Click on any article.
2. Scroll to the bottom and click on "View edit history".
3. In the overflow menu, click on "Share link".