### PR TITLE
Simplify adding of new PageActionItems in the future.

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -10,6 +10,7 @@ import org.wikipedia.analytics.SessionFunnel
 import org.wikipedia.analytics.eventplatform.StreamConfig
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.json.JsonUtil
+import org.wikipedia.page.action.PageActionItem
 import org.wikipedia.page.tabs.Tab
 import org.wikipedia.theme.Theme.Companion.fallback
 import org.wikipedia.util.DateUtil.dbDateFormat
@@ -567,9 +568,13 @@ object Prefs {
             ?: listOf(0, 1, 2, 3, 4)
         set(orderList) = PrefsIoUtil.setString(R.string.preference_key_customize_toolbar_order, JsonUtil.encodeToString(orderList))
 
-    var customizeToolbarMenuOrder
-        get() = JsonUtil.decodeFromString<List<Int>>(PrefsIoUtil.getString(R.string.preference_key_customize_toolbar_menu_order, null))
-            ?: listOf(5, 6, 7, 8, 9, 10)
+    var customizeToolbarMenuOrder: List<Int>
+        get() {
+            val notInToolbarList = PageActionItem.values().map { it.code() }.subtract(customizeToolbarOrder)
+            val currentList = JsonUtil.decodeFromString<List<Int>>(PrefsIoUtil.getString(R.string.preference_key_customize_toolbar_menu_order, null))
+                    ?: notInToolbarList
+            return currentList.union(notInToolbarList).toList()
+        }
         set(orderList) = PrefsIoUtil.setString(R.string.preference_key_customize_toolbar_menu_order, JsonUtil.encodeToString(orderList))
 
     fun resetToolbarAndMenuOrder() {


### PR DESCRIPTION
We currently have 10 possible PageActionItems, and our Prefs are _hard-coded_ to know about just those 10 items. If we ever add more PageActionItems, we will need to manually update the Prefs logic to account for the new items.
This PR makes the Prefs automatically detect any new PageActionItems, and append them to the end of the current list.