### PR TITLE
Add metrics REST API for showing graph in Edit history page

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/RestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.kt
@@ -4,6 +4,7 @@ import io.reactivex.rxjava3.core.Observable
 import org.wikipedia.dataclient.okhttp.OfflineCacheInterceptor
 import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.dataclient.page.TalkPage
+import org.wikipedia.dataclient.restbase.Metrics
 import org.wikipedia.dataclient.restbase.RbDefinition
 import org.wikipedia.dataclient.restbase.RbRelatedPages
 import org.wikipedia.feed.aggregated.AggregatedFeedContent
@@ -197,6 +198,15 @@ interface RestService {
     @Headers("Cache-Control: no-cache")
     @GET("page/talk/{title}")
     fun getTalkPage(@Path("title") title: String?): Observable<TalkPage>
+
+    @Headers("Cache-Control: no-cache")
+    @GET("metrics/edits/per-page/{wikiAuthority}/{title}/all-editor-types/monthly/{fromDate}/{toDate}")
+    suspend fun getArticleMetrics(
+        @Path("wikiAuthority") wikiAuthority: String,
+        @Path("title") title: String,
+        @Path("fromDate") fromDate: String,
+        @Path("toDate") toDate: String
+    ): Metrics
 
     companion object {
         const val REST_API_PREFIX = "/api/rest_v1"

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/Metrics.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/Metrics.kt
@@ -12,16 +12,16 @@ class Metrics {
 
     @Serializable
     class Items {
-        val project: String? = null
-        @SerialName("editor-type") val editorType: String? = null
-        @SerialName("page-title") val pageTitle: String? = null
-        val granularity: String? = null
+        val project: String = ""
+        @SerialName("editor-type") val editorType: String = ""
+        @SerialName("page-title") val pageTitle: String = ""
+        val granularity: String = ""
         val results: List<Results> = emptyList()
     }
 
     @Serializable
     class Results {
-        val timestamp: String? = null
-        val edits: Int? = null
+        val timestamp: String = ""
+        val edits: Int = 0
     }
 }

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/Metrics.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/Metrics.kt
@@ -1,0 +1,27 @@
+package org.wikipedia.dataclient.restbase
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Suppress("unused")
+class Metrics {
+
+    val items: List<Items> = emptyList()
+    val firstItem = items.first()
+
+    @Serializable
+    class Items {
+        val project: String? = null
+        @SerialName("editor-type") val editorType: String? = null
+        @SerialName("page-title") val pageTitle: String? = null
+        val granularity: String? = null
+        val results: List<Results> = emptyList()
+    }
+
+    @Serializable
+    class Results {
+        val timestamp: String? = null
+        val edits: Int? = null
+    }
+}


### PR DESCRIPTION
Based on Toni's comment, this API call can help us draw the graph on the edit history page.
https://phabricator.wikimedia.org/T299181#7698567