### PR TITLE
Even further optimize edit history filter and search.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -35,12 +35,14 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
         private set
     var currentQuery = ""
 
+    var editHistorySource: EditHistoryPagingSource? = null
     private val cachedRevisions = mutableListOf<MwQueryPage.Revision>()
     private var cachedContinueKey: String? = null
 
-    val editHistoryFlow = Pager(PagingConfig(pageSize = 50)) {
-        EditHistoryPagingSource(pageTitle)
-    }.flow.map { pagingData ->
+    val editHistoryFlow = Pager(PagingConfig(pageSize = 50), pagingSourceFactory = {
+        editHistorySource = EditHistoryPagingSource(pageTitle)
+        editHistorySource!!
+    }).flow.map { pagingData ->
         val anonEditsOnly = Prefs.editHistoryFilterType == EditCount.EDIT_TYPE_ANONYMOUS
         val userEditsOnly = Prefs.editHistoryFilterType == EditCount.EDIT_TYPE_EDITORS
 


### PR DESCRIPTION
@cooltey  I think this might be an even better solution:

* Change our local cache back to a simple list, instead of a map of lists.
* The real performance issue was actually in the Adapter. Nothing in the ViewModel is very expensive. Even if we keep 10000 items in our cache, and perform the filtering on all those items, that's not expensive. The heavy part actually happens in the Adapter on the Activity side. When we call `refresh()` on the adapter, it actually keeps all the current items in it! And when it receives an updated "page" of items, it checks whether each item is "the same" as every other item currently in the adapter, which becomes a O(n²) operation.