### PR TITLE
Removed unnecessary fields to simplify serialization

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/ExtMetadata.kt
+++ b/app/src/main/java/org/wikipedia/gallery/ExtMetadata.kt
@@ -8,22 +8,14 @@ import kotlinx.serialization.Serializable
 @Parcelize
 @Serializable
 class ExtMetadata(
-    @SerialName("DateTime") private val dateTime: Values? = null,
     @SerialName("ObjectName") private val objectName: Values? = null,
-    @SerialName("Categories") private val categories: Values? = null,
-    @SerialName("Assessments") private val assessments: Values? = null,
     @SerialName("ImageDescription") private val imageDescription: Values? = null,
     @SerialName("DateTimeOriginal") private val dateTimeOriginal: Values? = null,
     @SerialName("Artist") private val artist: Values? = null,
     @SerialName("Credit") private val credit: Values? = null,
-    @SerialName("Permission") private val permission: Values? = null,
-    @SerialName("AuthorCount") private val authorCount: Values? = null,
     @SerialName("LicenseShortName") private val licenseShortName: Values? = null,
     @SerialName("UsageTerms") private val usageTerms: Values? = null,
     @SerialName("LicenseUrl") private val licenseUrl: Values? = null,
-    @SerialName("AttributionRequired") private val attributionRequired: Values? = null,
-    @SerialName("Copyrighted") private val copyrighted: Values? = null,
-    @SerialName("Restrictions") private val restrictions: Values? = null,
     @SerialName("License") private val license: Values? = null,
 ) : Parcelable {
 


### PR DESCRIPTION
**Phab:** https://phabricator.wikimedia.org/T294869

Removed all unused fields to simplify serialization of ExtMetadata. 