### PR TITLE
Fix crash due to JobInfo request without constraints.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/PollNotificationService.kt
+++ b/app/src/main/java/org/wikipedia/notifications/PollNotificationService.kt
@@ -92,6 +92,7 @@ class PollNotificationService : JobService() {
         fun schedulePollNotificationJob(context: Context) {
             val serviceComponent = ComponentName(context, PollNotificationService::class.java)
             val builder = JobInfo.Builder(0, serviceComponent)
+                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
             val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
             jobScheduler.schedule(builder.build())
         }


### PR DESCRIPTION
On some devices, it is not allowed to schedule a `JobInfo` without any constraints. At least one constraint must be specified, so let's require a NetworkType to be available, since that's what we need anyway.