### PR TITLE
Refactor ArticleEditDetailsFragment to use ViewModel

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.dataclient
 
-import io.reactivex.rxjava3.core.Observable
 import org.wikipedia.dataclient.restbase.DiffResponse
 import org.wikipedia.dataclient.restbase.EditCount
 import retrofit2.http.GET
@@ -9,10 +8,10 @@ import retrofit2.http.Path
 interface CoreRestService {
 
     @GET("revision/{oldRev}/compare/{newRev}")
-    fun getDiff(
+    suspend fun getDiff(
         @Path("oldRev") oldRev: Long,
         @Path("newRev") newRev: Long
-    ): Observable<DiffResponse>
+    ): DiffResponse
 
     @GET("page/{title}/history/counts/{editType}")
     suspend fun getEditCount(

--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -149,6 +149,10 @@ interface Service {
     @get:Headers("Cache-Control: no-cache")
     val csrfToken: Observable<MwQueryResponse>
 
+    @GET(MW_API_PREFIX + "action=query&meta=tokens&type=csrf")
+    @Headers("Cache-Control: no-cache")
+    suspend fun getCsrfToken(): MwQueryResponse
+
     @FormUrlEncoded
     @POST(MW_API_PREFIX + "action=createaccount&createmessageformat=html")
     fun postCreateAccount(
@@ -405,6 +409,10 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched")
     fun getWatchedInfo(@Query("titles") titles: String): Observable<MwQueryResponse>
 
+    @Headers("Cache-Control: no-cache")
+    @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched")
+    suspend fun getWatchedStatus(@Query("titles") titles: String): MwQueryResponse
+
     @get:GET(MW_API_PREFIX + "action=query&list=watchlist&wllimit=500&wlallrev=1&wlprop=ids|title|flags|comment|parsedcomment|timestamp|sizes|user|loginfo")
     @get:Headers("Cache-Control: no-cache")
     val watchlist: Observable<MwQueryResponse>
@@ -413,17 +421,17 @@ interface Service {
     fun getLastModified(@Query("titles") titles: String): Observable<MwQueryResponse>
 
     @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=ids|timestamp|flags|comment|user&rvlimit=2&rvdir=newer")
-    fun getRevisionDetails(
+    suspend fun getRevisionDetails(
         @Query("titles") titles: String,
         @Query("rvstartid") revisionStartId: Long
-    ): Observable<MwQueryResponse>
+    ): MwQueryResponse
 
     @POST(MW_API_PREFIX + "action=thank")
     @FormUrlEncoded
-    fun postThanksToRevision(
+    suspend fun postThanksToRevision(
         @Field("rev") revisionId: Long,
         @Field("token") token: String
-    ): Observable<EntityPostResponse>
+    ): EntityPostResponse
 
     @POST(MW_API_PREFIX + "action=watch&converttitles=&redirects=")
     @FormUrlEncoded
@@ -435,9 +443,23 @@ interface Service {
         @Field("token") token: String
     ): Observable<WatchPostResponse>
 
+    @POST(MW_API_PREFIX + "action=watch&converttitles=&redirects=")
+    @FormUrlEncoded
+    suspend fun watch(
+            @Field("unwatch") unwatch: Int?,
+            @Field("pageids") pageIds: String?,
+            @Field("titles") titles: String?,
+            @Field("expiry") expiry: String?,
+            @Field("token") token: String
+    ): WatchPostResponse
+
     @get:GET(MW_API_PREFIX + "action=query&meta=tokens&type=watch")
     @get:Headers("Cache-Control: no-cache")
     val watchToken: Observable<MwQueryResponse>
+
+    @GET(MW_API_PREFIX + "action=query&meta=tokens&type=watch")
+    @Headers("Cache-Control: no-cache")
+    suspend fun getWatchToken(): MwQueryResponse
 
     companion object {
         const val WIKIPEDIA_URL = "https://wikipedia.org/"

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -469,10 +469,11 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         const val EXTRA_EDIT_LANGUAGE_CODE = "languageCode"
 
         fun newInstance(articleTitle: String, revisionId: Long, languageCode: String): ArticleEditDetailsFragment {
-            val articleEditDetailsFragment = ArticleEditDetailsFragment()
-            articleEditDetailsFragment.arguments = bundleOf(EXTRA_ARTICLE_TITLE to articleTitle,
-                    EXTRA_EDIT_REVISION_ID to revisionId, EXTRA_EDIT_LANGUAGE_CODE to languageCode)
-            return articleEditDetailsFragment
+            return ArticleEditDetailsFragment().apply {
+                arguments = bundleOf(EXTRA_ARTICLE_TITLE to articleTitle,
+                        EXTRA_EDIT_REVISION_ID to revisionId,
+                        EXTRA_EDIT_LANGUAGE_CODE to languageCode)
+            }
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -19,21 +19,16 @@ import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.widget.ImageViewCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.google.android.material.button.MaterialButton
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
-import io.reactivex.rxjava3.disposables.CompositeDisposable
-import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
-import org.wikipedia.analytics.WatchlistFunnel
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.FragmentArticleEditDetailsBinding
-import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage.Revision
 import org.wikipedia.dataclient.restbase.DiffResponse
 import org.wikipedia.dataclient.watch.Watch
-import org.wikipedia.dataclient.watch.WatchPostResponse
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.language.AppLanguageLookUpTable
 import org.wikipedia.page.ExclusiveBottomSheetPresenter
@@ -56,6 +51,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     private val binding get() = _binding!!
     private lateinit var articlePageTitle: PageTitle
     private lateinit var languageCode: String
+    private lateinit var wikiSite: WikiSite
     private var revisionId: Long = 0
     private var diffSize: Int = 0
     private var username: String? = null
@@ -63,21 +59,19 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     private var olderRevisionId: Long = 0
     private var currentRevision: Revision? = null
 
-    private var watchlistExpiryChanged = false
     private var isWatched = false
     private var hasWatchlistExpiry = false
-    private val watchlistFunnel = WatchlistFunnel()
-
-    private val disposables = CompositeDisposable()
     private val bottomSheetPresenter = ExclusiveBottomSheetPresenter()
+
+    private val viewModel: ArticleEditDetailsViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         retainInstance = true
         revisionId = requireArguments().getLong(EXTRA_EDIT_REVISION_ID, 0)
         languageCode = requireArguments().getString(EXTRA_EDIT_LANGUAGE_CODE, AppLanguageLookUpTable.FALLBACK_LANGUAGE_CODE)
-        articlePageTitle = PageTitle(requireArguments().getString(EXTRA_ARTICLE_TITLE, ""),
-                WikiSite.forLanguageCode(languageCode))
+        wikiSite = WikiSite.forLanguageCode(languageCode)
+        articlePageTitle = PageTitle(requireArguments().getString(EXTRA_ARTICLE_TITLE, ""), wikiSite)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -91,9 +85,84 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         setHasOptionsMenu(true)
         setUpInitialUI()
         setUpListeners()
-        getWatchedStatus()
-        fetchEditDetails()
+
+        viewModel.watchedStatus.observe(viewLifecycleOwner) {
+            if (it is Resource.Success) {
+                isWatched = it.data.query?.firstPage()?.watched ?: false
+                hasWatchlistExpiry = it.data.query?.firstPage()?.hasWatchlistExpiry() ?: false
+                updateWatchlistButtonUI()
+            } else if (it is Resource.Error) {
+                setErrorState(it.throwable)
+            }
+        }
+
+        viewModel.revisionDetails.observe(viewLifecycleOwner) {
+            if (it is Resource.Success) {
+                val firstPage = it.data.query?.firstPage()!!
+                currentRevision = firstPage.revisions[0]
+                revisionId = currentRevision!!.revId
+                username = currentRevision!!.user
+                newerRevisionId = if (firstPage.revisions.size < 2) {
+                    -1
+                } else {
+                    firstPage.revisions[1].revId
+                }
+                olderRevisionId = currentRevision!!.parentRevId
+                updateUI()
+                if (olderRevisionId > 0L) {
+                    viewModel.getDiffText(wikiSite, olderRevisionId, revisionId)
+                } else {
+                    binding.progressBar.visibility = INVISIBLE
+                }
+            } else if (it is Resource.Error) {
+                setErrorState(it.throwable)
+            }
+        }
+
+        viewModel.diffText.observe(viewLifecycleOwner) {
+            if (it is Resource.Success) {
+                binding.diffText.text = createSpannable(it.data.diff)
+                updateDiffCharCountView(diffSize)
+                binding.diffCharacterCountView.visibility = VISIBLE
+                binding.progressBar.visibility = INVISIBLE
+            } else if (it is Resource.Error) {
+                setErrorState(it.throwable)
+            }
+        }
+
+        viewModel.thankStatus.observe(viewLifecycleOwner) {
+            if (it is Resource.Success) {
+                FeedbackUtil.showMessage(requireActivity(), getString(R.string.thank_success_message, username))
+                setButtonTextAndIconColor(binding.thankButton, ResourceUtil.getThemedColor(requireContext(),
+                        R.attr.material_theme_de_emphasised_color))
+                binding.thankButton.isClickable = false
+            } else if (it is Resource.Error) {
+                setErrorState(it.throwable)
+            }
+        }
+
+        viewModel.watchResponse.observe(viewLifecycleOwner) {
+            if (it is Resource.Success) {
+                val firstWatch = it.data.getFirst()
+                if (firstWatch != null) {
+                    showWatchlistSnackbar(viewModel.lastWatchExpiry, firstWatch)
+                    updateWatchlistButtonUI()
+                }
+            } else if (it is Resource.Error) {
+                setErrorState(it.throwable)
+                binding.watchButton.isCheckable = true
+            }
+        }
+
+        viewModel.getWatchedStatus(articlePageTitle)
+        beginFetchEditDetails()
+
         L10nUtil.setConditionalLayoutDirection(requireView(), languageCode)
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 
     private fun setUpListeners() {
@@ -107,28 +176,21 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         }
         binding.newerIdButton.setOnClickListener {
             revisionId = newerRevisionId
-            disposables.clear()
-            fetchEditDetails()
+            beginFetchEditDetails()
         }
         binding.olderIdButton.setOnClickListener {
             revisionId = olderRevisionId
-            disposables.clear()
-            fetchEditDetails()
+            beginFetchEditDetails()
         }
         binding.watchButton.setOnClickListener {
-            if (isWatched) {
-                watchlistFunnel.logRemoveArticle()
-            } else {
-                watchlistFunnel.logAddArticle()
-            }
             binding.watchButton.isCheckable = false
-            watchOrUnwatchTitle(WatchlistExpiry.NEVER, isWatched)
+            viewModel.watchOrUnwatch(articlePageTitle, isWatched, WatchlistExpiry.NEVER, isWatched)
         }
         binding.usernameButton.setOnClickListener {
             if (AccountUtil.isLoggedIn && username != null) {
                 startActivity(TalkTopicsActivity.newIntent(requireActivity(),
                         PageTitle(UserTalkAliasData.valueFor(languageCode),
-                                username!!, WikiSite.forLanguageCode(languageCode)), InvokeSource.DIFF_ACTIVITY))
+                                username!!, wikiSite), InvokeSource.DIFF_ACTIVITY))
             }
         }
         binding.thankButton.setOnClickListener { showThankDialog() }
@@ -159,40 +221,9 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         }
     }
 
-    private fun getWatchedStatus() {
-        disposables.add(ServiceFactory.get(WikiSite.forLanguageCode(languageCode)).getWatchedInfo(articlePageTitle.prefixedText)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    isWatched = it.query?.firstPage()?.watched ?: false
-                    hasWatchlistExpiry = it.query?.firstPage()?.hasWatchlistExpiry() ?: false
-                    updateWatchlistButtonUI()
-                }) { setErrorState(it) })
-    }
-
-    private fun fetchEditDetails() {
+    private fun beginFetchEditDetails() {
         hideOrShowViews(true)
-        disposables.add(ServiceFactory.get(WikiSite.forLanguageCode(languageCode)).getRevisionDetails(articlePageTitle.prefixedText, revisionId)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    val firstPage = it.query?.firstPage()!!
-                    currentRevision = firstPage.revisions[0]
-                    revisionId = currentRevision!!.revId
-                    username = currentRevision!!.user
-                    newerRevisionId = if (firstPage.revisions.size < 2) {
-                        -1
-                    } else {
-                        firstPage.revisions[1].revId
-                    }
-                    olderRevisionId = currentRevision!!.parentRevId
-                    updateUI()
-                    if (olderRevisionId > 0L) {
-                        fetchDiffText()
-                    } else {
-                        binding.progressBar.visibility = INVISIBLE
-                    }
-                }) { setErrorState(it) })
+        viewModel.getRevisionDetails(articlePageTitle, revisionId)
     }
 
     private fun hideOrShowViews(isLoading: Boolean) {
@@ -243,42 +274,6 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         view.iconTint = ColorStateList.valueOf(themedColor)
     }
 
