### PR TITLE
Improve handling of errors when submitting Talk messages.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -427,6 +427,7 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
     private fun onSaveError(t: Throwable) {
         editFunnel.logError(t.message)
         binding.talkProgressBar.visibility = View.GONE
+        binding.replySaveButton.isEnabled = true
         FeedbackUtil.showError(this, t)
     }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T295811

This should also indirectly improve error handling in other places that depend on `CsrfTokenClient`.