### PR TITLE
Fix RTL consistency in Talk activities, and menu order.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -120,6 +120,7 @@ class TalkReplyActivity : BaseActivity(), LinkPreviewDialog.Callback, UserMentio
         updateEditLicenseText()
         setSaveButtonEnabled(false)
         setToolbarTitle(viewModel.pageTitle)
+        L10nUtil.setConditionalLayoutDirection(binding.talkScrollContainer, viewModel.pageTitle.wikiSite.languageCode)
 
         if (viewModel.topic != null) {
             binding.replyInputView.userNameHints = setOf(viewModel.topic!!.author)

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -83,7 +83,8 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
         linkHandler = TalkLinkHandler(this)
         linkHandler.wikiSite = viewModel.pageTitle.wikiSite
 
-        L10nUtil.setConditionalLayoutDirection(binding.talkRefreshView, viewModel.pageTitle.wikiSite.languageCode)
+        L10nUtil.setConditionalLayoutDirection(binding.talkRecyclerView, viewModel.pageTitle.wikiSite.languageCode)
+        L10nUtil.setConditionalLayoutDirection(binding.talkErrorView, viewModel.pageTitle.wikiSite.languageCode)
         binding.talkRefreshView.setColorSchemeResources(ResourceUtil.getThemedAttributeId(this, R.attr.colorAccent))
         binding.talkToolbarSubjectView.movementMethod = linkMovementMethod
 

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -272,7 +272,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
 
     private fun resetViews() {
         invalidateOptionsMenu()
-        L10nUtil.setConditionalLayoutDirection(binding.talkRefreshView, pageTitle.wikiSite.languageCode)
+        L10nUtil.setConditionalLayoutDirection(binding.talkContentsView, pageTitle.wikiSite.languageCode)
         binding.talkProgressBar.isVisible = true
         binding.talkErrorView.isVisible = false
         binding.talkEmptyContainer.isVisible = false

--- a/app/src/main/res/layout/activity_talk_topics.xml
+++ b/app/src/main/res/layout/activity_talk_topics.xml
@@ -35,6 +35,7 @@
         </androidx.appcompat.widget.Toolbar>
 
         <FrameLayout
+            android:id="@+id/talkContentsView"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 

--- a/app/src/main/res/menu/menu_talk.xml
+++ b/app/src/main/res/menu/menu_talk.xml
@@ -22,40 +22,34 @@
                 android:icon="@drawable/ic_translate_white_24dp"
                 android:title="@string/langlinks_activity_title"
                 android:visible="false"
-                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
                 android:id="@+id/menu_view_user_page"
                 android:icon="@drawable/ic_user_avatar"
                 android:title="@string/menu_option_user_page"
                 android:visible="false"
-                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
                 android:id="@+id/menu_view_edit_history"
                 android:icon="@drawable/ic_icon_revision_history_apps"
                 android:title="@string/menu_page_edit_history"
-                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
                 android:id="@+id/menu_read_article"
                 android:icon="@drawable/ic_article_ltr_ooui"
                 android:title="@string/button_continue_to_article"
                 android:visible="false"
-                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
                 android:id="@+id/menu_watch"
                 android:icon="@drawable/ic_star_24"
                 android:title="@string/menu_page_watch"
                 android:visible="false"
-                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
                 android:id="@+id/menu_talk_topic_share"
                 android:icon="@drawable/ic_share"
                 android:title="@string/menu_page_article_share"
-                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
         </menu>
     </item>

--- a/app/src/main/res/menu/menu_talk.xml
+++ b/app/src/main/res/menu/menu_talk.xml
@@ -18,39 +18,44 @@
         <menu>
 
             <item
-                android:id="@+id/menu_watch"
-                android:icon="@drawable/ic_star_24"
-                android:title="@string/menu_page_watch"
-                android:visible="false"
-                app:showAsAction="never" />
-            <item
                 android:id="@+id/menu_change_language"
-                android:icon="@drawable/ic_translate_toolbar_icon_color_themed"
+                android:icon="@drawable/ic_translate_white_24dp"
                 android:title="@string/langlinks_activity_title"
                 android:visible="false"
+                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
                 android:id="@+id/menu_view_user_page"
-                android:icon="@drawable/ic_user_avatar_material_secondary_themed"
+                android:icon="@drawable/ic_user_avatar"
                 android:title="@string/menu_option_user_page"
                 android:visible="false"
+                app:iconTint="?attr/material_theme_secondary_color"
+                app:showAsAction="never" />
+            <item
+                android:id="@+id/menu_view_edit_history"
+                android:icon="@drawable/ic_icon_revision_history_apps"
+                android:title="@string/menu_page_edit_history"
+                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
                 android:id="@+id/menu_read_article"
                 android:icon="@drawable/ic_article_ltr_ooui"
                 android:title="@string/button_continue_to_article"
                 android:visible="false"
+                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
-                android:id="@+id/menu_view_edit_history"
-                android:icon="@drawable/ic_icon_revision_history_apps"
-                app:iconTint="?attr/secondary_text_color"
-                android:title="@string/menu_page_edit_history"
+                android:id="@+id/menu_watch"
+                android:icon="@drawable/ic_star_24"
+                android:title="@string/menu_page_watch"
+                android:visible="false"
+                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
             <item
                 android:id="@+id/menu_talk_topic_share"
-                android:icon="@drawable/ic_share_material_secondary_themed"
+                android:icon="@drawable/ic_share"
                 android:title="@string/menu_page_article_share"
+                app:iconTint="?attr/material_theme_secondary_color"
                 app:showAsAction="never" />
         </menu>
     </item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -117,6 +117,8 @@
 
     <style name="ToolbarPopupTheme" parent="ThemeOverlay.MaterialComponents">
         <item name="android:backgroundTint">?android:colorBackground</item>
+        <item name="android:textColor">?attr/color_group_9</item>
+        <item name="android:tint">?attr/color_group_9</item>
     </style>
 
     <style name="BottomNavigationTextAppearanceInactive">


### PR DESCRIPTION
* Apply explicit RTL to specific subviews, not the root view.
* Update order of overflow menu items, and fix tinting.

https://phabricator.wikimedia.org/T297617#7991442