### PR TITLE
Apply a proper layout direction in NotificationActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -38,6 +38,7 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DateUtil.getFeedCardDateString
 import org.wikipedia.util.DeviceUtil.setContextClickAsLongClick
 import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
@@ -434,7 +435,9 @@ class NotificationActivity : BaseActivity(), NotificationItemActionsDialog.Callb
                     wikiCodeBackgroundView.visibility = View.VISIBLE
                     wikiCodeView.visibility = View.VISIBLE
                     wikiCodeImageView.visibility = View.GONE
-                    wikiCodeView.text = n.wiki().replace("wiki", "")
+                    val langCode = n.wiki().replace("wiki", "")
+                    wikiCodeView.text = langCode
+                    L10nUtil.setConditionalLayoutDirection(itemView, langCode)
                 }
             }
             if (container.selected) {


### PR DESCRIPTION
In the notification screen, the RTL language notifications should be displayed in a proper layout direction.