### PR TITLE
Improve debuggability of MEP events.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -153,7 +153,10 @@ object EventPlatformClient {
         }
 
         fun sendEventsForStream(streamConfig: StreamConfig, events: List<Event>) {
-            ServiceFactory.getAnalyticsRest(streamConfig).postEventsHasty(events)
+            (if (ReleaseUtil.isDevRelease)
+                ServiceFactory.getAnalyticsRest(streamConfig).postEvents(events)
+            else
+                ServiceFactory.getAnalyticsRest(streamConfig).postEventsHasty(events))
                     .subscribeOn(Schedulers.io())
                     .subscribe({
                         when (it.code()) {

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.kt
@@ -20,5 +20,5 @@ interface EventService {
     fun postEventsHasty(@Body events: @JvmSuppressWildcards List<Event>): Observable<Response<Unit>>
 
     @POST("/v1/events")
-    fun postEvents(@Body events: @JvmSuppressWildcards List<Event>): Observable<Response<EventServiceResponse>>
+    fun postEvents(@Body events: @JvmSuppressWildcards List<Event>): Observable<Response<Unit>>
 }

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/HttpStatusException.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/HttpStatusException.kt
@@ -29,7 +29,12 @@ class HttpStatusException : IOException {
         try {
             rsp.body?.let {
                 if (it.contentType().toString().contains("json")) {
-                    serviceError = RbServiceError.create(it.string())
+                    val body = it.string()
+                    if (body.contains("\$schema")) {
+                        message = body
+                    } else {
+                        serviceError = RbServiceError.create(body)
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/HttpStatusException.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/HttpStatusException.kt
@@ -31,6 +31,9 @@ class HttpStatusException : IOException {
                 if (it.contentType().toString().contains("json")) {
                     val body = it.string()
                     if (body.contains("\$schema")) {
+                        // This is likely an error from the Event service, and should not be parsed
+                        // as a Rest Service error. Just keep the whole body of the error as the
+                        // exception message.
                         message = body
                     } else {
                         serviceError = RbServiceError.create(body)


### PR DESCRIPTION
When we send improperly-formatted MEP events, the server actually responds with some useful debugging information. However, we were simply ignoring this information, and not passing it through to our `HttpStatusException` object.

For the `dev` build, we will now send events using the non-hasty call, which will give us the server-side error(s) properly, and then catch any errors in our exception class.