### PR TITLE
Fix: request new CAPTCHA when backing from the error view

### DIFF
--- a/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.kt
+++ b/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.kt
@@ -68,6 +68,7 @@ class CreateAccountActivity : BaseActivity() {
     private fun setClickListeners() {
         binding.viewCreateAccountError.backClickListener = View.OnClickListener {
             binding.viewCreateAccountError.visibility = View.GONE
+            captchaHandler.requestNewCaptcha()
         }
         binding.viewCreateAccountError.retryClickListener = View.OnClickListener { binding.viewCreateAccountError.visibility = View.GONE }
         binding.createAccountSubmitButton.setOnClickListener {

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -122,9 +122,12 @@ class EditSectionActivity : BaseActivity() {
         }
         binding.viewEditSectionError.retryClickListener = View.OnClickListener {
             binding.viewEditSectionError.visibility = View.GONE
+            captchaHandler.requestNewCaptcha()
             fetchSectionText()
         }
-        binding.viewEditSectionError.backClickListener = View.OnClickListener { onBackPressed() }
+        binding.viewEditSectionError.backClickListener = View.OnClickListener {
+            onBackPressed()
+        }
         L10nUtil.setConditionalTextDirection(binding.editSectionText, pageTitle.wikiSite.languageCode())
         fetchSectionText()
         if (savedInstanceState != null && savedInstanceState.containsKey("sectionTextModified")) {


### PR DESCRIPTION
This applies to `CreateAccountActivity` and also `EditSectionActivity`

https://phabricator.wikimedia.org/T286095