### PR TITLE
Fix: dismiss the notification action overflow menu when refreshing the list

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -61,6 +61,7 @@ class NotificationActivity : BaseActivity() {
     private val multiSelectActionModeCallback = MultiSelectCallback()
     private val searchActionModeCallback = SearchCallback()
     private var linkHandler = NotificationLinkHandler(this)
+    private var notificationActionOverflowView: NotificationActionsOverflowView? = null
     private val typefaceSansSerifMedium = Typeface.create("sans-serif-medium", Typeface.NORMAL)
     private val typefaceSansSerifBold = Typeface.create("sans-serif", Typeface.BOLD)
     var currentSearchQuery: String? = null
@@ -157,6 +158,7 @@ class NotificationActivity : BaseActivity() {
         binding.notificationsSearchEmptyContainer.visibility = View.GONE
         binding.notificationsProgressBar.visibility = View.VISIBLE
         binding.notificationTabLayout.visibility = View.GONE
+        notificationActionOverflowView?.dismiss()
         supportActionBar?.setTitle(R.string.notifications_activity_title)
         currentContinueStr = null
         disposables.clear()
@@ -510,7 +512,8 @@ class NotificationActivity : BaseActivity() {
         }
 
         private fun showOverflowMenu(anchorView: View) {
-            NotificationActionsOverflowView(this@NotificationActivity).show(anchorView, container) {
+            notificationActionOverflowView = NotificationActionsOverflowView(this@NotificationActivity)
+            notificationActionOverflowView?.show(anchorView, container) {
                     container, markRead -> markReadItems(listOf(container), !markRead)
             }
         }

--- a/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
@@ -98,6 +98,10 @@ class NotificationActionsOverflowView(context: Context) : FrameLayout(context) {
         }
     }
 
+    fun dismiss() {
+        popupWindowHost?.dismiss()
+    }
+
     private var actionClickListener = OnClickListener {
         val link = it.tag as Notification.Link
         val linkIndex = if (it.id == R.id.overflow_view_primary) NotificationInteractionEvent.ACTION_PRIMARY else if (it.id == R.id.overflow_view_secondary) NotificationInteractionEvent.ACTION_SECONDARY else NotificationInteractionEvent.ACTION_LINK_CLICKED


### PR DESCRIPTION
Steps to reproduce:

1. Open notification page.
2. Open the overflow menu on any list item.
3. Go back to the device's Home screen and back to the app.