### PR TITLE
Remove unused API layer for ImageLabels.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -75,13 +75,13 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=info|description&inprop=varianttitles&redirects=1")
     fun getInfoByPageId(@Query("pageids") pageIds: String): Observable<MwQueryResponse>
 
-    @GET(MW_API_PREFIX + "action=query&prop=imageinfo|imagelabels&iiprop=timestamp|user|url|mime|extmetadata&iiurlwidth=" + PREFERRED_THUMB_SIZE)
+    @GET(MW_API_PREFIX + "action=query&prop=imageinfo&iiprop=timestamp|user|url|mime|extmetadata&iiurlwidth=" + PREFERRED_THUMB_SIZE)
     fun getImageInfo(
         @Query("titles") titles: String,
         @Query("iiextmetadatalanguage") lang: String
     ): Observable<MwQueryResponse>
 
-    @GET(MW_API_PREFIX + "action=query&prop=videoinfo|imagelabels&viprop=timestamp|user|url|mime|extmetadata|derivatives&viurlwidth=" + PREFERRED_THUMB_SIZE)
+    @GET(MW_API_PREFIX + "action=query&prop=videoinfo&viprop=timestamp|user|url|mime|extmetadata|derivatives&viurlwidth=" + PREFERRED_THUMB_SIZE)
     fun getVideoInfo(
         @Query("titles") titles: String,
         @Query("viextmetadatalanguage") lang: String
@@ -111,14 +111,6 @@ interface Service {
     @GET(MW_API_PREFIX + "action=parse&prop=text&mobileformat=1&mainpage=1")
     fun parseTextForMainPage(@Query("page") mainPageTitle: String): Observable<MwParseResponse>
 
-    @get:GET(MW_API_PREFIX + "action=query&generator=random&redirects=1&grnnamespace=0&grnlimit=50&prop=pageprops|description")
-    @get:Headers("Cache-Control: no-cache")
-    val randomWithPageProps: Observable<MwQueryResponse>
-
-    @get:GET(MW_API_PREFIX + "action=query&generator=random&redirects=1&grnnamespace=6&grnlimit=100&prop=imagelabels")
-    @get:Headers("Cache-Control: no-cache")
-    val randomWithImageLabels: Observable<MwQueryResponse>
-
     @GET(MW_API_PREFIX + "action=query&prop=info&generator=categories&inprop=varianttitles&gclshow=!hidden&gcllimit=500")
     suspend fun getCategories(@Query("titles") titles: String): MwQueryResponse
 
@@ -133,9 +125,6 @@ interface Service {
     @get:GET(MW_API_PREFIX + "action=query&generator=random&redirects=1&grnnamespace=6&grnlimit=10&prop=description|imageinfo|revisions&rvprop=ids|timestamp|flags|comment|user|content&rvslots=mediainfo&iiprop=timestamp|user|url|mime|extmetadata&iiurlwidth=" + PREFERRED_THUMB_SIZE)
     @get:Headers("Cache-Control: no-cache")
     val randomWithImageInfo: Observable<MwQueryResponse>
-
-    @GET(MW_API_PREFIX + "action=query&generator=unreviewedimagelabels&guillimit=10&prop=imagelabels|imageinfo&iiprop=timestamp|user|url|mime|extmetadata&iiurlwidth=" + PREFERRED_THUMB_SIZE)
-    fun getImagesWithUnreviewedLabels(@Query("uselang") lang: String): Observable<MwQueryResponse>
 
     @FormUrlEncoded
     @POST(MW_API_PREFIX + "action=options")
@@ -333,15 +322,6 @@ interface Service {
     @get:GET(MW_API_PREFIX + "action=query&meta=wikimediaeditortaskscounts|userinfo&uiprop=groups|blockinfo|editcount|latestcontrib")
     val editorTaskCounts: Observable<MwQueryResponse>
 
-    @GET(MW_API_PREFIX + "action=query&generator=wikimediaeditortaskssuggestions&prop=pageprops&gwetstask=missingdescriptions&gwetslimit=3")
-    fun getEditorTaskMissingDescriptions(@Query("gwetstarget") targetLanguage: String): Observable<MwQueryResponse>
-
-    @GET(MW_API_PREFIX + "action=query&generator=wikimediaeditortaskssuggestions&prop=pageprops&gwetstask=descriptiontranslations&gwetslimit=3")
-    fun getEditorTaskTranslatableDescriptions(
-        @Query("gwetssource") sourceLanguage: String,
-        @Query("gwetstarget") targetLanguage: String
-    ): Observable<MwQueryResponse>
-
     // ------- Wikidata -------
 
     @GET(MW_API_PREFIX + "action=wbgetentities")
@@ -416,14 +396,6 @@ interface Service {
         @Field("summary") summary: String?,
         @Field("tags") tags: String?
     ): Observable<EntityPostResponse>
-
-    @POST(MW_API_PREFIX + "action=reviewimagelabels")
-    @FormUrlEncoded
-    fun postReviewImageLabels(
-        @Field("filename") fileName: String,
-        @Field("token") token: String,
-        @Field("batch") batchLabels: String
-    ): Observable<MwPostResponse>
 
     @GET(MW_API_PREFIX + "action=visualeditor&paction=metadata")
     fun getVisualEditorMetadata(@Query("page") page: String): Observable<MwVisualEditorResponse>

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.kt
@@ -14,7 +14,6 @@ class MwQueryPage {
     @SerialName("videoinfo") private val videoInfo: List<ImageInfo>? = null
     @SerialName("watchlistexpiry") private val watchlistExpiry: String? = null
     @SerialName("pageviews") val pageViewsMap: Map<String, Long?> = emptyMap()
-    @SerialName("imagelabels") val imageLabels: List<ImageLabel> = emptyList()
     @SerialName("pageid") val pageId = 0
     @SerialName("pageprops") val pageProps: PageProps? = null
 
@@ -124,30 +123,4 @@ class MwQueryPage {
         private val disambiguation: String? = null
         @SerialName("displaytitle") val displayTitle: String? = null
     }
-
-    @Serializable
-    class ImageLabel {
-
-        @SerialName("wikidata_id") var wikidataId: String? = ""
-        private val confidence: Confidence? = null
-        val state: String = ""
-        var label: String = ""
-        var description: String? = ""
-        var isSelected = false
-        var isCustom = false
-
-        constructor()
-        constructor(wikidataId: String, label: String, description: String?) {
-            this.wikidataId = wikidataId
-            this.label = label
-            this.description = description
-            isCustom = true
-        }
-
-        val confidenceScore: Float
-            get() = confidence?.google ?: 0f
-    }
-
-    @Serializable
-    class Confidence(val google: Float = 0f)
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/ImageTag.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/ImageTag.kt
@@ -1,0 +1,8 @@
+package org.wikipedia.suggestededits
+
+class ImageTag(
+        val wikidataId: String,
+        var label: String,
+        var description: String? = null,
+        var isSelected: Boolean = false
+)

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagDialog.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagDialog.kt
@@ -28,14 +28,13 @@ import org.wikipedia.databinding.DialogImageTagSelectBinding
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
-import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.log.L
 
 class SuggestedEditsImageTagDialog : DialogFragment() {
     interface Callback {
-        fun onSearchSelect(item: MwQueryPage.ImageLabel)
+        fun onSearchSelect(item: ImageTag)
         fun onSearchDismiss(searchTerm: String)
     }
 
@@ -130,14 +129,12 @@ class SuggestedEditsImageTagDialog : DialogFragment() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ search ->
-                    val labelList = search.results.map { MwQueryPage.ImageLabel(it.id, it.label, it.description) }
+                    val labelList = search.results.map { ImageTag(it.id, it.label, it.description) }
                     applyResults(labelList)
-                }) { t ->
-                    L.d(t)
-                })
+                }) { L.d(it) })
     }
 
