### PR TITLE
Optimizing the empty state of notification list

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -296,7 +296,7 @@ class NotificationActivity : BaseActivity() {
             if (filterList.contains(n.category) || Prefs.notificationsFilterLanguageCodes == null) notificationContainerList.add(NotificationListItemContainer(n))
         }
         binding.notificationsRecyclerView.adapter!!.notifyDataSetChanged()
-        if (notificationContainerList.isEmpty()) {
+        if (notificationContainerList.filterNot { it.type == NotificationListItemContainer.ITEM_SEARCH_BAR }.isEmpty()) {
             binding.notificationsEmptyContainer.visibility = if (actionMode == null) View.VISIBLE else View.GONE
             binding.notificationsSearchEmptyContainer.visibility = if (actionMode != null && enabledFiltersCount() != 0) View.VISIBLE else View.GONE
             binding.notificationsSearchEmptyText.visibility = if (actionMode != null && enabledFiltersCount() == 0) View.VISIBLE else View.GONE

--- a/app/src/main/java/org/wikipedia/views/DrawableItemDecoration.kt
+++ b/app/src/main/java/org/wikipedia/views/DrawableItemDecoration.kt
@@ -30,7 +30,7 @@ class DrawableItemDecoration @JvmOverloads constructor(context: Context, @AttrRe
 
     override fun onDraw(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         super.onDraw(canvas, parent, state)
-        if (parent.childCount == 0) {
+        if (parent.childCount == 0 || (skipSearchBar && parent.childCount == 1)) {
             return
         }
 


### PR DESCRIPTION
This fixes two things:

1. Show the empty message correctly since the `SEARCH_BAR` is in the `notificationContainerList` and we should filter it out.
2. Don't draw the bottom line if the list is empty.