### PR TITLE
Fix: should send InvokeSource value correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.kt
+++ b/app/src/main/java/org/wikipedia/Constants.kt
@@ -52,7 +52,7 @@ object Constants {
     const val RECENT_SEARCHES_FRAGMENT_LOADER_ID = 101
     const val SUGGESTION_REQUEST_ITEMS = 5
 
-    enum class InvokeSource(name: String) {
+    enum class InvokeSource(val value: String) {
         ANNOUNCEMENT("announcement"),
         APP_SHORTCUTS("appShortcuts"),
         BOOKMARK_BUTTON("bookmark"),

--- a/app/src/main/java/org/wikipedia/analytics/AppLanguageSettingsFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/AppLanguageSettingsFunnel.kt
@@ -2,7 +2,6 @@ package org.wikipedia.analytics
 
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.WikipediaApp
-import org.wikipedia.util.log.L
 
 class AppLanguageSettingsFunnel : TimedFunnel(WikipediaApp.getInstance(), SCHEMA_NAME, REV_ID, SAMPLE_LOG_ALL) {
 

--- a/app/src/main/java/org/wikipedia/analytics/AppLanguageSettingsFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/AppLanguageSettingsFunnel.kt
@@ -2,13 +2,14 @@ package org.wikipedia.analytics
 
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.WikipediaApp
+import org.wikipedia.util.log.L
 
 class AppLanguageSettingsFunnel : TimedFunnel(WikipediaApp.getInstance(), SCHEMA_NAME, REV_ID, SAMPLE_LOG_ALL) {
 
     fun logLanguageSetting(source: InvokeSource, initialLanguageList: String, finalLanguageList: String,
                            interactionsCount: Int, searched: Boolean) {
         log(
-                "source", source.name,
+                "source", source.value,
                 "initial", initialLanguageList,
                 "final", finalLanguageList,
                 "interactions", interactionsCount,

--- a/app/src/main/java/org/wikipedia/analytics/DescriptionEditFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/DescriptionEditFunnel.kt
@@ -17,7 +17,7 @@ class DescriptionEditFunnel(app: WikipediaApp, title: PageTitle, private val typ
     }
 
     override fun preprocessData(eventData: JSONObject): JSONObject {
-        preprocessData(eventData, "source", source.name)
+        preprocessData(eventData, "source", source.value)
         return super.preprocessData(eventData)
     }
 

--- a/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFeedFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFeedFunnel.kt
@@ -23,7 +23,7 @@ class SuggestedEditsFeedFunnel(private val type: DescriptionEditActivity.Action,
     override fun preprocessSessionToken(eventData: JSONObject) {}
 
     override fun preprocessData(eventData: JSONObject): JSONObject {
-        preprocessData(eventData, "source", source.name)
+        preprocessData(eventData, "source", source.value)
         preprocessData(eventData, "type", if (type === DescriptionEditActivity.Action.ADD_IMAGE_TAGS) "tags"
         else if (type === DescriptionEditActivity.Action.ADD_CAPTION || type === DescriptionEditActivity.Action.TRANSLATE_CAPTION) "captions"
         else "descriptions")

--- a/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/SuggestedEditsFunnel.kt
@@ -98,7 +98,7 @@ class SuggestedEditsFunnel private constructor(app: WikipediaApp, private val in
                 .create().toJson(statsCollection),
                 "help_opened", helpOpenedCount,
                 "scorecard_opened", contributionsOpenedCount,
-                "source", invokeSource.name
+                "source", invokeSource.value
         )
     }
 

--- a/app/src/main/java/org/wikipedia/analytics/TalkFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/TalkFunnel.kt
@@ -11,7 +11,7 @@ class TalkFunnel constructor(private val title: PageTitle, private val invokeSou
         TimedFunnel(WikipediaApp.getInstance(), SCHEMA_NAME, REV_ID, SAMPLE_LOG_ALL) {
 
     override fun preprocessData(eventData: JSONObject): JSONObject {
-        preprocessData(eventData, "source", invokeSource.name)
+        preprocessData(eventData, "source", invokeSource.value)
         preprocessData(eventData, "anon", !AccountUtil.isLoggedIn)
         preprocessData(eventData, "pageNS", title.namespace.lowercase(Locale.getDefault()).capitalize(Locale.getDefault()))
         return super.preprocessData(eventData)

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -369,7 +369,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
                             }
                             .subscribe({
                                 if (it.entity != null) {
-                                    funnel?.logSaved(it.entity.lastRevId, invokeSource.name)
+                                    funnel?.logSaved(it.entity.lastRevId, invokeSource.value)
                                 }
                                 publishSuccess = true
                                 onSuccess()


### PR DESCRIPTION
https://phabricator.wikimedia.org/T289598
The `name` in a Kotlin `enum` is a reserved word, which will output the item name instead of the assigned name by ourselves.