### PR TITLE
Add a bit of horizontal padding to PageActionTab items.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActionTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActionTabLayout.kt
@@ -28,7 +28,7 @@ class PageActionTabLayout constructor(context: Context, attrs: AttributeSet? = n
         Prefs.customizeToolbarOrder.forEach {
             val view = MaterialTextView(context)
             view.gravity = Gravity.CENTER
-            view.setPadding(0, DimenUtil.roundedDpToPx(8f), 0, 0)
+            view.setPadding(DimenUtil.roundedDpToPx(2f), DimenUtil.roundedDpToPx(8f), DimenUtil.roundedDpToPx(2f), 0)
             view.setBackgroundResource(ResourceUtil.getThemedAttributeId(context, R.attr.selectableItemBackgroundBorderless))
             view.setTextColor(ResourceUtil.getThemedColor(context, R.attr.chip_text_color))
             view.textAlignment = TEXT_ALIGNMENT_CENTER


### PR DESCRIPTION
...so that we avoid a situation where the labels clash against each other:
https://phabricator.wikimedia.org/T306282
