### PR TITLE
Add fundraising link to GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://donate.wikimedia.org/?utm_medium=githubRepo']


### PR DESCRIPTION
**Fixes Phabricator ticket:** N/A

### Notes
* Add a support WMF link. From conversation w/ advancement.
* This will cause a link to show up on the right side of our main repo webpage.

### Test Steps
1. N/A

