### PR TITLE
Update LeakCanary and fix deprecations.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -181,7 +181,7 @@ dependencies {
     String retrofitVersion = '2.9.0'
     String glideVersion = '4.11.0'
     String mockitoVersion = '3.4.0'
-    String leakCanaryVersion = '2.7'
+    String leakCanaryVersion = '2.8.1'
     String kotlinCoroutinesVersion = '1.3.9'
     String firebaseMessagingVersion = '23.0.0'
     String mlKitVersion = '17.0.3'

--- a/app/src/debug/java/LeakCanaryStub.kt
+++ b/app/src/debug/java/LeakCanaryStub.kt
@@ -1,11 +1,9 @@
 package org.wikipedia
 
-import leakcanary.AppWatcher
 import leakcanary.LeakCanary
 import org.wikipedia.settings.Prefs
 
 fun setupLeakCanary() {
     val enabled = Prefs.isMemoryLeakTestEnabled
     LeakCanary.config = LeakCanary.config.copy(dumpHeap = enabled)
-    AppWatcher.config = AppWatcher.config.copy(watchActivities = enabled, watchFragments = enabled, watchFragmentViews = enabled, watchViewModels = enabled)
 }


### PR DESCRIPTION
The latest version of LeakCanary no longer requires AppWatcher to be configured explicitly.