### PR TITLE
Dismiss tooltips only upon "DOWN" events.

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -153,8 +153,8 @@ abstract class BaseActivity : AppCompatActivity() {
     }
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
-        if (event.actionMasked == MotionEvent.ACTION_DOWN
-                || event.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
+        if (event.actionMasked == MotionEvent.ACTION_DOWN ||
+                event.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
             dismissCurrentTooltip()
         }
 

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -153,7 +153,11 @@ abstract class BaseActivity : AppCompatActivity() {
     }
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
-        dismissCurrentTooltip()
+        if (event.actionMasked == MotionEvent.ACTION_DOWN
+                || event.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
+            dismissCurrentTooltip()
+        }
+
         imageZoomHelper?.let {
             return it.onDispatchTouchEvent(event) || super.dispatchTouchEvent(event)
         }


### PR DESCRIPTION
I've observed a case where a tooltip is shown, but won't go away:

* The new Toolbar customization tooltip:  If you open an article and start scrolling it (i.e. touch the screen and don't let go), and then the tooltip appears, the tooltip will remain there permanently, and is no longer dismissable. This is because of a race condition between showing the tooltip and nulling it in BaseActivity.

This changes the logic so that the tooltip is dismissed only on a "down" event (`DOWN` or `POINTER_DOWN`).