### PR TITLE
Fix: card text should be aligned to center if no images on the card

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/news/NewsItemView.kt
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsItemView.kt
@@ -49,11 +49,11 @@ class NewsItemView(context: Context) : WikiCardView(context) {
         binding.horizontalScrollListItemText.text = removeImageCaption(StringUtil.fromHtml(newsItem.story))
         RichTextUtil.removeUnderlinesFromLinksAndMakeBold(binding.horizontalScrollListItemText)
         newsItem.thumb()?.let {
-            binding.horizontalScrollListItemImage.visibility = VISIBLE
+            binding.horizontalScrollListItemImageContainer.visibility = VISIBLE
             binding.horizontalScrollListItemImage.loadImage(it)
             ImageZoomHelper.setViewZoomable(binding.horizontalScrollListItemImage)
         } ?: run {
-            binding.horizontalScrollListItemImage.visibility = GONE
+            binding.horizontalScrollListItemImageContainer.visibility = GONE
             binding.horizontalScrollListItemText.maxLines = 10
         }
     }

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.kt
@@ -107,9 +107,9 @@ class OnThisDayCardView(context: Context) : DefaultFeedCardView<OnThisDayCard>(c
             val chosenPage = pages.find { it.thumbnailUrl != null }
             chosenPage?.let { page ->
                 if (page.thumbnailUrl.isNullOrEmpty()) {
-                    binding.eventLayout.page.image.visibility = GONE
+                    binding.eventLayout.page.imageContainer.visibility = GONE
                 } else {
-                    binding.eventLayout.page.image.visibility = VISIBLE
+                    binding.eventLayout.page.imageContainer.visibility = VISIBLE
                     binding.eventLayout.page.image.loadImage(Uri.parse(page.thumbnailUrl))
                     ImageZoomHelper.setViewZoomable(binding.eventLayout.page.image)
                 }

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.kt
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.kt
@@ -3,6 +3,7 @@ package org.wikipedia.feed.onthisday
 import android.app.Activity
 import android.net.Uri
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.FragmentManager
@@ -30,14 +31,16 @@ class OnThisDayPagesViewHolder(
     private val wiki: WikiSite
 ) : RecyclerView.ViewHolder(v) {
 
+    private val imageContainer: FrameLayout
+    private val image: FaceAndColorDetectImageView
     private var selectedPage: PageSummary? = null
     private val bottomSheetPresenter = ExclusiveBottomSheetPresenter()
-    private var image: FaceAndColorDetectImageView? = null
 
     init {
         DeviceUtil.setContextClickAsLongClick(v)
         this.itemView.setOnClickListener { onBaseViewClicked() }
         this.itemView.setOnLongClickListener { showOverflowMenu(it) }
+        imageContainer = this.itemView.findViewById(R.id.image_container)
         image = this.itemView.findViewById(R.id.image)
     }
 
@@ -54,17 +57,15 @@ class OnThisDayPagesViewHolder(
     }
 
     private fun setImage(url: String?) {
-        image?.let {
-            if (url == null) {
-                it.visibility = View.GONE
-            } else {
-                it.visibility = View.VISIBLE
-                it.loadImage(Uri.parse(url))
-            }
+        if (url.isNullOrEmpty()) {
+            imageContainer.visibility = View.GONE
+        } else {
+            imageContainer.visibility = View.VISIBLE
+            image.loadImage(Uri.parse(url))
         }
     }
 
-    fun onBaseViewClicked() {
+    private fun onBaseViewClicked() {
         val entry = HistoryEntry(
             selectedPage!!.getPageTitle(wiki),
             HistoryEntry.SOURCE_ON_THIS_DAY_ACTIVITY
@@ -81,7 +82,7 @@ class OnThisDayPagesViewHolder(
         )
     }
 
-    fun showOverflowMenu(anchorView: View?): Boolean {
+    private fun showOverflowMenu(anchorView: View?): Boolean {
         val entry = HistoryEntry(
             selectedPage!!.getPageTitle(wiki),
             HistoryEntry.SOURCE_ON_THIS_DAY_ACTIVITY

--- a/app/src/main/res/layout/item_on_this_day_pages.xml
+++ b/app/src/main/res/layout/item_on_this_day_pages.xml
@@ -12,6 +12,7 @@
         android:orientation="vertical">
 
         <FrameLayout
+            android:id="@+id/image_container"
             android:layout_width="match_parent"
             android:layout_height="148dp">
 
@@ -19,7 +20,7 @@
                 android:id="@+id/image"
                 style="@style/ImageViewDefault"
                 android:layout_width="match_parent"
-                android:layout_height="148dp"
+                android:layout_height="match_parent"
                 android:scaleType="centerCrop"
                 android:transitionName="@string/transition_article_image" />
 

--- a/app/src/main/res/layout/view_horizontal_scroll_list_item_card.xml
+++ b/app/src/main/res/layout/view_horizontal_scroll_list_item_card.xml
@@ -6,6 +6,7 @@
     android:orientation="vertical">
 
     <FrameLayout
+        android:id="@+id/horizontal_scroll_list_item_image_container"
         android:layout_width="match_parent"
         android:layout_height="164dp">
 


### PR DESCRIPTION
If there are no images showing on the card, the text should be aligned to the center.