-    private fun watchOrUnwatchTitle(expiry: WatchlistExpiry, unwatch: Boolean) {
-        disposables.add(ServiceFactory.get(WikiSite.forLanguageCode(languageCode)).watchToken
-                .subscribeOn(Schedulers.io())
-                .flatMap { response ->
-                    val watchToken = response.query?.watchToken()
-                    if (watchToken.isNullOrEmpty()) {
-                        throw RuntimeException("Received empty watch token.")
-                    }
-                    ServiceFactory.get(WikiSite.forLanguageCode(languageCode))
-                        .postWatch(if (unwatch) 1 else null, null, articlePageTitle.prefixedText, expiry.expiry, watchToken)
-                }
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({ watchPostResponse: WatchPostResponse ->
-                    val firstWatch = watchPostResponse.getFirst()
-                    if (firstWatch != null) {
-                        // Reset to make the "Change" button visible.
-                        if (watchlistExpiryChanged && unwatch) {
-                            watchlistExpiryChanged = false
-                        }
-
-                        if (unwatch) {
-                            watchlistFunnel.logRemoveSuccess()
-                        } else {
-                            watchlistFunnel.logAddSuccess()
-                        }
-
-                        showWatchlistSnackbar(expiry, firstWatch)
-
-                        updateWatchlistButtonUI()
-                    }
-                }) {
-                    setErrorState(it)
-                    binding.watchButton.isCheckable = true
-                })
-    }
-
     private fun updateWatchlistButtonUI() {
         setButtonTextAndIconColor(binding.watchButton, ResourceUtil.getThemedColor(requireContext(),
                 if (isWatched) R.attr.color_group_68 else R.attr.colorAccent))
@@ -308,9 +303,9 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                             articlePageTitle.displayText,
                             getString(expiry.stringId)),
                     FeedbackUtil.LENGTH_DEFAULT)
