### PR TITLE
Fix creation of PageTitle for certain User Talk pages.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageTitle.kt
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.kt
@@ -170,7 +170,7 @@ class PageTitle(
         val talkNamespace = if (namespace().user() || namespace().userTalk()) UserTalkAliasData.valueFor(wikiSite.languageCode) else TalkAliasData.valueFor(wikiSite.languageCode)
         val pageTitle = PageTitle(talkNamespace, text, wikiSite)
         pageTitle.displayText = "$talkNamespace:" +
-                if (namespace.isNotEmpty() && displayText.startsWith(namespace)) StringUtil.removeNamespace(displayText) else displayText
+                if (namespace.isNotEmpty() && (displayText.startsWith(namespace) || displayText.startsWith(StringUtil.removeUnderscores(namespace)))) StringUtil.removeNamespace(displayText) else displayText
         pageTitle.fragment = fragment
         return pageTitle
     }


### PR DESCRIPTION
For certain specific user talk namespaces, the `displayText` could end up containing the namespace twice, e.g. `User talk:User talk:Dbrant`