### PR TITLE
Update androidx work-runtime-ktx library, fixing potential crash.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -207,7 +207,7 @@ dependencies {
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
-    implementation 'androidx.work:work-runtime-ktx:2.6.0'
+    implementation 'androidx.work:work-runtime-ktx:2.7.1'
 
     implementation ('com.github.michael-rapp:chrome-like-tab-switcher:0.4.6') {
         exclude group: 'org.jetbrains'


### PR DESCRIPTION
This resolves a crash in Android 12 that was fixed in a recent version of this dependency:
* https://developer.android.com/jetpack/androidx/releases/work#2.7.0-alpha02
