### PR TITLE
Follow-up to EditHistory analytics (properly get pageId)

### DIFF
--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -60,8 +60,6 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
 
         binding.diffRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         FeedbackUtil.setButtonLongPressToast(binding.newerIdButton, binding.olderIdButton)
-        editHistoryInteractionEvent = EditHistoryInteractionEvent(viewModel.pageTitle.wikiSite.dbName(), -1)
-        editHistoryInteractionEvent?.logRevision()
         return binding.root
     }
 
@@ -75,8 +73,12 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
 
         viewModel.watchedStatus.observe(viewLifecycleOwner) {
             if (it is Resource.Success) {
-                isWatched = it.data.query?.firstPage()?.watched ?: false
-                hasWatchlistExpiry = it.data.query?.firstPage()?.hasWatchlistExpiry() ?: false
+                if (editHistoryInteractionEvent == null) {
+                    editHistoryInteractionEvent = EditHistoryInteractionEvent(viewModel.pageTitle.wikiSite.dbName(), viewModel.pageId)
+                    editHistoryInteractionEvent?.logRevision()
+                }
+                isWatched = it.data.watched
+                hasWatchlistExpiry = it.data.hasWatchlistExpiry()
             } else if (it is Resource.Error) {
                 setErrorState(it.throwable)
             }

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -10,7 +10,6 @@ import org.wikipedia.analytics.WatchlistFunnel
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
-import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.dataclient.restbase.DiffResponse
 import org.wikipedia.dataclient.watch.WatchPostResponse
 import org.wikipedia.dataclient.wikidata.EntityPostResponse
@@ -22,7 +21,7 @@ import org.wikipedia.watchlist.WatchlistExpiry
 
 class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
 
-    val watchedStatus = MutableLiveData<Resource<MwQueryResponse>>()
+    val watchedStatus = MutableLiveData<Resource<MwQueryPage>>()
     val revisionDetails = MutableLiveData<Resource<Unit>>()
     val diffText = MutableLiveData<Resource<DiffResponse>>()
     val thankStatus = SingleLiveData<Resource<EntityPostResponse>>()
@@ -31,6 +30,8 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
 
     var watchlistExpiryChanged = false
     var lastWatchExpiry = WatchlistExpiry.NEVER
+    var pageId = -1
+        private set
 
     val pageTitle = bundle.getParcelable<PageTitle>(ArticleEditDetailsActivity.EXTRA_ARTICLE_TITLE)!!
     var revisionToId = bundle.getLong(ArticleEditDetailsActivity.EXTRA_EDIT_REVISION_TO, -1)
@@ -46,16 +47,18 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
     private val watchlistFunnel = WatchlistFunnel()
 
     init {
-        getWatchedStatus()
+        getWatchedStatusAndPageId()
         getRevisionDetails(revisionToId, revisionFromId)
     }
 
-    private fun getWatchedStatus() {
+    private fun getWatchedStatusAndPageId() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             watchedStatus.postValue(Resource.Error(throwable))
         }) {
             withContext(Dispatchers.IO) {
-                watchedStatus.postValue(Resource.Success(ServiceFactory.get(pageTitle.wikiSite).getWatchedStatus(pageTitle.prefixedText)))
+                val page = ServiceFactory.get(pageTitle.wikiSite).getWatchedStatus(pageTitle.prefixedText).query?.firstPage()!!
+                pageId = page.pageId
+                watchedStatus.postValue(Resource.Success(page))
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -1427,7 +1427,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
         override fun onViewEditHistorySelected() {
             title?.run {
-                startActivity(EditHistoryListActivity.newIntent(requireContext(), this, model.page?.pageProperties?.pageId ?: -1))
+                startActivity(EditHistoryListActivity.newIntent(requireContext(), this))
             }
             articleInteractionEvent?.logEditHistoryClick()
         }

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -142,23 +142,24 @@ class EditHistoryListActivity : BaseActivity() {
 
         lifecycleScope.launchWhenCreated {
             viewModel.editHistoryStatsFlow.collectLatest {
+                if (editHistoryInteractionEvent == null) {
+                    editHistoryInteractionEvent = EditHistoryInteractionEvent(viewModel.pageTitle.wikiSite.dbName(), viewModel.pageId)
+                    editHistoryInteractionEvent?.logShowHistory()
+                }
                 editHistoryStatsAdapter.notifyItemChanged(0)
                 editHistorySearchBarAdapter.notifyItemChanged(0)
+            }
+        }
 
-                // Submit data after showing the stats and search bar.
-                lifecycleScope.launch {
-                    viewModel.editHistoryFlow.collectLatest {
-                        editHistoryListAdapter.submitData(it)
-                    }
-                }
+        lifecycleScope.launch {
+            viewModel.editHistoryFlow.collectLatest {
+                editHistoryListAdapter.submitData(it)
             }
         }
 
         if (viewModel.actionModeActive) {
             startSearchActionMode()
         }
-        editHistoryInteractionEvent = EditHistoryInteractionEvent(viewModel.pageTitle.wikiSite.dbName(), viewModel.pageId)
-        editHistoryInteractionEvent?.logShowHistory()
     }
 
     private fun updateCompareState() {
@@ -544,12 +545,10 @@ class EditHistoryListActivity : BaseActivity() {
         private const val VIEW_TYPE_SEPARATOR = 0
         private const val VIEW_TYPE_ITEM = 1
         const val INTENT_EXTRA_PAGE_TITLE = "pageTitle"
-        const val INTENT_EXTRA_PAGE_ID = "pageId"
 
-        fun newIntent(context: Context, pageTitle: PageTitle, pageId: Int = -1): Intent {
+        fun newIntent(context: Context, pageTitle: PageTitle): Intent {
             return Intent(context, EditHistoryListActivity::class.java)
                 .putExtra(FilePageActivity.INTENT_EXTRA_PAGE_TITLE, pageTitle)
-                .putExtra(INTENT_EXTRA_PAGE_ID, pageId)
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -26,7 +26,8 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
     val editHistoryStatsFlow = MutableStateFlow(EditHistoryItemModel())
 
     var pageTitle: PageTitle = bundle.getParcelable(EditHistoryListActivity.INTENT_EXTRA_PAGE_TITLE)!!
-    var pageId: Int = bundle.getInt(EditHistoryListActivity.INTENT_EXTRA_PAGE_ID)
+    var pageId = -1
+        private set
     var comparing = false
         private set
     var selectedRevisionFrom: MwQueryPage.Revision? = null
@@ -97,8 +98,11 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
                 val editCountsBotResponse = async { ServiceFactory.getCoreRest(pageTitle.wikiSite).getEditCount(pageTitle.prefixedText, EditCount.EDIT_TYPE_BOT) }
                 val articleMetricsResponse = async { ServiceFactory.getRest(WikiSite("wikimedia.org")).getArticleMetrics(pageTitle.wikiSite.authority(), pageTitle.prefixedText, lastYear, today) }
 
+                val page = mwResponse.await().query?.pages?.first()
+                pageId = page?.pageId ?: -1
+
                 editHistoryStatsFlow.value = EditHistoryStats(
-                    mwResponse.await().query?.pages?.first()?.revisions?.first()!!,
+                    page?.revisions?.first()!!,
                     articleMetricsResponse.await().firstItem.results,
                     editCountsResponse.await(),
                     editCountsUserResponse.await(),


### PR DESCRIPTION
@sharvaniharan 
* The EditHistory activity itself gets the `pageId` of the current page _for free_ from the API, so it doesn't need to be fed into the EditHistory activity by callers.
* Same for the EditDetails fragment.
* Since these activities get the `pageId` for free, why not include it in the Events that we send?