### PR TITLE
Fix parsing of Talk topic fragment due to API updates.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -263,8 +263,9 @@ class TalkTopicsActivity : BaseActivity() {
             intent.putExtra(EXTRA_GO_TO_TOPIC, false)
             var topic = topics.firstOrNull()
             if (!pageTitle.fragment.isNullOrEmpty()) {
+                val targetTopic = UriUtil.parseTalkTopicFromFragment(pageTitle.fragment.orEmpty())
                 topic = topics.find {
-                    StringUtil.addUnderscores(pageTitle.fragment) == StringUtil.addUnderscores(it.html)
+                    StringUtil.addUnderscores(targetTopic) == StringUtil.addUnderscores(it.html)
                 } ?: topic
             }
             if (topic != null) {

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -163,6 +163,7 @@ object UriUtil {
         return link.replaceFirst("#.*$".toRegex(), "")
     }
 
+    @JvmStatic
     fun parseTalkTopicFromFragment(fragment: String): String {
         val index = fragment.indexOf("Z-")
         return if (index >= 0) fragment.substring(index + 2) else fragment

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -162,4 +162,9 @@ object UriUtil {
     fun removeFragment(link: String): String {
         return link.replaceFirst("#.*$".toRegex(), "")
     }
+
+    fun parseTalkTopicFromFragment(fragment: String): String {
+        val index = fragment.indexOf("Z-")
+        return if (index >= 0) fragment.substring(index + 2) else fragment
+    }
 }

--- a/app/src/test/java/org/wikipedia/util/UriUtilTest.java
+++ b/app/src/test/java/org/wikipedia/util/UriUtilTest.java
@@ -85,4 +85,11 @@ public class UriUtilTest {
         assertThat(UriUtil.getFilenameFromUploadUrl("https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Needle_Galaxy_4565.jpeg/320px-Needle_Galaxy_4565.jpeg"), is("Needle_Galaxy_4565.jpeg"));
         assertThat(UriUtil.getFilenameFromUploadUrl(""), is(""));
     }
+
+    @Test
+    public void testParseTalkTopicFromFragment() {
+        assertThat(UriUtil.parseTalkTopicFromFragment("c-Dmitry_Brant-2021-10-01T12:36:00.000Z-test"), is("test"));
+        assertThat(UriUtil.parseTalkTopicFromFragment("c-Dmitry_Brant-2021-10-01T12:36:00.000Z-test-1-2-3"), is("test-1-2-3"));
+        assertThat(UriUtil.parseTalkTopicFromFragment("test"), is("test"));
+    }
 }


### PR DESCRIPTION
The Echo API was recently updated where they changed the formatting of the URL fragment that leads to the section heading on the user's Talk page. The fragment is now in this format:

`https://en.wikipedia.org/wiki/User_talk:Dbrant_testing?markasread=229188641&markasreadwiki=enwiki#c-Dmitry_Brant-2021-10-01T12:36:00.000Z-test`

Therefore we need a bit more complex logic to parse the name of the heading from that fragment.

https://phabricator.wikimedia.org/T286424