### PR TITLE
Use rest.php page/history API for the EditHistory page

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
@@ -2,8 +2,10 @@ package org.wikipedia.dataclient
 
 import org.wikipedia.dataclient.restbase.DiffResponse
 import org.wikipedia.dataclient.restbase.EditCount
+import org.wikipedia.dataclient.restbase.PageHistory
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface CoreRestService {
 
@@ -24,6 +26,13 @@ interface CoreRestService {
         @Path("oldRev") oldRev: Long,
         @Path("newRev") newRev: Long
     ): DiffResponse
+
+    @GET("page/{title}/history")
+    suspend fun getPageHistory(
+        @Path("title") title: String,
+        @Query("older_than") olderThan: Long?,
+        @Query("newer_than") newerThan: Long?
+    ): PageHistory
 
     companion object {
         const val CORE_REST_API_PREFIX = "w/rest.php/v1/"

--- a/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
@@ -31,7 +31,8 @@ interface CoreRestService {
     suspend fun getPageHistory(
         @Path("title") title: String,
         @Query("older_than") olderThan: Long?,
-        @Query("newer_than") newerThan: Long?
+        @Query("newer_than") newerThan: Long?,
+        @Query("filter") filter: String?
     ): PageHistory
 
     companion object {

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/PageHistory.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/PageHistory.kt
@@ -1,0 +1,32 @@
+package org.wikipedia.dataclient.restbase
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Suppress("unused")
+class PageHistory {
+
+    val revisions: List<Revision> = emptyList()
+    val latest: String = ""
+    val older: String? = null
+    val newer: String? = null
+
+    @Serializable
+    class Revision {
+        val id: Long = 0
+        val timestamp: String = ""
+        val minor: Boolean = false
+        val size: Long = 0
+        val comment: String = ""
+        val delta: Long = 0
+        val user: User? = null
+
+        val isAnon get() = user?.id == null
+    }
+
+    @Serializable
+    class User {
+        val id: Long? = null
+        val name: String = ""
+    }
+}

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryItemView.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryItemView.kt
@@ -13,7 +13,7 @@ import androidx.core.view.isVisible
 import androidx.core.widget.ImageViewCompat
 import org.wikipedia.R
 import org.wikipedia.databinding.ItemEditHistoryBinding
-import org.wikipedia.dataclient.mwapi.MwQueryPage.Revision
+import org.wikipedia.dataclient.restbase.PageHistory
 import org.wikipedia.util.DateUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
@@ -46,9 +46,9 @@ class EditHistoryItemView(context: Context) : FrameLayout(context) {
         }
     }
 
-    fun setContents(itemRevision: Revision) {
-        val diffSize = itemRevision.diffSize
-        binding.diffText.text = String.format(if (diffSize != 0) "%+d" else "%d", diffSize)
+    fun setContents(itemRevision: PageHistory.Revision) {
+        val diffSize = itemRevision.delta
+        binding.diffText.text = String.format(if (diffSize != 0L) "%+d" else "%d", diffSize)
         if (diffSize >= 0) {
             binding.diffText.setTextColor(if (diffSize > 0) ContextCompat.getColor(context, R.color.green50)
             else ResourceUtil.getThemedColor(context, R.attr.material_theme_secondary_color))
@@ -67,8 +67,8 @@ class EditHistoryItemView(context: Context) : FrameLayout(context) {
             binding.editHistoryTitle.text = if (itemRevision.minor) StringUtil.fromHtml(context.getString(R.string.page_edit_history_minor_edit, itemRevision.comment))
             else itemRevision.comment
         }
-        binding.userNameText.text = itemRevision.user
-        binding.editHistoryTimeText.text = DateUtil.getTimeString(DateUtil.iso8601DateParse(itemRevision.timeStamp))
+        binding.userNameText.text = itemRevision.user?.name
+        binding.editHistoryTimeText.text = DateUtil.getTimeString(DateUtil.iso8601DateParse(itemRevision.timestamp))
     }
 
     fun setSelectedState(selectedState: Int) {

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -26,7 +26,7 @@ import org.wikipedia.R
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.ActivityEditHistoryBinding
-import org.wikipedia.dataclient.mwapi.MwQueryPage
+import org.wikipedia.dataclient.restbase.PageHistory
 import org.wikipedia.diff.ArticleEditDetailsActivity
 import org.wikipedia.page.PageTitle
 import org.wikipedia.util.DateUtil
@@ -121,11 +121,11 @@ class EditHistoryListActivity : BaseActivity() {
     private fun updateCompareStateItems() {
         binding.compareFromCard.isVisible = viewModel.selectedRevisionFrom != null
         if (viewModel.selectedRevisionFrom != null) {
-            binding.compareFromText.text = DateUtil.getShortDayWithTimeString(DateUtil.iso8601DateParse(viewModel.selectedRevisionFrom!!.timeStamp))
+            binding.compareFromText.text = DateUtil.getShortDayWithTimeString(DateUtil.iso8601DateParse(viewModel.selectedRevisionFrom!!.timestamp))
         }
         binding.compareToCard.isVisible = viewModel.selectedRevisionTo != null
         if (viewModel.selectedRevisionTo != null) {
-            binding.compareToText.text = DateUtil.getShortDayWithTimeString(DateUtil.iso8601DateParse(viewModel.selectedRevisionTo!!.timeStamp))
+            binding.compareToText.text = DateUtil.getShortDayWithTimeString(DateUtil.iso8601DateParse(viewModel.selectedRevisionTo!!.timestamp))
         }
         if (viewModel.selectedRevisionFrom != null && viewModel.selectedRevisionTo != null) {
             binding.compareConfirmButton.isEnabled = true
@@ -172,7 +172,7 @@ class EditHistoryListActivity : BaseActivity() {
             if (oldItem is EditHistoryListViewModel.EditHistorySeparator && newItem is EditHistoryListViewModel.EditHistorySeparator) {
                 return oldItem.date == newItem.date
             } else if (oldItem is EditHistoryListViewModel.EditHistoryItem && newItem is EditHistoryListViewModel.EditHistoryItem) {
-                return oldItem.item.revId == newItem.item.revId
+                return oldItem.item.id == newItem.item.id
             }
             return false
         }
@@ -241,9 +241,9 @@ class EditHistoryListActivity : BaseActivity() {
     }
 
     private inner class EditHistoryListItemHolder constructor(private val view: EditHistoryItemView) : RecyclerView.ViewHolder(view), EditHistoryItemView.Listener {
-        private lateinit var revision: MwQueryPage.Revision
+        private lateinit var revision: PageHistory.Revision
 
-        fun bindItem(revision: MwQueryPage.Revision) {
+        fun bindItem(revision: PageHistory.Revision) {
             this.revision = revision
             view.setContents(revision)
             updateSelectState()
@@ -255,7 +255,7 @@ class EditHistoryListActivity : BaseActivity() {
                 toggleSelectState()
             } else {
                 startActivity(ArticleEditDetailsActivity.newIntent(this@EditHistoryListActivity,
-                        viewModel.pageTitle.prefixedText, revision.revId, viewModel.pageTitle.wikiSite.languageCode))
+                        viewModel.pageTitle.prefixedText, revision.id, viewModel.pageTitle.wikiSite.languageCode))
             }
         }
 

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -122,7 +122,7 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
             return try {
                 val response = ServiceFactory.getCoreRest(WikiSite.forLanguageCode(pageTitle.wikiSite.languageCode))
                         .getPageHistory(pageTitle.prefixedText, params.key, null)
-                LoadResult.Page(response.revisions, null, response.revisions.last().id)
+                LoadResult.Page(response.revisions, null, if (response.older.isNullOrEmpty()) null else response.revisions.last().id)
             } catch (e: Exception) {
                 LoadResult.Error(e)
             }


### PR DESCRIPTION
In order to support proper list filtering in #3181, it would be great if we switch to using the `rest.php/page/{title}/history`.