### PR TITLE
Skip markReadItems action when clicking on offline notification items

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -282,6 +282,10 @@ class NotificationActivity : BaseActivity() {
 
     private fun markReadItems(items: List<NotificationListItemContainer>, markUnread: Boolean, fromUndoOrClick: Boolean = false, position: Int? = null) {
         if (!WikipediaApp.getInstance().isOnline) {
+            if (fromUndoOrClick && position != null) {
+                // Skip if the action is from onClick.
+                return
+            }
             Toast.makeText(this, R.string.notifications_offline_disable_message, Toast.LENGTH_SHORT).show()
         } else {
             viewModel.markItemsAsRead(items, markUnread)


### PR DESCRIPTION
Tweak PR that based on the comment in [2872](https://github.com/wikimedia/apps-android-wikipedia/pull/2872#issuecomment-963740971), which will not show the toast message and skip the "markReadItems" action since maybe some pages will be available if the user visited them before.