### PR TITLE
Follow-up to breadcrumbs.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
@@ -1,12 +1,13 @@
 package org.wikipedia.analytics.eventplatform
 
 import android.app.Activity
+import android.content.Context
 import android.view.View
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
-import org.wikipedia.settings.SettingsActivity
+import org.wikipedia.util.log.L
 
 @Suppress("unused")
 @Serializable
@@ -15,58 +16,41 @@ class BreadCrumbLogEvent(private val screen_name: String,
                          private val action: String,
                          private val primary_language_code: String) : MobileAppsEvent(STREAM_NAME) {
 
+    init {
+        L.d(">>>>>> " + screen_name + " : " + action)
+    }
+
     companion object {
         private const val STREAM_NAME = "android.breadcrumb_log_event"
 
-        fun logClick(activity: Activity?, view: View?) {
-            activity?.let {
-                if (it is SettingsActivity || !view?.isClickable!!) {
-                    return
-                }
-                val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
-                if (viewReadableName != it.getString(R.string.breadcrumb_view_unnamed)) {
-                    EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(it), it.getString(R.string.breadcrumb_view_click, viewReadableName), WikipediaApp.instance.languageState.appLanguageCode))
-                }
-            }
+        fun logClick(activity: Activity, view: View) {
+            val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
+            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(activity), activity.getString(R.string.breadcrumb_view_click, viewReadableName), WikipediaApp.instance.languageState.appLanguageCode))
         }
 
-        fun logLongClick(activity: Activity?, view: View?) {
-            activity?.let {
-                val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
-                if (viewReadableName != it.getString(R.string.breadcrumb_view_unnamed)) {
-                    EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(it), it.getString(R.string.breadcrumb_view_long_click, viewReadableName), WikipediaApp.instance.languageState.appLanguageCode))
-                }
-            }
+        fun logLongClick(activity: Activity, view: View) {
+            val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
+            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(activity), activity.getString(R.string.breadcrumb_view_long_click, viewReadableName), WikipediaApp.instance.languageState.appLanguageCode))
         }
 
-        fun logSwipe(activity: Activity?) {
-            activity?.let {
-                EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(it), it.getString(R.string.breadcrumb_screen_swiped_to), WikipediaApp.instance.languageState.appLanguageCode))
-            }
+        fun logSwipe(activity: Activity) {
+            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(activity), activity.getString(R.string.breadcrumb_screen_swiped_to), WikipediaApp.instance.languageState.appLanguageCode))
         }
 
-        fun logScreenShown(activity: Activity?) {
-            activity?.let {
-                EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(it), it.getString(R.string.breadcrumb_screen_shown), WikipediaApp.instance.languageState.appLanguageCode))
-            }
+        fun logScreenShown(activity: Activity) {
+            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(activity), activity.getString(R.string.breadcrumb_screen_shown), WikipediaApp.instance.languageState.appLanguageCode))
         }
 
-        fun logBackPress(activity: Activity?) {
-            activity?.let {
-                EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(it), it.getString(R.string.breadcrumb_screen_back_press), WikipediaApp.instance.languageState.appLanguageCode))
-            }
+        fun logBackPress(activity: Activity) {
+            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(activity), activity.getString(R.string.breadcrumb_screen_back_press), WikipediaApp.instance.languageState.appLanguageCode))
         }
 
