### PR TITLE
Don't make unnecessary API calls for Lead Image CTA after orientation change

### DIFF
--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
@@ -38,6 +38,7 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
     private var callToActionSourceSummary: PageSummaryForEdit? = null
     private var callToActionTargetSummary: PageSummaryForEdit? = null
     private var callToActionIsTranslation = false
+    private var lastImageTitleForCallToAction = ""
     private var imageEditType: ImageEditType? = null
     private var captionSourcePageTitle: PageTitle? = null
     private var captionTargetPageTitle: PageTitle? = null
@@ -100,6 +101,11 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
         }
         title?.let {
             val imageTitle = "File:" + page!!.pageProperties.leadImageName
+            pageHeaderView.imageView.contentDescription = parentFragment.getString(R.string.image_content_description, it.displayText)
+            if (imageTitle == lastImageTitleForCallToAction) {
+                finalizeCallToAction()
+                return
+            }
             disposables.add(ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getProtectionInfo(imageTitle)
                 .subscribeOn(Schedulers.io())
                 .map { response -> response.query?.isEditProtected ?: false }
@@ -133,9 +139,9 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
                         imageEditType = ImageEditType.ADD_TAGS
                     }
                     finalizeCallToAction()
+                    lastImageTitleForCallToAction = imageTitle
                 }
             )
-            pageHeaderView.imageView.contentDescription = parentFragment.getString(R.string.image_content_description, it.displayText)
         }
     }
 


### PR DESCRIPTION
At the moment, when looking at an article with a Lead Image, and after rotating the display, all the API calls that determine which call-to-action to show over the image are repeated unnecessarily.

(This will all be solved in a better way when we switch to a ViewModel, but until then, this will have to do.)