### PR TITLE
Remove unnecessary slash in CORE_REST_API_PREFIX

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
@@ -14,6 +14,6 @@ interface CoreRestService {
     ): Observable<DiffResponse>
 
     companion object {
-        const val CORE_REST_API_PREFIX = "/w/rest.php/v1/"
+        const val CORE_REST_API_PREFIX = "w/rest.php/v1/"
     }
 }


### PR DESCRIPTION
You will notice there's a double `//` in the API request in `ArticleEditDetailsFragment`