-    private fun applyResults(results: List<MwQueryPage.ImageLabel>) {
+    private fun applyResults(results: List<ImageTag>) {
         adapter.setResults(results)
         adapter.notifyDataSetChanged()
         if (currentSearchTerm.isEmpty()) {
@@ -162,7 +159,7 @@ class SuggestedEditsImageTagDialog : DialogFragment() {
     }
 
     private inner class ResultItemHolder constructor(itemView: View) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
-        fun bindItem(item: MwQueryPage.ImageLabel) {
+        fun bindItem(item: ImageTag) {
             itemView.findViewById<TextView>(R.id.labelName).text = item.label
             itemView.findViewById<TextView>(R.id.labelDescription).text = item.description
             itemView.tag = item
@@ -170,14 +167,14 @@ class SuggestedEditsImageTagDialog : DialogFragment() {
         }
 
         override fun onClick(v: View?) {
-            val item = v!!.tag as MwQueryPage.ImageLabel
+            val item = v!!.tag as ImageTag
             callback()?.onSearchSelect(item)
             dismiss()
         }
     }
 
-    private inner class ResultListAdapter(private var results: List<MwQueryPage.ImageLabel>) : RecyclerView.Adapter<ResultItemHolder>() {
-        fun setResults(results: List<MwQueryPage.ImageLabel>) {
+    private inner class ResultListAdapter(private var results: List<ImageTag>) : RecyclerView.Adapter<ResultItemHolder>() {
+        fun setResults(results: List<ImageTag>) {
             this.results = results
         }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -52,7 +52,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
     private var publishSuccess = false
     private var page: MwQueryPage? = null
     private val pageTitle get() = PageTitle(page!!.title, WikiSite(Service.COMMONS_URL))
-    private val tagList = mutableListOf<MwQueryPage.ImageLabel>()
+    private val tagList = mutableListOf<ImageTag>()
     private var wasCaptionLongClicked = false
     private var lastSearchTerm = ""
     var invokeSource = InvokeSource.SUGGESTED_EDITS
@@ -210,7 +210,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
         callback().updateActionButton()
     }
 
-    private fun addChip(label: MwQueryPage.ImageLabel?, typeface: Typeface): Chip {
+    private fun addChip(label: ImageTag?, typeface: Typeface): Chip {
         val chip = Chip(requireContext())
         chip.text = label?.label ?: getString(R.string.suggested_edits_image_tags_add_tag)
         chip.textAlignment = TEXT_ALIGNMENT_CENTER
@@ -273,14 +273,14 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
             chip.isChipIconVisible = true
         }
         if (chip.tag != null) {
-            (chip.tag as MwQueryPage.ImageLabel).isSelected = chip.isChecked
+            (chip.tag as ImageTag).isSelected = chip.isChecked
         }
 
         updateLicenseTextShown()
         callback().updateActionButton()
     }
 
-    override fun onSearchSelect(item: MwQueryPage.ImageLabel) {
+    override fun onSearchSelect(item: ImageTag) {
         var exists = false
         for (tag in tagList) {
             if (tag.wikidataId == item.wikidataId) {
@@ -305,7 +305,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
             return
         }
 
-        val acceptedLabels = mutableListOf<MwQueryPage.ImageLabel>()
+        val acceptedLabels = mutableListOf<ImageTag>()
         val iterator = tagList.iterator()
         while (iterator.hasNext()) {
             val tag = iterator.next()


### PR DESCRIPTION
When the "image tags" feature was first rolled out, the workflow involved "reviewing" image labels that were suggested by an algorithm. However, shortly afterwards the machine suggestions were phased out, and the tags just became human-added. Therefore, the entire layer of automatic image labels (which we're still requesting in the API) is _completely unused_, and can be removed.