### PR TITLE
Fix: enable/disable downloading images on NewsCard and SECard correctly after changed it

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/news/NewsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsCardView.kt
@@ -10,6 +10,7 @@ import org.wikipedia.R
 import org.wikipedia.databinding.ViewCardNewsBinding
 import org.wikipedia.feed.view.DefaultFeedCardView
 import org.wikipedia.feed.view.FeedAdapter
+import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
@@ -22,6 +23,7 @@ class NewsCardView(context: Context) : DefaultFeedCardView<NewsCard>(context) {
     }
 
     private val binding = ViewCardNewsBinding.inflate(LayoutInflater.from(context), this, true)
+    private var prevImageDownloadSettings = Prefs.isImageDownloadEnabled()
     private var isSnapHelperAttached = false
 
     private fun setUpIndicatorDots(card: NewsCard) {
@@ -48,8 +50,9 @@ class NewsCardView(context: Context) : DefaultFeedCardView<NewsCard>(context) {
 
     override var card: NewsCard? = null
         set(value) {
-            if (field != value) {
+            if (field != value || prevImageDownloadSettings != Prefs.isImageDownloadEnabled()) {
                 field = value
+                prevImageDownloadSettings = Prefs.isImageDownloadEnabled()
                 value?.let {
                     header(it)
                     setLayoutDirectionByWikiSite(it.wikiSite(), binding.rtlContainer)

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -13,6 +13,7 @@ import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
 import org.wikipedia.feed.view.CardFooterView
 import org.wikipedia.feed.view.DefaultFeedCardView
 import org.wikipedia.feed.view.FeedAdapter
+import org.wikipedia.settings.Prefs
 import org.wikipedia.util.L10nUtil
 import org.wikipedia.views.PositionAwareFragmentStateAdapter
 
@@ -23,11 +24,13 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
     }
 
     private val binding = ViewSuggestedEditsCardBinding.inflate(LayoutInflater.from(context), this, true)
+    private var prevImageDownloadSettings = Prefs.isImageDownloadEnabled()
 
     override var card: SuggestedEditsCard? = null
         set(value) {
-            if (field != value) {
+            if (field != value || prevImageDownloadSettings != Prefs.isImageDownloadEnabled()) {
                 field = value
+                prevImageDownloadSettings = Prefs.isImageDownloadEnabled()
                 value?.let {
                     header(it)
                     updateContents(it)


### PR DESCRIPTION
Not sure if it is the best practice. Please advise if you have any other solution.
https://phabricator.wikimedia.org/T288990