### PR TITLE
Fix deserialization of pageId.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.kt
@@ -28,7 +28,7 @@ open class PageSummary(
     @SerialName("description_source") val descriptionSource: String = "",
     @Serializable(with = LocationSerializer::class) val geo: Location? = null,
     val type: String = TYPE_STANDARD,
-    val pageId: Int = 0,
+    @SerialName("pageid") val pageId: Int = 0,
     val revision: Long = 0L,
     val timestamp: String = "",
     val views: Long = 0,


### PR DESCRIPTION
@sharvaniharan When you converted the PageSummary class to Kotlin in #2627, the `pageId` field was not converted correctly.
It's gone undetected for so long because we haven't actually needed it until now.