### PR TITLE
Fix navigating to talk topics after switching language.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
@@ -433,7 +433,7 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
 
         override fun onCreateViewHolder(parent: ViewGroup, type: Int): TalkTopicHolder {
             return TalkTopicHolder(ItemTalkTopicBinding.inflate(fragment.layoutInflater, parent, false),
-                fragment.requireContext(), pageTitle, viewModel, Constants.InvokeSource.PAGE_ACTIVITY)
+                fragment.requireContext(), viewModel, Constants.InvokeSource.PAGE_ACTIVITY)
         }
 
         override fun onBindViewHolder(holder: TalkTopicHolder, pos: Int) {

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -318,7 +318,7 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
 
     private inner class HeaderViewHolder constructor(private val view: TalkThreadHeaderView) : RecyclerView.ViewHolder(view), TalkThreadHeaderView.Callback {
         fun bindItem() {
-            view.bind(viewModel.pageTitle, viewModel.topic!!, viewModel.subscribed, linkMovementMethod, viewModel.currentSearchQuery)
+            view.bind(viewModel.pageTitle, viewModel.topic, viewModel.subscribed, linkMovementMethod, viewModel.currentSearchQuery)
             view.callback = this
         }
 

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
@@ -16,7 +16,6 @@ import org.wikipedia.R
 import org.wikipedia.databinding.ItemTalkTopicBinding
 import org.wikipedia.dataclient.discussiontools.ThreadItem
 import org.wikipedia.page.Namespace
-import org.wikipedia.page.PageTitle
 import org.wikipedia.richtext.RichTextUtil
 import org.wikipedia.util.*
 import org.wikipedia.views.SwipeableItemTouchHelperCallback
@@ -26,7 +25,6 @@ import java.util.*
 class TalkTopicHolder internal constructor(
         private val binding: ItemTalkTopicBinding,
         private val context: Context,
-        private val pageTitle: PageTitle,
         private val viewModel: TalkTopicsViewModel,
         private val invokeSource: Constants.InvokeSource
 ) : RecyclerView.ViewHolder(binding.root), View.OnClickListener, SwipeableItemTouchHelperCallback.Callback {
@@ -77,7 +75,7 @@ class TalkTopicHolder internal constructor(
         binding.otherContentText.isVisible = false
 
         // Last comment
-        binding.topicContentText.isVisible = pageTitle.namespace() == Namespace.USER_TALK
+        binding.topicContentText.isVisible = viewModel.pageTitle?.namespace() == Namespace.USER_TALK
         binding.topicContentText.text = RichTextUtil.stripHtml(allReplies.last().html).trim().replace("\n", " ")
         binding.topicContentText.setTextColor(ResourceUtil.getThemedColor(context, if (threadItem.seen) android.R.attr.textColorTertiary else R.attr.primary_text_color))
         StringUtil.highlightAndBoldenText(binding.topicContentText, viewModel.currentSearchQuery, true, Color.YELLOW)
@@ -87,8 +85,8 @@ class TalkTopicHolder internal constructor(
         val usernameText = allReplies.maxByOrNull { it.date ?: Date() }?.author.orEmpty() + (if (usersInvolved > 1) " +$usersInvolved" else "")
         val usernameColor = if (threadItem.seen) android.R.attr.textColorTertiary else R.attr.colorAccent
         binding.topicUsername.text = usernameText
-        binding.topicUserIcon.isVisible = pageTitle.namespace() == Namespace.USER_TALK
-        binding.topicUsername.isVisible = pageTitle.namespace() == Namespace.USER_TALK
+        binding.topicUserIcon.isVisible = viewModel.pageTitle?.namespace() == Namespace.USER_TALK
+        binding.topicUsername.isVisible = viewModel.pageTitle?.namespace() == Namespace.USER_TALK
         binding.topicUsername.setTextColor(ResourceUtil.getThemedColor(context, usernameColor))
         ImageViewCompat.setImageTintList(binding.topicUserIcon, ResourceUtil.getThemedColorStateList(context, usernameColor))
         StringUtil.highlightAndBoldenText(binding.topicUsername, viewModel.currentSearchQuery, true, Color.YELLOW)
@@ -112,7 +110,7 @@ class TalkTopicHolder internal constructor(
 
     override fun onClick(v: View?) {
         markAsSeen(true)
-        context.startActivity(TalkTopicActivity.newIntent(context, pageTitle, threadItem.name, threadItem.id, null, viewModel.currentSearchQuery, invokeSource))
+        context.startActivity(TalkTopicActivity.newIntent(context, viewModel.pageTitle!!, threadItem.name, threadItem.id, null, viewModel.currentSearchQuery, invokeSource))
     }
 
     override fun onSwipe() {
@@ -147,7 +145,7 @@ class TalkTopicHolder internal constructor(
 
                 override fun shareClick() {
                     ShareUtil.shareText(context, context.getString(R.string.talk_share_discussion_subject,
-                        threadItem.html.ifEmpty { context.getString(R.string.talk_no_subject) }), pageTitle.uri + "#" + StringUtil.addUnderscores(threadItem.html))
+                        threadItem.html.ifEmpty { context.getString(R.string.talk_no_subject) }), viewModel.pageTitle?.uri + "#" + StringUtil.addUnderscores(threadItem.html))
                 }
             })
         }

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -518,7 +518,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, type: Int): RecyclerView.ViewHolder {
-            return TalkTopicHolder(ItemTalkTopicBinding.inflate(layoutInflater, parent, false), this@TalkTopicsActivity, pageTitle, viewModel, invokeSource)
+            return TalkTopicHolder(ItemTalkTopicBinding.inflate(layoutInflater, parent, false), this@TalkTopicsActivity, viewModel, invokeSource)
         }
 
         override fun onBindViewHolder(holder: RecyclerView.ViewHolder, pos: Int) {


### PR DESCRIPTION
In `TalkTopicsActivity` we allow the user to change the language to see their talk page on a different wiki. But after changing the language and navigating to a topic in the new language, the navigation fails, and may even result in a crash. This is because a reference to a `PageTitle` object is maintained by `TalkTopicHolder`, when it can just get the pageTitle from the ViewModel instead.