### PR TITLE
Fix updating of reading lists after renaming.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
@@ -233,10 +233,8 @@ class ReadingListsFragment : Fragment(), SortReadingListsDialog.Callback, Readin
                     if (displayedLists.size <= oldItemPosition || lists.size <= newItemPosition) {
                         return false
                     }
-                    return (displayedLists[oldItemPosition] is ReadingList && lists[newItemPosition] is ReadingList &&
-                            (displayedLists[oldItemPosition] as ReadingList).id == (lists[newItemPosition] as ReadingList).id &&
-                            (displayedLists[oldItemPosition] as ReadingList).pages.size == (lists[newItemPosition] as ReadingList).pages.size &&
-                            (displayedLists[oldItemPosition] as ReadingList).numPagesOffline == (lists[newItemPosition] as ReadingList).numPagesOffline)
+                    return (displayedLists[oldItemPosition] is ReadingList &&
+                            (displayedLists[oldItemPosition] as ReadingList).compareTo(lists[newItemPosition]))
                 }
             })
             // If the number of lists has changed, just invalidate everything, as a

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingList.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingList.kt
@@ -53,6 +53,15 @@ class ReadingList(
         atime = System.currentTimeMillis()
     }
 
+    fun compareTo(other: Any): Boolean {
+        return (other is ReadingList &&
+                id == other.id &&
+                pages.size == other.pages.size &&
+                numPagesOffline == numPagesOffline &&
+                title == other.title &&
+                description == other.description)
+    }
+
     companion object {
         const val SORT_BY_NAME_ASC = 0
         const val SORT_BY_NAME_DESC = 1


### PR DESCRIPTION
The diffing callback wasn't taking into account changes to the lists' name or description.

https://phabricator.wikimedia.org/T305555