### PR TITLE
Fix deserialization of Announcements with version numbers.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/announcement/Announcement.kt
+++ b/app/src/main/java/org/wikipedia/feed/announcement/Announcement.kt
@@ -2,6 +2,9 @@ package org.wikipedia.feed.announcement
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import org.wikipedia.util.DateUtil
 import java.util.*
 
@@ -19,8 +22,10 @@ class Announcement(val id: String = "",
                    @SerialName("image_height") val imageHeight: String? = "",
                    @SerialName("logged_in") val loggedIn: Boolean? = null,
                    @SerialName("reading_list_sync_enabled") val readingListSyncEnabled: Boolean? = null,
-                   @SerialName("min_version") val minVersion: Int = -1,
-                   @SerialName("max_version") val maxVersion: Int = -1,
+                   // The Min and Max version could be an integer for Android versions, or a string
+                   // for iOS versions, so these need to be serialized manually.
+                   @SerialName("min_version") private val minVersion: JsonElement? = null,
+                   @SerialName("max_version") private val maxVersion: JsonElement? = null,
                    val border: Boolean? = null,
                    val beta: Boolean? = null,
                    val placement: String = PLACEMENT_FEED,
@@ -52,6 +57,14 @@ class Announcement(val id: String = "",
 
     fun hasImageUrl(): Boolean {
         return !imageUrl.isNullOrEmpty()
+    }
+
+    fun minVersion(): Int {
+        return minVersion?.jsonPrimitive?.intOrNull ?: -1
+    }
+
+    fun maxVersion(): Int {
+        return maxVersion?.jsonPrimitive?.intOrNull ?: -1
     }
 
     @Serializable

--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementClient.kt
@@ -67,7 +67,7 @@ class AnnouncementClient : FeedClient {
             return (announcement != null && !announcement.platforms.isNullOrEmpty() && (announcement.platforms.contains(PLATFORM_CODE) ||
                     announcement.platforms.contains(PLATFORM_CODE_NEW)) &&
                     matchesCountryCode(announcement, country) && matchesDate(announcement, date) &&
-                    matchesVersionCodes(announcement.minVersion, announcement.maxVersion) && matchesConditions(announcement))
+                    matchesVersionCodes(announcement.minVersion(), announcement.maxVersion()) && matchesConditions(announcement))
         }
 
         private fun matchesCountryCode(announcement: Announcement, country: String?): Boolean {

--- a/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.kt
+++ b/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.kt
@@ -109,6 +109,8 @@ class AnnouncementClientTest : MockRetrofitTest() {
         val announcement = announcementList.items[ANNOUNCEMENT_BETA_WITH_VERSION]
         val dateDuring = dateFormat.parse("2016-11-20")!!
         MatcherAssert.assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), Matchers.`is`(true))
+        MatcherAssert.assertThat(announcement.minVersion(), Matchers.`is`(200))
+        MatcherAssert.assertThat(announcement.maxVersion(), Matchers.`is`(10000))
     }
 
     @Test

--- a/app/src/test/res/raw/announce_2016_11_21.json
+++ b/app/src/test/res/raw/announce_2016_11_21.json
@@ -18,7 +18,9 @@
         "US",
         "CA",
         "GB"
-      ]
+      ],
+      "min_version": "5.8.0",
+      "max_version": "6.1.0"
     },
     {
       "id": "EN11116SURVEYANDROID",


### PR DESCRIPTION
This should be fast-tracked to production, so that announcements are shown properly for fundraising.