### PR TITLE
Replace deprecated constraintlayout usage in item_notification

### DIFF
--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -142,14 +142,14 @@
 
     <TextView
         android:id="@+id/notificationSource"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:textColor="?attr/secondary_text_color"
         android:fontFamily="sans-serif-medium"
         android:drawablePadding="8dp"
         app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintWidth_default="wrap"
+        app:layout_constrainedWidth="true"
         app:layout_constraintStart_toEndOf="@id/notificationWikiCodeContainer"
         app:layout_constraintTop_toTopOf="@id/notificationWikiCodeContainer"
         app:layout_constraintBottom_toBottomOf="@id/notificationWikiCodeContainer"


### PR DESCRIPTION
The messages in the Logcat recommended replacing the deprecated usages.