### PR TITLE
Fix incorrect duplication of search results.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageTitle.kt
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.kt
@@ -24,7 +24,7 @@ import java.util.*
  */
 @Serializable
 @Parcelize
-class PageTitle(
+data class PageTitle(
     @SerialName("namespace") private var _namespace: String? = null,
     // TODO: remove this SerialName when Tab list is no longer serialized to shared prefs.
     @SerialName("site") var wikiSite: WikiSite,


### PR DESCRIPTION
At the moment, certain search results are duplicated, because we perform a prefix-search and then a full-text search, and combine the results into a single list; but we use an equality `=` operator to compare PageTitles between the two calls. After converting PageTitle to Kotlin, we left out the `equals` function, which was necessary for this behavior.

If we simply make PageTitle into a `data class`, it will automatically generate the correct `equals` function, so that search results will not be duplicated.

https://phabricator.wikimedia.org/T293931
