### PR TITLE
Create constant WikiSite for Commons and Wikidata.

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.kt
+++ b/app/src/main/java/org/wikipedia/Constants.kt
@@ -1,5 +1,8 @@
 package org.wikipedia
 
+import org.wikipedia.dataclient.Service
+import org.wikipedia.dataclient.WikiSite
+
 object Constants {
 
     const val ACTIVITY_REQUEST_ADD_A_LANGUAGE = 59
@@ -58,6 +61,9 @@ object Constants {
 
     const val WIKI_CODE_COMMONS = "commons"
     const val WIKI_CODE_WIKIDATA = "wikidata"
+
+    val commonsWikiSite = WikiSite(Service.COMMONS_URL)
+    val wikidataWikiSite = WikiSite(Service.WIKIDATA_URL)
 
     enum class InvokeSource(val value: String) {
         ANNOUNCEMENT("announcement"),

--- a/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
@@ -12,10 +12,9 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import org.wikipedia.Constants
 import org.wikipedia.databinding.FragmentFilePageBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.dataclient.mwapi.media.MediaHelper.getImageCaptions
 import org.wikipedia.descriptions.DescriptionEditActivity.Action
@@ -95,7 +94,7 @@ class FilePageFragment : Fragment() {
         binding.progressBar.visibility = View.VISIBLE
 
         disposables.add(Observable.zip(getImageCaptions(pageTitle.prefixedText),
-                ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(pageTitle.prefixedText,
+                ServiceFactory.get(Constants.commonsWikiSite).getImageInfo(pageTitle.prefixedText,
                     pageTitle.wikiSite.languageCode), { caption, response ->
                     // set image caption to pageTitle description
                     pageTitle.description = caption[pageTitle.wikiSite.languageCode]
@@ -135,7 +134,7 @@ class FilePageFragment : Fragment() {
                 }
                 .flatMap {
                     imageTags = it
-                    ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getProtectionInfo(pageTitle.prefixedText)
+                    ServiceFactory.get(Constants.commonsWikiSite).getProtectionInfo(pageTitle.prefixedText)
                 }
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
+++ b/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
@@ -2,15 +2,14 @@ package org.wikipedia.commons
 
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.schedulers.Schedulers
-import org.wikipedia.dataclient.Service
+import org.wikipedia.Constants
 import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.dataclient.wikidata.Claims
 
 object ImageTagsProvider {
     fun getImageTagsObservable(pageId: Int, langCode: String): Observable<Map<String, List<String>>> {
-        return ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getClaims("M$pageId", "P180")
+        return ServiceFactory.get(Constants.commonsWikiSite).getClaims("M$pageId", "P180")
                 .subscribeOn(Schedulers.io())
                 .onErrorReturnItem(Claims())
                 .flatMap { claims ->
@@ -18,7 +17,7 @@ object ImageTagsProvider {
                     if (ids.isNullOrEmpty()) {
                         Observable.just(MwQueryResponse())
                     } else {
-                        ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).getWikidataEntityTerms(ids.joinToString(separator = "|"), langCode)
+                        ServiceFactory.get(Constants.wikidataWikiSite).getWikidataEntityTerms(ids.joinToString(separator = "|"), langCode)
                     }
                 }
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -25,7 +25,6 @@ import org.wikipedia.analytics.eventplatform.EditAttemptStepEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.csrf.CsrfTokenClient
 import org.wikipedia.databinding.FragmentDescriptionEditBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwException
@@ -189,8 +188,6 @@ class DescriptionEditFragment : Fragment() {
     }
 
     private inner class EditViewCallback : DescriptionEditView.Callback {
-        private val wikiData = WikiSite(Service.WIKIDATA_URL, "")
-        private val wikiCommons = WikiSite(Service.COMMONS_URL)
         private val commonsDbName = "commonswiki"
         override fun onSaveClick() {
             if (!binding.fragmentDescriptionEditView.showingReviewContent()) {
@@ -208,9 +205,9 @@ class DescriptionEditFragment : Fragment() {
         private fun getEditTokenThenSave() {
             val csrfClient = if (action == DescriptionEditActivity.Action.ADD_CAPTION ||
                     action == DescriptionEditActivity.Action.TRANSLATE_CAPTION) {
-                CsrfTokenClient(wikiCommons)
+                CsrfTokenClient(Constants.commonsWikiSite)
             } else {
-                CsrfTokenClient(if (shouldWriteToLocalWiki()) pageTitle.wikiSite else wikiData)
+                CsrfTokenClient(if (shouldWriteToLocalWiki()) pageTitle.wikiSite else Constants.wikidataWikiSite)
             }
 
             disposables.add(csrfClient.token.subscribe({ token ->
@@ -341,11 +338,11 @@ class DescriptionEditFragment : Fragment() {
         private fun getPostObservable(editToken: String, languageCode: String): Observable<EntityPostResponse> {
             return if (action == DescriptionEditActivity.Action.ADD_CAPTION ||
                     action == DescriptionEditActivity.Action.TRANSLATE_CAPTION) {
-                ServiceFactory.get(wikiCommons).postLabelEdit(languageCode, languageCode, commonsDbName,
+                ServiceFactory.get(Constants.commonsWikiSite).postLabelEdit(languageCode, languageCode, commonsDbName,
                         pageTitle.prefixedText, binding.fragmentDescriptionEditView.description.orEmpty(),
                         getEditComment(), editToken, if (AccountUtil.isLoggedIn) "user" else null)
             } else {
-                ServiceFactory.get(wikiData).postDescriptionEdit(languageCode, languageCode, pageTitle.wikiSite.dbName(),
+                ServiceFactory.get(Constants.wikidataWikiSite).postDescriptionEdit(languageCode, languageCode, pageTitle.wikiSite.dbName(),
                         pageTitle.prefixedText, binding.fragmentDescriptionEditView.description.orEmpty(), getEditComment(), editToken,
                         if (AccountUtil.isLoggedIn) "user" else null)
             }

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
@@ -25,7 +25,6 @@ import org.wikipedia.analytics.GalleryFunnel
 import org.wikipedia.analytics.SuggestedEditsFunnel
 import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.FragmentSuggestedEditsCardItemBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
@@ -47,7 +46,6 @@ import org.wikipedia.suggestededits.provider.EditingSuggestionsProvider
 import org.wikipedia.util.ImageUrlUtil
 import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.StringUtil
-import java.util.*
 
 class SuggestedEditsCardItemFragment : Fragment() {
     private var _binding: FragmentSuggestedEditsCardItemBinding? = null
@@ -269,7 +267,7 @@ class SuggestedEditsCardItemFragment : Fragment() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .flatMap { title ->
-                    ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(title, langFromCode)
+                    ServiceFactory.get(Constants.commonsWikiSite).getImageInfo(title, langFromCode)
                             .subscribeOn(Schedulers.io())
                             .observeOn(AndroidSchedulers.mainThread())
                 }
@@ -310,7 +308,7 @@ class SuggestedEditsCardItemFragment : Fragment() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .flatMap { pair ->
                     fileCaption = pair.first
-                    ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(pair.second, langFromCode)
+                    ServiceFactory.get(Constants.commonsWikiSite).getImageInfo(pair.second, langFromCode)
                             .subscribeOn(Schedulers.io())
                             .observeOn(AndroidSchedulers.mainThread())
                 }

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -549,7 +549,7 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.Callback, GalleryItemF
         imageCaptionDisposable =
             Observable.zip<Map<String, String>, MwQueryResponse, Map<String, List<String>>, Pair<Boolean, Int>>(
                 MediaHelper.getImageCaptions(item.imageTitle!!.prefixedText),
-                ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getProtectionInfo(item.imageTitle!!.prefixedText),
+                ServiceFactory.get(Constants.commonsWikiSite).getProtectionInfo(item.imageTitle!!.prefixedText),
                 ImageTagsProvider.getImageTagsObservable(currentItem!!.mediaPage!!.pageId, sourceWiki.languageCode)
             ) { captions, protectionInfoRsp, imageTags ->
                 item.mediaInfo!!.captions = captions

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
@@ -22,9 +22,7 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
 import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.FragmentGalleryItemBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.page.PageTitle
@@ -54,7 +52,7 @@ class GalleryItemFragment : Fragment(), RequestListener<Drawable?> {
         mediaListItem = requireArguments().getParcelable(ARG_GALLERY_ITEM)!!
         pageTitle = requireArguments().getParcelable(ARG_PAGETITLE)
         if (pageTitle == null) {
-            pageTitle = PageTitle(mediaListItem.title, WikiSite(Service.COMMONS_URL))
+            pageTitle = PageTitle(mediaListItem.title, Constants.commonsWikiSite)
         }
         imageTitle = PageTitle("File:${StringUtil.removeNamespace(mediaListItem.title)}", pageTitle!!.wikiSite)
     }
@@ -181,10 +179,10 @@ class GalleryItemFragment : Fragment(), RequestListener<Drawable?> {
 
     private fun getMediaInfoDisposable(title: String, lang: String): Observable<MwQueryResponse> {
         return if (FileUtil.isVideo(mediaListItem.type)) {
-            ServiceFactory.get(if (mediaListItem.isInCommons) WikiSite(Service.COMMONS_URL)
+            ServiceFactory.get(if (mediaListItem.isInCommons) Constants.commonsWikiSite
             else pageTitle!!.wikiSite).getVideoInfo(title, lang)
         } else {
-            ServiceFactory.get(if (mediaListItem.isInCommons) WikiSite(Service.COMMONS_URL)
+            ServiceFactory.get(if (mediaListItem.isInCommons) Constants.commonsWikiSite
             else pageTitle!!.wikiSite).getImageInfo(title, lang)
         }
     }

--- a/app/src/main/java/org/wikipedia/notifications/NotificationRepository.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationRepository.kt
@@ -1,7 +1,7 @@
 package org.wikipedia.notifications
 
+import org.wikipedia.Constants
 import org.wikipedia.WikipediaApp
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.notifications.db.Notification
@@ -24,7 +24,7 @@ class NotificationRepository constructor(private val notificationDao: Notificati
     }
 
     suspend fun fetchUnreadWikiDbNames(): Map<String, WikiSite> {
-        val response = ServiceFactory.get(WikiSite(Service.COMMONS_URL)).unreadNotificationWikis()
+        val response = ServiceFactory.get(Constants.commonsWikiSite).unreadNotificationWikis()
         return response.query?.unreadNotificationWikis!!
             .mapNotNull { (key, wiki) -> wiki.source?.let { key to WikiSite(it.base) } }.toMap()
     }

--- a/app/src/main/java/org/wikipedia/notifications/NotificationViewModel.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationViewModel.kt
@@ -8,11 +8,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.wikipedia.Constants
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.NotificationInteractionFunnel
 import org.wikipedia.analytics.eventplatform.NotificationInteractionEvent
 import org.wikipedia.database.AppDatabase
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.notifications.db.Notification
 import org.wikipedia.settings.Prefs
@@ -162,8 +162,8 @@ class NotificationViewModel : ViewModel() {
             val notification = item.notification!!
             val wiki = dbNameMap.getOrElse(notification.wiki) {
                 when (notification.wiki) {
-                    "commonswiki" -> WikiSite(Service.COMMONS_URL)
-                    "wikidatawiki" -> WikiSite(Service.WIKIDATA_URL)
+                    "commonswiki" -> Constants.commonsWikiSite
+                    "wikidatawiki" -> Constants.wikidataWikiSite
                     else -> {
                         val langCode = StringUtil.dbNameToLangCode(notification.wiki)
                         WikiSite.forLanguageCode(WikipediaApp.getInstance().language().getDefaultLanguageCode(langCode) ?: langCode)

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
@@ -106,12 +106,12 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
                 finalizeCallToAction()
                 return
             }
-            disposables.add(ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getProtectionInfo(imageTitle)
+            disposables.add(ServiceFactory.get(Constants.commonsWikiSite).getProtectionInfo(imageTitle)
                 .subscribeOn(Schedulers.io())
                 .map { response -> response.query?.isEditProtected ?: false }
                 .flatMap { isProtected ->
                     if (isProtected) Observable.empty() else Observable.zip(MediaHelper.getImageCaptions(imageTitle),
-                        ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(imageTitle, WikipediaApp.getInstance().appOrSystemLanguageCode)) { first, second -> Pair(first, second) }
+                        ServiceFactory.get(Constants.commonsWikiSite).getImageInfo(imageTitle, WikipediaApp.getInstance().appOrSystemLanguageCode)) { first, second -> Pair(first, second) }
                 }
                 .flatMap { pair ->
                     captionSourcePageTitle = PageTitle(imageTitle, WikiSite(Service.COMMONS_URL, it.wikiSite.languageCode))

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -9,9 +9,9 @@ import android.view.View.VISIBLE
 import android.view.ViewGroup
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
+import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.databinding.FragmentSuggestedEditsCardsItemBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
@@ -121,7 +121,7 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .flatMap { title ->
-                            ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(title, parent().langFromCode)
+                            ServiceFactory.get(Constants.commonsWikiSite).getImageInfo(title, parent().langFromCode)
                                     .subscribeOn(Schedulers.io())
                                     .observeOn(AndroidSchedulers.mainThread())
                         }
@@ -129,7 +129,7 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
                             val page = response.query?.pages!![0]
                             if (page.imageInfo() != null) {
                                 val imageInfo = page.imageInfo()!!
-                                val title = if (imageInfo.commonsUrl.isEmpty()) page.title else WikiSite(Service.COMMONS_URL).titleForUri(Uri.parse(imageInfo.commonsUrl)).prefixedText
+                                val title = if (imageInfo.commonsUrl.isEmpty()) page.title else Constants.commonsWikiSite.titleForUri(Uri.parse(imageInfo.commonsUrl)).prefixedText
 
                                 sourceSummaryForEdit = PageSummaryForEdit(
                                         title,
@@ -162,7 +162,7 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
                         .observeOn(AndroidSchedulers.mainThread())
                         .flatMap { pair ->
                             fileCaption = pair.first
-                            ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(pair.second, parent().langFromCode)
+                            ServiceFactory.get(Constants.commonsWikiSite).getImageInfo(pair.second, parent().langFromCode)
                                     .subscribeOn(Schedulers.io())
                                     .observeOn(AndroidSchedulers.mainThread())
                         }
@@ -170,7 +170,7 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
                             val page = response.query?.pages!![0]
                             if (page.imageInfo() != null) {
                                 val imageInfo = page.imageInfo()!!
-                                val title = if (imageInfo.commonsUrl.isEmpty()) page.title else WikiSite(Service.COMMONS_URL).titleForUri(Uri.parse(imageInfo.commonsUrl)).prefixedText
+                                val title = if (imageInfo.commonsUrl.isEmpty()) page.title else Constants.commonsWikiSite.titleForUri(Uri.parse(imageInfo.commonsUrl)).prefixedText
 
                                 sourceSummaryForEdit = PageSummaryForEdit(
                                         title,

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagDialog.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagDialog.kt
@@ -21,13 +21,12 @@ import com.google.android.material.shape.ShapeAppearanceModel
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
 import org.wikipedia.databinding.DialogImageTagSelectBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.log.L
@@ -125,7 +124,7 @@ class SuggestedEditsImageTagDialog : DialogFragment() {
             applyResults(emptyList())
             return
         }
-        disposables.add(ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).searchEntities(searchTerm, WikipediaApp.getInstance().appOrSystemLanguageCode, WikipediaApp.getInstance().appOrSystemLanguageCode)
+        disposables.add(ServiceFactory.get(Constants.wikidataWikiSite).searchEntities(searchTerm, WikipediaApp.getInstance().appOrSystemLanguageCode, WikipediaApp.getInstance().appOrSystemLanguageCode)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ search ->

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -27,9 +27,7 @@ import org.wikipedia.analytics.SuggestedEditsFunnel
 import org.wikipedia.analytics.eventplatform.EditAttemptStepEvent
 import org.wikipedia.csrf.CsrfTokenClient
 import org.wikipedia.databinding.FragmentSuggestedEditsImageTagsItemBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.dataclient.mwapi.media.MediaHelper
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_IMAGE_TAGS
@@ -51,7 +49,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
     var publishing = false
     private var publishSuccess = false
     private var page: MwQueryPage? = null
-    private val pageTitle get() = PageTitle(page!!.title, WikiSite(Service.COMMONS_URL))
+    private val pageTitle get() = PageTitle(page!!.title, Constants.commonsWikiSite)
     private val tagList = mutableListOf<ImageTag>()
     private var wasCaptionLongClicked = false
     private var lastSearchTerm = ""
@@ -333,9 +331,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
         binding.publishProgressBarComplete.visibility = GONE
         binding.publishProgressBar.visibility = VISIBLE
 
-        val commonsSite = WikiSite(Service.COMMONS_URL)
-
-        disposables.add(CsrfTokenClient(WikiSite(Service.COMMONS_URL)).token
+        disposables.add(CsrfTokenClient(Constants.commonsWikiSite).token
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ token ->
@@ -364,7 +360,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
                     claimStr += "]}"
                     commentStr += " */"
 
-                    disposables.add(ServiceFactory.get(commonsSite).postEditEntity(mId, token, claimStr, commentStr, null)
+                    disposables.add(ServiceFactory.get(Constants.commonsWikiSite).postEditEntity(mId, token, claimStr, commentStr, null)
                             .subscribeOn(Schedulers.io())
                             .observeOn(AndroidSchedulers.mainThread())
                             .doAfterTerminate {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -25,9 +25,7 @@ import org.wikipedia.analytics.UserContributionFunnel
 import org.wikipedia.analytics.eventplatform.UserContributionEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.FragmentSuggestedEditsTasksBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwServiceError
 import org.wikipedia.dataclient.mwapi.UserContribution
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
@@ -172,8 +170,8 @@ class SuggestedEditsTasksFragment : Fragment() {
         binding.progressBar.visibility = VISIBLE
 
         disposables.add(Observable.zip(ServiceFactory.get(WikipediaApp.getInstance().wikiSite).getUserContributions(AccountUtil.userName!!, 10, null).subscribeOn(Schedulers.io()),
-                ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getUserContributions(AccountUtil.userName!!, 10, null).subscribeOn(Schedulers.io()),
-                ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).getUserContributions(AccountUtil.userName!!, 10, null).subscribeOn(Schedulers.io()),
+                ServiceFactory.get(Constants.commonsWikiSite).getUserContributions(AccountUtil.userName!!, 10, null).subscribeOn(Schedulers.io()),
+                ServiceFactory.get(Constants.wikidataWikiSite).getUserContributions(AccountUtil.userName!!, 10, null).subscribeOn(Schedulers.io()),
                 UserContributionsStats.getEditCountsObservable()) { homeSiteResponse, commonsResponse, wikidataResponse, _ ->
                     var blockInfo: MwServiceError.BlockInfo? = null
                     when {

--- a/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
@@ -2,7 +2,7 @@ package org.wikipedia.suggestededits.provider
 
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.schedulers.Schedulers
-import org.wikipedia.dataclient.Service
+import org.wikipedia.Constants
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
@@ -45,7 +45,7 @@ object EditingSuggestionsProvider {
             if (cachedTitle.isNotEmpty()) {
                 Observable.just(cachedTitle)
             } else {
-                ServiceFactory.getRest(WikiSite(Service.WIKIDATA_URL)).getArticlesWithoutDescriptions(WikiSite.normalizeLanguageCode(wiki.languageCode))
+                ServiceFactory.getRest(Constants.wikidataWikiSite).getArticlesWithoutDescriptions(WikiSite.normalizeLanguageCode(wiki.languageCode))
                         .flatMap { pages ->
                             val titleList = ArrayList<String>()
                             pages.forEach { titleList.add(it.title()) }
@@ -67,7 +67,7 @@ object EditingSuggestionsProvider {
                             }
                             title
                         }
-                        .retry(retryLimit) { t: Throwable -> t is ListEmptyException }
+                        .retry(retryLimit) { it is ListEmptyException }
             }
         }.flatMap { title -> ServiceFactory.getRest(wiki).getSummary(null, title) }
                 .doFinally { mutex.release() }
@@ -89,7 +89,7 @@ object EditingSuggestionsProvider {
             if (cachedPair != null) {
                 Observable.just(cachedPair)
             } else {
-                ServiceFactory.getRest(WikiSite(Service.WIKIDATA_URL)).getArticlesWithTranslatableDescriptions(WikiSite.normalizeLanguageCode(sourceWiki.languageCode), WikiSite.normalizeLanguageCode(targetLang))
+                ServiceFactory.getRest(Constants.wikidataWikiSite).getArticlesWithTranslatableDescriptions(WikiSite.normalizeLanguageCode(sourceWiki.languageCode), WikiSite.normalizeLanguageCode(targetLang))
                         .flatMap({ pages ->
                             if (pages.isEmpty()) {
                                 throw ListEmptyException()
@@ -127,9 +127,7 @@ object EditingSuggestionsProvider {
                             }
                             targetAndSourcePageTitles
                         }
-                        .retry(retryLimit) { t: Throwable ->
-                            t is ListEmptyException
-                        }
+                        .retry(retryLimit) { it is ListEmptyException }
             }
         }.flatMap { getSummary(it) }
                 .doFinally { mutex.release() }
@@ -159,7 +157,7 @@ object EditingSuggestionsProvider {
             if (cachedTitle != null) {
                 Observable.just(cachedTitle)
             } else {
-                ServiceFactory.getRest(WikiSite(Service.COMMONS_URL)).getImagesWithoutCaptions(WikiSite.normalizeLanguageCode(lang))
+                ServiceFactory.getRest(Constants.commonsWikiSite).getImagesWithoutCaptions(WikiSite.normalizeLanguageCode(lang))
                         .map { pages ->
                             imagesWithMissingCaptionsCacheLang = lang
                             pages.forEach { imagesWithMissingCaptionsCache.push(it.title()) }
@@ -172,7 +170,7 @@ object EditingSuggestionsProvider {
                             }
                             item
                         }
-                        .retry(retryLimit) { t: Throwable -> t is ListEmptyException }
+                        .retry(retryLimit) { it is ListEmptyException }
             }
         }.doFinally { mutex.release() }
     }
@@ -192,7 +190,7 @@ object EditingSuggestionsProvider {
             if (cachedPair != null) {
                 Observable.just(cachedPair)
             } else {
-                ServiceFactory.getRest(WikiSite(Service.COMMONS_URL)).getImagesWithTranslatableCaptions(WikiSite.normalizeLanguageCode(sourceLang), WikiSite.normalizeLanguageCode(targetLang))
+                ServiceFactory.getRest(Constants.commonsWikiSite).getImagesWithTranslatableCaptions(WikiSite.normalizeLanguageCode(sourceLang), WikiSite.normalizeLanguageCode(targetLang))
                         .map { pages ->
                             imagesWithTranslatableCaptionCacheFromLang = sourceLang
                             imagesWithTranslatableCaptionCacheToLang = targetLang
@@ -212,7 +210,7 @@ object EditingSuggestionsProvider {
                             }
                             item
                         }
-                        .retry(retryLimit) { t: Throwable -> t is ListEmptyException }
+                        .retry(retryLimit) { it is ListEmptyException }
             }
         }.doFinally { mutex.release() }
     }
@@ -227,7 +225,7 @@ object EditingSuggestionsProvider {
             if (cachedItem != null) {
                 Observable.just(cachedItem)
             } else {
-                ServiceFactory.get(WikiSite(Service.COMMONS_URL)).randomWithImageInfo
+                ServiceFactory.get(Constants.commonsWikiSite).randomWithImageInfo
                         .map { response ->
                             response.query?.pages?.filter { it.imageInfo()?.mime == "image/jpeg" }?.forEach { page ->
                                 if (page.revisions.none { "P180" in it.getContentFromSlot("mediainfo") }) {
@@ -243,7 +241,7 @@ object EditingSuggestionsProvider {
                             }
                             item
                         }
-                        .retry(retryLimit) { t: Throwable -> t is ListEmptyException }
+                        .retry(retryLimit) { it is ListEmptyException }
             }
         }.doFinally { mutex.release() }
     }

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -21,13 +21,13 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.time.DateUtils
+import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.UserContributionFunnel
 import org.wikipedia.analytics.eventplatform.UserContributionEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.FragmentContributionsSuggestedEditsBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
@@ -213,17 +213,17 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
     }
 
     private fun wikiDataObservable(): Observable<Pair<List<Contribution>, Int>> {
-        return if (allContributions.isNotEmpty() && !continuations.containsKey(WikiSite(Service.WIKIDATA_URL))) Observable.just(Pair(Collections.emptyList(), -1))
-        else ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).getUserContributions(AccountUtil.userName!!, 50, continuations[WikiSite(Service.WIKIDATA_URL)])
+        return if (allContributions.isNotEmpty() && !continuations.containsKey(Constants.wikidataWikiSite)) Observable.just(Pair(Collections.emptyList(), -1))
+        else ServiceFactory.get(Constants.wikidataWikiSite).getUserContributions(AccountUtil.userName!!, 50, continuations[Constants.wikidataWikiSite])
             .subscribeOn(Schedulers.io())
             .flatMap { response ->
                 val wikidataContributions = mutableListOf<Contribution>()
                 val qLangMap = hashMapOf<String, HashSet<String>>()
                 val cont = response.continuation?.ucContinuation
                 if (cont.isNullOrEmpty()) {
-                    continuations.remove(WikiSite(Service.WIKIDATA_URL))
+                    continuations.remove(Constants.wikidataWikiSite)
                 } else {
-                    continuations[WikiSite(Service.WIKIDATA_URL)] = cont
+                    continuations[Constants.wikidataWikiSite] = cont
                 }
                 response.query?.userContributions?.forEach { contribution ->
                     var contributionLanguage = WikipediaApp.getInstance().appOrSystemLanguageCode
@@ -257,7 +257,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
 
                     qLangMap[qNumber]?.add(contributionLanguage)
                 }
-                ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).getWikidataLabelsAndDescriptions(qLangMap.keys.joinToString("|"))
+                ServiceFactory.get(Constants.wikidataWikiSite).getWikidataLabelsAndDescriptions(qLangMap.keys.joinToString("|"))
                     .subscribeOn(Schedulers.io())
                     .flatMap { entities ->
                         for ((entityKey, entity) in entities.entities) {
@@ -275,16 +275,16 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
     }
 
     private fun wikiCommonsObservable(): Observable<Pair<List<Contribution>, Int>> {
-        return if (allContributions.isNotEmpty() && !continuations.containsKey(WikiSite(Service.COMMONS_URL))) Observable.just(Pair(Collections.emptyList(), -1)) else
-            ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getUserContributions(AccountUtil.userName!!, 200, continuations[WikiSite(Service.COMMONS_URL)])
+        return if (allContributions.isNotEmpty() && !continuations.containsKey(Constants.commonsWikiSite)) Observable.just(Pair(Collections.emptyList(), -1)) else
+            ServiceFactory.get(Constants.commonsWikiSite).getUserContributions(AccountUtil.userName!!, 200, continuations[Constants.commonsWikiSite])
                 .subscribeOn(Schedulers.io())
                 .flatMap { response ->
                     val contributions = mutableListOf<Contribution>()
                     val cont = response.continuation?.ucContinuation
                     if (cont.isNullOrEmpty()) {
-                        continuations.remove(WikiSite(Service.COMMONS_URL))
+                        continuations.remove(Constants.commonsWikiSite)
                     } else {
-                        continuations[WikiSite(Service.COMMONS_URL)] = cont
+                        continuations[Constants.commonsWikiSite] = cont
                     }
                     response.query?.userContributions?.forEach { contribution ->
                         var contributionLanguage = WikipediaApp.getInstance().appOrSystemLanguageCode
@@ -479,10 +479,10 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                             L.e(t)
                         }))
             } else if (contribution.editType == EDIT_TYPE_IMAGE_CAPTION || contribution.editType == EDIT_TYPE_IMAGE_TAG) {
-                disposables.add(Observable.zip(ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(contribution.apiTitle,
+                disposables.add(Observable.zip(ServiceFactory.get(Constants.commonsWikiSite).getImageInfo(contribution.apiTitle,
                     contribution.wikiSite.languageCode).subscribeOn(Schedulers.io()),
                     if (contribution.qNumber.isEmpty()) Observable.just(contribution.qNumber) else (
-                            ServiceFactory.get(WikiSite(Service.WIKIDATA_URL))
+                            ServiceFactory.get(Constants.wikidataWikiSite)
                                 .getWikidataEntityTerms(contribution.qNumber, contribution.wikiSite.languageCode)
                                 .subscribeOn(Schedulers.io())
                                 .flatMap { response ->

--- a/app/src/main/java/org/wikipedia/userprofile/UserContributionsStats.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/UserContributionsStats.kt
@@ -3,8 +3,8 @@ package org.wikipedia.userprofile
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import org.wikipedia.Constants
 import org.wikipedia.auth.AccountUtil
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
@@ -27,7 +27,7 @@ object UserContributionsStats {
     var totalImageTagEdits: Int = 0
 
     fun getEditCountsObservable(): Observable<MwQueryResponse> {
-        return ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).editorTaskCounts
+        return ServiceFactory.get(Constants.wikidataWikiSite).editorTaskCounts
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .doOnNext {
@@ -44,7 +44,7 @@ object UserContributionsStats {
     }
 
     fun getPageViewsObservable(): Observable<Long> {
-        return ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).getUserContributions(AccountUtil.userName!!, 10, null)
+        return ServiceFactory.get(Constants.wikidataWikiSite).getUserContributions(AccountUtil.userName!!, 10, null)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .flatMap { response ->
@@ -64,10 +64,10 @@ object UserContributionsStats {
                 continue
             }
 
-            qLangMap.getOrPut(userContribution.title, { HashSet() }).add(descLang)
+            qLangMap.getOrPut(userContribution.title) { HashSet() }.add(descLang)
         }
 
-        return ServiceFactory.get(WikiSite(Service.WIKIDATA_URL)).getWikidataLabelsAndDescriptions(qLangMap.keys.joinToString("|"))
+        return ServiceFactory.get(Constants.wikidataWikiSite).getWikidataLabelsAndDescriptions(qLangMap.keys.joinToString("|"))
                 .subscribeOn(Schedulers.io())
                 .flatMap { entities ->
                     if (entities.entities.isEmpty()) {
@@ -80,7 +80,7 @@ object UserContributionsStats {
                                 for (lang in langs) {
                                     val dbName = WikiSite.forLanguageCode(lang).dbName()
                                     if (entity.sitelinks.containsKey(dbName)) {
-                                        langArticleMap.getOrPut(lang, { ArrayList() })
+                                        langArticleMap.getOrPut(lang) { ArrayList() }
                                                 .add(entity.sitelinks[dbName]?.title!!)
                                     }
                                 }

--- a/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/ImagePreviewDialog.kt
@@ -13,12 +13,11 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.commons.ImageTagsProvider
 import org.wikipedia.databinding.DialogImagePreviewBinding
-import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.descriptions.DescriptionEditActivity.Action
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
@@ -81,7 +80,7 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
         var thumbnailWidth = 0
         var thumbnailHeight = 0
 
-        disposables.add(ServiceFactory.get(WikiSite(Service.COMMONS_URL)).getImageInfo(pageSummaryForEdit.title, pageSummaryForEdit.lang)
+        disposables.add(ServiceFactory.get(Constants.commonsWikiSite).getImageInfo(pageSummaryForEdit.title, pageSummaryForEdit.lang)
                 .subscribeOn(Schedulers.io())
                 .flatMap {
                     if (it.query?.firstPage()?.imageInfo() == null) {


### PR DESCRIPTION
There are a ton of places where we create new instances of `WikiSite` objects for Commons and Wikidata, when in fact these objects only need to be created once. The instantiation of `WikiSite` is actually a bit heavy, with text parsing and additional logic, so this is an optimization that could add up performance-wise.