### PR TITLE
Use WebViewClientCompat.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -202,6 +202,7 @@ dependencies {
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
+    implementation 'androidx.webkit:webkit:1.4.0'
 
     implementation ('com.github.michael-rapp:chrome-like-tab-switcher:0.4.6') {
         exclude group: 'org.jetbrains'

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
@@ -4,7 +4,7 @@ import android.view.KeyEvent
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
-import android.webkit.WebViewClient
+import androidx.webkit.WebViewClientCompat
 import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
@@ -18,7 +18,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.nio.charset.Charset
 
-abstract class OkHttpWebViewClient : WebViewClient() {
+abstract class OkHttpWebViewClient : WebViewClientCompat() {
     /*
         Note: Any data transformations performed here are only for the benefit of WebViews.
         They should not be made into general Interceptors.

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -22,6 +22,7 @@ import androidx.core.app.ActivityOptionsCompat
 import androidx.core.graphics.Insets
 import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
+import androidx.webkit.WebViewFeature
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.textview.MaterialTextView
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -354,8 +355,10 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
                 onPageLoadError(RuntimeException(description))
             }
 
+            // This method can be invoked on API levels below 23 if the WebView APK is up-to-date.
             override fun onReceivedHttpError(view: WebView, request: WebResourceRequest, errorResponse: WebResourceResponse) {
-                if (!request.url.toString().contains(RestService.PAGE_HTML_ENDPOINT)) {
+                if (!WebViewFeature.isFeatureSupported(WebViewFeature.RECEIVE_HTTP_ERROR) ||
+                    !request.url.toString().contains(RestService.PAGE_HTML_ENDPOINT)) {
                     // If the request is anything except the main mobile-html content request, then
                     // don't worry about any errors and let the WebView deal with it.
                     return


### PR DESCRIPTION
Use `WebViewClientCompat` instead of `WebViewClient` in `OkHttpWebViewClient` and override the non-deprecated methods (these can be used on API levels >= 21 with an up-to-date WebView).