### PR TITLE
Update verbiage for unwatching an article.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -981,7 +981,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
             if (pageActionItem == PageActionItem.SAVE) {
                 it.setCompoundDrawablesWithIntrinsicBounds(0, PageActionItem.readingListIcon(model.isInReadingList), 0, 0)
             } else if (pageActionItem == PageActionItem.ADD_TO_WATCHLIST) {
-                it.setText(if (model.isWatched) R.string.menu_page_watched else R.string.menu_page_watch)
+                it.setText(if (model.isWatched) R.string.menu_page_unwatch else R.string.menu_page_watch)
                 it.setCompoundDrawablesWithIntrinsicBounds(0, PageActionItem.watchlistIcon(model.isWatched, model.hasWatchlistExpiry), 0, 0)
                 it.isEnabled = enabled && AccountUtil.isLoggedIn
                 it.alpha = if (it.isEnabled) 1f else 0.5f

--- a/app/src/main/java/org/wikipedia/views/PageActionOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/PageActionOverflowView.kt
@@ -62,7 +62,7 @@ class PageActionOverflowView(context: Context) : FrameLayout(context) {
             val enabled = model.page != null && (!model.shouldLoadAsMobileWeb || (model.shouldLoadAsMobileWeb && pageActionItem.isAvailableOnMobileWeb))
             when (pageActionItem) {
                 PageActionItem.ADD_TO_WATCHLIST -> {
-                    view.setText(if (model.isWatched) R.string.menu_page_watched else R.string.menu_page_watch)
+                    view.setText(if (model.isWatched) R.string.menu_page_unwatch else R.string.menu_page_watch)
                     view.setCompoundDrawablesWithIntrinsicBounds(PageActionItem.watchlistIcon(model.isWatched, model.hasWatchlistExpiry), 0, 0, 0)
                     view.visibility = if (enabled && AccountUtil.isLoggedIn) VISIBLE else GONE
                 }

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -92,6 +92,7 @@
   <string name="menu_page_find_in_page">Menu item for invoking Find in page on current page plus the hint text for the Find in page control</string>
   <string name="menu_page_add_to_watchlist">Menu item for adding the current page to the Watchlist.</string>
   <string name="menu_page_watch">Menu item for adding the current page to the Watchlist.</string>
+  <string name="menu_page_unwatch">Menu item for unwatching the current page (removing it from the Watchlist).</string>
   <string name="menu_page_view_talk">Menu item text for accessing the article talk page.</string>
   <string name="menu_page_talk_page">Menu item text for accessing the article talk page.</string>
   <string name="menu_page_view_edit_history">Menu item text for accessing the article edit history.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="menu_page_find_in_page">Find in article</string>
     <string name="menu_page_add_to_watchlist">Add to Watchlist</string>
     <string name="menu_page_watch">Watch</string>
+    <string name="menu_page_unwatch">Unwatch</string>
     <string name="menu_page_view_talk">View talk page</string>
     <string name="menu_page_talk_page">Talk page</string>
     <string name="menu_page_view_edit_history">View edit history</string>


### PR DESCRIPTION
Per conversation with Design, the label for removing an article from the Watchlist should be "Unwatch", to be more clear and be consistent with Mobile Web.