### PR TITLE
Fix one more broken case of PageTitle equality.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -500,7 +500,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     private fun openInNewTab(title: PageTitle, entry: HistoryEntry, position: Int) {
         val selectedTabPosition = app.tabList.firstOrNull { it.backStackPositionTitle != null &&
-                it.backStackPositionTitle == title }?.let { app.tabList.indexOf(it) } ?: -1
+                title.matches(it.backStackPositionTitle) }?.let { app.tabList.indexOf(it) } ?: -1
 
         if (selectedTabPosition >= 0) {
             return

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -332,8 +332,7 @@ class SearchResultsFragment : Fragment() {
 
     private fun displayResults(results: List<SearchResult>) {
         for (newResult in results) {
-            val res = totalResults.find { newResult.pageTitle.prefixedText == it.pageTitle.prefixedText &&
-                    newResult.pageTitle.wikiSite.languageCode == it.pageTitle.wikiSite.languageCode }
+            val res = totalResults.find { newResult.pageTitle.matches(it.pageTitle) }
             if (res == null) {
                 totalResults.add(newResult)
             } else if (!newResult.pageTitle.description.isNullOrEmpty()) {


### PR DESCRIPTION
We cannot use the equality `==` operator to compare `PageTitle` objects. Instead we must use the `.matches()` convenience function.

https://phabricator.wikimedia.org/T310416