### PR TITLE
Dynamically resolve Talk page names.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -90,6 +90,9 @@ interface Service {
     @GET(MW_API_PREFIX + "action=sitematrix&smtype=language&smlangprop=code|name|localname&maxage=" + SITE_INFO_MAXAGE + "&smaxage=" + SITE_INFO_MAXAGE)
     suspend fun getSiteMatrix(): SiteMatrix
 
+    @GET(MW_API_PREFIX + "action=query&meta=siteinfo&siprop=namespaces")
+    fun getPageNamespaceWithSiteInfo(@Query("titles") title: String): Observable<MwQueryResponse>
+
     @get:GET(MW_API_PREFIX + "action=query&meta=siteinfo&maxage=" + SITE_INFO_MAXAGE + "&smaxage=" + SITE_INFO_MAXAGE)
     val siteInfo: Observable<MwQueryResponse>
 

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
@@ -30,6 +30,7 @@ class MwQueryResult {
     val echomarkseen: MarkReadResponse? = null
     val notifications: NotificationList? = null
     val watchlist: List<WatchlistItem> = emptyList()
+    val namespaces: Map<String, Namespace>? = null
 
     init {
         resolveConvertedTitles()
@@ -168,5 +169,11 @@ class MwQueryResult {
         @SerialName("parsedcomment") val parsedComment: String = ""
         val date: Date
             get() = DateUtil.iso8601DateParse(timestamp.orEmpty())
+    }
+
+    @Serializable
+    class Namespace {
+        val id: Int = 0
+        val name: String = ""
     }
 }

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -99,7 +99,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     private fun setUpListeners() {
         binding.articleTitleView.setOnClickListener {
             if (articlePageTitle.namespace() == Namespace.USER_TALK || articlePageTitle.namespace() == Namespace.TALK) {
-                startActivity(TalkTopicsActivity.newIntent(requireContext(), articlePageTitle.pageTitleForTalkPage(), InvokeSource.DIFF_ACTIVITY))
+                startActivity(TalkTopicsActivity.newIntent(requireContext(), articlePageTitle, InvokeSource.DIFF_ACTIVITY))
             } else {
                 bottomSheetPresenter.show(childFragmentManager, LinkPreviewDialog.newInstance(
                         HistoryEntry(articlePageTitle, HistoryEntry.SOURCE_EDIT_DIFF_DETAILS), null))

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
@@ -43,7 +43,7 @@ object NotificationPresenter {
                 if (NotificationCategory.EDIT_USER_TALK.id == n.category) {
                     val talkWiki = WikiSite(primary.url)
                     val talkTitle = talkWiki.titleForUri(Uri.parse(primary.url))
-                    activityIntent = addIntentExtras(TalkTopicsActivity.newIntent(context, talkTitle.pageTitleForTalkPage(), Constants.InvokeSource.NOTIFICATION), n.id, n.type)
+                    activityIntent = addIntentExtras(TalkTopicsActivity.newIntent(context, talkTitle, Constants.InvokeSource.NOTIFICATION), n.id, n.type)
                     addActionForTalkPage(context, builder, primary, n)
                 } else {
                     addAction(context, builder, primary, n)
@@ -117,7 +117,7 @@ object NotificationPresenter {
         val wiki = WikiSite(link.url)
         val title = wiki.titleForUri(Uri.parse(link.url))
         val pendingIntent = PendingIntent.getActivity(context, 0,
-                addIntentExtras(TalkTopicsActivity.newIntent(context, title.pageTitleForTalkPage(), Constants.InvokeSource.NOTIFICATION), n.id, n.type), PendingIntent.FLAG_UPDATE_CURRENT)
+                addIntentExtras(TalkTopicsActivity.newIntent(context, title, Constants.InvokeSource.NOTIFICATION), n.id, n.type), PendingIntent.FLAG_UPDATE_CURRENT)
         builder.addAction(0, StringUtil.fromHtml(link.label).toString(), pendingIntent)
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -546,7 +546,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
                 finish()
                 return true
             } else if (title.namespace() === Namespace.USER_TALK || title.namespace() === Namespace.TALK) {
-                startActivity(TalkTopicsActivity.newIntent(this, title.pageTitleForTalkPage(), InvokeSource.PAGE_ACTIVITY))
+                startActivity(TalkTopicsActivity.newIntent(this, title, InvokeSource.PAGE_ACTIVITY))
                 finish()
                 return true
             }
@@ -621,8 +621,8 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
         }
 
         override fun talkClick() {
-            pageFragment.title?.run {
-                startActivity(TalkTopicsActivity.newIntent(this@PageActivity, pageTitleForTalkPage(), InvokeSource.PAGE_ACTIVITY))
+            pageFragment.title?.let {
+                startActivity(TalkTopicsActivity.newIntent(this@PageActivity, it, InvokeSource.PAGE_ACTIVITY))
             }
         }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -548,7 +548,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     }
 
     private fun startTalkTopicActivity(pageTitle: PageTitle) {
-        startActivity(TalkTopicsActivity.newIntent(requireActivity(), pageTitle.pageTitleForTalkPage(), InvokeSource.PAGE_ACTIVITY))
+        startActivity(TalkTopicsActivity.newIntent(requireActivity(), pageTitle, InvokeSource.PAGE_ACTIVITY))
     }
 
     private fun startGalleryActivity(fileName: String) {

--- a/app/src/main/java/org/wikipedia/page/PageTitle.kt
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.kt
@@ -7,8 +7,6 @@ import kotlinx.serialization.Serializable
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.language.AppLanguageLookUpTable
 import org.wikipedia.settings.SiteInfoClient
-import org.wikipedia.staticdata.TalkAliasData
-import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
 import java.util.*
@@ -49,8 +47,9 @@ data class PageTitle(
     val prefixedText: String
         get() = if (namespace.isEmpty()) text else StringUtil.addUnderscores(namespace) + ":" + text
 
-    val namespace: String
+    var namespace: String
         get() = _namespace.orEmpty()
+        set(value) { _namespace = value; _displayText = null }
 
     val isFilePage: Boolean
         get() = namespace().file()
@@ -169,15 +168,6 @@ data class PageTitle(
             UriUtil.encodeURL(prefixedText),
             fragment
         )
-    }
-
-    fun pageTitleForTalkPage(): PageTitle {
-        val talkNamespace = if (namespace().user() || namespace().userTalk()) UserTalkAliasData.valueFor(wikiSite.languageCode) else TalkAliasData.valueFor(wikiSite.languageCode)
-        val pageTitle = PageTitle(talkNamespace, text, wikiSite)
-        pageTitle.displayText = "$talkNamespace:" +
-                if (namespace.isNotEmpty() && (displayText.startsWith(namespace) || displayText.startsWith(StringUtil.removeUnderscores(namespace)))) StringUtil.removeNamespace(displayText) else displayText
-        pageTitle.fragment = fragment
-        return pageTitle
     }
 
     override fun toString(): String {

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -268,7 +268,7 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
 
     private fun showLinkPreviewOrNavigate(title: PageTitle) {
         if (title.namespace() == Namespace.USER_TALK || title.namespace() == Namespace.TALK) {
-            startActivity(TalkTopicsActivity.newIntent(this, title.pageTitleForTalkPage(), Constants.InvokeSource.TALK_ACTIVITY))
+            startActivity(TalkTopicsActivity.newIntent(this, title, Constants.InvokeSource.TALK_ACTIVITY))
         } else {
             bottomSheetPresenter.show(supportFragmentManager,
                     LinkPreviewDialog.newInstance(HistoryEntry(title, HistoryEntry.SOURCE_TALK_TOPIC), null))

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -254,6 +254,11 @@ class TalkTopicsActivity : BaseActivity() {
                     resolveTitleRequired = false
                     response.query?.namespaces?.let { namespaces ->
                         response.query?.firstPage()?.let { page ->
+                            // In MediaWiki, namespaces that are even-numbered are "regular" pages,
+                            // and namespaces that are odd-numbered are the "Talk" versions of the
+                            // corresponding even-numbered namespace. For example, "User"=2, "User talk"=3.
+                            // So then, if the namespace of our pageTitle is even (i.e. not a Talk page),
+                            // then increment the namespace by 1, and update the pageTitle with it.
                             val newNs = namespaces.values.find { it.id == page.namespace().code() + 1 }
                             if (page.namespace().code() % 2 == 0 && newNs != null) {
                                 pageTitle.namespace = newNs.name

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -12,6 +12,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.Constants
@@ -26,6 +27,7 @@ import org.wikipedia.databinding.ActivityTalkTopicsBinding
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
+import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.dataclient.okhttp.HttpStatusException
 import org.wikipedia.dataclient.page.TalkPage
 import org.wikipedia.diff.ArticleEditDetailsActivity
@@ -38,6 +40,7 @@ import org.wikipedia.richtext.RichTextUtil
 import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
 import org.wikipedia.settings.languages.WikipediaLanguagesFragment
+import org.wikipedia.staticdata.TalkAliasData
 import org.wikipedia.staticdata.UserAliasData
 import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.util.*
@@ -57,6 +60,7 @@ class TalkTopicsActivity : BaseActivity() {
     private val topics = mutableListOf<TalkPage.Topic>()
     private val unreadTypeface = Typeface.create("sans-serif-medium", Typeface.NORMAL)
     private var revisionForLastEdit: MwQueryPage.Revision? = null
+    private var resolveTitleRequired = false
     private var goToTopic = false
 
     public override fun onCreate(savedInstanceState: Bundle?) {
@@ -104,6 +108,17 @@ class TalkTopicsActivity : BaseActivity() {
         }
         notificationButtonView = NotificationButtonView(this)
         Prefs.hasAnonymousNotification = false
+
+        // Determine whether we need to resolve the PageTitle, since the calling activity might
+        // have given us a non-Talk page, and we need to prepend the correct namespace.
+        if (pageTitle.namespace.isEmpty()) {
+            pageTitle.namespace = TalkAliasData.valueFor(pageTitle.wikiSite.languageCode)
+        } else if (pageTitle.isUserPage) {
+            pageTitle.namespace = UserTalkAliasData.valueFor(pageTitle.wikiSite.languageCode)
+        } else if (pageTitle.namespace() != Namespace.TALK && pageTitle.namespace() != Namespace.USER_TALK) {
+            // defer resolution of Talk page title for an API call.
+            resolveTitleRequired = true
+        }
     }
 
     public override fun onDestroy() {
@@ -232,8 +247,22 @@ class TalkTopicsActivity : BaseActivity() {
         binding.talkErrorView.visibility = View.GONE
         binding.talkEmptyContainer.visibility = View.GONE
 
-        disposables.add(ServiceFactory.get(pageTitle.wikiSite).getLastModified(pageTitle.prefixedText)
+        disposables.add(if (resolveTitleRequired) { ServiceFactory.get(pageTitle.wikiSite).getPageNamespaceWithSiteInfo(pageTitle.prefixedText) } else { Observable.just(MwQueryResponse()) }
                 .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMap { response ->
+                    resolveTitleRequired = false
+                    response.query?.namespaces?.let { namespaces ->
+                        response.query?.firstPage()?.let { page ->
+                            val newNs = namespaces.values.find { it.id == page.namespace().code() + 1 }
+                            if (page.namespace().code() % 2 == 0 && newNs != null) {
+                                pageTitle.namespace = newNs.name
+                            }
+                        }
+                    }
+                    binding.talkUsernameView.text = StringUtil.fromHtml(pageTitle.displayText)
+                    ServiceFactory.get(pageTitle.wikiSite).getLastModified(pageTitle.prefixedText)
+                }
                 .observeOn(AndroidSchedulers.mainThread())
                 .flatMap {
                     it.query?.firstPage()?.revisions?.getOrNull(0)?.let { revision ->


### PR DESCRIPTION
This will now automatically "resolve" the Talk page that corresponds to a regular page, without needing to construct the Talk title ourselves.
The Talk activity will now accept any regular page title, and will automatically query the API to get the correct Talk page.

https://phabricator.wikimedia.org/T297124