### PR TITLE
Don't show edit-notices that are parsed as blank.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -543,7 +543,8 @@ class EditSectionActivity : BaseActivity() {
                         // Populate edit notices, but filter out anonymous edit warnings, since
                         // we show that type of warning ourselves when previewing.
                         editNotices.addAll(it.visualeditor?.notices.orEmpty()
-                                .filterKeys { key -> key != "anoneditwarning" }.values)
+                                .filterKeys { key -> key != "anoneditwarning" }
+                                .values.filter { str -> StringUtil.fromHtml(str).trim().isNotEmpty() })
                         invalidateOptionsMenu()
                         if (Prefs.autoShowEditNotices) {
                             showEditNotices()


### PR DESCRIPTION
Certain edit notices don't get parsed correctly by the API, and are received by us as HTML tags with no textual content in them. This causes us to show an edit notice that appears "blank".

This will filter out edit notices that don't contain any text content.