### PR TITLE
Highly optimize syntax highlighting.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/richtext/SpanExtents.kt
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SpanExtents.kt
@@ -5,7 +5,22 @@ package org.wikipedia.edit.richtext
  * as well as the syntax rule with which the span is associated.
  */
 interface SpanExtents {
+
+    /**
+     * Starting position that this span will take.
+     * NOTE: This should only be used when initially applying the span. This variable does not get
+     * updated when the span is moved around in the Editable string, and should not be used to
+     * determine the span's position after setting it.
+     */
     var start: Int
+
+    /**
+     * Ending position that this span will take.
+     * NOTE: This should only be used when initially applying the span. This variable does not get
+     * updated when the span is moved around in the Editable string, and should not be used to
+     * determine the span's position after setting it.
+     */
     var end: Int
+
     var syntaxRule: SyntaxRule
 }

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.kt
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.kt
@@ -135,7 +135,7 @@ class SyntaxHighlighter(
                 var newSpanInfo: SpanExtents
                 var incrementDone = false
                 for (syntaxItem in syntaxRules) {
-                    if (i + syntaxItem.startChars.size > text.length) {
+                    if (i + syntaxItem.startChars.size > textChars.size) {
                         continue
                     }
                     if (syntaxItem.isStartEndSame) {
@@ -173,7 +173,7 @@ class SyntaxHighlighter(
                             incrementDone = true
                         }
                         // skip the check of end symbol when start symbol is found at end of the text
-                        if (i + syntaxItem.startChars.size > text.length) {
+                        if (i + syntaxItem.startChars.size > textChars.size) {
                             continue
                         }
                         pass = true

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.kt
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.kt
@@ -52,8 +52,7 @@ class SyntaxHighlighter(
                 .flatMap {
                     Observable.zip<MutableList<SpanExtents>, List<SpanExtents>, List<SpanExtents>>(Observable.fromCallable(currentHighlightTask!!),
                             if (searchText.isNullOrEmpty()) Observable.just(emptyList())
-                            else Observable.fromCallable(SyntaxHighlightSearchMatchesTask(textBox.text, searchText!!, selectedMatchResultPosition)))
-                    { f, s ->
+                            else Observable.fromCallable(SyntaxHighlightSearchMatchesTask(textBox.text, searchText!!, selectedMatchResultPosition))) { f, s ->
                         f.addAll(s)
                         f
                     }
@@ -118,8 +117,6 @@ class SyntaxHighlighter(
         }
 
         override fun call(): MutableList<SpanExtents> {
-            var time = System.currentTimeMillis()
-
             val spanStack = Stack<SpanExtents>()
             val spansToSet = mutableListOf<SpanExtents>()
             val textChars = text.toString().toCharArray()
@@ -201,9 +198,6 @@ class SyntaxHighlighter(
                     i++
                 }
             }
-
-            time = System.currentTimeMillis() - time
-            L.d(">>> Took $time ms")
             return spansToSet
         }
     }

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxRule.kt
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxRule.kt
@@ -10,10 +10,14 @@ package org.wikipedia.edit.richtext
  *                     |
  *                 spanStyle
  */
-class SyntaxRule(val startSymbol: String, val endSymbol: String, val spanStyle: SyntaxRuleStyle) {
+class SyntaxRule(val startSym: String, val endSym: String, val spanStyle: SyntaxRuleStyle) {
     /**
      * Whether the start symbol is the same as the end symbol
      * (for faster processing)
      */
-    val isStartEndSame: Boolean = startSymbol == endSymbol
+    val isStartEndSame: Boolean = startSym == endSym
+
+    val startChars = startSym.toCharArray()
+
+    val endChars = endSym.toCharArray()
 }

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxRule.kt
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxRule.kt
@@ -10,14 +10,14 @@ package org.wikipedia.edit.richtext
  *                     |
  *                 spanStyle
  */
-class SyntaxRule(val startSym: String, val endSym: String, val spanStyle: SyntaxRuleStyle) {
+class SyntaxRule(startSymbol: String, endSymbol: String, val spanStyle: SyntaxRuleStyle) {
     /**
      * Whether the start symbol is the same as the end symbol
      * (for faster processing)
      */
-    val isStartEndSame: Boolean = startSym == endSym
+    val isStartEndSame: Boolean = startSymbol == endSymbol
 
-    val startChars = startSym.toCharArray()
+    val startChars = startSymbol.toCharArray()
 
-    val endChars = endSym.toCharArray()
+    val endChars = endSymbol.toCharArray()
 }

--- a/app/src/main/java/org/wikipedia/views/PlainPasteEditText.kt
+++ b/app/src/main/java/org/wikipedia/views/PlainPasteEditText.kt
@@ -88,7 +88,9 @@ open class PlainPasteEditText : TextInputEditText {
 
                 override fun findTextMatches(spanExtents: List<SpanExtents>) {
                     findInPageTextPositionList.clear()
-                    findInPageTextPositionList.addAll(spanExtents.map { it.start })
+                    text?.let {
+                        findInPageTextPositionList.addAll(spanExtents.map { span -> it.getSpanStart(span) })
+                    }
                     onFinished(false, listener)
                 }
             })

--- a/app/src/main/res/layout/activity_edit_section.xml
+++ b/app/src/main/res/layout/activity_edit_section.xml
@@ -18,16 +18,13 @@
             android:id="@+id/edit_section_scroll"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingStart="@dimen/activity_horizontal_margin"
-            android:paddingEnd="@dimen/activity_horizontal_margin">
+            android:layout_weight="1">
 
             <org.wikipedia.views.PlainPasteEditText
                 android:id="@+id/edit_section_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:fontFamily="monospace"
-                android:gravity="top|start"
                 android:imeOptions="actionNone|flagNoExtractUi"
                 android:inputType="textMultiLine"
                 android:scrollbars="vertical"


### PR DESCRIPTION
The result of a quick and random rabbit-hole.
* This creates a simple diff algorithm to determine only which spans need to be set, instead of using brute force to remove and re-set all spans at once, every time. This basically brings that part of the routine from O(n^2) to O(n), and will make it more suitable for lower-end devices.
* Transform CharSequences to arrays of `char`, for optimized indexing.
* Remove usage of `post()` and `Handler`s.
* Remove incorrect padding from the EditText.