### PR TITLE
Error handling in FeedCoordinatorBase.kt.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedCoordinatorBase.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedCoordinatorBase.kt
@@ -181,7 +181,7 @@ abstract class FeedCoordinatorBase(private val context: Context) {
 
     private fun setOfflineState() {
         removeProgressCard()
-        appendCard(OfflineCard())
+        requestOfflineCard()
     }
 
     private fun removeAccessibilityCard() {


### PR DESCRIPTION
Use requestOfflineCard(),
instead of inserting the card unchecked with appendCard(),
to prevent duplication.

https://phabricator.wikimedia.org/T282388