### PR TITLE
Correctly show/hide secondary and tertiary actions in notifications.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -13,6 +13,7 @@ import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -394,6 +395,8 @@ class NotificationActivity : BaseActivity(), NotificationItemActionsDialog.Callb
             imageView.setImageResource(iconResId)
             DrawableCompat.setTint(imageBackgroundView.drawable,
                     ContextCompat.getColor(this@NotificationActivity, iconBackColor))
+            secondaryActionHintView.isVisible = false
+            tertiaryActionHintView.isVisible = false
             n.contents?.let {
                 titleView.text = StringUtil.fromHtml(it.header)
                 if (it.body.trim().isNotEmpty()) {

--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -90,6 +90,7 @@
         app:layout_constraintEnd_toStartOf="@id/notification_item_tertiary_action_hint"
         app:layout_constraintStart_toStartOf="@id/notification_item_title"
         app:layout_constraintTop_toBottomOf="@id/notification_item_description"
+        tools:visibility="visible"
         tools:text="Lorem ipsum" />
 
     <TextView
@@ -104,6 +105,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/notification_item_secondary_action_hint"
         app:layout_constraintTop_toTopOf="@id/notification_item_secondary_action_hint"
+        tools:visibility="visible"
         tools:text="Lorem ipsum" />
 
     <androidx.appcompat.widget.AppCompatImageView


### PR DESCRIPTION
Since NotificationItemHolders are reused by the RecyclerView, some notifications incorrectly have secondary and tertiary action links, when they actually shouldn't.