### PR TITLE
Fix: prevent showing incorrect edit message after submitting edits

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/Edit.kt
+++ b/app/src/main/java/org/wikipedia/edit/Edit.kt
@@ -18,11 +18,11 @@ class Edit : MwPostResponse() {
         val warning: String? = null
         val spamblacklist: String? = null
 
-        val editSucceeded = "Success" == status
-        val captchaId = captcha?.id.orEmpty()
-        val hasEditErrorCode = code != null
-        val hasCaptchaResponse = captcha != null
-        val hasSpamBlacklistResponse = spamblacklist != null
+        val editSucceeded get() = "Success" == status
+        val captchaId get() = captcha?.id.orEmpty()
+        val hasEditErrorCode get() = code != null
+        val hasCaptchaResponse get() = captcha != null
+        val hasSpamBlacklistResponse get() = spamblacklist != null
     }
 
     private class Captcha {


### PR DESCRIPTION
If we are going to use the values from the object itself when building it, we should apply `get()` for the variables.

Now the latest beta app has the issue that it will show `Received unrecognized edit response` after submitting edits.