### PR TITLE
Fix possible resource leaks from unsuccessful network responses.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/UnsuccessfulResponseInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/UnsuccessfulResponseInterceptor.kt
@@ -2,6 +2,7 @@ package org.wikipedia.dataclient.okhttp
 
 import okhttp3.Interceptor
 import okhttp3.Response
+import okhttp3.internal.closeQuietly
 import java.io.IOException
 
 class UnsuccessfulResponseInterceptor : Interceptor {
@@ -11,6 +12,9 @@ class UnsuccessfulResponseInterceptor : Interceptor {
         if (rsp.isSuccessful) {
             return rsp
         }
-        throw HttpStatusException(rsp)
+
+        val e = HttpStatusException(rsp)
+        rsp.closeQuietly()
+        throw e
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
@@ -2,6 +2,7 @@ package org.wikipedia.settings
 
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.internal.closeQuietly
 import org.json.JSONObject
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory.client
@@ -28,7 +29,7 @@ class RemoteConfigRefreshTask : RecurringTask() {
         } catch (e: Exception) {
             L.e(e)
         } finally {
-            response?.close()
+            response?.closeQuietly()
         }
     }
 


### PR DESCRIPTION
We have an Interceptor that checks the response code and _throws an exception_ if the code is a failure. This is OK to do, but it means that OkHttp internally might no longer have a chance to `close()` the response body.
We need to explicitly close the response ourselves, to make sure no resources are leaked.