### PR TITLE
Convert RemoteConfig to use kotlinx.serialization.

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.java
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.java
@@ -35,7 +35,6 @@ import org.wikipedia.notifications.NotificationPollBroadcastReceiver;
 import org.wikipedia.page.tabs.Tab;
 import org.wikipedia.push.WikipediaFirebaseMessagingService;
 import org.wikipedia.settings.Prefs;
-import org.wikipedia.settings.RemoteConfig;
 import org.wikipedia.settings.SiteInfoClient;
 import org.wikipedia.theme.Theme;
 import org.wikipedia.util.DimenUtil;
@@ -55,7 +54,6 @@ import static org.wikipedia.util.DimenUtil.getFontSizeFromSp;
 import static org.wikipedia.util.ReleaseUtil.getChannel;
 
 public class WikipediaApp extends Application {
-    private final RemoteConfig remoteConfig = new RemoteConfig();
     private Handler mainThreadHandler;
     private AppLanguageState appLanguageState;
     private FunnelManager funnelManager;
@@ -88,10 +86,6 @@ public class WikipediaApp extends Application {
 
     public FunnelManager getFunnelManager() {
         return funnelManager;
-    }
-
-    public RemoteConfig getRemoteConfig() {
-        return remoteConfig;
     }
 
     /**

--- a/app/src/main/java/org/wikipedia/analytics/Funnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/Funnel.kt
@@ -16,8 +16,6 @@ abstract class Funnel @JvmOverloads internal constructor(protected val app: Wiki
                                                          private val revision: Int, private val sampleRate: Int = SAMPLE_LOG_ALL,
                                                          private val wiki: WikiSite? = null) {
 
-    private val sampleRateRemoteParamName = schemaName + "_rate"
-
     val sessionToken = UUID.randomUUID().toString()
 
     internal constructor(app: WikipediaApp, schemaName: String, revision: Int, wiki: WikiSite?) :
@@ -73,7 +71,7 @@ abstract class Funnel @JvmOverloads internal constructor(protected val app: Wiki
      * depending on what they are logging.
      */
     protected fun log(wiki: WikiSite?, vararg params: Any?) {
-        if (ReleaseUtil.isDevRelease || isUserInSamplingGroup(app.appInstallID, getSampleRate())) {
+        if (ReleaseUtil.isDevRelease || isUserInSamplingGroup(app.appInstallID, sampleRate)) {
             val eventData = JSONObject()
             var i = 0
             while (i < params.size) {
@@ -88,15 +86,6 @@ abstract class Funnel @JvmOverloads internal constructor(protected val app: Wiki
             )
             EventLoggingService.instance.log(event.data)
         }
-    }
-
-    /**
-     * @return Sampling rate for this funnel, as given by the remote config parameter for this
-     * funnel (the name of which is defined as "[schema name]_rate"), with a fallback to the
-     * hard-coded sampling rate passed into the constructor.
-     */
-    private fun getSampleRate(): Int {
-        return app.remoteConfig.config.optInt(sampleRateRemoteParamName, sampleRate)
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
@@ -20,6 +20,7 @@ import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingList
 import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingListEntry
 import org.wikipedia.savedpages.SavedPageSyncService
 import org.wikipedia.settings.Prefs
+import org.wikipedia.settings.RemoteConfig
 import org.wikipedia.util.DateUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
@@ -486,7 +487,7 @@ class ReadingListSyncAdapter : JobIntentService() {
             manualSync()
         }
 
-        val isDisabledByRemoteConfig get() = WikipediaApp.getInstance().remoteConfig.config.optBoolean("disableReadingListSync", false)
+        val isDisabledByRemoteConfig get() = RemoteConfig.config.disableReadingListSync
 
         fun manualSyncWithDeleteList(list: ReadingList) {
             if (list.remoteId <= 0) {

--- a/app/src/main/java/org/wikipedia/settings/RemoteConfig.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfig.kt
@@ -1,27 +1,35 @@
 package org.wikipedia.settings
 
-import org.json.JSONException
-import org.json.JSONObject
+import kotlinx.serialization.Serializable
+import org.wikipedia.json.JsonUtil
+import org.wikipedia.util.log.L
 
-class RemoteConfig {
-    private var curConfig: JSONObject? = null
+object RemoteConfig {
+    private var curConfig: RemoteConfigImpl? = null
 
     // If there's no pref set, just give back the empty JSON Object
-    val config: JSONObject
+    val config: RemoteConfigImpl
         get() {
             if (curConfig == null) {
                 curConfig = try {
-                    // If there's no pref set, just give back the empty JSON Object
-                    JSONObject(Prefs.remoteConfigJson)
-                } catch (e: JSONException) {
-                    throw RuntimeException(e)
+                    JsonUtil.decodeFromString<RemoteConfigImpl>(Prefs.remoteConfigJson)
+                } catch (e: Exception) {
+                    L.e(e)
+                    RemoteConfigImpl()
                 }
             }
             return curConfig!!
         }
 
-    fun updateConfig(newConfig: JSONObject) {
-        Prefs.remoteConfigJson = newConfig.toString()
-        curConfig = newConfig
+    fun updateConfig(configStr: String) {
+        Prefs.remoteConfigJson = configStr
+        curConfig = null
+    }
+
+    @Suppress("unused")
+    @Serializable
+    class RemoteConfigImpl {
+        val disableReadingListSync = false
+        val disableAnonEditing = false
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
@@ -3,8 +3,6 @@ package org.wikipedia.settings
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.internal.closeQuietly
-import org.json.JSONObject
-import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory.client
 import org.wikipedia.recurring.RecurringTask
 import org.wikipedia.util.log.L
@@ -15,7 +13,7 @@ class RemoteConfigRefreshTask : RecurringTask() {
     override val name = "remote-config-refresher"
 
     override fun shouldRun(lastRun: Date): Boolean {
-        return System.currentTimeMillis() - lastRun.time >= RUN_INTERVAL_MILLI
+        return System.currentTimeMillis() - lastRun.time >= RUN_INTERVAL_MILLIS
     }
 
     override fun run(lastRun: Date) {
@@ -23,9 +21,9 @@ class RemoteConfigRefreshTask : RecurringTask() {
         try {
             val request = Request.Builder().url(REMOTE_CONFIG_URL).build()
             response = client.newCall(request).execute()
-            val config = JSONObject(response.body!!.string())
-            WikipediaApp.getInstance().remoteConfig.updateConfig(config)
-            L.d(config.toString())
+            val configStr = response.body!!.string()
+            RemoteConfig.updateConfig(configStr)
+            L.d(configStr)
         } catch (e: Exception) {
             L.e(e)
         } finally {
@@ -35,6 +33,6 @@ class RemoteConfigRefreshTask : RecurringTask() {
 
     companion object {
         private const val REMOTE_CONFIG_URL = "https://meta.wikimedia.org/w/extensions/MobileApp/config/android.json"
-        private val RUN_INTERVAL_MILLI = TimeUnit.DAYS.toMillis(1)
+        private val RUN_INTERVAL_MILLIS = TimeUnit.DAYS.toMillis(1)
     }
 }


### PR DESCRIPTION
This is pretty much the last thing that was using the old `JSONObject` routines, instead of our new `kotlinx.serialization` logic.

The only other stuff that still uses `JSONObject` is all of the `Funnel` classes, but those are all considered deprecated, and will be going away eventually anyway.