### PR TITLE
Fix behavior of article overflow menu in split-screen mode.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/PageActionOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/PageActionOverflowView.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.PopupWindow
+import androidx.core.view.doOnDetach
 import androidx.core.widget.PopupWindowCompat
 import com.google.android.material.textview.MaterialTextView
 import org.wikipedia.R
@@ -74,6 +75,10 @@ class PageActionOverflowView(context: Context) : FrameLayout(context) {
                     view.visibility = if (enabled) VISIBLE else GONE
                 }
             }
+        }
+
+        anchorView.doOnDetach {
+            dismissPopupWindowHost()
         }
     }
 

--- a/app/src/main/res/layout/view_page_action_overflow.xml
+++ b/app/src/main/res/layout/view_page_action_overflow.xml
@@ -9,22 +9,28 @@
     android:layout_marginEnd="2dp"
     app:cardUseCompatPadding="true">
 
-    <LinearLayout
-        android:id="@+id/overflowList"
+    <ScrollView
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="?attr/paper_color"
-        android:minWidth="180dp"
-        android:orientation="vertical">
+        android:layout_height="wrap_content">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/overflow_forward"
-            style="@style/OverflowMenuItem"
-            android:drawablePadding="16dp"
-            android:text="@string/nav_item_forward"
-            app:drawableStartCompat="@drawable/ic_arrow_forward_black_24dp"
-            app:drawableTint="?attr/material_theme_secondary_color" />
+        <LinearLayout
+            android:id="@+id/overflowList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/paper_color"
+            android:minWidth="180dp"
+            android:orientation="vertical">
 
-    </LinearLayout>
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/overflow_forward"
+                style="@style/OverflowMenuItem"
+                android:drawablePadding="16dp"
+                android:text="@string/nav_item_forward"
+                app:drawableStartCompat="@drawable/ic_arrow_forward_black_24dp"
+                app:drawableTint="?attr/material_theme_secondary_color" />
+
+        </LinearLayout>
+
+    </ScrollView>
 
 </org.wikipedia.views.WikiCardView>


### PR DESCRIPTION
* Automatically dismiss the menu if the screen configuration changes.
* Put the menu in a ScrollView, so that all options are accessible on a very narrow viewport.

https://phabricator.wikimedia.org/T305346
