### PR TITLE
Improve parsing of ISO 8601 dates.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/DateUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.kt
@@ -22,7 +22,7 @@ object DateUtil {
 
     @Synchronized
     fun iso8601DateParse(date: String): Date {
-        return getCachedDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT, true).parse(date)!!
+        return getCachedDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT, true).parse(date)!!
     }
 
     @Synchronized

--- a/app/src/test/java/org/wikipedia/util/DateUtilTest.kt
+++ b/app/src/test/java/org/wikipedia/util/DateUtilTest.kt
@@ -24,6 +24,7 @@ class DateUtilTest {
     @Throws(Throwable::class)
     fun testIso8601Identity() {
         MatcherAssert.assertThat(DateUtil.iso8601DateFormat(DateUtil.iso8601DateParse("2017-05-25T21:13:47Z")), Matchers.`is`("2017-05-25T21:13:47Z"))
+        MatcherAssert.assertThat(DateUtil.iso8601DateFormat(DateUtil.iso8601DateParse("2017-05-25T21:13:47.000Z")), Matchers.`is`("2017-05-25T21:13:47Z"))
     }
 
     companion object {


### PR DESCRIPTION
The timestamps returned by the new Talk API are formatted as ISO 8601, with millisecond resolution, e.g. `2022-04-26T11:13:47.000Z`, which is not handled correctly by our date parsing.
This simplifies the parsing pattern to allow all variations of ISO 8601 time.