### PR TITLE
Fix: show the ErrorView in a correct position in the diff view

### DIFF
--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -317,6 +317,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
         binding.thankButton.isEnabled = true
         binding.thankButton.isVisible = AccountUtil.isLoggedIn && !AccountUtil.userName.equals(viewModel.revisionTo?.user)
         binding.revisionDetailsView.isVisible = true
+        binding.errorView.isVisible = false
     }
 
     private fun updateAfterDiffFetchSuccess() {

--- a/app/src/main/res/layout/fragment_article_edit_details.xml
+++ b/app/src/main/res/layout/fragment_article_edit_details.xml
@@ -45,13 +45,6 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
-            <org.wikipedia.views.WikiErrorView
-                android:id="@+id/errorView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:visibility="gone" />
-
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/articleTitleContainer"
                 android:layout_width="match_parent"
@@ -371,6 +364,13 @@
                     app:layout_constraintTop_toBottomOf="@id/diffCharacterCountView" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <org.wikipedia.views.WikiErrorView
+                android:id="@+id/errorView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:visibility="gone" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/diffRecyclerView"


### PR DESCRIPTION
Now the position of the `errorView` in the diff view is not quite correct, it will show above the detail view and will not disappear after going forward/back to another revision.

Steps to reproduce:
1. Add "Queen angelfish" to the watchlist
2. Scroll down to the revision that was published by user `Dylan620`, which is the revision before it got protected. 
3. Enter the revision and you will see the error.
4. Go forward/back and the error view is still there.
