### PR TITLE
200ms faster startup time + ANR fix

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -163,6 +163,10 @@ public class WikipediaApp extends Application {
         // For good measure, explicitly call our token subscription function, in case the
         // API failed in previous attempts.
         WikipediaFirebaseMessagingService.Companion.updateSubscription();
+
+        /*
+        Moving this code to a Runnable gains 100ms of app startup on a Moto G10.
+         */
         new Runnable() {
             @Override
             public void run() {

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -165,7 +165,7 @@ public class WikipediaApp extends Application {
         WikipediaFirebaseMessagingService.Companion.updateSubscription();
 
         /*
-        Moving this code to a Runnable gains 100ms of app startup on a Moto G10.
+        Moving this code to a Runnable gains 200ms of app startup on a Moto G10.
          */
         new Runnable() {
             @Override

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -44,6 +44,7 @@ import org.wikipedia.util.log.L;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.internal.functions.Functions;
@@ -167,12 +168,14 @@ public class WikipediaApp extends Application {
         /*
         Moving this code to a Runnable gains 200ms of app startup on a Moto G10.
          */
-        new Runnable() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 EventPlatformClient.INSTANCE.setUpStreamConfigs();
             }
-        };    }
+        };
+        Executors.newSingleThreadExecutor().execute(r);
+    }
 
     public int getVersionCode() {
         // Our ABI-specific version codes are structured in increments of 10000, so just

--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -163,8 +163,12 @@ public class WikipediaApp extends Application {
         // For good measure, explicitly call our token subscription function, in case the
         // API failed in previous attempts.
         WikipediaFirebaseMessagingService.Companion.updateSubscription();
-        EventPlatformClient.INSTANCE.setUpStreamConfigs();
-    }
+        new Runnable() {
+            @Override
+            public void run() {
+                EventPlatformClient.INSTANCE.setUpStreamConfigs();
+            }
+        };    }
 
     public int getVersionCode() {
         // Our ABI-specific version codes are structured in increments of 10000, so just

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.analytics.eventplatform
 
+import android.util.Log
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.BuildConfig
 import org.wikipedia.WikipediaApp

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -86,7 +86,7 @@ object EventPlatformClient {
     @Synchronized
     fun submit(event: Event) {
 
-        if (! areStreamConfigsReady) {
+        if (!areStreamConfigsReady) {
             submitQueue.add(event)
             return
         }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -136,6 +136,8 @@ object EventPlatformClient {
         STREAM_CONFIGS.clear()
         STREAM_CONFIGS.putAll(Prefs.streamConfigs)
         refreshStreamConfigs()
+        areStreamConfigsReady = true
+        processSubmitQueue()
     }
 
     /**

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.analytics.eventplatform
 
-import android.util.Log
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.BuildConfig
 import org.wikipedia.WikipediaApp


### PR DESCRIPTION
# About
We detected an ANR in the App startup due to a DiskRead. We analyzed the stack trace and found a potential speed up by moving an object initialization to a thread.


# Changes
- we moved EventPlatformClient.STREAM_CONFIGS setup to a thread
- we added non blocking code for the EventPlatformClient to keep working when STREAM_CONFIGS is not yet setup

# Improvements
- On a Moto G10, we got a 200 ms faster startup
- We removed a StrictMode.DiskReadViolation

# ANR Path Details
```
StrictMode policy violation; ~duration=94 ms: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1611)
	at libcore.io.BlockGuardOs.access(BlockGuardOs.java:71)
	at libcore.io.ForwardingOs.access(ForwardingOs.java:72)
	at android.app.ActivityThread$AndroidOs.access(ActivityThread.java:7679)
	at java.io.UnixFileSystem.checkAccess(UnixFileSystem.java:281)
	at java.io.File.exists(File.java:815)
	at android.app.ContextImpl.ensurePrivateDirExists(ContextImpl.java:686)
	at android.app.ContextImpl.ensurePrivateCacheDirExists(ContextImpl.java:682)
	at android.app.ContextImpl.getCacheDir(ContextImpl.java:793)
	at android.content.ContextWrapper.getCacheDir(ContextWrapper.java:293)
	at org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory.<clinit>(OkHttpConnectionFactory.kt:20)
	at org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory.getClient(OkHttpConnectionFactory.kt:21)
	at org.wikipedia.dataclient.ServiceFactory.createRetrofit(ServiceFactory.kt:81)
	at org.wikipedia.dataclient.ServiceFactory.access$createRetrofit(ServiceFactory.kt:20)
	at org.wikipedia.dataclient.ServiceFactory$special$$inlined$lruCache$default$1.create(LruCache.kt:54)
	at androidx.collection.LruCache.get(LruCache.java:104)
	at org.wikipedia.dataclient.ServiceFactory.get(ServiceFactory.kt:44)
	at org.wikipedia.analytics.eventplatform.EventPlatformClient.refreshStreamConfigs(EventPlatformClient.kt:91)
	at org.wikipedia.analytics.eventplatform.EventPlatformClient.setUpStreamConfigs(EventPlatformClient.kt:106)  200ms
	at org.wikipedia.WikipediaApp.onCreate(WikipediaApp.java:180)
	at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1192)
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6846)
	at android.app.ActivityThread.access$1400(ActivityThread.java:251)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1978)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loop(Looper.java:250)
	at android.app.ActivityThread.main(ActivityThread.java:7806)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:958)
```

# Tests
- We executed all tests (described [here](https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/Android/App_hacking))