### PR TITLE
Update AppCompat to 1.3.1.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,6 +192,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
     implementation "com.google.android.material:material:1.4.0"
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "androidx.core:core-ktx:1.6.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
     implementation "androidx.fragment:fragment-ktx:1.3.6"


### PR DESCRIPTION
In [AppCompat 1.3.0](https://developer.android.com/jetpack/androidx/releases/appcompat#version_130_3), the library size was reduced by converting several PNG resources to vector drawables, and RTL support for menu items with icons was added.