### PR TITLE
Minor tweak and fix for Focus Mode.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -308,6 +308,9 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         page?.let {
             bridge.execute(JavaScriptActionHandler.setUpEditButtons(!Prefs.readingFocusModeEnabled, !it.pageProperties.canEdit))
         }
+        // We disable and then re-enable scroll events coming from the WebView, because toggling
+        // reading focus mode within the article could actually change the dimensions of the page,
+        // which will cause extraneous scroll events to be sent.
         binding.root.postDelayed({
             if (isAdded) {
                 webView.scrollEventsEnabled = true

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -302,11 +302,17 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     }
 
     override fun onToggleReadingFocusMode() {
+        webView.scrollEventsEnabled = false
         bottomBarHideHandler.enabled = Prefs.readingFocusModeEnabled
         leadImagesHandler.refreshCallToActionVisibility()
         page?.let {
             bridge.execute(JavaScriptActionHandler.setUpEditButtons(!Prefs.readingFocusModeEnabled, !it.pageProperties.canEdit))
         }
+        binding.root.postDelayed({
+            if (isAdded) {
+                webView.scrollEventsEnabled = true
+            }
+        }, 250)
     }
 
     override fun onCancelThemeChooser() {

--- a/app/src/main/java/org/wikipedia/views/ObservableWebView.kt
+++ b/app/src/main/java/org/wikipedia/views/ObservableWebView.kt
@@ -51,6 +51,8 @@ class ObservableWebView : WebView {
     private var totalAmountScrolled = 0
     private var drawEventsWhileSwiping = 0
     private var touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+
+    var scrollEventsEnabled = true
     var touchStartX = 0f
         private set
     var touchStartY = 0f
@@ -96,8 +98,10 @@ class ObservableWebView : WebView {
     override fun onScrollChanged(left: Int, top: Int, oldLeft: Int, oldTop: Int) {
         super.onScrollChanged(left, top, oldLeft, oldTop)
         val isHumanScroll = abs(top - oldTop) < MAX_HUMAN_SCROLL
-        onScrollChangeListeners.forEach {
-            it.onScrollChanged(oldTop, top, isHumanScroll)
+        if (scrollEventsEnabled) {
+            onScrollChangeListeners.forEach {
+                it.onScrollChanged(oldTop, top, isHumanScroll)
+            }
         }
         if (!isHumanScroll) {
             return


### PR DESCRIPTION
https://phabricator.wikimedia.org/T254771#7617426

This fixes some scrolling issues when turning Focus Mode on/off, due to the fact that enabling focus mode in the article itself would change the height of the article, which would generate scroll events that would shift the position of the hideable toolbars.