### PR TITLE
Fix pref storage of Watchlist disabled languages.

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -384,7 +384,7 @@ object Prefs {
         get() = JsonUtil.decodeFromString<Set<String>>(PrefsIoUtil.getString(R.string.preference_key_announcement_shown_dialogs, null))
             ?: emptySet()
         set(newAnnouncementIds) {
-            val announcementIds = announcementShownDialogs.toMutableList()
+            val announcementIds = announcementShownDialogs.toMutableSet()
             announcementIds.addAll(newAnnouncementIds)
             PrefsIoUtil.setString(R.string.preference_key_announcement_shown_dialogs, JsonUtil.encodeToString(announcementIds))
         }
@@ -396,11 +396,7 @@ object Prefs {
     var watchlistDisabledLanguages
         get() = JsonUtil.decodeFromString<Set<String>>(PrefsIoUtil.getString(R.string.preference_key_watchlist_disabled_langs, null))
             ?: emptySet()
-        set(langCodes) {
-            val codes = watchlistDisabledLanguages.toMutableList()
-            codes.addAll(langCodes)
-            PrefsIoUtil.setString(R.string.preference_key_watchlist_disabled_langs, JsonUtil.encodeToString(langCodes))
-        }
+        set(langCodes) = PrefsIoUtil.setString(R.string.preference_key_watchlist_disabled_langs, JsonUtil.encodeToString(langCodes))
 
     var shouldMatchSystemTheme
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_match_system_theme, true)


### PR DESCRIPTION
This doesn't actually manifest as a bug, but it can lead to endless duplicated values in this preference.