### PR TITLE
Fix explicit bouncing of links to external browser app.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,13 @@
     -->
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:fullBackupContent="@xml/full_backup_rules"

--- a/app/src/main/java/org/wikipedia/util/ShareUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ShareUtil.kt
@@ -168,8 +168,9 @@ object ShareUtil {
                 excludedComponents.add(componentName)
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            return Intent.createChooser(intent, chooserTitle)
-                    .putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludedComponents.toTypedArray())
+            return if (excludedComponents.size >= infoList.size) null
+            else Intent.createChooser(intent, chooserTitle)
+                .putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludedComponents.toTypedArray())
         }
         if (infoList.isEmpty()) {
             return null

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -1,7 +1,9 @@
 package org.wikipedia.util
 
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.TransactionTooLargeException
 import androidx.annotation.StringRes
@@ -52,8 +54,12 @@ object UriUtil {
     fun visitInExternalBrowser(context: Context, uri: Uri) {
         try {
             val chooserIntent = ShareUtil.getIntentChooser(context, Intent(Intent.ACTION_VIEW, uri))
-            chooserIntent!!.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            context.startActivity(chooserIntent)
+            if (chooserIntent != null) {
+                chooserIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                context.startActivity(chooserIntent)
+            } else {
+                visitInExternalBrowserExplicit(context, uri)
+            }
         } catch (e: TransactionTooLargeException) {
             L.logRemoteErrorIfProd(RuntimeException("Transaction too large for external link intent."))
         } catch (e: Exception) {
@@ -61,6 +67,20 @@ object UriUtil {
             // We will just show a toast now. FIXME: Make this more visible?
             ShareUtil.showUnresolvableIntentMessage(context)
         }
+    }
+
+    private fun visitInExternalBrowserExplicit(context: Context, uri: Uri) {
+        val infoList = context.packageManager.queryIntentActivities(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com")), PackageManager.MATCH_DEFAULT_ONLY)
+        L.d(infoList.toString())
+
+        context.packageManager.queryIntentActivities(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com")), PackageManager.MATCH_DEFAULT_ONLY)
+            .first().let {
+                val componentName = ComponentName(it.activityInfo.packageName, it.activityInfo.name)
+                val newIntent = Intent(Intent.ACTION_VIEW)
+                newIntent.data = uri
+                newIntent.component = componentName
+                context.startActivity(newIntent)
+            }
     }
 
     @JvmStatic

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -70,9 +70,6 @@ object UriUtil {
     }
 
     private fun visitInExternalBrowserExplicit(context: Context, uri: Uri) {
-        val infoList = context.packageManager.queryIntentActivities(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com")), PackageManager.MATCH_DEFAULT_ONLY)
-        L.d(infoList.toString())
-
         context.packageManager.queryIntentActivities(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com")), PackageManager.MATCH_DEFAULT_ONLY)
             .first().let {
                 val componentName = ComponentName(it.activityInfo.packageName, it.activityInfo.name)


### PR DESCRIPTION
https://phabricator.wikimedia.org/T291199

Here's what seems to be happening:
On Android 11 (and possibly 10?) if our app is set as the default app for our intent filter, we can no longer use `queryIntentActivities()` to get a list of other external apps that can handle links.  The guidance from the documentation is to use a `<queries>` element in our manifest to state that we need to query activities that match a certain intent.  But even with a proper `<queries>` tag, the system is still not returning other apps that can handle the intent, if the intent is "tightly bound" to our app (i.e. if our app is the explicit default).

This PR makes the following workaround:
If our current way of bouncing to an external browser fails (i.e. if the intent chooser is empty), we will query apps that can handle a _generic_ link ("example.com"), and explicitly open the _first_ app in this list, which should ideally be the user's "default" browser app, feeding it the URI that needs to be opened.

This should be considered a temporary workaround, while we continue to research the most proper method of enumerating external activities.