### PR TITLE
Analytics wiring for talk bubble

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.kt
+++ b/app/src/main/java/org/wikipedia/Constants.kt
@@ -88,6 +88,8 @@ object Constants {
         PAGE_ACTION_TAB("pageActionTab"),
         PAGE_ACTIVITY("page"),
         PAGE_OVERFLOW_MENU("pageOverflowMenu"),
+        PAGE_TALK_BUBBLE("pageTalkBubble"),
+        PAGE_SIDE_PANEL("pageSidePanel"),
         RANDOM_ACTIVITY("random"),
         READ_MORE_BOOKMARK_BUTTON("readMoreBookmark"),
         READING_LIST_ACTIVITY("readingList"),

--- a/app/src/main/java/org/wikipedia/analytics/TalkFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/TalkFunnel.kt
@@ -45,6 +45,10 @@ class TalkFunnel constructor(private val title: PageTitle, private val invokeSou
         log("action", "submit")
     }
 
+    fun pageTalkBubbleClick() {
+        log("action", "bubble_click")
+    }
+
     companion object {
         private const val SCHEMA_NAME = "MobileWikiAppTalk"
         private const val REV_ID = 21020341

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -18,7 +18,6 @@ import androidx.core.animation.doOnEnd
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.graphics.Insets
-import androidx.core.view.forEach
 import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -34,7 +33,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.wikipedia.*
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.Constants.InvokeSource.PAGE_ACTIVITY
-import org.wikipedia.Constants.InvokeSource.PAGE_SIDE_PANEL
 import org.wikipedia.activity.FragmentUtil.getCallback
 import org.wikipedia.analytics.*
 import org.wikipedia.auth.AccountUtil

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -819,7 +819,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         bridge.addListener("footer_item") { _, messagePayload ->
             messagePayload?.let { payload ->
                 when (payload["itemType"]?.jsonPrimitive?.content) {
-                    "talkPage" -> model.title?.run { startTalkTopicActivity(this, PAGE_SIDE_PANEL) }
+                    "talkPage" -> model.title?.run { startTalkTopicActivity(this, PAGE_ACTIVITY) }
                     "languages" -> startLangLinksActivity()
                     "lastEdited" -> {
                         model.title?.run {

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -18,6 +18,7 @@ import androidx.core.animation.doOnEnd
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.graphics.Insets
+import androidx.core.view.forEach
 import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -18,7 +18,6 @@ import androidx.core.animation.doOnEnd
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.graphics.Insets
-import androidx.core.view.forEach
 import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -33,6 +32,8 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.wikipedia.*
 import org.wikipedia.Constants.InvokeSource
+import org.wikipedia.Constants.InvokeSource.PAGE_ACTIVITY
+import org.wikipedia.Constants.InvokeSource.PAGE_SIDE_PANEL
 import org.wikipedia.activity.FragmentUtil.getCallback
 import org.wikipedia.analytics.*
 import org.wikipedia.auth.AccountUtil
@@ -454,7 +455,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
             return
         }
         if (title.namespace() === Namespace.USER_TALK || title.namespace() === Namespace.TALK) {
-            startTalkTopicActivity(title)
+            startTalkTopicActivity(title, PAGE_ACTIVITY)
             return
         }
         dismissBottomSheet()
@@ -569,8 +570,8 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         }
     }
 
-    private fun startTalkTopicActivity(pageTitle: PageTitle) {
-        startActivity(TalkTopicsActivity.newIntent(requireActivity(), pageTitle, InvokeSource.PAGE_ACTIVITY))
+    private fun startTalkTopicActivity(pageTitle: PageTitle, source: InvokeSource) {
+        startActivity(TalkTopicsActivity.newIntent(requireActivity(), pageTitle, source))
     }
 
     private fun startGalleryActivity(fileName: String) {
@@ -807,14 +808,17 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         bridge.addListener("header_item") { _, messagePayload ->
             messagePayload?.let { payload ->
                 when (payload["itemType"]?.jsonPrimitive?.content) {
-                    "talkPage" -> sidePanelHandler.showTalkTopics()
+                    "talkPage" -> {
+                        TalkFunnel(model.title!!, InvokeSource.PAGE_TALK_BUBBLE).pageTalkBubbleClick()
+                        sidePanelHandler.showTalkTopics()
+                    }
                 }
             }
         }
         bridge.addListener("footer_item") { _, messagePayload ->
             messagePayload?.let { payload ->
                 when (payload["itemType"]?.jsonPrimitive?.content) {
-                    "talkPage" -> model.title?.run { startTalkTopicActivity(this) }
+                    "talkPage" -> model.title?.run { startTalkTopicActivity(this, PAGE_SIDE_PANEL) }
                     "languages" -> startLangLinksActivity()
                     "lastEdited" -> {
                         model.title?.run {

--- a/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
@@ -431,7 +431,7 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
 
         override fun onCreateViewHolder(parent: ViewGroup, type: Int): TalkTopicHolder {
             return TalkTopicHolder(ItemTalkTopicBinding.inflate(fragment.layoutInflater, parent, false),
-                fragment.requireContext(), pageTitle, Constants.InvokeSource.PAGE_ACTIVITY)
+                fragment.requireContext(), pageTitle, Constants.InvokeSource.PAGE_SIDE_PANEL)
         }
 
         override fun onBindViewHolder(holder: TalkTopicHolder, pos: Int) {


### PR DESCRIPTION
**Phab:** https://phabricator.wikimedia.org/T303772

What to measure:
Measure clicks on the bubble in MobileWikiAppTalk as "action" = "bubble_click" and "source" will be "article_bubble"
Add another new source as "article_side_panel" and log it as source when Talk page is opened from bubble->side panel -> talk page and "action" as always will be "open_talk"
This will equip us to measure the number of users who clicked the bubble, and of them, how many actually opened the full view talk page.