### PR TITLE
Increase overflow button size to 48dp in talk page thread view

### DIFF
--- a/app/src/main/res/layout/item_talk_thread_item.xml
+++ b/app/src/main/res/layout/item_talk_thread_item.xml
@@ -28,18 +28,17 @@
 
     <ImageView
         android:id="@+id/overflowButton"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        app:srcCompat="@drawable/ic_more_vert_white_24dp"
-        app:tint="?attr/material_theme_secondary_color"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:paddingVertical="12dp"
         android:clickable="true"
         android:focusable="true"
         android:background="?attr/selectableItemBackgroundBorderless"
-        android:contentDescription="@string/menu_feed_overflow_label"/>
+        android:contentDescription="@string/menu_feed_overflow_label"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_more_vert_white_24dp"
+        app:tint="?attr/material_theme_secondary_color"/>
 
     <View
         android:id="@+id/userNameTapTarget"


### PR DESCRIPTION
The button size should be `48dp` x `48dp` for accessibility reasons.