### PR TITLE
Update Robolectric to 4.5.1.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -223,7 +223,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttpVersion"
     testImplementation "commons-io:commons-io:2.6"


### PR DESCRIPTION
The newest version finally runs Robolectric tests successfully on my Windows machine.