### PR TITLE
Fix: update talk page pageTitle after changing the language

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -145,6 +145,8 @@ class TalkTopicsActivity : BaseActivity() {
 
                     pageTitle = PageTitle(newNamespace, StringUtil.removeNamespace(pageTitle.prefixedText),
                             WikiSite.forLanguageCode(WikipediaApp.getInstance().language().appLanguageCodes[pos]))
+
+                    talkTopicsProvider = TalkTopicsProvider(pageTitle)
                     loadTopics()
                 }
             }


### PR DESCRIPTION
Make sure to create a new `TalkTopicsProvider` after changing the language.