### PR TITLE
Hygiene: remove unnecessary Jvm annotations

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageActivity.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageActivity.kt
@@ -28,8 +28,6 @@ class FilePageActivity : SingleFragmentActivity<FilePageFragment>() {
         const val INTENT_EXTRA_ALLOW_EDIT = "allowEdit"
         const val INTENT_EXTRA_SUGGESTION_REASON = "suggestionReason"
 
-        @JvmStatic
-        @JvmOverloads
         fun newIntent(context: Context, pageTitle: PageTitle, allowEdit: Boolean = true, suggestionReason: String? = null): Intent {
             return Intent(context, FilePageActivity::class.java)
                     .putExtra(INTENT_EXTRA_PAGE_TITLE, pageTitle)

--- a/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.kt
+++ b/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.kt
@@ -308,7 +308,6 @@ class CreateAccountActivity : BaseActivity() {
         const val CREATE_ACCOUNT_RESULT_USERNAME = "username"
         const val CREATE_ACCOUNT_RESULT_PASSWORD = "password"
 
-        @JvmField
         val USERNAME_PATTERN: Pattern = Pattern.compile("[^#<>\\[\\]|{}/@]*")
 
         @JvmStatic

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
@@ -106,7 +106,6 @@ class DescriptionEditActivity : SingleFragmentActivity<DescriptionEditFragment>(
         private const val EXTRA_SOURCE_SUMMARY = "sourceSummary"
         private const val EXTRA_TARGET_SUMMARY = "targetSummary"
 
-        @JvmStatic
         fun newIntent(context: Context,
                       title: PageTitle,
                       highlightText: String?,

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditSuccessActivity.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditSuccessActivity.kt
@@ -19,7 +19,6 @@ class DescriptionEditSuccessActivity : SingleFragmentActivityTransparent<Descrip
     companion object {
         const val RESULT_OK_FROM_EDIT_SUCCESS = 1
 
-        @JvmStatic
         fun newIntent(context: Context, invokeSource: InvokeSource): Intent {
             return Intent(context, DescriptionEditSuccessActivity::class.java)
                     .putExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE, invokeSource)

--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureActivity.kt
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureActivity.kt
@@ -12,7 +12,6 @@ class ConfigureActivity : SingleFragmentActivity<ConfigureFragment>() {
     }
 
     companion object {
-        @JvmStatic
         fun newIntent(context: Context, invokeSource: Int): Intent {
             return Intent(context, ConfigureActivity::class.java)
                 .putExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE, invokeSource)

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
@@ -438,7 +438,6 @@ class SuggestedEditsCardItemFragment : Fragment() {
         private const val CARD_TYPE = "cardType"
         const val MAX_RETRY_LIMIT: Long = 5
 
-        @JvmStatic
         fun newInstance(age: Int, cardType: Action) =
                 SuggestedEditsCardItemFragment().apply {
                     arguments = bundleOf(AGE to age, CARD_TYPE to cardType)

--- a/app/src/main/java/org/wikipedia/feed/topread/TopReadArticlesActivity.kt
+++ b/app/src/main/java/org/wikipedia/feed/topread/TopReadArticlesActivity.kt
@@ -19,7 +19,6 @@ class TopReadArticlesActivity : SingleFragmentActivity<TopReadFragment>() {
 
     companion object {
         const val TOP_READ_CARD = "item"
-        @JvmStatic
         fun newIntent(context: Context, card: TopReadListCard): Intent {
             return Intent(context, TopReadArticlesActivity::class.java)
                 .putExtra(TOP_READ_CARD, card)

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -59,7 +59,6 @@ import org.wikipedia.views.PositionAwareFragmentStateAdapter
 import org.wikipedia.views.ViewAnimations
 import org.wikipedia.views.ViewUtil
 import java.io.File
-import java.util.*
 
 class GalleryActivity : BaseActivity(), LinkPreviewDialog.Callback, GalleryItemFragment.Callback {
 
@@ -708,7 +707,6 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.Callback, GalleryItemF
         const val EXTRA_SOURCE = "source"
         private var TRANSITION_INFO: JavaScriptActionHandler.ImageHitInfo? = null
 
-        @JvmStatic
         fun newIntent(context: Context, pageTitle: PageTitle?, filename: String, wiki: WikiSite, revision: Long, source: Int): Intent {
             val intent = Intent()
                 .setClass(context, GalleryActivity::class.java)
@@ -722,7 +720,6 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.Callback, GalleryItemF
             return intent
         }
 
-        @JvmStatic
         fun setTransitionInfo(hitInfo: JavaScriptActionHandler.ImageHitInfo) {
             TRANSITION_INFO = hitInfo
         }

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -136,7 +136,6 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
     }
 
     companion object {
-        @JvmStatic
         fun newIntent(context: Context): Intent {
             return Intent(context, MainActivity::class.java)
         }

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -22,7 +22,10 @@ import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.BaseActivity
-import org.wikipedia.analytics.*
+import org.wikipedia.analytics.GalleryFunnel
+import org.wikipedia.analytics.IntentFunnel
+import org.wikipedia.analytics.LinkPreviewFunnel
+import org.wikipedia.analytics.WatchlistFunnel
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.ActivityPageBinding
@@ -49,7 +52,9 @@ import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.suggestededits.SuggestedEditsSnackbars
 import org.wikipedia.talk.TalkTopicsActivity
 import org.wikipedia.util.*
-import org.wikipedia.views.*
+import org.wikipedia.views.FrameLayoutNavMenuTriggerer
+import org.wikipedia.views.ObservableWebView
+import org.wikipedia.views.ViewUtil
 import org.wikipedia.watchlist.WatchlistExpiry
 import org.wikipedia.widgets.WidgetProviderFeaturedPage
 import java.util.*
@@ -793,7 +798,6 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
             return Intent(ACTION_CREATE_NEW_TAB).setClass(context, PageActivity::class.java)
         }
 
-        @JvmStatic
         fun newIntentForNewTab(context: Context, entry: HistoryEntry, title: PageTitle): Intent {
             return Intent(ACTION_LOAD_IN_NEW_TAB)
                 .setClass(context, PageActivity::class.java)
@@ -801,8 +805,6 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
                 .putExtra(EXTRA_PAGETITLE, title)
         }
 
-        @JvmStatic
-        @JvmOverloads
         fun newIntentForCurrentTab(context: Context, entry: HistoryEntry, title: PageTitle, squashBackstack: Boolean = true): Intent {
             return Intent(if (squashBackstack) ACTION_LOAD_IN_CURRENT_TAB_SQUASH else ACTION_LOAD_IN_CURRENT_TAB)
                 .setClass(context, PageActivity::class.java)

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -300,7 +300,6 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
         private const val ARG_ENTRY = "entry"
         private const val ARG_LOCATION = "location"
 
-        @JvmStatic
         fun newInstance(entry: HistoryEntry, location: Location?): LinkPreviewDialog {
             return LinkPreviewDialog().apply {
                 arguments = bundleOf(ARG_ENTRY to entry, ARG_LOCATION to location)

--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
@@ -33,7 +33,6 @@ import org.wikipedia.readinglist.AddToReadingListDialog
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.*
 import org.wikipedia.util.log.L
-import java.util.*
 
 class TabActivity : BaseActivity() {
     private lateinit var binding: ActivityTabsBinding
@@ -327,7 +326,6 @@ class TabActivity : BaseActivity() {
         const val RESULT_LOAD_FROM_BACKSTACK = 10
         const val RESULT_NEW_TAB = 11
 
-        @JvmStatic
         fun captureFirstTabBitmap(view: View) {
             clearFirstTabBitmap()
             var bmp: Bitmap? = null
@@ -372,7 +370,6 @@ class TabActivity : BaseActivity() {
             return Intent(context, TabActivity::class.java)
         }
 
-        @JvmStatic
         fun newIntentFromPageActivity(context: Context): Intent {
             return Intent(context, TabActivity::class.java)
                     .putExtra(LAUNCHED_FROM_PAGE_ACTIVITY, true)

--- a/app/src/main/java/org/wikipedia/random/RandomActivity.kt
+++ b/app/src/main/java/org/wikipedia/random/RandomActivity.kt
@@ -13,7 +13,6 @@ class RandomActivity : SingleFragmentActivity<RandomFragment>() {
     companion object {
         const val INTENT_EXTRA_WIKISITE = "wikiSite"
 
-        @JvmStatic
         fun newIntent(context: Context, wikiSite: WikiSite, invokeSource: InvokeSource?): Intent {
             return Intent(context, RandomActivity::class.java).apply {
                 putExtra(INTENT_EXTRA_WIKISITE, wikiSite)

--- a/app/src/main/java/org/wikipedia/search/SearchActivity.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchActivity.kt
@@ -8,7 +8,6 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.SingleFragmentActivity
 import org.wikipedia.analytics.IntentFunnel
 import org.wikipedia.util.log.L
-import java.lang.RuntimeException
 
 class SearchActivity : SingleFragmentActivity<SearchFragment>() {
     public override fun createFragment(): SearchFragment {
@@ -29,7 +28,6 @@ class SearchActivity : SingleFragmentActivity<SearchFragment>() {
     companion object {
         const val QUERY_EXTRA = "query"
 
-        @JvmStatic
         fun newIntent(context: Context, source: InvokeSource, query: String?): Intent {
             if (source == InvokeSource.WIDGET) {
                 IntentFunnel(WikipediaApp.getInstance()).logSearchWidgetTap()

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -223,11 +223,8 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
 
     override fun onSearchAddPageToList(entry: HistoryEntry, addToDefault: Boolean) {
         if (addToDefault) {
-            addToDefaultList(requireActivity(), entry.title, InvokeSource.FEED, object : AddToDefaultListCallback {
-                override fun onMoveClicked(readingListId: Long) {
-                    onSearchMovePageToList(readingListId, entry)
-                }
-            })
+            addToDefaultList(requireActivity(), entry.title, InvokeSource.FEED,
+                AddToDefaultListCallback { readingListId -> onSearchMovePageToList(readingListId, entry) })
         } else {
             bottomSheetPresenter.show(childFragmentManager,
                     AddToReadingListDialog.newInstance(entry.title, InvokeSource.FEED))
@@ -379,7 +376,6 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
         const val LANG_BUTTON_TEXT_SIZE_MEDIUM = 10
         const val LANG_BUTTON_TEXT_SIZE_SMALLER = 8
 
-        @JvmStatic
         fun newInstance(source: InvokeSource, query: String?): SearchFragment =
                 SearchFragment().apply {
                     arguments = bundleOf(

--- a/app/src/main/java/org/wikipedia/settings/DeveloperSettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/DeveloperSettingsActivity.kt
@@ -10,7 +10,6 @@ class DeveloperSettingsActivity : SingleFragmentActivity<DeveloperSettingsFragme
     }
 
     companion object {
-        @JvmStatic
         fun newIntent(context: Context): Intent {
             return Intent(context, DeveloperSettingsActivity::class.java)
         }

--- a/app/src/main/java/org/wikipedia/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/SettingsActivity.kt
@@ -41,7 +41,7 @@ class SettingsActivity : SingleFragmentActivity<SettingsFragment>() {
         const val ACTIVITY_RESULT_LANGUAGE_CHANGED = 1
         const val ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED = 2
         const val ACTIVITY_RESULT_LOG_OUT = 3
-        @JvmStatic
+
         fun newIntent(ctx: Context): Intent {
             return Intent(ctx, SettingsActivity::class.java)
         }

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesActivity.kt
@@ -21,7 +21,6 @@ class WikipediaLanguagesActivity : SingleFragmentActivity<WikipediaLanguagesFrag
     }
 
     companion object {
-        @JvmStatic
         fun newIntent(context: Context, invokeSource: InvokeSource): Intent {
             return Intent(context, WikipediaLanguagesActivity::class.java)
                     .putExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE, invokeSource)

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.kt
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.kt
@@ -361,7 +361,7 @@ class WikipediaLanguagesFragment : Fragment(), WikipediaLanguagesItemView.Callba
         const val ACTIVITY_RESULT_LANG_POSITION_DATA = "activity_result_lang_position_data"
         const val ADD_LANGUAGE_INTERACTIONS = "add_language_interactions"
         const val SESSION_TOKEN = "session_token"
-        @JvmStatic
+
         fun newInstance(invokeSource: InvokeSource): WikipediaLanguagesFragment {
             val instance = WikipediaLanguagesFragment()
             instance.arguments = bundleOf(Constants.INTENT_EXTRA_INVOKE_SOURCE to invokeSource)

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagEditActivity.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagEditActivity.kt
@@ -86,7 +86,6 @@ class SuggestedEditsImageTagEditActivity : BaseActivity(), SuggestedEditsItemFra
     companion object {
         private const val ARG_PAGE = "imageTagPage"
 
-        @JvmStatic
         fun newIntent(context: Context, page: MwQueryPage, invokeSource: Constants.InvokeSource): Intent {
             return Intent(context, SuggestedEditsImageTagEditActivity::class.java)
                     .putExtra(ARG_PAGE, JsonUtil.encodeToString(page))

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestionsActivity.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestionsActivity.kt
@@ -39,7 +39,6 @@ class SuggestionsActivity : SingleFragmentActivity<SuggestedEditsCardsFragment>(
     companion object {
         const val EXTRA_SOURCE_ADDED_CONTRIBUTION = "addedContribution"
 
-        @JvmStatic
         fun newIntent(context: Context, action: Action, source: Constants.InvokeSource): Intent {
             return Intent(context, SuggestionsActivity::class.java)
                     .putExtra(INTENT_EXTRA_ACTION, action)

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -555,7 +555,6 @@ class TalkTopicsActivity : BaseActivity() {
         private const val MAX_CHARS_NO_SUBJECT = 100
         const val NEW_TOPIC_ID = -2
 
-        @JvmStatic
         fun newIntent(context: Context, pageTitle: PageTitle, invokeSource: Constants.InvokeSource): Intent {
             return Intent(context, TalkTopicsActivity::class.java)
                 .putExtra(EXTRA_PAGE_TITLE, pageTitle)

--- a/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomFragment.kt
+++ b/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomFragment.kt
@@ -58,7 +58,6 @@ class ThemeFittingRoomFragment : Fragment() {
     }
 
     companion object {
-        @JvmStatic
         fun newInstance(): ThemeFittingRoomFragment {
             return ThemeFittingRoomFragment()
         }

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistExpiryDialog.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistExpiryDialog.kt
@@ -90,7 +90,6 @@ class WatchlistExpiryDialog : ExtendedBottomSheetDialogFragment() {
     companion object {
         private const val ARG_EXPIRY = "expiry"
 
-        @JvmStatic
         fun newInstance(expiry: WatchlistExpiry): WatchlistExpiryDialog {
             val dialog = WatchlistExpiryDialog()
             dialog.arguments = bundleOf(ARG_EXPIRY to expiry)


### PR DESCRIPTION
We used to add `@Jvm` annotations for the communication between Java code and Kotlin code, and now it is not necessary between Kotlin code and it's safe to delete the annotations.