### PR TITLE
Fix deduplication of search results.

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -331,7 +331,15 @@ class SearchResultsFragment : Fragment() {
         get() = binding.searchResultsList.adapter as SearchResultAdapter
 
     private fun displayResults(results: List<SearchResult>) {
-        totalResults.addAll(results.distinctBy { it.pageTitle.wikiSite.languageCode + it.pageTitle.prefixedText })
+        for (newResult in results) {
+            val res = totalResults.find { newResult.pageTitle.prefixedText == newResult.pageTitle.prefixedText &&
+                    newResult.pageTitle.wikiSite.languageCode == newResult.pageTitle.wikiSite.languageCode }
+            if (res == null) {
+                totalResults.add(newResult)
+            } else if (!newResult.pageTitle.description.isNullOrEmpty()) {
+                res.pageTitle.description = newResult.pageTitle.description
+            }
+        }
         binding.searchResultsContainer.visibility = View.VISIBLE
         adapter.notifyDataSetChanged()
     }

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -331,18 +331,7 @@ class SearchResultsFragment : Fragment() {
         get() = binding.searchResultsList.adapter as SearchResultAdapter
 
     private fun displayResults(results: List<SearchResult>) {
-        for (newResult in results) {
-            var contains = false
-            for ((pageTitle) in totalResults) {
-                if (newResult.pageTitle == pageTitle) {
-                    contains = true
-                    break
-                }
-            }
-            if (!contains) {
-                totalResults.add(newResult)
-            }
-        }
+        totalResults.addAll(results.distinctBy { it.pageTitle.wikiSite.languageCode + it.pageTitle.prefixedText })
         binding.searchResultsContainer.visibility = View.VISIBLE
         adapter.notifyDataSetChanged()
     }


### PR DESCRIPTION
Deduplication of search results (from different sources) is currently broken because it was relying on the equality `==` operator of the `PageTitle` object, which was changed after conversion to Kotlin.

This fixes deduplication, and also streamlines it with Kotlin sugar.