### PR TITLE
Follow up: add dev preference toggle option for the survey

### DIFF
--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -359,6 +359,10 @@
             android:summary="Show Talk Page survey" />
 
         <SwitchPreferenceCompat
+            android:key="@string/preference_key_show_talk_page_survey"
+            android:title="@string/preference_key_show_talk_page_survey" />
+
+        <SwitchPreferenceCompat
             android:key="@string/preference_developer_override_talk_page_survey"
             android:title="@string/preference_developer_override_talk_page_survey"
             android:summary="Override Talk Page survey country flags" />


### PR DESCRIPTION
Adding the `preference_key_show_talk_page_survey` for a regular test purpose.