### PR TITLE
Follow-up to Talk Page last edited time.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.graphics.Typeface
 import android.net.Uri
 import android.os.Bundle
+import android.text.format.DateUtils
 import android.view.*
 import android.widget.TextView
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -158,7 +159,8 @@ class TalkTopicsActivity : BaseActivity() {
                 .flatMap {
                     it.query?.firstPage()?.revisions()?.getOrNull(0)?.let { revision ->
                         binding.talkLastModified.text = StringUtil.fromHtml(getString(R.string.talk_last_modified,
-                            DateUtil.getLastSyncDateString(revision.timeStamp()), revision.user))
+                            DateUtils.getRelativeTimeSpanString(DateUtil.iso8601DateParse(revision.timeStamp()).time,
+                                System.currentTimeMillis(), 0L), revision.user))
                     }
                     ServiceFactory.getRest(pageTitle.wikiSite).getTalkPage(pageTitle.prefixedText)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1034,7 +1034,7 @@
     <string name="talk_message_hint">Compose message</string>
     <string name="talk_message_empty">The message cannot be empty.</string>
     <string name="talk_subject_empty">The subject cannot be empty.</string>
-    <string name="talk_last_modified"><![CDATA[<b>Last edited on %1$s</b> by %2$s]]></string>
+    <string name="talk_last_modified"><![CDATA[<b>Last edited %1$s</b> by %2$s]]></string>
     <string name="menu_option_share_edit">Share edit</string>
     <string name="menu_option_user_profile">%s\'s profile</string>
     <string name="menu_option_user_contributions">%s\'s contributions</string>


### PR DESCRIPTION
This states the last-edit time as a relative time, e.g. "5 minutes ago", "13 hours ago", "5 days ago", etc.