### PR TITLE
Remove direct replies for now.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
@@ -40,9 +40,8 @@ object NotificationPresenter {
                 if (NotificationCategory.EDIT_USER_TALK.id == n.category) {
                     val talkWiki = WikiSite(primary.url)
                     val talkTitle = talkWiki.titleForUri(Uri.parse(primary.url))
-
                     activityIntent = addIntentExtras(TalkTopicsActivity.newIntent(context, talkTitle.pageTitleForTalkPage(), Constants.InvokeSource.NOTIFICATION), n.id, n.type)
-                    addActionWithDirectReply(context, builder, talkTitle, n.agent?.name.orEmpty(), id)
+                    addActionForTalkPage(context, builder, primary, n)
                 } else {
                     addAction(context, builder, primary, n)
                 }
@@ -109,6 +108,14 @@ object NotificationPresenter {
             StringUtil.fromHtml(link.label).toString()
         }
         builder.addAction(0, labelStr, pendingIntent)
+    }
+
+    private fun addActionForTalkPage(context: Context, builder: NotificationCompat.Builder, link: Notification.Link, n: Notification) {
+        val wiki = WikiSite(link.url)
+        val title = wiki.titleForUri(Uri.parse(link.url))
+        val pendingIntent = PendingIntent.getActivity(context, 0,
+                addIntentExtras(TalkTopicsActivity.newIntent(context, title.pageTitleForTalkPage(), Constants.InvokeSource.NOTIFICATION), n.id, n.type), PendingIntent.FLAG_UPDATE_CURRENT)
+        builder.addAction(0, StringUtil.fromHtml(link.label).toString(), pendingIntent)
     }
 
     private fun addActionWithDirectReply(context: Context, builder: NotificationCompat.Builder,


### PR DESCRIPTION
This removes the "direct reply" functionality from the redesigned Notifications, while we figure out whether it will be possible to do, given the current APIs that we can use.