### PR TITLE
Follow-up to Statistics in Edit History.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -426,28 +426,18 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=timestamp|user|ids|comment|tags")
     fun getLastModified(@Query("titles") titles: String): Observable<MwQueryResponse>
 
-    @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=ids|timestamp|flags|comment|user&rvlimit=2&rvdir=newer")
-    suspend fun getRevisionDetails(
+    @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=ids|timestamp|size|flags|comment|user&rvdir=newer")
+    suspend fun getRevisionDetailsAscending(
         @Query("titles") titles: String,
-        @Query("rvstartid") revisionStartId: Long
+        @Query("rvlimit") count: Int,
+        @Query("rvstartid") revisionStartId: Long?
     ): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=ids|timestamp|flags|comment|user&rvlimit=2&rvdir=newer")
-    suspend fun getEditDetails(
-        @Query("titles") titles: String,
-        @Query("rvstartid") revisionStartId: Long
-    ): Observable<MwQueryResponse>
-
     @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=ids|timestamp|size|flags|comment|user&rvdir=older")
-    suspend fun getEditHistoryDetails(
+    suspend fun getRevisionDetailsDescending(
         @Query("titles") titles: String,
         @Query("rvlimit") count: Int,
         @Query("rvcontinue") continueStr: String?,
-    ): MwQueryResponse
-
-    @GET(MW_API_PREFIX + "action=query&prop=revisions&rvprop=ids|timestamp|flags|comment|user&rvlimit=1&rvdir=newer")
-    suspend fun getArticleCreatedDate(
-        @Query("titles") titles: String
     ): MwQueryResponse
 
     @POST(MW_API_PREFIX + "action=thank")

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -58,7 +58,7 @@ class ArticleEditDetailsViewModel : ViewModel() {
             revisionDetails.postValue(Resource.Error(throwable))
         }) {
             withContext(Dispatchers.IO) {
-                val response = ServiceFactory.get(title.wikiSite).getRevisionDetails(title.prefixedText, revisionId)
+                val response = ServiceFactory.get(title.wikiSite).getRevisionDetailsAscending(title.prefixedText, 2, revisionId)
                 val revisions = response.query?.firstPage()!!.revisions
                 if (revisions.isNotEmpty()) {
                     revisionDetails.postValue(Resource.Success(revisions))

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -51,7 +51,7 @@ class EditHistoryListActivity : BaseActivity() {
         setContentView(binding.root)
         setSupportActionBar(binding.toolbar)
 
-        binding.articleTitleView.visibility = View.GONE
+        binding.articleTitleView.isVisible = false
         binding.articleTitleView.text = getString(R.string.page_edit_history_activity_title, StringUtil.fromHtml(viewModel.pageTitle.displayText))
 
         val colorCompareBackground = ResourceUtil.getThemedColor(this, android.R.attr.colorBackground)
@@ -76,8 +76,7 @@ class EditHistoryListActivity : BaseActivity() {
         binding.editHistoryRecycler.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
-                val isVisible = if (binding.editHistoryRecycler.computeVerticalScrollOffset() > recyclerView.getChildAt(0).height) View.VISIBLE else View.INVISIBLE
-                binding.articleTitleView.visibility = isVisible
+                binding.articleTitleView.isVisible = binding.editHistoryRecycler.computeVerticalScrollOffset() > recyclerView.getChildAt(0).height
             }
         })
 

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -64,7 +64,7 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
                 calendar.add(Calendar.YEAR, -1)
                 val lastYear = DateUtil.getYMDDateString(calendar.time)
 
-                val mwResponse = async { ServiceFactory.get(pageTitle.wikiSite).getArticleCreatedDate(pageTitle.prefixedText) }
+                val mwResponse = async { ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsAscending(pageTitle.prefixedText, 0, null) }
                 val editCountsResponse = async { ServiceFactory.getCoreRest(pageTitle.wikiSite).getEditCount(pageTitle.prefixedText, EditCount.EDIT_TYPE_EDITS) }
                 val articleMetricsResponse = async { ServiceFactory.getRest(WikiSite("wikimedia.org")).getArticleMetrics(pageTitle.wikiSite.authority(), pageTitle.prefixedText, lastYear, today) }
 
@@ -123,7 +123,7 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
         override suspend fun load(params: LoadParams<String>): LoadResult<String, MwQueryPage.Revision> {
             return try {
                 val response = ServiceFactory.get(WikiSite.forLanguageCode(pageTitle.wikiSite.languageCode))
-                        .getEditHistoryDetails(pageTitle.prefixedText, params.loadSize, params.key)
+                        .getRevisionDetailsDescending(pageTitle.prefixedText, params.loadSize, params.key)
                 LoadResult.Page(response.query!!.pages?.get(0)?.revisions!!, null, response.continuation?.rvContinuation)
             } catch (e: Exception) {
                 LoadResult.Error(e)

--- a/app/src/main/java/org/wikipedia/views/EditHistoryStatsView.kt
+++ b/app/src/main/java/org/wikipedia/views/EditHistoryStatsView.kt
@@ -30,7 +30,8 @@ class EditHistoryStatsView constructor(context: Context, attrs: AttributeSet? = 
     }
 
     fun setup(pageTitle: PageTitle, editHistoryStats: EditHistoryListViewModel.EditHistoryStats) {
-        binding.articleTitleView.text = StringUtil.fromHtml(context.getString(R.string.page_edit_history_activity_title_with_url, pageTitle.displayText))
+        binding.articleTitleView.text = StringUtil.fromHtml(context.getString(R.string.page_edit_history_activity_title,
+                "<a href=\"#\">${pageTitle.displayText}</a>"))
         RichTextUtil.removeUnderlinesFromLinks(binding.articleTitleView)
         val timestamp = editHistoryStats.revision.timeStamp
         if (timestamp.isNotBlank()) {

--- a/app/src/main/res/layout/activity_edit_history.xml
+++ b/app/src/main/res/layout/activity_edit_history.xml
@@ -10,10 +10,11 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
         style="@style/ToolbarStyle">
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center_vertical">
@@ -22,11 +23,16 @@
                 android:id="@+id/articleTitleView"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/compareButton"
                 android:layout_marginEnd="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
                 android:lineSpacingExtra="4sp"
                 android:fontFamily="sans-serif"
-                android:maxLines="1"
+                android:maxLines="2"
                 android:ellipsize="end"
                 android:text="@string/page_edit_history_activity_title"
                 android:textColor="?attr/primary_text_color"
@@ -37,6 +43,9 @@
                 android:id="@+id/compareButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 android:clickable="true"
                 android:focusable="true"
                 android:background="?android:selectableItemBackgroundBorderless"
@@ -45,7 +54,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:text="@string/revision_compare_button"/>
 
-        </LinearLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.appcompat.widget.Toolbar>
 

--- a/app/src/main/res/layout/activity_edit_history.xml
+++ b/app/src/main/res/layout/activity_edit_history.xml
@@ -32,7 +32,7 @@
                 android:layout_marginBottom="8dp"
                 android:lineSpacingExtra="4sp"
                 android:fontFamily="sans-serif"
-                android:maxLines="2"
+                android:maxLines="1"
                 android:ellipsize="end"
                 android:text="@string/page_edit_history_activity_title"
                 android:textColor="?attr/primary_text_color"

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -80,7 +80,6 @@
   <string name="image_share_via">Text for button to share image via different means.\n{{Identical|Share via}}</string>
   <string name="search_redirect_from">Label shown when a search result is redirected from the original search query. The \"%s\" symbol is replaced with the redirect source.</string>
   <string name="page_edit_history_activity_title">Label text for the new edit history screen when the edit history stats view is not visible. %s will be replaced by the title of the article.</string>
-  <string name="page_edit_history_activity_title_with_url">Label text for the new edit history screen when the edit history stats view is not visible. %s will be replaced by the title of the article.</string>
   <string name="page_edit_history_minor_edit">Letter m to represent that the edit is a minor edit. %s represents the edit comment.</string>
   <string name="page_edit_history_comment_placeholder">Placeholder text when a comment is not available on an edit.</string>
   <string name="page_edit_history_article_created_date">Text of showing the year since the article has been created and the total edit counts. The %d will be replaced by the total edit counts, and the %s will be replaced by the year.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,6 @@
 
     <!-- Page Edit History -->
     <string name="page_edit_history_activity_title">Revision history: %s</string>
-    <string name="page_edit_history_activity_title_with_url"><![CDATA[Revision history: <a href="#">%s</a>]]></string>
     <string name="page_edit_history_minor_edit"><![CDATA[<b>m</b> %s]]></string>
     <string name="page_edit_history_comment_placeholder">Empty edit summary</string>
     <string name="page_edit_history_article_created_date">%d edits since %s</string>


### PR DESCRIPTION
* Consolidate a couple of API calls.
* When scrolling, increase the activity title text to 2 lines.
* Remove basically duplicate string resource.