### PR TITLE
Add "else" to the "when" statements in SuggestedEditsCardItemFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
@@ -170,6 +170,7 @@ class SuggestedEditsCardItemFragment : Fragment() {
             ADD_CAPTION -> addCaption()
             TRANSLATE_CAPTION -> translateCaption()
             ADD_IMAGE_TAGS -> addImageTags()
+            else -> {}
         }
     }
 


### PR DESCRIPTION
When running the Android Studio Kotlin code inspection, here's the suggestion from the `SuggestedEditsCardItemFragment`:

Non exhaustive 'when' statements on enum will be prohibited in 1.7, add 'null' branch or 'else' branch instead