### PR TITLE
Fix: make sure fontSize can be changed correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -196,7 +196,7 @@ class WikipediaApp : Application() {
 
     fun setFontSizeMultiplier(mult: Int): Boolean {
         val multiplier = mult.coerceIn(resources.getInteger(R.integer.minTextSizeMultiplier),
-            resources.getInteger(R.integer.minTextSizeMultiplier))
+            resources.getInteger(R.integer.maxTextSizeMultiplier))
         if (multiplier != Prefs.textSizeMultiplier) {
             Prefs.textSizeMultiplier = multiplier
             bus.post(ChangeTextSizeEvent())


### PR DESCRIPTION
To fix the issue, users cannot change the font size on the article page.