### PR TITLE
MEP: Factor out `is_anon` parameter into a base class.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/AppearanceSettingInteractionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/AppearanceSettingInteractionEvent.kt
@@ -3,7 +3,6 @@ package org.wikipedia.analytics.eventplatform
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.wikipedia.Constants.InvokeSource
-import org.wikipedia.auth.AccountUtil
 import org.wikipedia.theme.Theme
 
 class AppearanceSettingInteractionEvent(private val source: InvokeSource) {
@@ -25,14 +24,13 @@ class AppearanceSettingInteractionEvent(private val source: InvokeSource) {
     }
 
     private fun submitEvent(action: String, currentValue: String, newValue: String) {
-        EventPlatformClient.submit(AppearanceSettingInteractionEventImpl(action, !AccountUtil.isLoggedIn, currentValue, newValue, source.value))
+        EventPlatformClient.submit(AppearanceSettingInteractionEventImpl(action, currentValue, newValue, source.value))
     }
 
     @Suppress("unused")
     @Serializable
     @SerialName("/analytics/mobile_apps/android_app_appearance_settings_interaction/1.0.0")
     class AppearanceSettingInteractionEventImpl(private val action: String,
-                                                @SerialName("is_anon") private val isAnon: Boolean,
                                                 @SerialName("current_value") private val currentValue: String,
                                                 @SerialName("new_value") private val newValue: String,
                                                 private val source: String) :

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/ArticleFindInPageInteractionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/ArticleFindInPageInteractionEvent.kt
@@ -2,7 +2,6 @@ package org.wikipedia.analytics.eventplatform
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.wikipedia.auth.AccountUtil
 
 class ArticleFindInPageInteractionEvent(private val wikiDb: String, private val pageId: Int) :
     TimedEvent() {
@@ -21,14 +20,13 @@ class ArticleFindInPageInteractionEvent(private val wikiDb: String, private val 
     }
 
     fun logDone() {
-        EventPlatformClient.submit(ArticleFindInPageInteractionEventImpl(!AccountUtil.isLoggedIn, wikiDb, pageId, findText, numFindNext, numFindPrev, pageHeight, duration))
+        EventPlatformClient.submit(ArticleFindInPageInteractionEventImpl(wikiDb, pageId, findText, numFindNext, numFindPrev, pageHeight, duration))
     }
 
     @Suppress("unused")
     @Serializable
     @SerialName("/analytics/mobile_apps/android_find_in_page_interaction/1.0.0")
-    class ArticleFindInPageInteractionEventImpl(@SerialName("is_anon") private val isAnon: Boolean,
-                                                @SerialName("wiki_db") private val wikiDb: String,
+    class ArticleFindInPageInteractionEventImpl(@SerialName("wiki_db") private val wikiDb: String,
                                                 @SerialName("page_id") private val pageId: Int,
                                                 @SerialName("find_text") private val findText: String,
                                                 @SerialName("find_next_clicks_count") private val findNextClicksCount: Int,

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/ArticleInteractionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/ArticleInteractionEvent.kt
@@ -2,7 +2,6 @@ package org.wikipedia.analytics.eventplatform
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.wikipedia.auth.AccountUtil
 
 class ArticleInteractionEvent(private val wikiDb: String, private val pageId: Int) : TimedEvent() {
 
@@ -99,16 +98,15 @@ class ArticleInteractionEvent(private val wikiDb: String, private val pageId: In
     }
 
     private fun submitEvent(action: String) {
-        EventPlatformClient.submit(ArticleInteractionEventImpl(!AccountUtil.isLoggedIn, duration, wikiDb, pageId, action))
+        EventPlatformClient.submit(ArticleInteractionEventImpl(duration, wikiDb, pageId, action))
     }
 
     @Suppress("unused")
     @Serializable
     @SerialName("/analytics/mobile_apps/android_article_toolbar_interaction/1.0.0")
-    class ArticleInteractionEventImpl(@SerialName("is_anon") private val isAnon: Boolean,
-                                      @SerialName("time_spent_ms") private val timeSpentMs: Int,
+    class ArticleInteractionEventImpl(@SerialName("time_spent_ms") private val timeSpentMs: Int,
                                       @SerialName("wiki_db") private val wikiDb: String,
                                       @SerialName("page_id") private val pageId: Int,
                                       private val action: String) :
-        MobileAppsEvent("android.article_toolbar_interaction")
+        MobileAppsEventBase("android.article_toolbar_interaction")
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/ArticleLinkPreviewInteractionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/ArticleLinkPreviewInteractionEvent.kt
@@ -2,7 +2,6 @@ package org.wikipedia.analytics.eventplatform
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.wikipedia.auth.AccountUtil
 import org.wikipedia.settings.Prefs
 
 class ArticleLinkPreviewInteractionEvent(private val wikiDb: String,
@@ -22,7 +21,7 @@ class ArticleLinkPreviewInteractionEvent(private val wikiDb: String,
     }
 
     private fun submitEvent(action: String) {
-        EventPlatformClient.submit(ArticleLinkPreviewInteractionEventImpl(action, source, !AccountUtil.isLoggedIn, duration, wikiDb, pageId, PROD_LINK_PREVIEW_VERSION))
+        EventPlatformClient.submit(ArticleLinkPreviewInteractionEventImpl(action, source, duration, wikiDb, pageId, PROD_LINK_PREVIEW_VERSION))
     }
 
     @Suppress("unused")
@@ -30,7 +29,6 @@ class ArticleLinkPreviewInteractionEvent(private val wikiDb: String,
     @SerialName("/analytics/mobile_apps/android_article_link_preview_interaction/1.0.0")
     class ArticleLinkPreviewInteractionEventImpl(private val action: String,
                                                  private val source: Int,
-                                                 @SerialName("is_anon") private val isAnon: Boolean,
                                                  @SerialName("time_spent_ms") private val timeSpentMs: Int,
                                                  @SerialName("wiki_db") private val wikiDb: String,
                                                  @SerialName("page_id") private val pageId: Int,

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/ArticleTocInteractionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/ArticleTocInteractionEvent.kt
@@ -2,7 +2,6 @@ package org.wikipedia.analytics.eventplatform
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.wikipedia.auth.AccountUtil
 import java.util.concurrent.TimeUnit
 
 class ArticleTocInteractionEvent(private val pageId: Int,
@@ -36,14 +35,13 @@ class ArticleTocInteractionEvent(private val pageId: Int,
         if (numSections == 0 || numOpens == 0) {
             return
         }
-        EventPlatformClient.submit(ArticleTocInteractionEventImpl(!AccountUtil.isLoggedIn, wikiDb, pageId, numOpens, numSectionClicks, totalOpenedSec, numSections))
+        EventPlatformClient.submit(ArticleTocInteractionEventImpl(wikiDb, pageId, numOpens, numSectionClicks, totalOpenedSec, numSections))
     }
 
     @Suppress("unused")
     @Serializable
     @SerialName("/analytics/mobile_apps/android_article_toc_interaction/1.0.0")
-    class ArticleTocInteractionEventImpl(@SerialName("is_anon") private val isAnon: Boolean,
-                                         @SerialName("wiki_db") private val wikiDb: String,
+    class ArticleTocInteractionEventImpl(@SerialName("wiki_db") private val wikiDb: String,
                                          @SerialName("page_id") private val pageId: Int,
                                          @SerialName("num_opens") private val numberOfOpens: Int,
                                          @SerialName("num_section_clicks") private val numberOfSectionClicks: Int,

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/CustomizeToolbarEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/CustomizeToolbarEvent.kt
@@ -3,7 +3,6 @@ package org.wikipedia.analytics.eventplatform
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.wikipedia.Constants.InvokeSource
-import org.wikipedia.auth.AccountUtil
 import org.wikipedia.page.action.PageActionItem
 import org.wikipedia.settings.Prefs
 
@@ -11,7 +10,6 @@ class CustomizeToolbarEvent : TimedEvent() {
 
     fun logCustomization(favoritesOrder: List<Int>, menuOrder: List<Int>) {
         EventPlatformClient.submit(CustomizeToolbarEventImpl(
-                !AccountUtil.isLoggedIn,
                 Prefs.readingFocusModeEnabled,
                 favoritesOrder,
                 menuOrder,
@@ -25,7 +23,6 @@ class CustomizeToolbarEvent : TimedEvent() {
     @Serializable
     @SerialName("/analytics/mobile_apps/android_customize_toolbar_interaction/1.0.0")
     class CustomizeToolbarEventImpl(
-        @SerialName("is_anon") private val isAnon: Boolean,
         @SerialName("is_rfm_enabled") private val isRfmEnabled: Boolean,
         @SerialName("favorites_order") private val favoritesOrder: List<Int>,
         @SerialName("menu_order") private val menuOrder: List<Int>,

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/DailyStatsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/DailyStatsEvent.kt
@@ -5,21 +5,19 @@ import android.content.pm.PackageManager
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.wikipedia.WikipediaApp
-import org.wikipedia.auth.AccountUtil
 import java.util.concurrent.TimeUnit
 
 @Suppress("unused")
 @Serializable
 @SerialName("/analytics/mobile_apps/android_daily_stats/1.0.0")
 class DailyStatsEvent(private val app_install_age_in_days: Long,
-                      private val languages: List<String>,
-                      private val is_anon: Boolean) : MobileAppsEvent(STREAM_NAME) {
+                      private val languages: List<String>) : MobileAppsEvent(STREAM_NAME) {
 
     companion object {
         private const val STREAM_NAME = "android.daily_stats"
 
         fun log(app: WikipediaApp) {
-            EventPlatformClient.submit(DailyStatsEvent(getInstallAgeDays(app), app.language().appLanguageCodes, !AccountUtil.isLoggedIn))
+            EventPlatformClient.submit(DailyStatsEvent(getInstallAgeDays(app), app.language().appLanguageCodes))
         }
 
         private fun getInstallAgeDays(context: Context): Long {

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EditHistoryInteractionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EditHistoryInteractionEvent.kt
@@ -2,7 +2,6 @@ package org.wikipedia.analytics.eventplatform
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.wikipedia.auth.AccountUtil
 
 class EditHistoryInteractionEvent(private val wikiDb: String, private val pageId: Int) :
     TimedEvent() {
@@ -90,14 +89,13 @@ class EditHistoryInteractionEvent(private val wikiDb: String, private val pageId
     }
 
     private fun submitEvent(action: String) {
-        EventPlatformClient.submit(EditHistoryInteractionEventImpl(!AccountUtil.isLoggedIn, duration, wikiDb, pageId, action))
+        EventPlatformClient.submit(EditHistoryInteractionEventImpl(duration, wikiDb, pageId, action))
     }
 
     @Suppress("unused")
     @Serializable
     @SerialName("/analytics/mobile_apps/android_edit_history_interaction/1.0.0")
-    class EditHistoryInteractionEventImpl(@SerialName("is_anon") private val isAnon: Boolean,
-                                      @SerialName("time_spent_ms") private val timeSpentMs: Int,
+    class EditHistoryInteractionEventImpl(@SerialName("time_spent_ms") private val timeSpentMs: Int,
                                       @SerialName("wiki_db") private val wikiDb: String,
                                       @SerialName("page_id") private val pageId: Int,
                                       private val action: String) :

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/Event.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/Event.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.analytics.eventplatform
 
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import org.wikipedia.util.DateUtil
@@ -7,18 +8,13 @@ import java.util.*
 
 // Base class for an Event Platform event.
 // This class MUST be `sealed` for Serialization polymorphism to work automatically.
+@Suppress("unused")
 @Serializable
 sealed class Event(@Transient val stream: String = "") {
 
     private val meta = Meta(stream)
-    private val dt: String
-
-    init {
-        // Note: DO NOT join the declaration of these fields with the assignment. This seems to be
-        // necessary for polymorphic serialization.
-        dt = DateUtil.iso8601DateFormat(Date())
-    }
+    @Required private val dt = DateUtil.iso8601DateFormat(Date())
 
     @Serializable
-    private class Meta(val stream: String)
+    private class Meta(@Required val stream: String)
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/Event.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/Event.kt
@@ -2,15 +2,22 @@ package org.wikipedia.analytics.eventplatform
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import org.wikipedia.util.DateUtil
+import java.util.*
 
 // Base class for an Event Platform event.
 // This class MUST be `sealed` for Serialization polymorphism to work automatically.
 @Serializable
 sealed class Event(@Transient val stream: String = "") {
 
-    private val meta: Meta = Meta(stream)
+    private val meta = Meta(stream)
+    private val dt: String
 
-    var dt: String? = null
+    init {
+        // Note: DO NOT join the declaration of these fields with the assignment. This seems to be
+        // necessary for polymorphic serialization.
+        dt = DateUtil.iso8601DateFormat(Date())
+    }
 
     @Serializable
     private class Meta(val stream: String)

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -104,7 +104,7 @@ object EventPlatformClient {
          * If another item is added to QUEUE during this time, reset the countdown.
          */
         private const val WAIT_MS = 30000
-        private const val MAX_QUEUE_SIZE = 1
+        private const val MAX_QUEUE_SIZE = 64
         private val SEND_RUNNABLE = Runnable { sendAllScheduled() }
 
         @Synchronized

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -7,7 +7,6 @@ import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.okhttp.HttpStatusException
 import org.wikipedia.settings.Prefs
-import org.wikipedia.util.DateUtil
 import org.wikipedia.util.log.L
 import java.net.HttpURLConnection
 import java.util.*
@@ -62,25 +61,7 @@ object EventPlatformClient {
         if (!SamplingController.isInSample(event)) {
             return
         }
-        addEventMetadata(event)
         OutputBuffer.schedule(event)
-    }
-
-    /**
-     * Supplement the outgoing event with additional metadata, if not already present.
-     * These include:
-     * - dt: ISO 8601 timestamp
-     * - app_session_id: the current session ID
-     * - app_install_id: app install ID
-     *
-     * @param event event
-     */
-    fun addEventMetadata(event: Event) {
-        if (event is MobileAppsEvent) {
-            event.sessionId = AssociationController.sessionId
-            event.appInstallId = Prefs.appInstallId
-        }
-        event.dt = DateUtil.iso8601DateFormat(Date())
     }
 
     fun flushCachedEvents() {
@@ -123,7 +104,7 @@ object EventPlatformClient {
          * If another item is added to QUEUE during this time, reset the countdown.
          */
         private const val WAIT_MS = 30000
-        private const val MAX_QUEUE_SIZE = 64
+        private const val MAX_QUEUE_SIZE = 1
         private val SEND_RUNNABLE = Runnable { sendAllScheduled() }
 
         @Synchronized

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MobileAppsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MobileAppsEvent.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.analytics.eventplatform
 
+import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -8,11 +9,6 @@ import org.wikipedia.auth.AccountUtil
 @Suppress("unused")
 @Serializable
 sealed class MobileAppsEvent(@Transient private val _streamName: String = "") : MobileAppsEventBase(_streamName) {
-    @SerialName("is_anon") private val anon: Boolean
 
-    init {
-        // Note: DO NOT join the declaration of these fields with the assignment. This seems to be
-        // necessary for polymorphic serialization.
-        anon = !AccountUtil.isLoggedIn
-    }
+    @SerialName("is_anon") @Required private val anon = !AccountUtil.isLoggedIn
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MobileAppsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MobileAppsEvent.kt
@@ -3,13 +3,16 @@ package org.wikipedia.analytics.eventplatform
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import org.wikipedia.auth.AccountUtil
 
+@Suppress("unused")
 @Serializable
-sealed class MobileAppsEvent(@Transient val streamName: String = "") : Event(streamName) {
+sealed class MobileAppsEvent(@Transient private val _streamName: String = "") : MobileAppsEventBase(_streamName) {
+    @SerialName("is_anon") private val anon: Boolean
 
-    @SerialName("app_session_id")
-    var sessionId: String? = null
-
-    @SerialName("app_install_id")
-    var appInstallId: String? = null
+    init {
+        // Note: DO NOT join the declaration of these fields with the assignment. This seems to be
+        // necessary for polymorphic serialization.
+        anon = !AccountUtil.isLoggedIn
+    }
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MobileAppsEventBase.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MobileAppsEventBase.kt
@@ -1,0 +1,20 @@
+package org.wikipedia.analytics.eventplatform
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import org.wikipedia.settings.Prefs
+
+@Serializable
+sealed class MobileAppsEventBase(@Transient private val streamName: String = "") : Event(streamName) {
+
+    @SerialName("app_session_id") private val sessionId: String
+    @SerialName("app_install_id") private val appInstallId: String
+
+    init {
+        // Note: DO NOT join the declaration of these fields with the assignment. This seems to be
+        // necessary for polymorphic serialization.
+        sessionId = EventPlatformClient.AssociationController.sessionId
+        appInstallId = Prefs.appInstallId.orEmpty()
+    }
+}

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MobileAppsEventBase.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MobileAppsEventBase.kt
@@ -1,20 +1,15 @@
 package org.wikipedia.analytics.eventplatform
 
+import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import org.wikipedia.settings.Prefs
 
+@Suppress("unused")
 @Serializable
 sealed class MobileAppsEventBase(@Transient private val streamName: String = "") : Event(streamName) {
 
-    @SerialName("app_session_id") private val sessionId: String
-    @SerialName("app_install_id") private val appInstallId: String
-
-    init {
-        // Note: DO NOT join the declaration of these fields with the assignment. This seems to be
-        // necessary for polymorphic serialization.
-        sessionId = EventPlatformClient.AssociationController.sessionId
-        appInstallId = Prefs.appInstallId.orEmpty()
-    }
+    @SerialName("app_session_id") @Required private val sessionId = EventPlatformClient.AssociationController.sessionId
+    @SerialName("app_install_id") @Required private val appInstallId = Prefs.appInstallId.orEmpty()
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/NotificationInteractionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/NotificationInteractionEvent.kt
@@ -21,7 +21,7 @@ class NotificationInteractionEvent(
     private val selection_token: String,
     private val incoming_only: Boolean,
     private val device_level_enabled: Boolean
-) : MobileAppsEvent(STREAM_NAME) {
+) : MobileAppsEventBase(STREAM_NAME) {
 
     companion object {
         private const val STREAM_NAME = "android.notification_interaction"

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/TestAppsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/TestAppsEvent.kt
@@ -3,6 +3,6 @@ package org.wikipedia.analytics.eventplatform
 import kotlinx.serialization.Serializable
 
 @Serializable
-class TestAppsEvent : MobileAppsEvent {
+class TestAppsEvent : MobileAppsEventBase {
     constructor(_stream: String) : super(_stream)
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/UserContributionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/UserContributionEvent.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("/analytics/mobile_apps/android_user_contribution_screen/2.0.0")
-class UserContributionEvent(val action: String) : MobileAppsEvent(STREAM_NAME) {
+class UserContributionEvent(val action: String) : MobileAppsEventBase(STREAM_NAME) {
 
     companion object {
         private const val STREAM_NAME = "android.user_contribution_screen"

--- a/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.kt
+++ b/app/src/test/java/org/wikipedia/analytics/eventplatform/EventPlatformClientTest.kt
@@ -47,7 +47,6 @@ class EventPlatformClientTest {
     @Test
     fun testEventSerialization() {
         val event = TestAppsEvent("test")
-        EventPlatformClient.addEventMetadata(event)
         val serialized = JsonUtil.encodeToString(event)!!
         MatcherAssert.assertThat(serialized.contains("dt"), CoreMatchers.`is`(true))
         MatcherAssert.assertThat(serialized.contains("app_session_id"), CoreMatchers.`is`(true))


### PR DESCRIPTION
Using the magic of object-oriented programming™ we can create a base class that contains an `is_anon` parameter, and make child classes that inherit from it, so that we don't have to re-declare `is_anon` in every single class.

Additionally, the `sessionId`, `appInstallId`, and `dt` parameters can be initialized on instantiation, which simplifies the submission of events.
