### PR TITLE
Fix showing long-press menu over WebView in Android 12.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/shareafact/ShareHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/shareafact/ShareHandler.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.page.shareafact
 
+import android.os.Build
 import android.view.ActionMode
 import android.view.MenuItem
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -13,7 +14,6 @@ import org.wikipedia.bridge.JavaScriptActionHandler
 import org.wikipedia.page.PageFragment
 import org.wikipedia.util.log.L
 import org.wikipedia.wiktionary.WiktionaryDialog
-import java.util.*
 
 class ShareHandler(private val fragment: PageFragment, private val bridge: CommunicationBridge) {
     private var webViewActionMode: ActionMode? = null
@@ -56,19 +56,22 @@ class ShareHandler(private val fragment: PageFragment, private val bridge: Commu
 
     fun onTextSelected(mode: ActionMode) {
         webViewActionMode = mode
-        mode.menu.findItem(R.id.menu_text_select_define).run {
+        mode.menu.findItem(R.id.menu_text_select_define)?.run {
             if (shouldEnableWiktionaryDialog()) {
                 isVisible = true
                 setOnMenuItemClickListener(RequestTextSelectOnMenuItemClickListener(PAYLOAD_PURPOSE_DEFINE))
             }
         }
-        mode.menu.findItem(R.id.menu_text_edit_here).run {
+        mode.menu.findItem(R.id.menu_text_edit_here)?.run {
             setOnMenuItemClickListener(RequestTextSelectOnMenuItemClickListener(PAYLOAD_PURPOSE_EDIT_HERE))
             fragment.page?.run {
                 if (!isArticle) {
                     isVisible = false
                 }
             }
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            mode.invalidateContentRect()
         }
         if (funnel == null) {
             createFunnel()


### PR DESCRIPTION
The long-press menu in the WebView was no longer showing our custom items (`Define` and `Edit here`).
Apparently in Android 12 we are required to `invalidate()` the ActionMode if we update it ourselves.

https://phabricator.wikimedia.org/T302078