### PR TITLE
Fix incorrect stream name of BreadcrumbEvent object.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
@@ -10,13 +10,13 @@ import org.wikipedia.WikipediaApp
 
 @Suppress("unused")
 @Serializable
-@SerialName("/analytics/mobile_apps/android_breadcrumb_log_event/1.0.0")
+@SerialName("/analytics/mobile_apps/android_breadcrumbs_event/1.0.0")
 class BreadCrumbLogEvent(private val screen_name: String,
                          private val action: String,
                          private val primary_language_code: String) : MobileAppsEvent(STREAM_NAME) {
 
     companion object {
-        private const val STREAM_NAME = "android.breadcrumb_log_event"
+        private const val STREAM_NAME = "android.breadcrumbs_event"
 
         fun logClick(activity: Activity, view: View) {
             val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)


### PR DESCRIPTION
The `stream` name of this event was different (??) from the name that's defined in the schema. Therefore these events were not being sent.

https://gerrit.wikimedia.org/r/c/schemas/event/secondary/+/794023
