### PR TITLE
Tweak: should close the compose response input field before exiting the topic page

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -34,7 +34,6 @@ import org.wikipedia.page.*
 import org.wikipedia.page.linkpreview.LinkPreviewDialog
 import org.wikipedia.readinglist.AddToReadingListDialog
 import org.wikipedia.util.*
-import org.wikipedia.util.UriUtil
 import org.wikipedia.util.log.L
 import org.wikipedia.views.DrawableItemDecoration
 import java.util.concurrent.TimeUnit
@@ -453,6 +452,14 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
 
     override fun onLinkPreviewShareLink(title: PageTitle) {
         ShareUtil.shareText(this, title)
+    }
+
+    override fun onBackPressed() {
+        if (replyActive && !isNewTopic()) {
+            onInitialLoad()
+        } else {
+            super.onBackPressed()
+        }
     }
 
     companion object {


### PR DESCRIPTION
Steps:

1. Go to talk page and click on any topic.
2. In topic page, click on reply.
3. Press "back" button, and it should close the compose response input view.