### PR TITLE
Follow-up to showing all contributions

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -171,7 +171,7 @@ class SuggestedEditsTasksFragment : Fragment() {
         revertSeverity = 0
         binding.progressBar.visibility = VISIBLE
 
-        disposables.add(Observable.zip(ServiceFactory.get(WikipediaApp.getInstance().wikiSite).userInfo.subscribeOn(Schedulers.io()),
+        disposables.add(Observable.zip(ServiceFactory.get(WikipediaApp.getInstance().wikiSite).getUserContributions(AccountUtil.userName!!, 10, null).subscribeOn(Schedulers.io()),
                 ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getUserContributions(AccountUtil.userName!!, 10, null).subscribeOn(Schedulers.io()),
                 ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).getUserContributions(AccountUtil.userName!!, 10, null).subscribeOn(Schedulers.io()),
                 UserContributionsStats.getEditCountsObservable(), { homeSiteResponse, commonsResponse, wikidataResponse, _ ->
@@ -202,6 +202,7 @@ class SuggestedEditsTasksFragment : Fragment() {
                     val contributions = ArrayList<UserContribution>()
                     contributions.addAll(wikidataResponse.query!!.userContributions())
                     contributions.addAll(commonsResponse.query!!.userContributions())
+                    contributions.addAll(homeSiteResponse.query!!.userContributions())
                     contributions.sortWith { o2, o1 -> (o1.date().compareTo(o2.date())) }
                     latestEditStreak = getEditStreak(contributions)
                     revertSeverity = UserContributionsStats.getRevertSeverity()

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -366,7 +366,7 @@ class SuggestedEditsTasksFragment : Fragment() {
         // Start with a calendar that is fixed at the beginning of today's date
         val baseCal = GregorianCalendar(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH))
         val dayMillis = TimeUnit.DAYS.toMillis(1)
-        var streak = 1
+        var streak = 0
         for (c in contributions) {
             if (c.date().time >= baseCal.timeInMillis) {
                 // this contribution was on the same day.
@@ -376,7 +376,7 @@ class SuggestedEditsTasksFragment : Fragment() {
                 break
             }
             streak++
-            calendar.timeInMillis = calendar.timeInMillis - dayMillis
+            baseCal.timeInMillis = baseCal.timeInMillis - dayMillis
         }
         return streak
     }

--- a/app/src/main/java/org/wikipedia/userprofile/Contribution.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/Contribution.kt
@@ -3,8 +3,10 @@ package org.wikipedia.userprofile
 import org.wikipedia.dataclient.WikiSite
 import java.util.*
 
-class Contribution internal constructor(val qNumber: String, var apiTitle: String, var displayTitle: String, var description: String, val editType: Int, var imageUrl: String?,
-                                        val date: Date, val wikiSite: WikiSite, var pageViews: Long, var sizeDiff: Int, var top: Boolean, var tagCount: Int) {
+class Contribution internal constructor(val qNumber: String, val revId: Long, var apiTitle: String, var displayTitle: String,
+                                        var description: String, val editType: Int, var imageUrl: String?,
+                                        val date: Date, val wikiSite: WikiSite, var pageViews: Long,
+                                        var sizeDiff: Int, var top: Boolean, var tagCount: Int) {
 
     companion object {
         const val EDIT_TYPE_GENERIC = 0


### PR DESCRIPTION
This does a few things:
* Fixes the edit streak shown in the Edits screen by taking into account edits from the user's home wiki.
* In the Contributions activity, it will now show all contributions from the user's home wiki (which we weren't doing yet??)