### PR TITLE
Fix: remove unnecessary retry logic and unused parameter in TalkTopicsActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -175,7 +175,7 @@ class TalkTopicsActivity : BaseActivity() {
         }
     }
 
-    private fun loadTopics(newRevision: Long = 0) {
+    private fun loadTopics() {
         invalidateOptionsMenu()
         L10nUtil.setConditionalLayoutDirection(binding.talkRefreshView, pageTitle.wikiSite.languageCode())
         binding.talkUsernameView.text = StringUtil.fromHtml(pageTitle.displayText)
@@ -201,15 +201,6 @@ class TalkTopicsActivity : BaseActivity() {
                 .doAfterTerminate {
                     binding.talkProgressBar.visibility = View.GONE
                     binding.talkRefreshView.isRefreshing = false
-                }
-                .map { response ->
-                    if (newRevision != 0L && response.revision < newRevision) {
-                        throw IllegalStateException()
-                    }
-                    response
-                }
-                .retry(20) { t ->
-                    (t is IllegalStateException) || (t is HttpStatusException && t.code == 404)
                 }
                 .subscribe({ response ->
                     topics.clear()


### PR DESCRIPTION
Steps to reproduce:
1. Go to your Talk page from the "More" menu
2. Change the language that does not have a talk page yet.

The list will remain the same items in the previous language and will need to wait 20 times of retrying, which will make the user a little bit confused.