### PR TITLE
Hygiene: remove unused preference key and rename a key with a proper name

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
         if (Prefs.isInitialOnboardingEnabled && savedInstanceState == null) {
             // Updating preference so the search multilingual tooltip
             // is not shown again for first time users
-            Prefs.isMultilingualSearchTutorialEnabled = false
+            Prefs.isMultilingualSearchTooltipShown = false
 
             // Use startActivityForResult to avoid preload the Feed contents before finishing the initial onboarding.
             // The ACTIVITY_REQUEST_INITIAL_ONBOARDING has not been used in any onActivityResult

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -163,22 +163,22 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
             binding.searchLanguageScrollView.setUpLanguageScrollTabData(app.language().appLanguageCodes, pos, this)
             binding.searchLangButtonContainer.visibility = View.GONE
         } else {
-            showMultiLingualOnboarding()
+            maybeShowMultilingualSearchTooltip()
             binding.searchLanguageScrollViewContainer.visibility = View.GONE
             binding.searchLangButtonContainer.visibility = View.VISIBLE
             initLangButton()
         }
     }
 
-    private fun showMultiLingualOnboarding() {
-        if (Prefs.isMultilingualSearchTutorialEnabled) {
+    private fun maybeShowMultilingualSearchTooltip() {
+        if (Prefs.isMultilingualSearchTooltipShown) {
             binding.searchLangButton.postDelayed({
                 if (isAdded) {
                     FeedbackUtil.showTooltip(requireActivity(), binding.searchLangButton, getString(R.string.tool_tip_lang_button),
                             aboveOrBelow = false, autoDismiss = false)
                 }
             }, 500)
-            Prefs.isMultilingualSearchTutorialEnabled = false
+            Prefs.isMultilingualSearchTooltipShown = false
         }
     }
 

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -352,9 +352,9 @@ object Prefs {
         get() = PrefsIoUtil.getInt(R.string.preference_key_editing_text_size_extra, 0)
         set(extra) = PrefsIoUtil.setInt(R.string.preference_key_editing_text_size_extra, extra)
 
-    var isMultilingualSearchTutorialEnabled
-        get() = PrefsIoUtil.getBoolean(R.string.preference_key_multilingual_search_tutorial_enabled, true)
-        set(enabled) = PrefsIoUtil.setBoolean(R.string.preference_key_multilingual_search_tutorial_enabled, enabled)
+    var isMultilingualSearchTooltipShown
+        get() = PrefsIoUtil.getBoolean(R.string.preference_key_multilingual_search_tooltip_shown, true)
+        set(enabled) = PrefsIoUtil.setBoolean(R.string.preference_key_multilingual_search_tooltip_shown, enabled)
 
     var shouldShowRemoveChineseVariantPrompt
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_show_remove_chinese_variant_prompt, true)

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -12,7 +12,7 @@
     <string name="preference_key_app_channel">channel</string>
     <string name="preference_key_language_mru">languageMru</string>
     <string name="preference_key_language_app">languageApp</string>
-    <string name="preference_key_multilingual_search_tutorial_enabled">multilingualSearchTutorialEnabled</string>
+    <string name="preference_key_multilingual_search_tooltip_shown">multilingualSearchTooltipShown</string>
     <string name="preference_key_show_images">showImages</string>
     <string name="preference_key_announcement_country_override">announcementCountryOverride</string>
     <string name="preference_key_announcement_ignore_date">announcementIgnoreDate</string>
@@ -88,7 +88,6 @@
     <string name="preference_key_remote_notifications_seen_time">remoteNotificationsSeenTime</string>
     <string name="preference_key_save_count_reading_lists">saveCountReadingLists</string>
     <string name="preference_key_history_offline_articles_toast">historyOfflineArticlesToast</string>
-    <string name="preference_key_show_edit_tasks_onboarding">showEditTasksOnboarding</string>
     <string name="preference_key_logged_out_in_background">loggedOutInBackground</string>
     <string name="preference_key_show_description_edit_success_prompt">showDescriptionEditSuccessPrompt</string>
     <string name="preference_key_suggested_edits_count_for_survey">surveyShownCount</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -219,8 +219,8 @@
             android:title="@string/preference_key_description_edit_tutorial_enabled" />
 
         <SwitchPreferenceCompat
-            android:key="@string/preference_key_multilingual_search_tutorial_enabled"
-            android:title="@string/preference_key_multilingual_search_tutorial_enabled" />
+            android:key="@string/preference_key_multilingual_search_tooltip_shown"
+            android:title="@string/preference_key_multilingual_search_tooltip_shown" />
 
         <SwitchPreferenceCompat
             android:key="@string/preference_key_reading_list_sync_reminder_enabled"
@@ -348,10 +348,6 @@
         <SwitchPreferenceCompat
             android:key="@string/preference_key_show_suggested_edits_tooltip"
             android:title="@string/preference_key_show_suggested_edits_tooltip" />
-
-        <SwitchPreferenceCompat
-            android:key="@string/preference_key_show_edit_tasks_onboarding"
-            android:title="@string/preference_key_show_edit_tasks_onboarding" />
 
         <org.wikipedia.settings.EditTextAutoSummarizePreference
             style="@style/DataStringPreference"


### PR DESCRIPTION
While doing this ticket: https://phabricator.wikimedia.org/T301426

Rename `preference_key_multilingual_search_tutorial_enabled` to `preference_key_multilingual_search_tooltip_shown` and also its related method names, since it is showing a tooltip.