### PR TITLE
Fix: handle Chinese language variant and Cantonese correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/language/LanguageUtil.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguageUtil.kt
@@ -106,16 +106,20 @@ object LanguageUtil {
         return TRADITIONAL_CHINESE_COUNTRY_CODES.contains(country)
     }
 
-    @JvmStatic
     val firstSelectedChineseVariant: String
         get() {
             val firstSelectedChineseLangCode =
                 WikipediaApp.getInstance().language().appLanguageCodes.firstOrNull {
-                    it.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE)
+                    isChineseVariant(it)
                 }
             return firstSelectedChineseLangCode.orEmpty()
                 .ifEmpty { AppLanguageLookUpTable.TRADITIONAL_CHINESE_LANGUAGE_CODE }
         }
+
+    fun isChineseVariant(langCode: String): Boolean {
+        return langCode.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE) &&
+                langCode != AppLanguageLookUpTable.CHINESE_YUE_LANGUAGE_CODE
+    }
 
     fun startsWithArticle(text: String, language: String): Boolean {
         val first = text.split(" ".toRegex()).toTypedArray()[0].lowercase(Locale.getDefault()).trim()

--- a/app/src/main/java/org/wikipedia/page/PageTitle.kt
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.wikipedia.dataclient.WikiSite
-import org.wikipedia.language.AppLanguageLookUpTable
+import org.wikipedia.language.LanguageUtil
 import org.wikipedia.settings.SiteInfoClient
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
@@ -179,7 +179,7 @@ data class PageTitle(
             "%1\$s://%2\$s/%3\$s/%4\$s%5\$s",
             wikiSite.scheme(),
             domain,
-            if (domain.startsWith(AppLanguageLookUpTable.CHINESE_LANGUAGE_CODE)) wikiSite.languageCode else "wiki",
+            if (LanguageUtil.isChineseVariant(domain)) wikiSite.languageCode else "wiki",
             UriUtil.encodeURL(prefixedText),
             if (!fragment.isNullOrEmpty()) "#" + UriUtil.encodeURL(fragment!!) else ""
         )


### PR DESCRIPTION
We used to use `startsWith` to find the `zh` variant, but `zh-yue` is not a part of the Chinese language variant and it causes some issues. 

https://phabricator.wikimedia.org/T298448