-        fun logTooltipShown(activity: Activity?, anchor: View) {
-            activity?.let {
-                EventPlatformClient.submit(BreadCrumbLogEvent(it.javaClass.simpleName.orEmpty(), it.getString(R.string.breadcrumb_tooltip_shown_on_view, BreadCrumbViewUtil.getReadableNameForView(anchor)), WikipediaApp.instance.languageState.appLanguageCode))
-            }
+        fun logTooltipShown(context: Context, anchor: View) {
+            EventPlatformClient.submit(BreadCrumbLogEvent(context.javaClass.simpleName.orEmpty(), context.getString(R.string.breadcrumb_tooltip_shown_on_view, BreadCrumbViewUtil.getReadableNameForView(anchor)), WikipediaApp.instance.languageState.appLanguageCode))
         }
 
-        fun logSettingsSelection(activity: Activity?, title: String?) {
-            activity?.let {
-                EventPlatformClient.submit(BreadCrumbLogEvent(it.javaClass.simpleName.orEmpty(), it.getString(R.string.breadcrumb_view_click, title), WikipediaApp.instance.languageState.appLanguageCode))
-            }
+        fun logSettingsSelection(context: Context, title: String) {
+            EventPlatformClient.submit(BreadCrumbLogEvent(context.javaClass.simpleName.orEmpty(), context.getString(R.string.breadcrumb_view_click, title), WikipediaApp.instance.languageState.appLanguageCode))
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
-import org.wikipedia.util.log.L
 
 @Suppress("unused")
 @Serializable
@@ -15,10 +14,6 @@ import org.wikipedia.util.log.L
 class BreadCrumbLogEvent(private val screen_name: String,
                          private val action: String,
                          private val primary_language_code: String) : MobileAppsEvent(STREAM_NAME) {
-
-    init {
-        L.d(">>>>>> " + screen_name + " : " + action)
-    }
 
     companion object {
         private const val STREAM_NAME = "android.breadcrumb_log_event"

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbViewUtil.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbViewUtil.kt
@@ -21,32 +21,26 @@ import org.wikipedia.onboarding.InitialOnboardingFragment.OnboardingPage
 
 object BreadCrumbViewUtil {
 
-    fun getReadableNameForView(view: View?): String {
-        view?.let {
-            val context = it.context
-            context?.let { viewContext ->
-                if (it.parent != null && it.parent is RecyclerView) {
-                    val position =
-                        (it.parent as RecyclerView).getChildViewHolder(it).layoutPosition + 1
-                    if (it is ListCardItemView) {
-                        var currentParent = it.parent
-                        while (currentParent !is ListCardView<*>) {
-                            if (currentParent.parent != null) {
-                                currentParent = currentParent.parent
-                            } else {
-                                // ListItemView is not in a CardView
-                                return viewContext.getString(R.string.breadcrumb_view_with_position, getReadableNameForView(it.parent as RecyclerView), position)
-                            }
-                        }
-                        return viewContext.getString(R.string.breadcrumb_view_with_position, currentParent.javaClass.simpleName, position)
+    fun getReadableNameForView(view: View): String {
+        if (view.parent != null && view.parent is RecyclerView) {
+            val position =
+                    (view.parent as RecyclerView).getChildViewHolder(view).layoutPosition + 1
+            if (view is ListCardItemView) {
+                var currentParent = view.parent
+                while (currentParent !is ListCardView<*>) {
+                    if (currentParent.parent != null) {
+                        currentParent = currentParent.parent
+                    } else {
+                        // ListItemView is not in a CardView
+                        return view.context.getString(R.string.breadcrumb_view_with_position, getReadableNameForView(view.parent as RecyclerView), position)
                     }
-                    // Returning only recyclerview name and click position for non-cardView recyclerViews
-                    return viewContext.getString(R.string.breadcrumb_view_with_position, getReadableNameForView(it.parent as RecyclerView), position)
                 }
-                return if (it.id == View.NO_ID) context.getString(R.string.breadcrumb_view_unnamed) else getViewResourceName(it)
+                return view.context.getString(R.string.breadcrumb_view_with_position, currentParent.javaClass.simpleName, position)
             }
+            // Returning only recyclerview name and click position for non-cardView recyclerViews
+            return view.context.getString(R.string.breadcrumb_view_with_position, getReadableNameForView(view.parent as RecyclerView), position)
         }
-        return "unnamed"
+        return if (view.id == View.NO_ID) view.context.getString(R.string.breadcrumb_view_unnamed) else getViewResourceName(view)
     }
 
     private fun getViewResourceName(view: View): String {
@@ -110,19 +104,14 @@ object BreadCrumbViewUtil {
     }
 
     private fun getVisibleFragment(activity: Activity): Fragment? {
-        (activity is FragmentActivity).let {
-            val fragmentManager = (activity as FragmentActivity).supportFragmentManager
-
-            if (activity is SingleFragmentActivity<*>) {
-                return fragmentManager.findFragmentById(R.id.fragment_container)
-            } else {
-                val fragments: List<Fragment> = fragmentManager.fragments
-                for (fragment in fragments) {
-                    if (fragment.isVisible) return fragment
-                }
+        if (activity is SingleFragmentActivity<*>) {
+            return activity.supportFragmentManager.findFragmentById(R.id.fragment_container)
+        } else if (activity is FragmentActivity) {
+            val fragments: List<Fragment> = activity.supportFragmentManager.fragments
+            for (fragment in fragments) {
+                if (fragment.isVisible) return fragment
             }
         }
-
         return null
     }
 }

--- a/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
+++ b/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
@@ -36,7 +36,7 @@ class MenuNavTabDialog : ExtendedBottomSheetDialogFragment() {
         _binding = ViewMainDrawerBinding.inflate(inflater, container, false)
 
         binding.mainDrawerAccountContainer.setOnClickListener {
-            BreadCrumbLogEvent.logClick(activity, binding.mainDrawerAccountContainer)
+            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerAccountContainer)
             if (AccountUtil.isLoggedIn) {
                 callback()?.usernameClick()
             } else {
@@ -46,25 +46,25 @@ class MenuNavTabDialog : ExtendedBottomSheetDialogFragment() {
         }
 
         binding.mainDrawerTalkContainer.setOnClickListener {
-            BreadCrumbLogEvent.logClick(activity, binding.mainDrawerTalkContainer)
+            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerTalkContainer)
             callback()?.talkClick()
             dismiss()
         }
 
         binding.mainDrawerWatchlistContainer.setOnClickListener {
-            BreadCrumbLogEvent.logClick(activity, binding.mainDrawerWatchlistContainer)
+            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerWatchlistContainer)
             callback()?.watchlistClick()
             dismiss()
         }
 
         binding.mainDrawerSettingsContainer.setOnClickListener {
-            BreadCrumbLogEvent.logClick(activity, binding.mainDrawerSettingsContainer)
+            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerSettingsContainer)
             callback()?.settingsClick()
             dismiss()
         }
 
         binding.mainDrawerDonateContainer.setOnClickListener {
-            BreadCrumbLogEvent.logClick(activity, binding.mainDrawerDonateContainer)
+            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerDonateContainer)
             visitInExternalBrowser(requireContext(),
                     Uri.parse(getString(R.string.donate_url,
                             BuildConfig.VERSION_NAME, WikipediaApp.instance.languageState.systemLanguageCode)))

--- a/app/src/main/java/org/wikipedia/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/OnboardingFragment.kt
@@ -116,7 +116,7 @@ abstract class OnboardingFragment(val enableSkip: Boolean = true) : Fragment(), 
 
     private inner class PageChangeCallback : OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
-            BreadCrumbLogEvent.logSwipe(activity)
+            BreadCrumbLogEvent.logSwipe(requireActivity())
             updateButtonState()
             updatePageIndicatorContentDescription()
             // TODO: request focus to child view to make it readable after switched page.

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -26,6 +26,7 @@ import org.wikipedia.analytics.GalleryFunnel
 import org.wikipedia.analytics.IntentFunnel
 import org.wikipedia.analytics.LinkPreviewFunnel
 import org.wikipedia.analytics.WatchlistFunnel
+import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.ActivityPageBinding
@@ -664,9 +665,9 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
         }
         enqueueTooltip {
             FeedbackUtil.getTooltip(
-                binding.pageToolbarButtonShowOverflowMenu,
+                this,
                 getString(R.string.theme_chooser_menu_item_short_tooltip),
-                arrowAnchorPadding = -DimenUtil.roundedDpToPx(10f),
+                arrowAnchorPadding = -DimenUtil.roundedDpToPx(6f),
                 topOrBottomMargin = -12,
                 aboveOrBelow = true,
                 autoDismiss = false,
@@ -676,6 +677,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
                     Prefs.showOneTimeCustomizeToolbarTooltip = false
                     Prefs.toolbarTooltipVisible = false
                 }
+                BreadCrumbLogEvent.logTooltipShown(this@PageActivity, binding.pageToolbarButtonShowOverflowMenu)
                 showAlignBottom(binding.pageToolbarButtonShowOverflowMenu)
                 setCurrentTooltip(this)
                 Prefs.toolbarTooltipVisible = true

--- a/app/src/main/java/org/wikipedia/settings/LogoutPreference.kt
+++ b/app/src/main/java/org/wikipedia/settings/LogoutPreference.kt
@@ -29,9 +29,9 @@ class LogoutPreference : Preference {
         super.onBindViewHolder(holder)
         holder.itemView.isClickable = false
         holder.itemView.findViewById<TextView>(R.id.accountName).text = AccountUtil.userName
-        holder.itemView.findViewById<Button>(R.id.logoutButton).setOnClickListener {
+        holder.itemView.findViewById<Button>(R.id.logoutButton).setOnClickListener { view ->
             activity?.let {
-                BreadCrumbLogEvent.logSettingsSelection(it, it.getString(R.string.breadcrumb_settings_logout))
+                BreadCrumbLogEvent.logSettingsSelection(it, (view as Button).text.toString())
                 AlertDialog.Builder(it)
                     .setMessage(R.string.logout_prompt)
                     .setNegativeButton(R.string.logout_dialog_cancel_button_text, null)

--- a/app/src/main/java/org/wikipedia/settings/PreferenceMultiLine.kt
+++ b/app/src/main/java/org/wikipedia/settings/PreferenceMultiLine.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.settings
 
-import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.util.AttributeSet
@@ -27,7 +26,7 @@ class PreferenceMultiLine : Preference {
         // (but only do this if the preference doesn't already have a click listener)
         if (onPreferenceClickListener == null) {
             onPreferenceClickListener = OnPreferenceClickListener { preference ->
-                BreadCrumbLogEvent.logSettingsSelection(context as Activity, preference.title.toString())
+                BreadCrumbLogEvent.logSettingsSelection(context, preference.title.toString())
                 if (preference.intent != null) {
                     try {
                         context.startActivity(preference.intent)

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -21,6 +21,7 @@ import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.SuggestedEditsFunnel
+import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.analytics.eventplatform.UserContributionEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.FragmentSuggestedEditsTasksBinding
@@ -65,12 +66,13 @@ class SuggestedEditsTasksFragment : Fragment() {
         if (!isAdded) {
             return@Runnable
         }
-        val balloon = FeedbackUtil.getTooltip(binding.contributionsStatsView, binding.contributionsStatsView.tooltipText, autoDismiss = true, showDismissButton = true)
+        val balloon = FeedbackUtil.getTooltip(requireContext(), binding.contributionsStatsView.tooltipText, autoDismiss = true, showDismissButton = true)
         balloon.showAlignBottom(binding.contributionsStatsView.getDescriptionView())
-        balloon.relayShowAlignBottom(FeedbackUtil.getTooltip(binding.editStreakStatsView, binding.editStreakStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editStreakStatsView.getDescriptionView())
-            .relayShowAlignBottom(FeedbackUtil.getTooltip(binding.pageViewStatsView, binding.pageViewStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.pageViewStatsView.getDescriptionView())
-            .relayShowAlignBottom(FeedbackUtil.getTooltip(binding.editQualityStatsView, binding.editQualityStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editQualityStatsView.getDescriptionView())
+        balloon.relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editStreakStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editStreakStatsView.getDescriptionView())
+            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.pageViewStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.pageViewStatsView.getDescriptionView())
+            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editQualityStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editQualityStatsView.getDescriptionView())
         Prefs.showOneTimeSequentialUserStatsTooltip = false
+        BreadCrumbLogEvent.logTooltipShown(requireActivity(), binding.contributionsStatsView)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -32,7 +32,6 @@ import org.wikipedia.staticdata.SpecialAliasData
 import org.wikipedia.staticdata.UserAliasData
 import org.wikipedia.suggestededits.SuggestionsActivity
 import org.wikipedia.talk.TalkTopicsActivity
-import org.wikipedia.views.ViewUtil.getActivity
 import java.util.concurrent.TimeUnit
 
 object FeedbackUtil {
@@ -160,7 +159,7 @@ object FeedbackUtil {
 
     fun showTooltip(activity: Activity, anchor: View, text: CharSequence, aboveOrBelow: Boolean,
                     autoDismiss: Boolean, arrowAnchorPadding: Int = 0, topOrBottomMargin: Int = 0): Balloon {
-        return showTooltip(activity, getTooltip(anchor, text, autoDismiss, arrowAnchorPadding, topOrBottomMargin, aboveOrBelow), anchor, aboveOrBelow, autoDismiss)
+        return showTooltip(activity, getTooltip(anchor.context, text, autoDismiss, arrowAnchorPadding, topOrBottomMargin, aboveOrBelow), anchor, aboveOrBelow, autoDismiss)
     }
 
     fun showTooltip(activity: Activity, anchor: View, @LayoutRes layoutRes: Int,
@@ -177,19 +176,19 @@ object FeedbackUtil {
         if (!autoDismiss) {
             (activity as BaseActivity).setCurrentTooltip(balloon)
         }
+        BreadCrumbLogEvent.logTooltipShown(activity, anchor)
         return balloon
     }
 
-    fun getTooltip(anchor: View, text: CharSequence, autoDismiss: Boolean, arrowAnchorPadding: Int = 0,
+    fun getTooltip(context: Context, text: CharSequence, autoDismiss: Boolean, arrowAnchorPadding: Int = 0,
                    topOrBottomMargin: Int = 0, aboveOrBelow: Boolean = false, showDismissButton: Boolean = false): Balloon {
-        BreadCrumbLogEvent.logTooltipShown(anchor.context.getActivity(), anchor)
-        val binding = ViewPlainTextTooltipBinding.inflate(LayoutInflater.from(anchor.context))
+        val binding = ViewPlainTextTooltipBinding.inflate(LayoutInflater.from(context))
         binding.textView.text = text
         if (showDismissButton) {
             binding.buttonView.visibility = View.VISIBLE
         }
 
-        val balloon = createBalloon(anchor.context) {
+        val balloon = createBalloon(context) {
             setArrowDrawableResource(R.drawable.ic_tooltip_arrow_up)
             setArrowPositionRules(ArrowPositionRules.ALIGN_ANCHOR)
             setArrowOrientationRules(ArrowOrientationRules.ALIGN_ANCHOR)
@@ -198,7 +197,7 @@ object FeedbackUtil {
             setMarginRight(8)
             setMarginTop(if (aboveOrBelow) 0 else topOrBottomMargin)
             setMarginBottom(if (aboveOrBelow) topOrBottomMargin else 0)
-            setBackgroundColorResource(ResourceUtil.getThemedAttributeId(anchor.context, R.attr.colorAccent))
+            setBackgroundColorResource(ResourceUtil.getThemedAttributeId(context, R.attr.colorAccent))
             setDismissWhenTouchOutside(autoDismiss)
             setLayout(binding.root)
             setWidth(BalloonSizeSpec.WRAP)

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -90,13 +90,12 @@
     <string name="breadcrumb_view_click">%s click</string>
     <string name="breadcrumb_view_long_click">%s long click</string>
     <string name="breadcrumb_switch_view_click">%s turn %s</string>
-    <string name="breadcrumb_switch_view_state_on">ON</string>
-    <string name="breadcrumb_switch_view_state_off">OFF</string>
+    <string name="breadcrumb_switch_view_state_on">on</string>
+    <string name="breadcrumb_switch_view_state_off">off</string>
     <string name="breadcrumb_screen_shown">shown</string>
     <string name="breadcrumb_screen_back_press">back press</string>
     <string name="breadcrumb_screen_swiped_to">swiped to</string>
     <string name="breadcrumb_screen_fragment_name">%s screen %s</string>
     <string name="breadcrumb_view_unnamed">unnamed</string>
-    <string name="breadcrumb_settings_logout">settings logout</string>
     <string name="breadcrumb_tooltip_shown_on_view">tooltip shown on %s</string>
 </resources>


### PR DESCRIPTION
* Remove a lot of unnecessary null checks and `let { }` blocks.
* Greatly simplify click detection, with system-provided touch slop and timeout values.
* Revert changes to `getTooltip` function, where the new `anchor` parameter did not do what it says.