### PR TITLE
Apply correct loading circle icon color for talk topic activites

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -70,12 +70,11 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
         topicId = intent.extras?.getInt(EXTRA_TOPIC, -1)!!
 
         L10nUtil.setConditionalLayoutDirection(binding.talkRefreshView, pageTitle.wikiSite.languageCode())
+        binding.talkRefreshView.setColorSchemeResources(ResourceUtil.getThemedAttributeId(this, R.attr.colorAccent))
 
         binding.talkRecyclerView.layoutManager = LinearLayoutManager(this)
         binding.talkRecyclerView.addItemDecoration(DrawableItemDecoration(this, R.attr.list_separator_drawable, drawStart = false, drawEnd = false))
         binding.talkRecyclerView.adapter = TalkReplyItemAdapter()
-
-        L10nUtil.setConditionalLayoutDirection(binding.talkRefreshView, pageTitle.wikiSite.languageCode())
 
         binding.talkErrorView.backClickListener = View.OnClickListener {
             finish()

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -76,6 +76,7 @@ class TalkTopicsActivity : BaseActivity() {
             funnel.logRefresh()
             loadTopics()
         }
+        binding.talkRefreshView.setColorSchemeResources(ResourceUtil.getThemedAttributeId(this, R.attr.colorAccent))
 
         invokeSource = intent.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as Constants.InvokeSource
         funnel = TalkFunnel(pageTitle, invokeSource)


### PR DESCRIPTION
Now they are showing the default color on the circle icons.