### PR TITLE
Fix: send proper action value to avoid crash in DescriptionEditActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
@@ -26,12 +26,11 @@ class DescriptionEditActivity : SingleFragmentActivity<DescriptionEditFragment>(
         ADD_DESCRIPTION, TRANSLATE_DESCRIPTION, ADD_CAPTION, TRANSLATE_CAPTION, ADD_IMAGE_TAGS
     }
 
-    private lateinit var action: Action
     private val bottomSheetPresenter = ExclusiveBottomSheetPresenter()
 
     public override fun createFragment(): DescriptionEditFragment {
         val invokeSource = intent.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as InvokeSource
-        action = intent.getSerializableExtra(Constants.INTENT_EXTRA_ACTION) as Action
+        val action = intent.getSerializableExtra(Constants.INTENT_EXTRA_ACTION) as Action
         val title = intent.getParcelableExtra<PageTitle>(EXTRA_TITLE)!!
         SuggestedEditsFunnel.get().click(title.displayText, action)
         return DescriptionEditFragment.newInstance(title,
@@ -47,7 +46,7 @@ class DescriptionEditActivity : SingleFragmentActivity<DescriptionEditFragment>(
             fragment.binding.fragmentDescriptionEditView.loadReviewContent(false)
         } else {
             DeviceUtil.hideSoftKeyboard(this)
-            SuggestedEditsFunnel.get().cancel(action)
+            SuggestedEditsFunnel.get().cancel(fragment.action)
             super.onBackPressed()
         }
     }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -53,9 +53,9 @@ class DescriptionEditFragment : Fragment() {
     private var _binding: FragmentDescriptionEditBinding? = null
     val binding get() = _binding!!
     private lateinit var funnel: DescriptionEditFunnel
-    private lateinit var action: DescriptionEditActivity.Action
     private lateinit var invokeSource: InvokeSource
     private lateinit var pageTitle: PageTitle
+    lateinit var action: DescriptionEditActivity.Action
     private var sourceSummary: PageSummaryForEdit? = null
     private var targetSummary: PageSummaryForEdit? = null
     private var highlightText: String? = null


### PR DESCRIPTION
Steps to reproduce:

1. Turn on "Don't keep activities"
2. Go to any article and click on "edit article description"
3. Press the "home" button and go back to the app again.
4. Click on the "back" button and the app crashes.