### PR TITLE
Don't dismiss Theme chooser on page reload.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.kt
+++ b/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.kt
@@ -46,10 +46,7 @@ class ExclusiveBottomSheetPresenter {
     }
 
     fun dismiss(manager: FragmentManager) {
-        if (manager.isStateSaved || manager.isDestroyed) {
-            return
-        }
-        (manager.findFragmentByTag(BOTTOM_SHEET_FRAGMENT_TAG) as DialogFragment?)?.dismiss()
+        getCurrentBottomSheet(manager)?.dismiss()
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.kt
+++ b/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.kt
@@ -38,12 +38,22 @@ class ExclusiveBottomSheetPresenter {
         dialog.show(manager, BOTTOM_SHEET_FRAGMENT_TAG)
     }
 
+    fun getCurrentBottomSheet(manager: FragmentManager): DialogFragment? {
+        if (manager.isStateSaved || manager.isDestroyed) {
+            return null
+        }
+        return manager.findFragmentByTag(BOTTOM_SHEET_FRAGMENT_TAG) as DialogFragment?
+    }
+
     fun dismiss(manager: FragmentManager) {
         if (manager.isStateSaved || manager.isDestroyed) {
             return
         }
-        val dialog = manager.findFragmentByTag(BOTTOM_SHEET_FRAGMENT_TAG) as DialogFragment?
-        dialog?.dismiss()
+        dismiss(manager.findFragmentByTag(BOTTOM_SHEET_FRAGMENT_TAG) as DialogFragment?)
+    }
+
+    fun dismiss(fragment: DialogFragment?) {
+        fragment?.dismiss()
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.kt
+++ b/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.kt
@@ -49,11 +49,7 @@ class ExclusiveBottomSheetPresenter {
         if (manager.isStateSaved || manager.isDestroyed) {
             return
         }
-        dismiss(manager.findFragmentByTag(BOTTOM_SHEET_FRAGMENT_TAG) as DialogFragment?)
-    }
-
-    fun dismiss(fragment: DialogFragment?) {
-        fragment?.dismiss()
+        (manager.findFragmentByTag(BOTTOM_SHEET_FRAGMENT_TAG) as DialogFragment?)?.dismiss()
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -957,7 +957,10 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     fun loadPage(title: PageTitle, entry: HistoryEntry, pushBackStack: Boolean, stagedScrollY: Int, isRefresh: Boolean = false) {
         // clear the title in case the previous page load had failed.
         clearActivityActionBarTitle()
-        dismissBottomSheet()
+
+        if (bottomSheetPresenter.getCurrentBottomSheet(childFragmentManager) !is ThemeChooserDialog) {
+            dismissBottomSheet()
+        }
 
         if (AccountUtil.isLoggedIn) {
             // explicitly check notifications for the current user


### PR DESCRIPTION
Sometime in recent history, we started explicitly dismissing any bottom sheet upon loading/reloading an article. However this is not actually correct behavior in the case of the Theme chooser. This updates the logic to dismiss the bottom sheet only if it's _not_ the Theme chooser.

https://phabricator.wikimedia.org/T308349