### PR TITLE
Fix usage of pageId in EditHistory analytics.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -48,10 +48,7 @@ import org.wikipedia.richtext.RichTextUtil
 import org.wikipedia.settings.Prefs
 import org.wikipedia.staticdata.UserAliasData
 import org.wikipedia.talk.UserTalkPopupHelper
-import org.wikipedia.util.DateUtil
-import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.ResourceUtil
-import org.wikipedia.util.StringUtil
+import org.wikipedia.util.*
 import org.wikipedia.views.EditHistoryFilterOverflowView
 import org.wikipedia.views.EditHistoryStatsView
 import org.wikipedia.views.SearchAndFilterActionProvider
@@ -141,8 +138,8 @@ class EditHistoryListActivity : BaseActivity() {
             }
         }
 
-        lifecycleScope.launchWhenCreated {
-            viewModel.editHistoryStatsFlow.collectLatest {
+        viewModel.editHistoryStatsData.observe(this) {
+            if (it is Resource.Success) {
                 if (editHistoryInteractionEvent == null) {
                     editHistoryInteractionEvent = EditHistoryInteractionEvent(viewModel.pageTitle.wikiSite.dbName(), viewModel.pageId)
                     editHistoryInteractionEvent?.logShowHistory()
@@ -221,12 +218,12 @@ class EditHistoryListActivity : BaseActivity() {
 
     fun showFilterOverflowMenu() {
         editHistoryInteractionEvent?.logFilterClick()
-        val editCountsFlowValue = viewModel.editHistoryStatsFlow.value
-        if (editCountsFlowValue is EditHistoryListViewModel.EditHistoryStats) {
+        val editCountsValue = viewModel.editHistoryStatsData.value
+        if (editCountsValue is Resource.Success) {
             val anchorView = if (actionMode != null && searchActionModeCallback.searchAndFilterActionProvider != null)
                 searchActionModeCallback.searchBarFilterIcon!! else if (editHistorySearchBarAdapter.viewHolder != null)
                     editHistorySearchBarAdapter.viewHolder!!.binding.filterByButton else binding.root
-            EditHistoryFilterOverflowView(this@EditHistoryListActivity).show(anchorView, editCountsFlowValue) {
+            EditHistoryFilterOverflowView(this@EditHistoryListActivity).show(anchorView, editCountsValue.data) {
                 editHistoryInteractionEvent?.logFilterSelection(Prefs.editHistoryFilterType.ifEmpty { EditCount.EDIT_TYPE_ALL })
                 setupAdapters()
                 editHistoryListAdapter.reload()
@@ -350,9 +347,9 @@ class EditHistoryListActivity : BaseActivity() {
 
     private inner class StatsViewHolder constructor(private val view: EditHistoryStatsView) : RecyclerView.ViewHolder(view) {
         fun bindItem() {
-            val statsFlowValue = viewModel.editHistoryStatsFlow.value
-            if (statsFlowValue is EditHistoryListViewModel.EditHistoryStats) {
-                view.setup(viewModel.pageTitle, statsFlowValue)
+            val statsFlowValue = viewModel.editHistoryStatsData.value
+            if (statsFlowValue is Resource.Success) {
+                view.setup(viewModel.pageTitle, statsFlowValue.data)
             }
         }
     }
@@ -372,8 +369,8 @@ class EditHistoryListActivity : BaseActivity() {
         }
 
         fun bindItem() {
-            val editCountsFlowValue = viewModel.editHistoryStatsFlow.value
-            if (editCountsFlowValue is EditHistoryListViewModel.EditHistoryStats) {
+            val statsFlowValue = viewModel.editHistoryStatsData.value
+            if (statsFlowValue is Resource.Success) {
                 binding.root.setCardBackgroundColor(
                     ResourceUtil.getThemedColor(this@EditHistoryListActivity, R.attr.color_group_22)
                 )

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -1,12 +1,12 @@
 package org.wikipedia.page.edithistory
 
 import android.os.Bundle
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.paging.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
@@ -16,6 +16,7 @@ import org.wikipedia.dataclient.restbase.Metrics
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DateUtil
+import org.wikipedia.util.Resource
 import org.wikipedia.util.log.L
 import retrofit2.HttpException
 import java.io.IOException
@@ -23,7 +24,7 @@ import java.util.*
 
 class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
 
-    val editHistoryStatsFlow = MutableStateFlow(EditHistoryItemModel())
+    val editHistoryStatsData = MutableLiveData<Resource<EditHistoryStats>>()
 
     var pageTitle: PageTitle = bundle.getParcelable(EditHistoryListActivity.INTENT_EXTRA_PAGE_TITLE)!!
     var pageId = -1
@@ -101,14 +102,14 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
                 val page = mwResponse.await().query?.pages?.first()
                 pageId = page?.pageId ?: -1
 
-                editHistoryStatsFlow.value = EditHistoryStats(
+                editHistoryStatsData.postValue(Resource.Success(EditHistoryStats(
                     page?.revisions?.first()!!,
                     articleMetricsResponse.await().firstItem.results,
                     editCountsResponse.await(),
                     editCountsUserResponse.await(),
                     editCountsAnonResponse.await(),
                     editCountsBotResponse.await()
-                )
+                )))
             }
         }
     }


### PR DESCRIPTION
In the EditHistory activity, the `pageId` is being ascertained while gathering the stats, which produces a `Flow`. However, when the ViewModel is first initialized, the Flow emits an empty object which causes the analytics Event to be constructed before the `pageId` is initialized.
Let's turn the stats into a LiveData instead of Flow, which simplifies things a bit and ensures that the Event will get a valid `pageId`.