### PR TITLE
Fix loading sequence of video thumbnail in Gallery.

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
@@ -239,7 +239,7 @@ class GalleryItemFragment : Fragment(), RequestListener<Drawable?> {
         } else {
             // show the video thumbnail while the video loads...
             binding.videoThumbnail.visibility = View.VISIBLE
-            ViewUtil.loadImage(binding.videoThumbnail, mediaInfo!!.thumbUrl)
+            ViewUtil.loadImage(binding.videoThumbnail, mediaInfo!!.thumbUrl, roundedCorners = false, largeRoundedSize = false, force = true, listener = this)
         }
         binding.videoThumbnail.setOnClickListener(videoThumbnailClickListener)
     }


### PR DESCRIPTION
Under our current logic, the animated transition bitmap (coming from the lead image in an article) will incorrectly remain visible, if the selected media is a video.

https://phabricator.wikimedia.org/T294508