### PR TITLE
Follow-up to updated contribution icons.

### DIFF
--- a/app/src/main/java/org/wikipedia/userprofile/Contribution.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/Contribution.kt
@@ -12,6 +12,7 @@ import java.util.*
 class Contribution(
     val qNumber: String,
     val revId: Long,
+    val ns: Int,
     var apiTitle: String,
     var displayTitle: String,
     var description: String,

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -199,7 +199,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                     continuations[WikipediaApp.instance.wikiSite] = cont
                 }
                 response.query?.userContributions?.forEach {
-                    contributions.add(Contribution("", it.revid, it.title, it.title, it.title, EDIT_TYPE_GENERIC, null, it.date(),
+                    contributions.add(Contribution("", it.revid, it.ns, it.title, it.title, it.title, EDIT_TYPE_GENERIC, null, it.date(),
                         WikipediaApp.instance.wikiSite, 0, it.sizediff, it.top, 0))
                 }
                 Observable.just(Pair(contributions, response.query?.userInfo!!.editCount))
@@ -246,7 +246,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                         qLangMap[qNumber] = HashSet()
                     }
 
-                    wikidataContributions.add(Contribution(qNumber, contribution.revid, contribution.title, contribution.title, contributionDescription, editType, null, contribution.date(),
+                    wikidataContributions.add(Contribution(qNumber, contribution.revid, contribution.ns, contribution.title, contribution.title, contributionDescription, editType, null, contribution.date(),
                         WikiSite.forLanguageCode(contributionLanguage), 0, contribution.sizediff, contribution.top, 0))
 
                     qLangMap[qNumber]?.add(contributionLanguage)
@@ -321,7 +321,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                             }
                         }
 
-                        contributions.add(Contribution(qNumber, contribution.revid, contribution.title, contribution.title, contributionDescription, editType, null, contribution.date(),
+                        contributions.add(Contribution(qNumber, contribution.revid, contribution.ns, contribution.title, contribution.title, contributionDescription, editType, null, contribution.date(),
                             WikiSite.forLanguageCode(contributionLanguage), 0, contribution.sizediff, contribution.top, tagCount))
                     }
                     Observable.just(Pair(contributions, response.query?.userInfo!!.editCount))

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsItemView.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsItemView.kt
@@ -8,7 +8,6 @@ import android.widget.LinearLayout
 import org.wikipedia.R
 import org.wikipedia.databinding.ItemSuggestedEditsContributionsBinding
 import org.wikipedia.page.Namespace
-import org.wikipedia.page.PageTitle
 import org.wikipedia.userprofile.Contribution.Companion.EDIT_TYPE_IMAGE_CAPTION
 import org.wikipedia.userprofile.Contribution.Companion.EDIT_TYPE_IMAGE_TAG
 import org.wikipedia.util.DimenUtil
@@ -64,11 +63,10 @@ class ContributionsItemView constructor(context: Context, attrs: AttributeSet? =
                 binding.contributionIcon.setImageResource(R.drawable.ic_image_tag)
             }
             else -> {
-                val pageTitle = PageTitle(contribution.apiTitle, contribution.wikiSite)
-                val icon = when (pageTitle.namespace()) {
-                    Namespace.TALK -> R.drawable.ic_icon_speech_bubbles_ooui_ltr
-                    Namespace.USER_TALK -> R.drawable.ic_user_talk
-                    Namespace.USER -> R.drawable.ic_user_avatar
+                val icon = when (contribution.ns) {
+                    Namespace.TALK.code() -> R.drawable.ic_icon_speech_bubbles_ooui_ltr
+                    Namespace.USER_TALK.code() -> R.drawable.ic_user_talk
+                    Namespace.USER.code() -> R.drawable.ic_user_avatar
                     else -> R.drawable.ic_article_ltr_ooui
                 }
                 binding.contributionIcon.setImageResource(icon)


### PR DESCRIPTION
I think it's pretty useful to store the namespace of a contribution in the `Contribution` object itself, so that we don't need to construct a `PageTitle` object just to ascertain the namespace from the text.