### PR TITLE
Follow-up to TalkFunnel.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
@@ -121,7 +121,7 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
         }
 
         talkTopicsProvider?.cancel()
-        talkTopicsProvider = TalkTopicsProvider(pageTitle.copy())
+        talkTopicsProvider = TalkTopicsProvider(pageTitle)
 
         talkTopicsProvider?.load(object : TalkTopicsProvider.Callback {
             override fun onUpdatePageTitle(title: PageTitle) {

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -244,6 +244,7 @@ class TalkTopicsActivity : BaseActivity() {
         talkTopicsProvider.load(object : TalkTopicsProvider.Callback {
             override fun onUpdatePageTitle(title: PageTitle) {
                 pageTitle = title
+                funnel = TalkFunnel(pageTitle, invokeSource)
                 binding.toolbarTitle.text = StringUtil.fromHtml(pageTitle.displayText)
             }
 
@@ -310,7 +311,6 @@ class TalkTopicsActivity : BaseActivity() {
             binding.talkRecyclerView.visibility = View.VISIBLE
             binding.talkRecyclerView.adapter?.notifyDataSetChanged()
         }
-        funnel = TalkFunnel(pageTitle, invokeSource)
         funnel?.logOpenTalk()
     }
 

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsProvider.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsProvider.kt
@@ -14,7 +14,7 @@ import org.wikipedia.staticdata.TalkAliasData
 import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.util.log.L
 
-class TalkTopicsProvider(private val pageTitle: PageTitle) {
+class TalkTopicsProvider(title: PageTitle) {
 
     interface Callback {
         fun onUpdatePageTitle(title: PageTitle)
@@ -24,6 +24,7 @@ class TalkTopicsProvider(private val pageTitle: PageTitle) {
         fun onFinished()
     }
 
+    private val pageTitle = title.copy()
     private var resolveTitleRequired = false
     private val disposables = CompositeDisposable()
 


### PR DESCRIPTION
* It's more logical to (re)create the funnel when our pageTitle is updated by the Provider.
* The Provider actually modifies the PageTitle object that it receives, which can be unexpected. It should always make an internal `copy()` of the PageTitle.