-            if (!watchlistExpiryChanged) {
+            if (!viewModel.watchlistExpiryChanged) {
                 snackbar.setAction(R.string.watchlist_page_add_to_watchlist_snackbar_action) {
-                    watchlistExpiryChanged = true
+                    viewModel.watchlistExpiryChanged = true
                     bottomSheetPresenter.show(childFragmentManager, WatchlistExpiryDialog.newInstance(expiry))
                 }
             }
@@ -324,7 +319,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         val dialog: AlertDialog = AlertDialog.Builder(activity)
                 .setView(parent)
                 .setPositiveButton(R.string.thank_dialog_positive_button_text) { _, _ ->
-                    sendThanks()
+                    viewModel.sendThanks(wikiSite, revisionId)
                 }
                 .setNegativeButton(R.string.thank_dialog_negative_button_text, null)
                 .create()
@@ -334,38 +329,6 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                     .setTextColor(ResourceUtil.getThemedColor(requireContext(), R.attr.secondary_text_color))
         }
         dialog.show()
-    }
-
-    private fun sendThanks() {
-        disposables.add(ServiceFactory.get(WikiSite.forLanguageCode(languageCode)).csrfToken
-                .subscribeOn(Schedulers.io())
-                .flatMap {
-                    ServiceFactory.get(WikiSite.forLanguageCode(languageCode)).postThanksToRevision(revisionId, it.query?.csrfToken()!!)
-                }
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    FeedbackUtil.showMessage(requireActivity(), getString(R.string.thank_success_message, username))
-                    setButtonTextAndIconColor(binding.thankButton, ResourceUtil.getThemedColor(requireContext(),
-                            R.attr.material_theme_de_emphasised_color))
-                    binding.thankButton.isClickable = false
-                }) { setErrorState(it) })
-    }
-
-    private fun fetchDiffText() {
-        disposables.add(ServiceFactory.getCoreRest(WikiSite.forLanguageCode(languageCode)).getDiff(olderRevisionId, revisionId)
-                .map {
-                    createSpannable(it.diff)
-                }
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    binding.diffText.text = it
-                    updateDiffCharCountView(diffSize)
-                    binding.diffCharacterCountView.visibility = VISIBLE
-                    binding.progressBar.visibility = INVISIBLE
-                }) {
-                    setErrorState(it)
-                })
     }
 
     private fun createSpannable(diffs: List<DiffResponse.DiffItem>): CharSequence {
@@ -463,7 +426,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         return when (item.itemId) {
             R.id.menu_share_edit -> {
                 ShareUtil.shareText(requireContext(), PageTitle(articlePageTitle.prefixedText,
-                        WikiSite.forLanguageCode(languageCode)), revisionId, olderRevisionId)
+                        wikiSite), revisionId, olderRevisionId)
                 true
             }
             R.id.menu_user_profile_page -> {
@@ -478,29 +441,9 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         }
     }
 
