### PR TITLE
Use default WikiSite when re-logging-in from CsrfClient.

### DIFF
--- a/app/src/main/java/org/wikipedia/csrf/CsrfTokenClient.kt
+++ b/app/src/main/java/org/wikipedia/csrf/CsrfTokenClient.kt
@@ -16,8 +16,7 @@ import java.util.concurrent.Semaphore
 
 class CsrfTokenClient(private val loginWikiSite: WikiSite, private val numRetries: Int,
                       private val csrfService: Service) {
-    constructor(site: WikiSite) : this(site, site)
-    constructor(csrfWikiSite: WikiSite, loginWikiSite: WikiSite) : this(loginWikiSite, MAX_RETRIES, ServiceFactory.get(csrfWikiSite))
+    constructor(site: WikiSite) : this(WikipediaApp.getInstance().wikiSite, MAX_RETRIES, ServiceFactory.get(site))
 
     val token: Observable<String>
         get() {

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -210,7 +210,7 @@ class DescriptionEditFragment : Fragment() {
                     action == DescriptionEditActivity.Action.TRANSLATE_CAPTION) {
                 CsrfTokenClient(wikiCommons)
             } else {
-                CsrfTokenClient(if (shouldWriteToLocalWiki()) pageTitle.wikiSite else wikiData, pageTitle.wikiSite)
+                CsrfTokenClient(if (shouldWriteToLocalWiki()) pageTitle.wikiSite else wikiData)
             }
 
             disposables.add(csrfClient.token.subscribe({ token ->

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
@@ -190,7 +190,7 @@ class NotificationPollBroadcastReceiver : BroadcastReceiver() {
 
         fun markRead(wiki: WikiSite, notifications: List<Notification>, unread: Boolean) {
             val idListStr = notifications.joinToString("|")
-            CsrfTokenClient(wiki, wiki).token
+            CsrfTokenClient(wiki).token
                     .subscribeOn(Schedulers.io())
                     .flatMap {
                         ServiceFactory.get(wiki).markRead(it, if (unread) null else idListStr, if (unread) idListStr else null)


### PR DESCRIPTION
There are cases when fetching a CSRF token will cause us to re-login the current user (due to expired cookies, etc).
In such cases, there is no reason to use any other WikiSite than the default site, i.e. the "first" language selected in the app.