### PR TITLE
Simplify flow of bumping versionCode.

### DIFF
--- a/scripts/bump-version-code.py
+++ b/scripts/bump-version-code.py
@@ -70,4 +70,4 @@ def bump(file_path):
 
 if __name__ == '__main__':
     bump('app/build.gradle')
-    print('BUMP NOTICE! Push the current branch with bumped version and merge if appropriate. (Note: do not delete the `bumpVersionCode` branch!)')
+    print('BUMP NOTICE! Merge the new `bumpVersionCode` into Main.)')

--- a/scripts/bump-version-code.py
+++ b/scripts/bump-version-code.py
@@ -56,9 +56,16 @@ def transform_file(file_path, *funcs):
 def bump(file_path):
     transform_file(file_path, set_version_code)
     sh.cd(path_prefix)
-    sh.git.checkout('bumpVersionCode')
+    sh.git.checkout('main')
+    try:
+        sh.git.branch('-D', 'bumpVersionCode')
+    except:
+        print('Branch not deleted (safe to ignore).')
+    sh.git.checkout('-b', 'bumpVersionCode')
     sh.git.add('-u', file_path)
-    sh.git.commit('-m', 'Bump versionCode')
+    sh.git.commit('-m', 'Bump versionCode.')
+    sh.git.push('--set-upstream', 'origin', 'bumpVersionCode')
+    sh.git.checkout('main')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We will no longer have a "permanent" branch called `bumpVersionCode`. Instead, this branch will be created whenever a new bump occurs, just like any other pull request, and will be deleted automatically by GitHub when merged.