### PR TITLE
Fix: handle redirected title properly before saving into database.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -1131,14 +1131,17 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     fun addToReadingList(title: PageTitle, source: InvokeSource, addToDefault: Boolean) {
         if (addToDefault) {
+            var finalPageTitle = title
             // Make sure handle redirected title before saving into database
             disposables.add(ServiceFactory.getRest(title.wikiSite).getSummary(null, title.prefixedText)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({ summary ->
-                    val finalPageTitle = summary.getPageTitle(title.wikiSite)
+                .doAfterTerminate {
                     ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), finalPageTitle, source) { readingListId ->
                         moveToReadingList(readingListId, finalPageTitle, source, false) }
+                }
+                .subscribe({
+                    finalPageTitle = it.getPageTitle(title.wikiSite)
                 }, {
                     L.e(it)
                 }))


### PR DESCRIPTION
https://phabricator.wikimedia.org/T184828

The way of preventing saving an incorrect prefix title to the database is by calling the `/page/summary` endpoint to get the correct title. 

In this case, the user tended to store "B*-tree" article, but it is actually a section inside the "B-tree" article, and the API request will be redirected to "B-tree#Variants" and that's why the offline reading list does not work properly.