### PR TITLE
Add Edit History menu item in Talk Page activity.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -39,6 +39,7 @@ import org.wikipedia.notifications.NotificationActivity
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
+import org.wikipedia.page.edithistory.EditHistoryListActivity
 import org.wikipedia.richtext.RichTextUtil
 import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
@@ -215,6 +216,10 @@ class TalkTopicsActivity : BaseActivity() {
             R.id.menu_view_user_page -> {
                 val entry = HistoryEntry(PageTitle(UserAliasData.valueFor(pageTitle.wikiSite.languageCode) + ":" + pageTitle.text, pageTitle.wikiSite), HistoryEntry.SOURCE_TALK_TOPIC)
                 startActivity(PageActivity.newIntentForNewTab(this, entry, entry.title))
+                return true
+            }
+            R.id.menu_view_edit_history -> {
+                startActivity(EditHistoryListActivity.newIntent(this, pageTitle))
                 return true
             }
             R.id.menu_talk_topic_share -> {

--- a/app/src/main/res/menu/menu_talk.xml
+++ b/app/src/main/res/menu/menu_talk.xml
@@ -33,6 +33,12 @@
                 android:title="@string/page_view_in_browser"
                 app:showAsAction="never" />
             <item
+                android:id="@+id/menu_view_edit_history"
+                android:icon="@drawable/ic_icon_revision_history_apps"
+                app:iconTint="?attr/secondary_text_color"
+                android:title="@string/menu_page_view_edit_history"
+                app:showAsAction="never" />
+            <item
                 android:id="@+id/menu_talk_topic_share"
                 android:icon="@drawable/ic_share_material_secondary_themed"
                 android:title="@string/menu_option_share_talk_page"


### PR DESCRIPTION
This adds a "View edit history" menu item when looking at Talk pages, as approved by Design. Previously there was no way to see the full edit history of a talk page. This will also appear in the updated design refresh of Talk pages, but we can have this particular item before beginning the design refresh.