### PR TITLE
Don't show "external link" icon for edit history.

### DIFF
--- a/app/src/main/res/layout/view_page_action_overflow.xml
+++ b/app/src/main/res/layout/view_page_action_overflow.xml
@@ -53,7 +53,6 @@
             style="@style/OverflowMenuItem"
             android:drawablePadding="16dp"
             android:text="@string/menu_page_view_edit_history"
-            app:drawableEndCompat="@drawable/ic_open_in_new_black_24px"
             app:drawableStartCompat="@drawable/ic_icon_revision_history_apps"
             app:drawableTint="?attr/material_theme_secondary_color" />
 


### PR DESCRIPTION
Since we're now loading Edit History inside the WebView (via #3078), we should no longer show the "external" icon next to that menu item.