### PR TITLE
Fix: find items in filtered list correct in NotificationActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -259,7 +259,6 @@ class NotificationActivity : BaseActivity() {
             }
         }
 
-        L.d("onNotificationsComplete " + notificationList.size)
         postprocessAndDisplay()
     }
 


### PR DESCRIPTION
`filterList.contains(n.category)` does not work properly in some cases, such as `system-noemail` will not match the condition.