### PR TITLE
Update the logic to include all wikis

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -222,13 +222,18 @@ class NotificationActivity : BaseActivity() {
         }
 
     private fun delimitedFilteredWikiList(): String {
-        val excludedWikiCodes = Prefs.notificationExcludedWikiCodes
+        val excludedWikiCodes = Prefs.notificationExcludedWikiCodes.toMutableList()
+
+        excludedWikiCodes.forEachIndexed { index, _ ->
+            excludedWikiCodes[index] = "${excludedWikiCodes[index]}wiki"
+        }
+
         val filteredWikiList =
-            (dbNameMap.keys.plus(NotificationsFilterActivity.allWikisList())).filterNot { excludedWikiCodes.contains(it) }.map {
+            (dbNameMap.keys.plus(NotificationsFilterActivity.allWikisList())).map {
                 val langCode = (if (it.endsWith("wiki")) it.substring(0, it.length - "wiki".length) else it).replace("_", "-")
                 val defaultLangCode = WikipediaApp.getInstance().language().getDefaultLanguageCode(langCode) ?: langCode
                 "${defaultLangCode}wiki"
-            }
+            }.filterNot { excludedWikiCodes.contains(it) }
         return filteredWikiList.toSet().joinToString("|")
     }
 

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -224,16 +224,12 @@ class NotificationActivity : BaseActivity() {
     private fun delimitedFilteredWikiList(): String {
         val excludedWikiCodes = Prefs.notificationExcludedWikiCodes
         val filteredWikiList =
-            (if (allWikisSelected()) dbNameMap.keys else NotificationsFilterActivity.allWikisList()).filterNot { excludedWikiCodes.contains(it) }.map {
+            (dbNameMap.keys.plus(NotificationsFilterActivity.allWikisList())).filterNot { excludedWikiCodes.contains(it) }.map {
                 val langCode = (if (it.endsWith("wiki")) it.substring(0, it.length - "wiki".length) else it).replace("_", "-")
                 val defaultLangCode = WikipediaApp.getInstance().language().getDefaultLanguageCode(langCode) ?: langCode
                 "${defaultLangCode}wiki"
             }
-        return filteredWikiList.joinToString("|")
-    }
-
-    private fun allWikisSelected(): Boolean {
-        return !NotificationsFilterActivity.allWikisList().any { Prefs.notificationExcludedWikiCodes.contains(it) }
+        return filteredWikiList.toSet().joinToString("|")
     }
 
     private fun setErrorState(t: Throwable) {

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -224,12 +224,16 @@ class NotificationActivity : BaseActivity() {
     private fun delimitedFilteredWikiList(): String {
         val excludedWikiCodes = Prefs.notificationExcludedWikiCodes
         val filteredWikiList =
-            NotificationsFilterActivity.allWikisList().filterNot { excludedWikiCodes.contains(it) }.map {
-                val defaultLangCode =
-                    WikipediaApp.getInstance().language().getDefaultLanguageCode(it) ?: it
-                "${defaultLangCode.replace("-", "_")}wiki"
+            (if (allWikisSelected()) dbNameMap.keys else NotificationsFilterActivity.allWikisList()).filterNot { excludedWikiCodes.contains(it) }.map {
+                val langCode = (if (it.endsWith("wiki")) it.substring(0, it.length - "wiki".length) else it).replace("_", "-")
+                val defaultLangCode = WikipediaApp.getInstance().language().getDefaultLanguageCode(langCode) ?: langCode
+                "${defaultLangCode}wiki"
             }
         return filteredWikiList.joinToString("|")
+    }
+
+    private fun allWikisSelected(): Boolean {
+        return !NotificationsFilterActivity.allWikisList().any { Prefs.notificationExcludedWikiCodes.contains(it) }
     }
 
     private fun setErrorState(t: Throwable) {


### PR DESCRIPTION
When "All Wikis" option is selected, we need to fetch notifications from all wikis including metawiki, commonswiki etc
When there is at least one filter then we fetch only wikis that are selected and within `appLanguagecodes`.
`val langCode = (if (it.endsWith("wiki")) it.substring(0, it.length - "wiki".length) else it)`
The above manipulation is to accommodate wikis like `wikidata` whicch, with a simple replace would have resulted in `datawiki` instead of `wikidatawiki`