### PR TITLE
Don't fetch all notifications from Commons wiki only.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationRepository.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationRepository.kt
@@ -1,6 +1,6 @@
 package org.wikipedia.notifications
 
-import org.wikipedia.dataclient.Service
+import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.notifications.db.Notification
@@ -24,7 +24,7 @@ class NotificationRepository constructor(private val notificationDao: Notificati
 
     suspend fun fetchUnreadWikiDbNames(): Map<String, WikiSite> {
         val dbNameMap = mutableMapOf<String, WikiSite>()
-        val response = ServiceFactory.get(WikiSite(Service.COMMONS_URL)).unreadNotificationWikis()
+        val response = ServiceFactory.get(WikipediaApp.getInstance().wikiSite).unreadNotificationWikis()
         val wikiMap = response.query?.unreadNotificationWikis
         dbNameMap.clear()
         for (key in wikiMap!!.keys) {
@@ -37,7 +37,7 @@ class NotificationRepository constructor(private val notificationDao: Notificati
 
     suspend fun fetchAndSave(wikiList: String?, filter: String?, continueStr: String? = null): String? {
         var newContinueStr: String? = null
-        val response = ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getAllNotifications(wikiList, filter, continueStr)
+        val response = ServiceFactory.get(WikipediaApp.getInstance().wikiSite).getAllNotifications(wikiList, filter, continueStr)
         response.query?.notifications?.let {
             // TODO: maybe add a logic to avoid adding same data into database.
             insertNotifications(it.list.orEmpty())


### PR DESCRIPTION
Technically it doesn't matter which wiki we fetch notifications from, as long as it's part of the CentralAuth collection of wikis. But it doesn't seem right to hardcode Commons wiki for getting notifications every time. This is a remnant of some previous logic that might have "required" getting it from Commons, but is no longer relevant.
It makes more sense to fetch notifications from the user's home wiki. And in fact this is already how the polling notification background worker does it.