### PR TITLE
Follow-up to LanguageState conversion.

### DIFF
--- a/app/src/main/java/org/wikipedia/language/AppLanguageState.kt
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageState.kt
@@ -1,11 +1,9 @@
 package org.wikipedia.language
 
 import android.content.Context
-import org.apache.commons.lang3.StringUtils
 import org.wikipedia.WikipediaApp
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.ReleaseUtil
-import org.wikipedia.util.StringUtil
 import java.util.*
 
 class AppLanguageState(context: Context) {
@@ -14,8 +12,8 @@ class AppLanguageState(context: Context) {
 
     // Language codes that have been explicitly chosen by the user in most recently used order. This
     // list includes both app and article languages.
-    private val _mruLanguageCodes = StringUtil.csvToList(Prefs.mruLanguageCodeCsv.orEmpty()).toMutableList()
-    private val _appLanguageCodes = StringUtil.csvToList(Prefs.appLanguageCodeCsv.orEmpty()).toMutableList()
+    private val _mruLanguageCodes = Prefs.mruLanguageCodeList.toMutableList()
+    private val _appLanguageCodes = Prefs.appLanguageCodeList.toMutableList()
 
     init {
         initAppLanguageCodes()
@@ -65,14 +63,14 @@ class AppLanguageState(context: Context) {
     val appLanguageLocalizedNames: String
         get() {
             return appLanguageCodes.joinToString(", ") {
-                StringUtils.capitalize(getAppLanguageLocalizedName(it))
+                getAppLanguageLocalizedName(it).orEmpty()
             }
         }
 
     fun addMruLanguageCode(code: String) {
         _mruLanguageCodes.remove(code)
         _mruLanguageCodes.add(0, code)
-        Prefs.mruLanguageCodeCsv = StringUtil.listToCsv(_mruLanguageCodes)
+        Prefs.mruLanguageCodeList = _mruLanguageCodes
     }
 
     /** @return English name if app language is supported.
@@ -110,21 +108,21 @@ class AppLanguageState(context: Context) {
     fun addAppLanguageCode(code: String) {
         _appLanguageCodes.remove(code)
         _appLanguageCodes.add(code)
-        Prefs.appLanguageCodeCsv = StringUtil.listToCsv(_appLanguageCodes)
+        Prefs.appLanguageCodeList = _appLanguageCodes
         WikipediaApp.getInstance().resetWikiSite()
     }
 
     fun setAppLanguageCodes(codes: List<String>) {
         _appLanguageCodes.clear()
         _appLanguageCodes.addAll(codes.filter { it.isNotEmpty() })
-        Prefs.appLanguageCodeCsv = StringUtil.listToCsv(_appLanguageCodes)
+        Prefs.appLanguageCodeList = _appLanguageCodes
         WikipediaApp.getInstance().resetWikiSite()
     }
 
     fun removeAppLanguageCodes(codes: List<String>) {
         if (_appLanguageCodes.size > 1) {
             _appLanguageCodes.removeAll(codes)
-            Prefs.appLanguageCodeCsv = StringUtil.listToCsv(_appLanguageCodes)
+            Prefs.appLanguageCodeList = _appLanguageCodes
         }
     }
 

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -15,6 +15,7 @@ import org.wikipedia.theme.Theme.Companion.fallback
 import org.wikipedia.util.DateUtil.dbDateFormat
 import org.wikipedia.util.DateUtil.dbDateParse
 import org.wikipedia.util.ReleaseUtil.isDevRelease
+import org.wikipedia.util.StringUtil
 import java.util.*
 
 /** Shared preferences utility for convenient POJO access.  */
@@ -68,13 +69,13 @@ object Prefs {
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_show_developer_settings, isDevRelease)
         set(enabled) = PrefsIoUtil.setBoolean(R.string.preference_key_show_developer_settings, enabled)
 
-    var mruLanguageCodeCsv
-        get() = PrefsIoUtil.getString(R.string.preference_key_language_mru, null)
-        set(csv) = PrefsIoUtil.setString(R.string.preference_key_language_mru, csv)
+    var mruLanguageCodeList
+        get() = StringUtil.csvToList(PrefsIoUtil.getString(R.string.preference_key_language_mru, null).orEmpty())
+        set(value) = PrefsIoUtil.setString(R.string.preference_key_language_mru, StringUtil.listToCsv(value))
 
-    var appLanguageCodeCsv
-        get() = PrefsIoUtil.getString(R.string.preference_key_language_app, null)
-        set(csv) = PrefsIoUtil.setString(R.string.preference_key_language_app, csv)
+    var appLanguageCodeList
+        get() = StringUtil.csvToList(PrefsIoUtil.getString(R.string.preference_key_language_app, null).orEmpty())
+        set(value) = PrefsIoUtil.setString(R.string.preference_key_language_app, StringUtil.listToCsv(value))
 
     var remoteConfigJson
         get() = PrefsIoUtil.getString(R.string.preference_key_remote_config, "").orEmpty().ifEmpty { "{}" }


### PR DESCRIPTION
* Move the logic of converting csv to lists into the Prefs class, so that consumers of Prefs never worry about how the prefs are actually stored internally.
* Remove explicit capitalization of language names when stating them in a joined list, since many language names actually shouldn't be capitalized.