### PR TITLE
Tweak style of "add languages" button in Recent Searches.

### DIFF
--- a/app/src/main/res/layout/fragment_search_recent.xml
+++ b/app/src/main/res/layout/fragment_search_recent.xml
@@ -33,17 +33,15 @@
             android:layout_marginEnd="30dp"
             android:text="@string/search_empty_message" />
 
-        <TextView
+        <Button
             android:id="@+id/add_languages_button"
             style="@style/App.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:clickable="true"
-            android:focusable="true"
             android:text="@string/add_wikipedia_languages_text"
-            android:textColor="?attr/secondary_text_color"
-            app:backgroundTint="?attr/button_background_color"
+            android:textColor="?attr/material_theme_secondary_color"
+            app:backgroundTint="?attr/chip_background_color"
             tools:text="Add Wikipedia languages" />
     </LinearLayout>
 


### PR DESCRIPTION
Per Design suggestion, the "Add Wikipedia Languages" button should have a slightly darker background, so that it looks more like a button:
![image](https://user-images.githubusercontent.com/1682214/171650992-cd0174cb-c31c-43bf-9b0b-2bc5ee7c5349.png)
