### PR TITLE
Fix showing of notifications with themed attribute.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
@@ -8,6 +8,7 @@ import android.graphics.*
 import android.net.Uri
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
+import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
 import androidx.core.content.ContextCompat
@@ -16,6 +17,7 @@ import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
 import org.wikipedia.Constants
 import org.wikipedia.R
+import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.page.PageTitle
 import org.wikipedia.talk.TalkTopicsActivity
@@ -55,8 +57,10 @@ object NotificationPresenter {
             }
         }
 
+        val themedContext = ContextThemeWrapper(context, WikipediaApp.getInstance().currentTheme.resourceId)
+
         showNotification(context, builder, id, n.agent?.name ?: wikiSiteName, title, title, lang,
-                notificationCategory.iconResId, ResourceUtil.getThemedAttributeId(context, notificationCategory.iconColor), activityIntent)
+                notificationCategory.iconResId, ResourceUtil.getThemedAttributeId(themedContext, notificationCategory.iconColor), activityIntent)
     }
 
     fun showMultipleUnread(context: Context, unreadCount: Int) {


### PR DESCRIPTION
In the notification redesign branch, the actual system notifications no longer work. (it crashes silently when it tries to show a notification.)
This is because we try to use an attribute id (`R.attr`) with a Context that doesn't have a theme (the application context). In order to use `attr` values with the application context, you need to use a `ContextThemeWrapper`.