### PR TITLE
Fix: use resolved pageTitle in TalkTopicHolder

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
@@ -18,6 +18,7 @@ import org.wikipedia.dataclient.discussiontools.ThreadItem
 import org.wikipedia.page.Namespace
 import org.wikipedia.richtext.RichTextUtil
 import org.wikipedia.util.*
+import org.wikipedia.util.log.L
 import org.wikipedia.views.SwipeableItemTouchHelperCallback
 import org.wikipedia.views.TalkTopicsActionsOverflowView
 import java.util.*
@@ -75,7 +76,7 @@ class TalkTopicHolder internal constructor(
         binding.otherContentText.isVisible = false
 
         // Last comment
-        binding.topicContentText.isVisible = viewModel.pageTitle?.namespace() == Namespace.USER_TALK
+        binding.topicContentText.isVisible = viewModel.resolvedPageTitle?.namespace() == Namespace.USER_TALK
         binding.topicContentText.text = RichTextUtil.stripHtml(allReplies.last().html).trim().replace("\n", " ")
         binding.topicContentText.setTextColor(ResourceUtil.getThemedColor(context, if (threadItem.seen) android.R.attr.textColorTertiary else R.attr.primary_text_color))
         StringUtil.highlightAndBoldenText(binding.topicContentText, viewModel.currentSearchQuery, true, Color.YELLOW)
@@ -85,8 +86,8 @@ class TalkTopicHolder internal constructor(
         val usernameText = allReplies.maxByOrNull { it.date ?: Date() }?.author.orEmpty() + (if (usersInvolved > 1) " +$usersInvolved" else "")
         val usernameColor = if (threadItem.seen) android.R.attr.textColorTertiary else R.attr.colorAccent
         binding.topicUsername.text = usernameText
-        binding.topicUserIcon.isVisible = viewModel.pageTitle?.namespace() == Namespace.USER_TALK
-        binding.topicUsername.isVisible = viewModel.pageTitle?.namespace() == Namespace.USER_TALK
+        binding.topicUserIcon.isVisible = viewModel.resolvedPageTitle?.namespace() == Namespace.USER_TALK
+        binding.topicUsername.isVisible = viewModel.resolvedPageTitle?.namespace() == Namespace.USER_TALK
         binding.topicUsername.setTextColor(ResourceUtil.getThemedColor(context, usernameColor))
         ImageViewCompat.setImageTintList(binding.topicUserIcon, ResourceUtil.getThemedColorStateList(context, usernameColor))
         StringUtil.highlightAndBoldenText(binding.topicUsername, viewModel.currentSearchQuery, true, Color.YELLOW)
@@ -110,7 +111,7 @@ class TalkTopicHolder internal constructor(
 
     override fun onClick(v: View?) {
         markAsSeen(true)
-        context.startActivity(TalkTopicActivity.newIntent(context, viewModel.pageTitle!!, threadItem.name, threadItem.id, null, viewModel.currentSearchQuery, invokeSource))
+        context.startActivity(TalkTopicActivity.newIntent(context, viewModel.resolvedPageTitle!!, threadItem.name, threadItem.id, null, viewModel.currentSearchQuery, invokeSource))
     }
 
     override fun onSwipe() {
@@ -145,7 +146,7 @@ class TalkTopicHolder internal constructor(
 
                 override fun shareClick() {
                     ShareUtil.shareText(context, context.getString(R.string.talk_share_discussion_subject,
-                        threadItem.html.ifEmpty { context.getString(R.string.talk_no_subject) }), viewModel.pageTitle?.uri + "#" + StringUtil.addUnderscores(threadItem.html))
+                        threadItem.html.ifEmpty { context.getString(R.string.talk_no_subject) }), viewModel.resolvedPageTitle?.uri + "#" + StringUtil.addUnderscores(threadItem.html))
                 }
             })
         }

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
@@ -18,7 +18,6 @@ import org.wikipedia.dataclient.discussiontools.ThreadItem
 import org.wikipedia.page.Namespace
 import org.wikipedia.richtext.RichTextUtil
 import org.wikipedia.util.*
-import org.wikipedia.util.log.L
 import org.wikipedia.views.SwipeableItemTouchHelperCallback
 import org.wikipedia.views.TalkTopicsActionsOverflowView
 import java.util.*

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
@@ -35,6 +35,7 @@ class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : V
 
     private val watchlistFunnel = WatchlistFunnel()
     private var resolveTitleRequired = false
+    var resolvedPageTitle: PageTitle? = null
     val threadItems = mutableListOf<ThreadItem>()
     var sortedThreadItems = listOf<ThreadItem>()
     var lastRevision: MwQueryPage.Revision? = null
@@ -114,6 +115,7 @@ class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : V
 
             isWatched = watchStatus.watched
             hasWatchlistExpiry = watchStatus.hasWatchlistExpiry()
+            resolvedPageTitle = pageTitle
 
             uiState.value = UiState.LoadTopic(pageTitle, threadItems)
         }


### PR DESCRIPTION
Looks like fix #3427 will make every topic show "(No subject)" with an empty content in the `TalkTopicActivity`.
