### PR TITLE
Add proper description for talk_edit_disclaimer in qq/strings

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1070,7 +1070,7 @@
   <string name="talk_snackbar_survey_action_text">Button label for navigating to a survey page.</string>
   <string name="talk_share_discussion_subject">Subject text while sharing a talk topic discussion. %s represents the topic subject.</string>
   <string name="talk_share_talk_page">Subject text while sharing a talk page</string>
-  <string name="talk_edit_disclaimer">Disclaimer of editing a talk page.</string>
+  <string name="talk_edit_disclaimer">Disclaimer of editing a talk page. When possible, please use the appropriate language-specific URL, and the mobile version of the site.</string>
   <string name="menu_option_share_talk_discussion">Label text for menu option to share a talk topic discussion.</string>
   <string name="menu_option_share_talk_page">Label text for menu option to share the talk page.</string>
   <string name="menu_option_share_edit">Menu option label for sharing edit.</string>


### PR DESCRIPTION
Per the request from Amir, we should add a note to the `qq/strings.xml` about using a language-specific URL for the disclaimer.