### PR TITLE
Update setup-java action to v2 for workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,9 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'adopt'
+        java-version: '11'
     - name: Check for missing qq strings
       run: ./scripts/missing-qq.py
     - name: Checkout submodules

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '11'
     - name: Check for missing qq strings
       run: ./scripts/missing-qq.py

--- a/.github/workflows/android_branch.yml
+++ b/.github/workflows/android_branch.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '11'
     - name: Checkout submodules
       run: git submodule update --init --recursive

--- a/.github/workflows/android_branch.yml
+++ b/.github/workflows/android_branch.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'adopt'
+        java-version: '11'
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Build, test, and lint

--- a/.github/workflows/android_pr.yml
+++ b/.github/workflows/android_pr.yml
@@ -12,9 +12,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: gradle/wrapper-validation-action@v1
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'adopt'
+        java-version: '11'
     - name: Check for missing qq strings
       run: ./scripts/missing-qq.py
     - name: Build, test, and lint

--- a/.github/workflows/android_pr.yml
+++ b/.github/workflows/android_pr.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '11'
     - name: Check for missing qq strings
       run: ./scripts/missing-qq.py

--- a/.github/workflows/android_smoke_test.yml
+++ b/.github/workflows/android_smoke_test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '11'
 
     - name: Instrumentation Tests

--- a/.github/workflows/android_smoke_test.yml
+++ b/.github/workflows/android_smoke_test.yml
@@ -13,9 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'adopt'
+        java-version: '11'
 
     - name: Instrumentation Tests
       uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
Updating the [setup-java](https://github.com/actions/setup-java) action to v2. 

- V2 supports custom distributions and provides support for `Zulu OpenJDK`, `Eclipse` `Temurin` and `Adopt OpenJDK`. V1 supports only `Zulu OpenJDK`.
- V1 supported legacy Java syntax such as 1.8 (same as 8) and 1.8.0.212 (same as 8.0.212). V2 dropped support for legacy syntax.