### PR TITLE
Edit history follow-up 1.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -301,7 +301,7 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize" />
 
         <activity
-            android:name=".page.edit_history.EditHistoryListActivity"
+            android:name=".page.edithistory.EditHistoryListActivity"
             android:label="@string/page_edit_history_activity_label"
             android:theme="@style/AppTheme.ActionBar" />
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -64,7 +64,7 @@ import org.wikipedia.navtab.NavTab
 import org.wikipedia.notifications.PollNotificationWorker
 import org.wikipedia.page.PageCacher.loadIntoCache
 import org.wikipedia.page.action.PageActionItem
-import org.wikipedia.page.edit_history.EditHistoryListActivity
+import org.wikipedia.page.edithistory.EditHistoryListActivity
 import org.wikipedia.page.leadimages.LeadImagesHandler
 import org.wikipedia.page.references.PageReferences
 import org.wikipedia.page.references.ReferenceDialog

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryItemView.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryItemView.kt
@@ -1,4 +1,4 @@
-package org.wikipedia.page.edit_history
+package org.wikipedia.page.edithistory
 
 import android.content.Context
 import android.view.LayoutInflater
@@ -13,14 +13,12 @@ import org.wikipedia.util.StringUtil
 class EditHistoryItemView(context: Context) : FrameLayout(context) {
 
     private val binding = ItemEditHistoryBinding.inflate(LayoutInflater.from(context), this, true)
-    private lateinit var revision: Revision
 
     init {
         layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
 
     fun setContents(itemRevision: Revision) {
-        this.revision = itemRevision
         binding.diffText.text = context.getString(R.string.page_edit_history_item_size_text, itemRevision.size)
         binding.editHistoryTitle.text = itemRevision.comment.ifEmpty { context.getString(R.string.page_edit_history_comment_placeholder) }
         binding.editHistoryTitle.text = if (itemRevision.minor) StringUtil.fromHtml(context.getString(R.string.page_edit_history_minor_edit, binding.editHistoryTitle.text))

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -1,4 +1,4 @@
-package org.wikipedia.page.edit_history
+package org.wikipedia.page.edithistory
 
 import android.content.Context
 import android.content.Intent
@@ -18,7 +18,6 @@ import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.ActivityEditHistoryBinding
 import org.wikipedia.dataclient.mwapi.MwQueryPage.Revision
 import org.wikipedia.diff.ArticleEditDetailsActivity
-import org.wikipedia.page.EditHistoryListViewModel
 import org.wikipedia.page.PageTitle
 import org.wikipedia.util.DateUtil
 import org.wikipedia.util.Resource.Success
@@ -61,7 +60,7 @@ class EditHistoryListActivity : BaseActivity() {
         }
 
         override fun getItemViewType(position: Int): Int {
-            return if (listItems[position] is Revision) VIEW_TYPE_ITEM else VIEW_TYPE_HEADER
+            return if (listItems[position] is Revision) VIEW_TYPE_ITEM else VIEW_TYPE_SEPARATOR
         }
 
         override fun getItemCount(): Int {
@@ -70,15 +69,15 @@ class EditHistoryListActivity : BaseActivity() {
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
             val inflater = LayoutInflater.from(this@EditHistoryListActivity)
-            return if (viewType == VIEW_TYPE_HEADER) {
-                HeaderViewHolder(inflater.inflate(R.layout.edit_history_section_header, parent, false))
+            return if (viewType == VIEW_TYPE_SEPARATOR) {
+                SeparatorViewHolder(inflater.inflate(R.layout.item_edit_history_separator, parent, false))
             } else {
                 EditHistoryListItemHolder(EditHistoryItemView(this@EditHistoryListActivity))
             }
         }
 
         override fun onBindViewHolder(holder: ViewHolder, pos: Int) {
-            if (holder is HeaderViewHolder) {
+            if (holder is SeparatorViewHolder) {
                 holder.bindItem(listItems[pos] as String)
             } else if (holder is EditHistoryListItemHolder) {
                 holder.bindItem(listItems[pos] as Revision)
@@ -105,10 +104,10 @@ class EditHistoryListActivity : BaseActivity() {
         }
     }
 
-    private inner class HeaderViewHolder constructor(itemView: View) :
+    private inner class SeparatorViewHolder constructor(itemView: View) :
         ViewHolder(itemView) {
         fun bindItem(listItem: String) {
-            itemView.findViewById<TextView>(R.id.section_header_text).text = listItem
+            itemView.findViewById<TextView>(R.id.date_text).text = listItem
         }
     }
 
@@ -121,7 +120,7 @@ class EditHistoryListActivity : BaseActivity() {
 
     companion object {
 
-        private const val VIEW_TYPE_HEADER = 0
+        private const val VIEW_TYPE_SEPARATOR = 0
         private const val VIEW_TYPE_ITEM = 1
         const val INTENT_EXTRA_PAGE_TITLE = "pageTitle"
 

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -1,4 +1,4 @@
-package org.wikipedia.page
+package org.wikipedia.page.edithistory
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -10,6 +10,7 @@ import kotlinx.coroutines.withContext
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage.Revision
+import org.wikipedia.page.PageTitle
 import org.wikipedia.util.Resource
 import org.wikipedia.util.Resource.Success
 import org.wikipedia.util.log.L

--- a/app/src/main/res/layout/item_edit_history_separator.xml
+++ b/app/src/main/res/layout/item_edit_history_separator.xml
@@ -6,17 +6,15 @@
     android:layout_marginStart="16dp"
     android:layout_marginTop="16dp"
     android:layout_marginBottom="4dp"
-    android:background="?attr/paper_color"
     android:gravity="center_vertical"
-    android:orientation="vertical"
-    tools:context=".page.edit_history.EditHistoryListActivity">
+    android:orientation="vertical">
 
     <TextView
-        android:id="@+id/section_header_text"
+        android:id="@+id/date_text"
         style="@style/MaterialLargePrimaryTitle"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:gravity="center_vertical"
         android:textSize="18sp"
-        tools:text="section 1" />
+        tools:text="Date" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="search_redirect_from">Redirected from %s</string>
 
     <!-- Page Edit History -->
-    <string name="page_edit_history_activity_label">Page history</string>
+    <string name="page_edit_history_activity_label">Revision history</string>
     <string name="page_edit_history_minor_edit"><![CDATA[<b>m</b> %s]]></string>
     <string name="page_edit_history_comment_placeholder">There is no comment associated with this edit</string>
     <string name="page_edit_history_item_size_text">%d bytes</string>


### PR DESCRIPTION
* Update the package name from `edit_history` to `edithistory`, since we don't use an underscore in any other package names.
* The ViewModel class was incorrectly in the base `page` package instead of the `edithistory` package.
* Change the activity title from "Page history" to "Revision history", as specified in the designs.
* Change the nomenclature of "header" to the more accurate "separator", for reasons that will become apparent in future updates.