### PR TITLE
Add saveAttempt funnel event when submitting Talk messages.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -338,6 +338,8 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
         undoneBody = body
         undoneSubject = subject
 
+        editFunnel.logSaveAttempt()
+
         if (isNewTopic() && subject.isEmpty()) {
             binding.replySubjectLayout.error = getString(R.string.talk_subject_empty)
             binding.replySubjectLayout.requestFocus()


### PR DESCRIPTION
In order to be consistent with the general article editing interface, we should send an `editAttempt` event when submitting a Talk message. (Since the edit could fail for various reasons, it's useful to know when an attempt was made.)