### PR TITLE
Correctly pluralize notification read/unread messages.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -15,6 +15,7 @@ import android.text.style.ForegroundColorSpan
 import android.view.*
 import android.view.View
 import android.widget.TextView
+import androidx.annotation.PluralsRes
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -384,10 +385,10 @@ class NotificationActivity : BaseActivity() {
     }
 
     private fun showMarkReadItemsUndoSnackbar(items: List<NotificationListItemContainer>, markUnread: Boolean) {
-        val snackbarStringRes = if (markUnread) R.string.notifications_mark_all_as_unread_message else R.string.notifications_mark_all_as_read_message
-        val snackbar = FeedbackUtil.makeSnackbar(this, getString(snackbarStringRes, items.size), FeedbackUtil.LENGTH_DEFAULT)
-        snackbar.setAction(R.string.notification_archive_undo) { markReadItems(items, !markUnread, true) }
-        snackbar.show()
+        @PluralsRes val snackbarStringRes = if (markUnread) R.plurals.notifications_mark_as_unread_plural else R.plurals.notifications_mark_as_read_plural
+        FeedbackUtil.makeSnackbar(this, resources.getQuantityString(snackbarStringRes, items.size, items.size), FeedbackUtil.LENGTH_DEFAULT)
+                .setAction(R.string.notification_archive_undo) { markReadItems(items, !markUnread, true) }
+                .show()
     }
 
     private fun finishActionMode() {

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -611,6 +611,14 @@
   <string name="notifications_direct_reply_error">Message shown when there was an error while posting a reply.</string>
   <string name="notifications_mark_all_as_read_message">Message shown when notifications are marked as read. The %d is replaced with the number of notifications.</string>
   <string name="notifications_mark_all_as_unread_message">Message shown when notifications are marked as unread. The %d is replaced with the number of notifications.</string>
+  <plurals name="notifications_mark_as_read_plural">
+    <item quantity="one">Message shown when a single notification is marked as read.</item>
+    <item quantity="other">Message shown when multiple notifications are marked as read. The %d is replaced with the number of notifications.</item>
+  </plurals>
+  <plurals name="notifications_mark_as_unread_plural">
+    <item quantity="one">Message shown when a single notification is marked as unread.</item>
+    <item quantity="other">Message shown when multiple notifications are marked as unread. The %d is replaced with the number of notifications.</item>
+  </plurals>
   <string name="watchlist_title">Title of screen that contains the watchlist for the current user.</string>
   <string name="preference_title_notification_poll">Label for settings switch that enables or disables polling of new notifications.\n\n{{doc-important|\"Poll\" is a verb here. This is about the polling of notifications, not about notifications of polls.}}</string>
   <string name="preference_summary_notification_poll">Short summary explaining what polling of notification means.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -605,6 +605,14 @@
     <string name="notifications_direct_reply_error">Could not post reply automatically.</string>
     <string name="notifications_mark_all_as_read_message">%d marked as read</string>
     <string name="notifications_mark_all_as_unread_message">%d marked as unread</string>
+    <plurals name="notifications_mark_as_read_plural">
+        <item quantity="one">1 marked as read</item>
+        <item quantity="other">%d marked as read</item>
+    </plurals>
+    <plurals name="notifications_mark_as_unread_plural">
+        <item quantity="one">1 marked as unread</item>
+        <item quantity="other">%d marked as unread</item>
+    </plurals>
     <string name="watchlist_title">Watchlist</string>
     <string name="preference_title_notification_poll">Poll notifications</string>
     <string name="preference_summary_notification_poll">Allow the app to use data to check for new notifications in the background.</string>


### PR DESCRIPTION
(The previous non-plural string resources will be removed after the next TWN sync, to avoid a possible renaming conflict on the TWN side.)

https://phabricator.wikimedia.org/T294531