### PR TITLE
Update RemoteConfig URL.

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
@@ -33,8 +33,7 @@ class RemoteConfigRefreshTask : RecurringTask() {
     }
 
     companion object {
-        // Switch over to production when it is available
-        private const val REMOTE_CONFIG_URL = "https://meta.wikimedia.org/static/current/extensions/MobileApp/config/android.json"
+        private const val REMOTE_CONFIG_URL = "https://meta.wikimedia.org/w/extensions/MobileApp/config/android.json"
         private val RUN_INTERVAL_MILLI = TimeUnit.DAYS.toMillis(1)
     }
 }


### PR DESCRIPTION
The URL for fetching our RemoteConfig parameters has been updated recently (or a long time ago, and we hadn't noticed?) and is now returning 404.
This is the new URL.