### PR TITLE
Remove unused variable from EditHandler and EditSectionActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditHandler.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditHandler.kt
@@ -86,7 +86,6 @@ class EditHandler(private val fragment: PageFragment, bridge: CommunicationBridg
             intent.putExtra(EditSectionActivity.EXTRA_SECTION_ID, section.id)
             intent.putExtra(EditSectionActivity.EXTRA_SECTION_ANCHOR, section.anchor)
             intent.putExtra(EditSectionActivity.EXTRA_TITLE, it.title)
-            intent.putExtra(EditSectionActivity.EXTRA_PAGE_PROPS, it.pageProperties)
             intent.putExtra(EditSectionActivity.EXTRA_HIGHLIGHT_TEXT, highlightText)
             fragment.startActivityForResult(intent, Constants.ACTIVITY_REQUEST_EDIT_SECTION)
         }

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -63,7 +63,6 @@ class EditSectionActivity : BaseActivity() {
 
     private var sectionID = 0
     private var sectionAnchor: String? = null
-    private var pageProps: PageProperties? = null
     private var textToHighlight: String? = null
     private var sectionWikitext: String? = null
     private val editNotices = mutableListOf<String>()
@@ -99,7 +98,6 @@ class EditSectionActivity : BaseActivity() {
         pageTitle = intent.getParcelableExtra(EXTRA_TITLE)!!
         sectionID = intent.getIntExtra(EXTRA_SECTION_ID, 0)
         sectionAnchor = intent.getStringExtra(EXTRA_SECTION_ANCHOR)
-        pageProps = intent.getParcelableExtra(EXTRA_PAGE_PROPS)
         textToHighlight = intent.getStringExtra(EXTRA_HIGHLIGHT_TEXT)
         supportActionBar?.title = ""
         syntaxHighlighter = SyntaxHighlighter(this, binding.editSectionText)
@@ -640,7 +638,6 @@ class EditSectionActivity : BaseActivity() {
         const val EXTRA_TITLE = "org.wikipedia.edit_section.title"
         const val EXTRA_SECTION_ID = "org.wikipedia.edit_section.sectionid"
         const val EXTRA_SECTION_ANCHOR = "org.wikipedia.edit_section.anchor"
-        const val EXTRA_PAGE_PROPS = "org.wikipedia.edit_section.pageprops"
         const val EXTRA_HIGHLIGHT_TEXT = "org.wikipedia.edit_section.highlight"
     }
 }


### PR DESCRIPTION
The `var pageProps` is not being used in `EditSectionActivity` and it is safe to be removed.