### PR TITLE
Design tweaks for Edit History screen, part 1.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryItemView.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryItemView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Typeface
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
@@ -21,6 +22,7 @@ class EditHistoryItemView(context: Context) : FrameLayout(context) {
     interface Listener {
         fun onClick()
         fun onLongClick()
+        fun onUserNameClick(v: View)
         fun onToggleSelect()
     }
 
@@ -40,7 +42,7 @@ class EditHistoryItemView(context: Context) : FrameLayout(context) {
             listener?.onToggleSelect()
         }
         binding.userNameText.setOnClickListener {
-            // TODO
+            listener?.onUserNameClick(it)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -251,8 +251,12 @@ class EditHistoryListActivity : BaseActivity() {
         }
 
         override fun onClick() {
-            startActivity(ArticleEditDetailsActivity.newIntent(this@EditHistoryListActivity,
-                    viewModel.pageTitle.prefixedText, revision.revId, viewModel.pageTitle.wikiSite.languageCode))
+            if (viewModel.comparing) {
+                toggleSelectState()
+            } else {
+                startActivity(ArticleEditDetailsActivity.newIntent(this@EditHistoryListActivity,
+                        viewModel.pageTitle.prefixedText, revision.revId, viewModel.pageTitle.wikiSite.languageCode))
+            }
         }
 
         override fun onLongClick() {
@@ -261,6 +265,14 @@ class EditHistoryListActivity : BaseActivity() {
                 updateCompareState()
             }
             toggleSelectState()
+        }
+
+        override fun onUserNameClick(v: View) {
+            if (viewModel.comparing) {
+                toggleSelectState()
+            } else {
+                // TODO: will be done in subsequent PR.
+            }
         }
 
         override fun onToggleSelect() {

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -115,6 +115,7 @@ class EditHistoryListActivity : BaseActivity() {
         binding.compareContainer.isVisible = viewModel.comparing
         binding.compareButton.text = getString(if (!viewModel.comparing) R.string.revision_compare_button else android.R.string.cancel)
         editHistoryListAdapter.notifyItemRangeChanged(0, editHistoryListAdapter.itemCount)
+        setNavigationBarColor(ResourceUtil.getThemedColor(this, if (viewModel.comparing) android.R.attr.colorBackground else R.attr.paper_color))
         updateCompareStateItems()
     }
 

--- a/app/src/main/res/layout/activity_edit_history.xml
+++ b/app/src/main/res/layout/activity_edit_history.xml
@@ -42,7 +42,7 @@
             <TextView
                 android:id="@+id/compareButton"
                 android:layout_width="wrap_content"
-                android:layout_height="0dp"
+                android:layout_height="48dp"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_edit_history.xml
+++ b/app/src/main/res/layout/activity_edit_history.xml
@@ -43,6 +43,7 @@
                 android:textColor="?attr/colorAccent"
                 android:textAllCaps="true"
                 android:fontFamily="sans-serif-medium"
+                android:letterSpacing="0.05"
                 android:text="@string/revision_compare_button"/>
 
         </LinearLayout>
@@ -152,6 +153,7 @@
                 android:textColor="?attr/colorAccent"
                 android:textAllCaps="true"
                 android:fontFamily="sans-serif-medium"
+                android:letterSpacing="0.05"
                 android:text="@string/revision_compare_button"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_edit_history.xml
+++ b/app/src/main/res/layout/activity_edit_history.xml
@@ -36,10 +36,11 @@
             <TextView
                 android:id="@+id/compareButton"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:clickable="true"
                 android:focusable="true"
                 android:background="?android:selectableItemBackgroundBorderless"
+                android:gravity="center_vertical"
                 android:textColor="?attr/colorAccent"
                 android:textAllCaps="true"
                 android:fontFamily="sans-serif-medium"


### PR DESCRIPTION
* When in Compare mode, make the entire item into a tap target.
* Proper letter spacing of Compare button.
* Proper Navigation bar color when comparing.

https://phabricator.wikimedia.org/T299180