### PR TITLE
Follow-up to notification settings.

### DIFF
--- a/app/src/extra/java/org/wikipedia/push/WikipediaFirebaseMessagingService.kt
+++ b/app/src/extra/java/org/wikipedia/push/WikipediaFirebaseMessagingService.kt
@@ -24,7 +24,7 @@ class WikipediaFirebaseMessagingService : FirebaseMessagingService() {
         L.d("Message from: ${remoteMessage.from}")
 
         if (remoteMessage.data.containsValue(MESSAGE_TYPE_CHECK_ECHO)) {
-            handleCheckEcho()
+            NotificationPollBroadcastReceiver.pollNotifications(this)
         }
 
         // The message could also contain a notification payload, but that's not how we're using it.
@@ -46,13 +46,6 @@ class WikipediaFirebaseMessagingService : FirebaseMessagingService() {
         Prefs.setPushNotificationTokenSubscribed(false)
 
         updateSubscription()
-    }
-
-    private fun handleCheckEcho() {
-        if (!Prefs.notificationPollEnabled()) {
-            return
-        }
-        NotificationPollBroadcastReceiver.pollNotifications(this)
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -18,6 +18,7 @@ import org.wikipedia.analytics.FunnelManager;
 import org.wikipedia.analytics.InstallReferrerListener;
 import org.wikipedia.analytics.SessionFunnel;
 import org.wikipedia.analytics.eventplatform.EventPlatformClient;
+import org.wikipedia.appshortcuts.AppShortcuts;
 import org.wikipedia.auth.AccountUtil;
 import org.wikipedia.concurrency.RxBus;
 import org.wikipedia.connectivity.NetworkConnectivityReceiver;
@@ -28,6 +29,7 @@ import org.wikipedia.events.ChangeTextSizeEvent;
 import org.wikipedia.events.ThemeFontChangeEvent;
 import org.wikipedia.language.AcceptLanguageUtil;
 import org.wikipedia.language.AppLanguageState;
+import org.wikipedia.notifications.NotificationCategory;
 import org.wikipedia.notifications.NotificationPollBroadcastReceiver;
 import org.wikipedia.page.tabs.Tab;
 import org.wikipedia.push.WikipediaFirebaseMessagingService;
@@ -149,6 +151,9 @@ public class WikipediaApp extends Application {
 
         registerActivityLifecycleCallbacks(activityLifecycleHandler);
         registerComponentCallbacks(activityLifecycleHandler);
+
+        NotificationCategory.Companion.createNotificationChannels(this);
+        AppShortcuts.Companion.setShortcuts(this);
 
         // Kick the notification receiver, in case it hasn't yet been started by the system.
         NotificationPollBroadcastReceiver.startPollTask(this);

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -30,7 +30,6 @@ import org.wikipedia.auth.AccountUtil
 import org.wikipedia.events.*
 import org.wikipedia.login.LoginActivity
 import org.wikipedia.main.MainActivity
-import org.wikipedia.notifications.NotificationPollBroadcastReceiver
 import org.wikipedia.readinglist.ReadingListSyncBehaviorDialogs
 import org.wikipedia.readinglist.sync.ReadingListSyncAdapter
 import org.wikipedia.readinglist.sync.ReadingListSyncEvent
@@ -73,7 +72,6 @@ abstract class BaseActivity : AppCompatActivity() {
             NotificationInteractionFunnel.processIntent(intent)
             NotificationInteractionEvent.processIntent(intent)
         }
-        NotificationPollBroadcastReceiver.startPollTask(WikipediaApp.getInstance())
 
         // Conditionally execute all recurring tasks
         RecurringTasksExecutor(WikipediaApp.getInstance()).run()

--- a/app/src/main/java/org/wikipedia/analytics/NotificationPreferencesFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/NotificationPreferencesFunnel.kt
@@ -7,7 +7,6 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.json.GsonUtil
 import org.wikipedia.notifications.NotificationCategory
-import org.wikipedia.settings.Prefs
 
 class NotificationPreferencesFunnel(app: WikipediaApp) : Funnel(app, SCHEMA_NAME, REV_ID) {
 
@@ -28,10 +27,7 @@ class NotificationPreferencesFunnel(app: WikipediaApp) : Funnel(app, SCHEMA_NAME
 
             log(
                 "type_toggles", GsonUtil.getDefaultGson().toJson(toggleMap),
-                "background_fetch",
-                if (Prefs.notificationPollEnabled()) app.resources.getInteger(R.integer.notification_poll_interval_minutes)
-                    .toString()
-                else "disabled"
+                "background_fetch", app.resources.getInteger(R.integer.notification_poll_interval_minutes)
             )
         }
     }

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -10,10 +10,8 @@ import androidx.fragment.app.Fragment
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.activity.SingleFragmentActivity
-import org.wikipedia.appshortcuts.AppShortcuts.Companion.setShortcuts
 import org.wikipedia.databinding.ActivityMainBinding
 import org.wikipedia.navtab.NavTab
-import org.wikipedia.notifications.NotificationCategory
 import org.wikipedia.onboarding.InitialOnboardingActivity
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DimenUtil
@@ -33,8 +31,6 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        NotificationCategory.createNotificationChannels(this)
-        setShortcuts(this)
         setImageZoomHelper()
         if (Prefs.isInitialOnboardingEnabled() && savedInstanceState == null) {
             // Updating preference so the search multilingual tooltip

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -97,7 +97,6 @@ class NotificationActivity : BaseActivity(), NotificationItemActionsDialog.Callb
         NotificationsABCTestFunnel().logSelect()
 
         beginUpdateList()
-        NotificationSettingsActivity.promptEnablePollDialog(this)
     }
 
     public override fun onDestroy() {

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
@@ -46,9 +46,6 @@ class NotificationPollBroadcastReceiver : BroadcastReceiver() {
                     return
                 }
                 maybeShowLocalNotificationForEditorReactivation(context)
-                if (!Prefs.notificationPollEnabled()) {
-                    return
-                }
 
                 // If push notifications are active, then don't actually do any polling.
                 if (WikipediaFirebaseMessagingService.isUsingPush()) {

--- a/app/src/main/java/org/wikipedia/settings/NotificationSettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/NotificationSettingsActivity.kt
@@ -1,12 +1,7 @@
 package org.wikipedia.settings
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.widget.CheckBox
-import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
-import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.SingleFragmentActivity
 import org.wikipedia.analytics.NotificationPreferencesFunnel
@@ -24,24 +19,6 @@ class NotificationSettingsActivity : SingleFragmentActivity<NotificationSettings
     companion object {
         fun newIntent(ctx: Context): Intent {
             return Intent(ctx, NotificationSettingsActivity::class.java)
-        }
-
-        fun promptEnablePollDialog(activity: Activity) {
-            if (!Prefs.notificationPollReminderEnabled() || Prefs.notificationPollEnabled()) {
-                return
-            }
-            val view = activity.layoutInflater.inflate(R.layout.dialog_with_checkbox, null)
-            val message = view.findViewById<TextView>(R.id.dialog_message)
-            val checkbox = view.findViewById<CheckBox>(R.id.dialog_checkbox)
-            message.text = activity.getString(R.string.preference_summary_notification_poll)
-            AlertDialog.Builder(activity)
-                    .setCancelable(false)
-                    .setTitle(R.string.notifications_poll_enable_title)
-                    .setView(view)
-                    .setPositiveButton(R.string.notifications_poll_enable_positive) { _, _ -> Prefs.setNotificationPollEnabled(true) }
-                    .setNegativeButton(R.string.notifications_poll_enable_negative, null)
-                    .setOnDismissListener { Prefs.setNotificationPollReminderEnabled(!checkbox.isChecked) }
-                    .show()
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/Prefs.java
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.java
@@ -431,22 +431,6 @@ public final class Prefs {
         setBoolean(R.string.preference_key_dim_dark_mode_images, enabled);
     }
 
-    public static boolean notificationPollEnabled() {
-        return getBoolean(R.string.preference_key_notification_poll_enable, true);
-    }
-
-    public static void setNotificationPollEnabled(boolean enabled) {
-        setBoolean(R.string.preference_key_notification_poll_enable, enabled);
-    }
-
-    public static boolean notificationPollReminderEnabled() {
-        return getBoolean(R.string.preference_key_notification_poll_reminder, true);
-    }
-
-    public static void setNotificationPollReminderEnabled(boolean enabled) {
-        setBoolean(R.string.preference_key_notification_poll_reminder, enabled);
-    }
-
     public static int getNotificationUnreadCount() {
         return getInt(R.string.preference_key_notification_unread_count, 0);
     }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -53,8 +53,6 @@
     <string name="preference_key_initial_onboarding_enabled">initialOnboardingEnabled</string>
     <string name="preference_key_permission_asked">permissionAsked</string>
     <string name="preference_key_dim_dark_mode_images">dimDarkModeImages</string>
-    <string name="preference_key_notification_poll_reminder">enableNotificationPollingReminder</string>
-    <string name="preference_key_notification_poll_enable">enableNotificationPolling</string>
     <string name="preference_key_notification_customize_push">customizePushNotifications</string>
     <string name="preference_key_notification_hide_read">hideReadNotifications</string>
     <string name="preference_key_notification_unread_count">notificationUnreadCount</string>


### PR DESCRIPTION
This cleans up a couple of things:
* Move the creation of notification channels to `WikipediaApp.onCreate()` instead of `MainActivity.onCreate()`. (the channels don't need to be created every time the activity is launched)
* Removed unused preferences related to polling. The polling broadcast receiver runs in the background unconditionally, and should no longer be constrained by a preference. (the polling is already constrained by whether FCM is active)