### PR TITLE
Fix: make sure the notification "Pause" and "Resume" button showing correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncNotification.kt
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncNotification.kt
@@ -29,16 +29,20 @@ class SavedPageSyncNotification : BroadcastReceiver() {
                 SavedPageSyncService.enqueue()
             }
             instance.setSyncCanceled(true)
-            notification.isPaused = false
+            instance.setSyncPaused(false)
         } else if (intent.getBooleanExtra(Constants.INTENT_EXTRA_NOTIFICATION_SYNC_PAUSE_RESUME, false)) {
             instance.setSyncCanceled(false)
             if (instance.isSyncPaused()) {
-                notification.isPaused = false
+                instance.setSyncPaused(false)
                 SavedPageSyncService.enqueue()
             } else {
-                notification.isPaused = true
+                instance.setSyncPaused(true)
             }
         }
+    }
+
+    private fun setSyncPaused(paused: Boolean) {
+        notification.isPaused = paused
     }
 
     fun setSyncCanceled(canceled: Boolean) {


### PR DESCRIPTION
Steps to reproduce:

1. Clear app data.
2. Log in to an account that has multiple reading lists synced.
3. While downloading the articles, click on "Pause" to pause the procedure.

The "Pause" button should change to "Resume" when it is paused.