-    companion object {
-        const val EXTRA_ARTICLE_TITLE = "articleTitle"
-        const val EXTRA_EDIT_REVISION_ID = "revisionId"
-        const val EXTRA_EDIT_LANGUAGE_CODE = "languageCode"
-
-        fun newInstance(articleTitle: String, revisionId: Long, languageCode: String): ArticleEditDetailsFragment {
-            val articleEditDetailsFragment = ArticleEditDetailsFragment()
-            articleEditDetailsFragment.arguments = bundleOf(EXTRA_ARTICLE_TITLE to articleTitle,
-                    EXTRA_EDIT_REVISION_ID to revisionId, EXTRA_EDIT_LANGUAGE_CODE to languageCode)
-            return articleEditDetailsFragment
-        }
-    }
-
     override fun onExpirySelect(expiry: WatchlistExpiry) {
-        watchlistFunnel.logAddExpiry()
-        watchOrUnwatchTitle(expiry, false)
+        viewModel.watchOrUnwatch(articlePageTitle, isWatched, expiry, false)
         bottomSheetPresenter.dismiss(childFragmentManager)
-    }
-
-    override fun onDestroyView() {
-        disposables.clear()
-        _binding = null
-        super.onDestroyView()
     }
 
     override fun onLinkPreviewLoadPage(title: PageTitle, entry: HistoryEntry, inNewTab: Boolean) {
@@ -527,5 +470,18 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     private fun copyLink(uri: String?) {
         setPlainText(requireContext(), null, uri)
         FeedbackUtil.showMessage(this, R.string.address_copied)
+    }
+
+    companion object {
+        const val EXTRA_ARTICLE_TITLE = "articleTitle"
+        const val EXTRA_EDIT_REVISION_ID = "revisionId"
+        const val EXTRA_EDIT_LANGUAGE_CODE = "languageCode"
+
+        fun newInstance(articleTitle: String, revisionId: Long, languageCode: String): ArticleEditDetailsFragment {
+            val articleEditDetailsFragment = ArticleEditDetailsFragment()
+            articleEditDetailsFragment.arguments = bundleOf(EXTRA_ARTICLE_TITLE to articleTitle,
+                    EXTRA_EDIT_REVISION_ID to revisionId, EXTRA_EDIT_LANGUAGE_CODE to languageCode)
+            return articleEditDetailsFragment
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -1,0 +1,106 @@
+package org.wikipedia.diff
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wikipedia.analytics.WatchlistFunnel
+import org.wikipedia.dataclient.ServiceFactory
+import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.mwapi.MwQueryResponse
+import org.wikipedia.dataclient.restbase.DiffResponse
+import org.wikipedia.dataclient.watch.WatchPostResponse
+import org.wikipedia.dataclient.wikidata.EntityPostResponse
+import org.wikipedia.page.PageTitle
+import org.wikipedia.util.Resource
+import org.wikipedia.watchlist.WatchlistExpiry
+
+class ArticleEditDetailsViewModel : ViewModel() {
+
+    val watchedStatus = MutableLiveData<Resource<MwQueryResponse>>()
+    val revisionDetails = MutableLiveData<Resource<MwQueryResponse>>()
+    val diffText = MutableLiveData<Resource<DiffResponse>>()
+    val thankStatus = MutableLiveData<Resource<EntityPostResponse>>()
+    val watchResponse = MutableLiveData<Resource<WatchPostResponse>>()
+    var watchlistExpiryChanged = false
+    var lastWatchExpiry = WatchlistExpiry.NEVER
+
+    private val watchlistFunnel = WatchlistFunnel()
+
+    fun getWatchedStatus(title: PageTitle) {
+        viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
+            watchedStatus.postValue(Resource.Error(throwable))
+        }) {
+            withContext(Dispatchers.IO) {
+                watchedStatus.postValue(Resource.Success(ServiceFactory.get(title.wikiSite).getWatchedStatus(title.prefixedText)))
+            }
+        }
+    }
+
+    fun getRevisionDetails(title: PageTitle, revisionId: Long) {
+        viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
+            revisionDetails.postValue(Resource.Error(throwable))
+        }) {
+            withContext(Dispatchers.IO) {
+                revisionDetails.postValue(Resource.Success(ServiceFactory.get(title.wikiSite).getRevisionDetails(title.prefixedText, revisionId)))
+            }
+        }
+    }
+
+    fun getDiffText(wikiSite: WikiSite, oldRevisionId: Long, newRevisionId: Long) {
+        viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
+            diffText.postValue(Resource.Error(throwable))
+        }) {
+            withContext(Dispatchers.IO) {
+                diffText.postValue(Resource.Success(ServiceFactory.getCoreRest(wikiSite).getDiff(oldRevisionId, newRevisionId)))
+            }
+        }
+    }
+
+    fun sendThanks(wikiSite: WikiSite, revisionId: Long) {
+        viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
+            thankStatus.postValue(Resource.Error(throwable))
+        }) {
+            withContext(Dispatchers.IO) {
+                val token = ServiceFactory.get(wikiSite).getCsrfToken().query?.csrfToken()
+                thankStatus.postValue(Resource.Success(ServiceFactory.get(wikiSite).postThanksToRevision(revisionId, token!!)))
+            }
+        }
+    }
+
+    fun watchOrUnwatch(title: PageTitle, isWatched: Boolean, expiry: WatchlistExpiry, unwatch: Boolean) {
+        viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
+            watchResponse.postValue(Resource.Error(throwable))
+        }) {
+            withContext(Dispatchers.IO) {
+                if (expiry != WatchlistExpiry.NEVER) {
+                    watchlistFunnel.logAddExpiry()
+                } else {
+                    if (isWatched) {
+                        watchlistFunnel.logRemoveArticle()
+                    } else {
+                        watchlistFunnel.logAddArticle()
+                    }
+                }
+                val token = ServiceFactory.get(title.wikiSite).getWatchToken().query?.watchToken()
+                val response = ServiceFactory.get(title.wikiSite)
+                        .watch(if (unwatch) 1 else null, null, title.prefixedText, expiry.expiry, token!!)
+
+                lastWatchExpiry = expiry
+                if (watchlistExpiryChanged && unwatch) {
+                    watchlistExpiryChanged = false
+                }
+
+                if (unwatch) {
+                    watchlistFunnel.logRemoveSuccess()
+                } else {
+                    watchlistFunnel.logAddSuccess()
+                }
+                watchResponse.postValue(Resource.Success(response))
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -31,7 +31,7 @@ class ArticleEditDetailsViewModel : ViewModel() {
     var watchlistExpiryChanged = false
     var lastWatchExpiry = WatchlistExpiry.NEVER
     var curTitle: PageTitle? = null
-    var diffRevisionId = 0L
+    private var diffRevisionId = 0L
 
     private val watchlistFunnel = WatchlistFunnel()
 
@@ -43,7 +43,7 @@ class ArticleEditDetailsViewModel : ViewModel() {
         }
     }
 
-    fun getWatchedStatus(title: PageTitle) {
+    private fun getWatchedStatus(title: PageTitle) {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             watchedStatus.postValue(Resource.Error(throwable))
         }) {

--- a/app/src/main/java/org/wikipedia/language/LanguagesListActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguagesListActivity.kt
@@ -50,12 +50,12 @@ class LanguagesListActivity : BaseActivity() {
 
         searchingFunnel = AppLanguageSearchingFunnel(intent.getStringExtra(WikipediaLanguagesFragment.SESSION_TOKEN).orEmpty())
 
-        viewModel.siteListData.observe(this, {
+        viewModel.siteListData.observe(this) {
             if (it is Resource.Success) {
                 binding.languagesListLoadProgress.visibility = View.INVISIBLE
                 languageAdapter.notifyItemRangeChanged(0, languageAdapter.itemCount)
             }
-        })
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/org/wikipedia/language/LanguagesListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguagesListViewModel.kt
@@ -78,7 +78,11 @@ class LanguagesListViewModel : ViewModel() {
     }
 
     fun getCanonicalName(code: String): String? {
-        return siteListData.value?.data?.find { it.code == code }?.localname.orEmpty()
+        val value = siteListData.value
+        if (value !is Resource.Success) {
+            return null
+        }
+        return value.data.find { it.code == code }?.localname.orEmpty()
                 .ifEmpty { WikipediaApp.getInstance().language().getAppLanguageCanonicalName(code) }
     }
 

--- a/app/src/main/java/org/wikipedia/util/Resource.kt
+++ b/app/src/main/java/org/wikipedia/util/Resource.kt
@@ -1,7 +1,6 @@
 package org.wikipedia.util
 
-open class Resource<T>(val data: T? = null, val throwable: Throwable? = null) {
-    class Success<T>(data: T) : Resource<T>(data)
-    class Loading<T>(data: T? = null) : Resource<T>(data)
-    class Error<T>(throwable: Throwable, data: T? = null) : Resource<T>(data, throwable)
+open class Resource<T> {
+    class Success<T>(val data: T) : Resource<T>()
+    class Error<T>(val throwable: Throwable) : Resource<T>()
 }

--- a/app/src/main/java/org/wikipedia/util/SingleLiveData.kt
+++ b/app/src/main/java/org/wikipedia/util/SingleLiveData.kt
@@ -1,0 +1,31 @@
+package org.wikipedia.util
+
+import androidx.annotation.MainThread
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.atomic.AtomicBoolean
+
+class SingleLiveData<T> : MutableLiveData<T>() {
+    private val pending = AtomicBoolean(false)
+
+    @MainThread
+    override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
+        super.observe(owner) {
+            if (pending.compareAndSet(true, false)) {
+                observer.onChanged(it)
+            }
+        }
+    }
+
+    @MainThread
+    override fun setValue(t: T?) {
+        pending.set(true)
+        super.setValue(t)
+    }
+
+    @MainThread
+    fun call() {
+        value = null
+    }
+}


### PR DESCRIPTION
In preparation for: https://phabricator.wikimedia.org/T299180

Using the new ViewModel pattern in this fragment means:
* No more RxJava, only coroutines + LiveData
* I introduced a new `SingleLiveData` helper class, to allow LiveData objects that should be consumed _once_ only, for example the result of a network call that should trigger a Snackbar to be shown. (we don't want the snackbar to be shown again upon screen rotation, which would happen with the standard `MutableLiveData`)