### PR TITLE
Don't show implicit edit notice for anonymous users.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -525,7 +525,10 @@ class EditSectionActivity : BaseActivity() {
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({
                         editNotices.clear()
-                        editNotices.addAll(it.visualeditor?.notices.orEmpty().values)
+                        // Populate edit notices, but filter out anonymous edit warnings, since
+                        // we show that type of warning ourselves when previewing.
+                        editNotices.addAll(it.visualeditor?.notices.orEmpty()
+                                .filterKeys { key -> key != "anoneditwarning" }.values)
                         invalidateOptionsMenu()
                         if (Prefs.autoShowEditNotices) {
                             showEditNotices()


### PR DESCRIPTION
If you are an anonymous user, and you go into our Editing workflow, you will now always be greeted with an Edit Notice that contains a warning about editing as an IP user. The problem is that this warning contains links for logging in, which will be bounced out to an external browser and won't actually make the user log in within the app.

Let's just suppress these types of edit notices, because we already show a warning about anonymous IP editing in the Preview screen before submitting an edit.
