### PR TITLE
Disable flaky test of EventPlatformClient.

### DIFF
--- a/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.kt
+++ b/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.kt
@@ -181,8 +181,8 @@ class EventPlatformClientTest {
         )
     }
 
+    @Ignore("Disabled because of flakiness on CI systems, and only marginally useful.")
     @Test
-    @Throws(IOException::class)
     fun testStreamConfigMapSerializationDeserialization() {
         val originalStreamConfigs = JsonUtil.decodeFromString<MwStreamConfigsResponse>(TestFileUtil.readRawFile(STREAM_CONFIGS_RESPONSE))!!.streamConfigs
         Prefs.streamConfigs = originalStreamConfigs

--- a/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.kt
+++ b/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.kt
@@ -16,7 +16,6 @@ import org.wikipedia.dataclient.mwapi.MwStreamConfigsResponse
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.settings.Prefs
 import org.wikipedia.test.TestFileUtil
-import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
 class EventPlatformClientTest {


### PR DESCRIPTION
I'm tired of this test failing randomly during our CI runs.
The test itself is not particularly useful -- it's basically testing whether `kotlinx.serialization` is working properly, which we know it does, and it's tested implicitly everywhere else in the app.