### PR TITLE
Follow-up to Edit History

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -308,8 +308,7 @@
 
         <activity
             android:name=".page.edithistory.EditHistoryListActivity"
-            android:theme="@style/AppTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize" />
+            android:theme="@style/AppTheme" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -33,6 +33,7 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
     var selectedRevisionTo: MwQueryPage.Revision? = null
         private set
     var currentQuery = ""
+    var actionModeActive = false
 
     var editHistorySource: EditHistoryPagingSource? = null
     private val cachedRevisions = mutableListOf<MwQueryPage.Revision>()

--- a/app/src/main/java/org/wikipedia/views/SearchAndFilterActionProvider.kt
+++ b/app/src/main/java/org/wikipedia/views/SearchAndFilterActionProvider.kt
@@ -84,4 +84,8 @@ class SearchAndFilterActionProvider(context: Context,
                 ColorStateList.valueOf(ResourceUtil.getThemedColor(context, R.attr.colorAccent)))
         }
     }
+
+    fun setQueryText(text: String?) {
+        binding.searchInput.setQuery(text, false)
+    }
 }


### PR DESCRIPTION
@cooltey A few notes:

* We should try to never resort to using `configChanges` flags in our activities. I assume you added it to preserve the ActionMode state, but this should now be done in the ViewModel.
* Ideally the `ViewHolder` of an adapter should not be accessed from a different adapter, because it might not have been created yet (due to Activity re-creation), and if we really need to access it, it should be guarded by a null check.