### PR TITLE
Prevent possible crash when highlighting text for editing.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -307,7 +307,11 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
 
     fun setHighlightText(text: String?) {
         if (text != null && originalDescription != null) {
-            postDelayed({ StringUtil.highlightEditText(binding.viewDescriptionEditText, originalDescription!!, text) }, 500)
+            postDelayed({
+                if (isAttachedToWindow) {
+                    StringUtil.highlightEditText(binding.viewDescriptionEditText, originalDescription!!, text)
+                }
+            }, 500)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -615,7 +615,9 @@ class EditSectionActivity : BaseActivity() {
         binding.editSectionText.post {
             binding.editSectionScroll.fullScroll(View.FOCUS_DOWN)
             binding.editSectionText.postDelayed(500) {
-                StringUtil.highlightEditText(binding.editSectionText, sectionWikitext!!, highlightText)
+                if (!isDestroyed) {
+                    StringUtil.highlightEditText(binding.editSectionText, sectionWikitext!!, highlightText)
+                }
             }
         }
     }


### PR DESCRIPTION
Whenever a `postDelayed` is performed, the result must always check if the current context still exists.