### PR TITLE
Follow-up to PageTitle in TalkTopics.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -324,7 +324,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
     override fun onNavMenuSwipeRequest(gravity: Int) {
         if (!isCabOpen && gravity == Gravity.END) {
             pageFragment.articleInteractionEvent?.logTocSwipe()
-            pageFragment.sidePanelHandler?.showToC()
+            pageFragment.sidePanelHandler.showToC()
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -324,7 +324,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
     override fun onNavMenuSwipeRequest(gravity: Int) {
         if (!isCabOpen && gravity == Gravity.END) {
             pageFragment.articleInteractionEvent?.logTocSwipe()
-            pageFragment.sidePanelHandler.showToC()
+            pageFragment.sidePanelHandler?.showToC()
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -149,6 +149,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     override val referencesGroup get() = references?.referencesGroup
     override val selectedReferenceIndex get() = references?.selectedIndex ?: 0
 
+    lateinit var sidePanelHandler: SidePanelHandler
     lateinit var shareHandler: ShareHandler
     lateinit var editHandler: EditHandler
     var revision = 0L
@@ -157,7 +158,6 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     private val backgroundTabPosition get() = 0.coerceAtLeast(foregroundTabPosition - 1)
     private val foregroundTabPosition get() = app.tabList.size
     private val tabLayoutOffsetParams get() = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, binding.pageActionsTabLayout.height)
-    var sidePanelHandler: SidePanelHandler? = null
     val currentTab get() = app.tabList.last()!!
     val title get() = model.title
     val page get() = model.page
@@ -248,7 +248,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         }
         // uninitialize the bridge, so that no further JS events can have any effect.
         bridge.cleanup()
-        sidePanelHandler?.log()
+        sidePanelHandler.log()
         leadImagesHandler.dispose()
         disposables.clear()
         webView.clearAllListeners()
@@ -301,8 +301,8 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     override fun onBackPressed(): Boolean {
         articleInteractionEvent?.logBackClick()
-        if (sidePanelHandler?.isVisible == true) {
-            sidePanelHandler?.hide()
+        if (sidePanelHandler.isVisible) {
+            sidePanelHandler.hide()
             return true
         }
         if (pageFragmentLoadState.goBack()) {
@@ -437,11 +437,9 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
                     sections.add(0, Section(0, 0, model.title?.displayText.orEmpty(), model.title?.displayText.orEmpty(), ""))
                     page.sections = sections
                 }
-            }
 
-            model.page?.let {
-                sidePanelHandler?.setupForNewPage(it)
-                sidePanelHandler?.setEnabled(true)
+                sidePanelHandler.setupForNewPage(page)
+                sidePanelHandler.setEnabled(true)
             }
         }
         bridge.evaluate(JavaScriptActionHandler.getProtection()) { value ->
@@ -974,7 +972,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         addTimeSpentReading(activeTimer.elapsedSec)
         activeTimer.reset()
         callback()?.onPageSetToolbarElevationEnabled(false)
-        sidePanelHandler?.setEnabled(false)
+        sidePanelHandler.setEnabled(false)
         errorState = false
         binding.pageError.visibility = View.GONE
         watchlistExpiryChanged = false
@@ -1018,7 +1016,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
                 it.alpha = if (it.isEnabled) 1f else 0.5f
             }
         }
-        sidePanelHandler?.setEnabled(false)
+        sidePanelHandler.setEnabled(false)
         requireActivity().invalidateOptionsMenu()
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -149,7 +149,6 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     override val referencesGroup get() = references?.referencesGroup
     override val selectedReferenceIndex get() = references?.selectedIndex ?: 0
 
-    lateinit var sidePanelHandler: SidePanelHandler
     lateinit var shareHandler: ShareHandler
     lateinit var editHandler: EditHandler
     var revision = 0L
@@ -158,6 +157,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     private val backgroundTabPosition get() = 0.coerceAtLeast(foregroundTabPosition - 1)
     private val foregroundTabPosition get() = app.tabList.size
     private val tabLayoutOffsetParams get() = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, binding.pageActionsTabLayout.height)
+    var sidePanelHandler: SidePanelHandler? = null
     val currentTab get() = app.tabList.last()!!
     val title get() = model.title
     val page get() = model.page
@@ -248,7 +248,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         }
         // uninitialize the bridge, so that no further JS events can have any effect.
         bridge.cleanup()
-        sidePanelHandler.log()
+        sidePanelHandler?.log()
         leadImagesHandler.dispose()
         disposables.clear()
         webView.clearAllListeners()
@@ -301,8 +301,8 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     override fun onBackPressed(): Boolean {
         articleInteractionEvent?.logBackClick()
-        if (sidePanelHandler.isVisible) {
-            sidePanelHandler.hide()
+        if (sidePanelHandler?.isVisible == true) {
+            sidePanelHandler?.hide()
             return true
         }
         if (pageFragmentLoadState.goBack()) {
@@ -439,9 +439,9 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
                 }
             }
 
-            model.title?.let {
-                sidePanelHandler.setupForNewPage(model.page)
-                sidePanelHandler.setEnabled(true)
+            model.page?.let {
+                sidePanelHandler?.setupForNewPage(it)
+                sidePanelHandler?.setEnabled(true)
             }
         }
         bridge.evaluate(JavaScriptActionHandler.getProtection()) { value ->
@@ -974,7 +974,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         addTimeSpentReading(activeTimer.elapsedSec)
         activeTimer.reset()
         callback()?.onPageSetToolbarElevationEnabled(false)
-        sidePanelHandler.setEnabled(false)
+        sidePanelHandler?.setEnabled(false)
         errorState = false
         binding.pageError.visibility = View.GONE
         watchlistExpiryChanged = false
@@ -1018,7 +1018,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
                 it.alpha = if (it.isEnabled) 1f else 0.5f
             }
         }
-        sidePanelHandler.setEnabled(false)
+        sidePanelHandler?.setEnabled(false)
         requireActivity().invalidateOptionsMenu()
     }
 
@@ -1407,7 +1407,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         }
 
         override fun onContentsSelected() {
-            sidePanelHandler.showToC()
+            sidePanelHandler?.showTalkTopics()//  .showToC()
             articleInteractionEvent?.logContentsClick()
         }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -1405,7 +1405,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         }
 
         override fun onContentsSelected() {
-            sidePanelHandler?.showToC()
+            sidePanelHandler.showToC()
             articleInteractionEvent?.logContentsClick()
         }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -1407,7 +1407,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         }
 
         override fun onContentsSelected() {
-            sidePanelHandler?.showTalkTopics()//  .showToC()
+            sidePanelHandler?.showToC()
             articleInteractionEvent?.logContentsClick()
         }
 

--- a/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
@@ -107,6 +107,15 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
                 enableToCorTalkTopics(true)
             }
         })
+
+        binding.talkTitleView.setOnClickListener { openTalkPage() }
+        binding.talkFullscreenButton.setOnClickListener { openTalkPage() }
+        binding.talkLastModified.setOnClickListener { _ ->
+            talkViewModel?.let {
+                fragment.startActivity(ArticleEditDetailsActivity.newIntent(fragment.requireContext(), it.pageTitle, it.lastRevision!!.revId))
+            }
+        }
+
         setScrollerPosition()
         enableToCorTalkTopics()
     }
@@ -142,18 +151,12 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
 
     private fun updateOnSuccess(pageTitle: PageTitle) {
         binding.talkTitleView.text = StringUtil.fromHtml(pageTitle.displayText)
-        binding.talkTitleView.setOnClickListener(openTalkPageOnClickListener(pageTitle))
-        binding.talkFullscreenButton.setOnClickListener(openTalkPageOnClickListener(pageTitle))
 
         talkViewModel?.lastRevision?.let {
             binding.talkLastModified.text = StringUtil.fromHtml(fragment.getString(R.string.talk_last_modified,
                 DateUtils.getRelativeTimeSpanString(DateUtil.iso8601DateParse(it.timeStamp).time,
                     System.currentTimeMillis(), 0L), it.user))
             binding.talkLastModified.isVisible = true
-            binding.talkLastModified.setOnClickListener {
-                fragment.startActivity(ArticleEditDetailsActivity.newIntent(fragment.requireContext(),
-                        talkViewModel!!.pageTitle, talkViewModel!!.lastRevision!!.revId))
-            }
         }
 
         binding.talkErrorView.visibility = View.GONE
@@ -173,9 +176,9 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
         }
     }
 
-    private fun openTalkPageOnClickListener(title: PageTitle): View.OnClickListener {
-        return View.OnClickListener {
-            fragment.startActivity(TalkTopicsActivity.newIntent(fragment.requireContext(), title, Constants.InvokeSource.PAGE_ACTIVITY))
+    private fun openTalkPage() {
+        talkViewModel?.let {
+            fragment.startActivity(TalkTopicsActivity.newIntent(fragment.requireContext(), it.pageTitle, Constants.InvokeSource.PAGE_ACTIVITY))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
@@ -18,7 +18,6 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.drawerlayout.widget.DrawerLayout
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -52,7 +51,7 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
         ObservableWebView.OnClickListener, ObservableWebView.OnScrollChangeListener, OnContentHeightChangedListener {
 
     private val binding = (fragment.requireActivity() as PageActivity).binding
-    private val viewModel: TalkTopicsViewModel by fragment.viewModels { TalkTopicsViewModel.Factory(fragment.title, true) }
+    private var talkViewModel: TalkTopicsViewModel? = null
     private val talkTopicsAdapter = TalkTopicItemAdapter()
     private val scrollerViewParams = FrameLayout.LayoutParams(DimenUtil.roundedDpToPx(SCROLLER_BUTTON_SIZE), DimenUtil.roundedDpToPx(SCROLLER_BUTTON_SIZE))
     private val webView = fragment.webView
@@ -110,15 +109,6 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
         })
         setScrollerPosition()
         enableToCorTalkTopics()
-
-        fragment.lifecycleScope.launchWhenCreated {
-            viewModel.uiState.collect {
-                when (it) {
-                    is TalkTopicsViewModel.UiState.LoadTopic -> updateOnSuccess(it.pageTitle)
-                    is TalkTopicsViewModel.UiState.LoadError -> updateOnError(it.throwable)
-                }
-            }
-        }
     }
 
     private fun setupTalkTopics(pageTitle: PageTitle) {
@@ -134,8 +124,20 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
             hide()
         }
 
-        viewModel.pageTitle = pageTitle
-        viewModel.loadTopics()
+        if (talkViewModel == null) {
+            talkViewModel = TalkTopicsViewModel(pageTitle.copy(), true)
+
+            fragment.lifecycleScope.launchWhenCreated {
+                talkViewModel?.uiState?.collect {
+                    when (it) {
+                        is TalkTopicsViewModel.UiState.LoadTopic -> updateOnSuccess(it.pageTitle)
+                        is TalkTopicsViewModel.UiState.LoadError -> updateOnError(it.throwable)
+                    }
+                }
+            }
+        } else {
+            talkViewModel?.updatePageTitle(pageTitle)
+        }
     }
 
     private fun updateOnSuccess(pageTitle: PageTitle) {
@@ -143,17 +145,17 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
         binding.talkTitleView.setOnClickListener(openTalkPageOnClickListener(pageTitle))
         binding.talkFullscreenButton.setOnClickListener(openTalkPageOnClickListener(pageTitle))
 
-        viewModel.lastRevision?.let {
+        talkViewModel?.lastRevision?.let {
             binding.talkLastModified.text = StringUtil.fromHtml(fragment.getString(R.string.talk_last_modified,
                 DateUtils.getRelativeTimeSpanString(DateUtil.iso8601DateParse(it.timeStamp).time,
                     System.currentTimeMillis(), 0L), it.user))
             binding.talkLastModified.isVisible = true
-            binding.talkLastModified.setOnClickListener { _ ->
-                fragment.startActivity(ArticleEditDetailsActivity.newIntent(fragment.requireContext(), pageTitle, it.revId))
+            binding.talkLastModified.setOnClickListener {
+                fragment.startActivity(ArticleEditDetailsActivity.newIntent(fragment.requireContext(),
+                        talkViewModel!!.pageTitle, talkViewModel!!.lastRevision!!.revId))
             }
         }
 
-        talkTopicsAdapter.pageTitle = pageTitle
         binding.talkErrorView.visibility = View.GONE
         binding.talkProgressBar.visibility = View.GONE
         binding.talkRecyclerView.visibility = View.VISIBLE
@@ -178,22 +180,20 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
     }
 
     @SuppressLint("RtlHardcoded")
-    fun setupForNewPage(page: Page?) {
-        page?.let {
-            tocAdapter.setPage(it)
-            rtl = L10nUtil.isLangRTL(it.title.wikiSite.languageCode)
-            binding.tocList.rtl = rtl
-            L10nUtil.setConditionalLayoutDirection(binding.sidePanelContainer, it.title.wikiSite.languageCode)
-            binding.sidePanelContainer.updateLayoutParams<DrawerLayout.LayoutParams> {
-                gravity = if (rtl) Gravity.LEFT else Gravity.RIGHT
-            }
-            log()
-            funnel = ToCInteractionFunnel(WikipediaApp.instance, it.title.wikiSite, it.pageProperties.pageId, tocAdapter.count)
-            articleTocInteractionEvent = ArticleTocInteractionEvent(it.pageProperties.pageId, it.title.wikiSite.dbName(), tocAdapter.count)
-            articleTocInteractionEvent?.logClick()
-            if (ReleaseUtil.isPreBetaRelease) {
-                setupTalkTopics(it.title)
-            }
+    fun setupForNewPage(page: Page) {
+        tocAdapter.setPage(page)
+        rtl = L10nUtil.isLangRTL(page.title.wikiSite.languageCode)
+        binding.tocList.rtl = rtl
+        L10nUtil.setConditionalLayoutDirection(binding.sidePanelContainer, page.title.wikiSite.languageCode)
+        binding.sidePanelContainer.updateLayoutParams<DrawerLayout.LayoutParams> {
+            gravity = if (rtl) Gravity.LEFT else Gravity.RIGHT
+        }
+        log()
+        funnel = ToCInteractionFunnel(WikipediaApp.instance, page.title.wikiSite, page.pageProperties.pageId, tocAdapter.count)
+        articleTocInteractionEvent = ArticleTocInteractionEvent(page.pageProperties.pageId, page.title.wikiSite.dbName(), tocAdapter.count)
+        articleTocInteractionEvent?.logClick()
+        if (ReleaseUtil.isPreBetaRelease) {
+            setupTalkTopics(page.title)
         }
     }
 
@@ -424,20 +424,17 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
     }
 
     inner class TalkTopicItemAdapter : RecyclerView.Adapter<TalkTopicHolder>() {
-
-        lateinit var pageTitle: PageTitle
-
         override fun getItemCount(): Int {
-            return viewModel.sortedThreadItems.size
+            return talkViewModel?.sortedThreadItems?.size ?: 0
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, type: Int): TalkTopicHolder {
             return TalkTopicHolder(ItemTalkTopicBinding.inflate(fragment.layoutInflater, parent, false),
-                fragment.requireContext(), viewModel, Constants.InvokeSource.PAGE_ACTIVITY)
+                fragment.requireContext(), talkViewModel!!, Constants.InvokeSource.PAGE_ACTIVITY)
         }
 
         override fun onBindViewHolder(holder: TalkTopicHolder, pos: Int) {
-             holder.bindItem(viewModel.sortedThreadItems[pos])
+             holder.bindItem(talkViewModel!!.sortedThreadItems[pos])
         }
     }
 

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
@@ -75,7 +75,7 @@ class TalkTopicHolder internal constructor(
         binding.otherContentText.isVisible = false
 
         // Last comment
-        binding.topicContentText.isVisible = viewModel.resolvedPageTitle?.namespace() == Namespace.USER_TALK
+        binding.topicContentText.isVisible = viewModel.pageTitle.namespace() == Namespace.USER_TALK
         binding.topicContentText.text = RichTextUtil.stripHtml(allReplies.last().html).trim().replace("\n", " ")
         binding.topicContentText.setTextColor(ResourceUtil.getThemedColor(context, if (threadItem.seen) android.R.attr.textColorTertiary else R.attr.primary_text_color))
         StringUtil.highlightAndBoldenText(binding.topicContentText, viewModel.currentSearchQuery, true, Color.YELLOW)
@@ -85,8 +85,8 @@ class TalkTopicHolder internal constructor(
         val usernameText = allReplies.maxByOrNull { it.date ?: Date() }?.author.orEmpty() + (if (usersInvolved > 1) " +$usersInvolved" else "")
         val usernameColor = if (threadItem.seen) android.R.attr.textColorTertiary else R.attr.colorAccent
         binding.topicUsername.text = usernameText
-        binding.topicUserIcon.isVisible = viewModel.resolvedPageTitle?.namespace() == Namespace.USER_TALK
-        binding.topicUsername.isVisible = viewModel.resolvedPageTitle?.namespace() == Namespace.USER_TALK
+        binding.topicUserIcon.isVisible = viewModel.pageTitle.namespace() == Namespace.USER_TALK
+        binding.topicUsername.isVisible = viewModel.pageTitle.namespace() == Namespace.USER_TALK
         binding.topicUsername.setTextColor(ResourceUtil.getThemedColor(context, usernameColor))
         ImageViewCompat.setImageTintList(binding.topicUserIcon, ResourceUtil.getThemedColorStateList(context, usernameColor))
         StringUtil.highlightAndBoldenText(binding.topicUsername, viewModel.currentSearchQuery, true, Color.YELLOW)
@@ -110,7 +110,7 @@ class TalkTopicHolder internal constructor(
 
     override fun onClick(v: View?) {
         markAsSeen(true)
-        context.startActivity(TalkTopicActivity.newIntent(context, viewModel.resolvedPageTitle!!, threadItem.name, threadItem.id, null, viewModel.currentSearchQuery, invokeSource))
+        context.startActivity(TalkTopicActivity.newIntent(context, viewModel.pageTitle, threadItem.name, threadItem.id, null, viewModel.currentSearchQuery, invokeSource))
     }
 
     override fun onSwipe() {
@@ -145,7 +145,7 @@ class TalkTopicHolder internal constructor(
 
                 override fun shareClick() {
                     ShareUtil.shareText(context, context.getString(R.string.talk_share_discussion_subject,
-                        threadItem.html.ifEmpty { context.getString(R.string.talk_no_subject) }), viewModel.resolvedPageTitle?.uri + "#" + StringUtil.addUnderscores(threadItem.html))
+                        threadItem.html.ifEmpty { context.getString(R.string.talk_no_subject) }), viewModel.pageTitle.uri + "#" + StringUtil.addUnderscores(threadItem.html))
                 }
             })
         }

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -54,10 +54,9 @@ import org.wikipedia.watchlist.WatchlistExpiryDialog
 
 class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
     private lateinit var binding: ActivityTalkTopicsBinding
-    private lateinit var pageTitle: PageTitle
     private lateinit var invokeSource: Constants.InvokeSource
     private lateinit var notificationButtonView: NotificationButtonView
-    private val viewModel: TalkTopicsViewModel by viewModels { TalkTopicsViewModel.Factory(intent.getParcelableExtra(EXTRA_PAGE_TITLE)) }
+    private val viewModel: TalkTopicsViewModel by viewModels { TalkTopicsViewModel.Factory(intent.getParcelableExtra(EXTRA_PAGE_TITLE)!!) }
     private val concatAdapter = ConcatAdapter()
     private val headerAdapter = HeaderItemAdapter()
     private val talkTopicItemAdapter = TalkTopicItemAdapter()
@@ -77,21 +76,20 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
                         funnel?.logChangeLanguage()
 
                         val newNamespace = when {
-                            pageTitle.namespace() == Namespace.USER -> {
+                            viewModel.pageTitle.namespace() == Namespace.USER -> {
                                 UserAliasData.valueFor(WikipediaApp.instance.languageState.appLanguageCodes[pos])
                             }
-                            pageTitle.namespace() == Namespace.USER_TALK -> {
+                            viewModel.pageTitle.namespace() == Namespace.USER_TALK -> {
                                 UserTalkAliasData.valueFor(WikipediaApp.instance.languageState.appLanguageCodes[pos])
                             }
-                            else -> pageTitle.namespace
+                            else -> viewModel.pageTitle.namespace
                         }
 
-                        pageTitle = PageTitle(newNamespace, StringUtil.removeNamespace(pageTitle.prefixedText),
+                        val newPageTitle = PageTitle(newNamespace, StringUtil.removeNamespace(viewModel.pageTitle.prefixedText),
                             WikiSite.forLanguageCode(WikipediaApp.instance.languageState.appLanguageCodes[pos]))
 
                         resetViews()
-                        viewModel.pageTitle = pageTitle
-                        viewModel.loadTopics()
+                        viewModel.updatePageTitle(newPageTitle)
                     }
                 }
             }
@@ -131,7 +129,6 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         goToTopic = intent.getBooleanExtra(EXTRA_GO_TO_TOPIC, false)
-        pageTitle = intent.getParcelableExtra(EXTRA_PAGE_TITLE)!!
         binding.talkRecyclerView.layoutManager = LinearLayoutManager(this)
         binding.talkRecyclerView.addItemDecoration(DrawableItemDecoration(this, R.attr.list_separator_drawable, drawStart = false, drawEnd = false, skipSearchBar = true))
         binding.talkRecyclerView.itemAnimator = null
@@ -154,7 +151,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
 
         binding.talkNewTopicButton.setOnClickListener {
             funnel?.logNewTopicClick()
-            requestNewTopic.launch(TalkReplyActivity.newIntent(this@TalkTopicsActivity, pageTitle, null, null, invokeSource))
+            requestNewTopic.launch(TalkReplyActivity.newIntent(this@TalkTopicsActivity, viewModel.pageTitle, null, null, invokeSource))
         }
 
         binding.talkRefreshView.setOnRefreshListener {
@@ -200,10 +197,10 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
         if (!goToTopic) {
-            menu!!.findItem(R.id.menu_change_language).isVisible = pageTitle.namespace() == Namespace.USER_TALK
-            menu.findItem(R.id.menu_read_article).isVisible = pageTitle.namespace() != Namespace.USER_TALK
-            menu.findItem(R.id.menu_view_user_page).isVisible = pageTitle.namespace() == Namespace.USER_TALK
-            menu.findItem(R.id.menu_view_user_page).title = getString(R.string.menu_option_user_page, StringUtil.removeNamespace(pageTitle.displayText))
+            menu!!.findItem(R.id.menu_change_language).isVisible = viewModel.pageTitle.namespace() == Namespace.USER_TALK
+            menu.findItem(R.id.menu_read_article).isVisible = viewModel.pageTitle.namespace() != Namespace.USER_TALK
+            menu.findItem(R.id.menu_view_user_page).isVisible = viewModel.pageTitle.namespace() == Namespace.USER_TALK
+            menu.findItem(R.id.menu_view_user_page).title = getString(R.string.menu_option_user_page, StringUtil.removeNamespace(viewModel.pageTitle.displayText))
 
             val notificationMenuItem = menu.findItem(R.id.menu_notifications)
             val watchMenuItem = menu.findItem(R.id.menu_watch)
@@ -246,11 +243,11 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
                 return true
             }
             R.id.menu_view_edit_history -> {
-                startActivity(EditHistoryListActivity.newIntent(this, pageTitle))
+                startActivity(EditHistoryListActivity.newIntent(this, viewModel.pageTitle))
                 return true
             }
             R.id.menu_talk_topic_share -> {
-                ShareUtil.shareText(this, getString(R.string.talk_share_talk_page), pageTitle.uri)
+                ShareUtil.shareText(this, getString(R.string.talk_share_talk_page), viewModel.pageTitle.uri)
                 return true
             }
             R.id.menu_watch -> {
@@ -274,7 +271,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
 
     private fun resetViews() {
         invalidateOptionsMenu()
-        L10nUtil.setConditionalLayoutDirection(binding.talkContentsView, pageTitle.wikiSite.languageCode)
+        L10nUtil.setConditionalLayoutDirection(binding.talkContentsView, viewModel.pageTitle.wikiSite.languageCode)
         binding.talkProgressBar.isVisible = true
         binding.talkErrorView.isVisible = false
         binding.talkEmptyContainer.isVisible = false
@@ -282,8 +279,6 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
     }
 
     private fun updateOnSuccess(pageTitle: PageTitle, threadItems: List<ThreadItem>) {
-        // Update page title and start the funnel
-        this.pageTitle = pageTitle
         funnel = TalkFunnel(pageTitle, invokeSource)
         setToolbarTitle(pageTitle)
 
@@ -365,7 +360,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
     }
 
     private fun updateOnUndoSave(undoneSubject: CharSequence, undoneBody: CharSequence) {
-        requestNewTopic.launch(TalkReplyActivity.newIntent(this@TalkTopicsActivity, pageTitle, null, null, invokeSource, undoneSubject, undoneBody))
+        requestNewTopic.launch(TalkReplyActivity.newIntent(this@TalkTopicsActivity, viewModel.pageTitle, null, null, invokeSource, undoneSubject, undoneBody))
     }
 
     private fun updateOnWatch() {
@@ -396,17 +391,17 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
     }
 
     private fun goToPage() {
-        val entry = HistoryEntry(getNonTalkPageTitle(pageTitle), HistoryEntry.SOURCE_TALK_TOPIC)
+        val entry = HistoryEntry(getNonTalkPageTitle(viewModel.pageTitle), HistoryEntry.SOURCE_TALK_TOPIC)
         startActivity(PageActivity.newIntentForNewTab(this, entry, entry.title))
     }
 
     private fun showWatchlistSnackbar() {
         if (!viewModel.isWatched) {
-            FeedbackUtil.showMessage(this, getString(R.string.watchlist_page_removed_from_watchlist_snackbar, viewModel.pageTitle?.displayText))
+            FeedbackUtil.showMessage(this, getString(R.string.watchlist_page_removed_from_watchlist_snackbar, viewModel.pageTitle.displayText))
         } else if (viewModel.isWatched) {
             val snackbar = FeedbackUtil.makeSnackbar(this,
                 getString(R.string.watchlist_page_add_to_watchlist_snackbar,
-                    viewModel.pageTitle?.displayText,
+                    viewModel.pageTitle.displayText,
                     getString(viewModel.lastWatchExpiry.stringId)))
             if (!viewModel.watchlistExpiryChanged) {
                 snackbar.setAction(R.string.watchlist_page_add_to_watchlist_snackbar_action) {
@@ -465,9 +460,9 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
         }
 
         fun bindItem() {
-            binding.talkLeadImageContainer.isVisible = pageTitle.namespace() != Namespace.USER_TALK
-            pageTitle.thumbUrl?.let {
-                binding.talkLeadImage.contentDescription = StringUtil.removeNamespace(pageTitle.displayText)
+            binding.talkLeadImageContainer.isVisible = viewModel.pageTitle.namespace() != Namespace.USER_TALK
+            viewModel.pageTitle.thumbUrl?.let {
+                binding.talkLeadImage.contentDescription = StringUtil.removeNamespace(viewModel.pageTitle.displayText)
                 binding.talkLeadImage.loadImage(Uri.parse(ImageUrlUtil.getUrlForPreferredSize(it, Constants.PREFERRED_CARD_THUMBNAIL_SIZE)))
             }
         }
@@ -492,7 +487,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
                         System.currentTimeMillis(), 0L), revision.user))
 
                 binding.viewEditHistoryContainer.setOnClickListener {
-                    startActivity(ArticleEditDetailsActivity.newIntent(this@TalkTopicsActivity, pageTitle, revision.revId))
+                    startActivity(ArticleEditDetailsActivity.newIntent(this@TalkTopicsActivity, viewModel.pageTitle, revision.revId))
                 }
             }
 
@@ -500,14 +495,14 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
                 goToPage()
             }
 
-            if (pageTitle.namespace() == Namespace.USER_TALK) {
+            if (viewModel.pageTitle.namespace() == Namespace.USER_TALK) {
                 binding.viewPageIcon.setImageResource(R.drawable.ic_user_avatar)
                 binding.viewPageTitle.text = getString(R.string.talk_footer_view_user_page)
             } else {
                 binding.viewPageIcon.setImageResource(R.drawable.ic_article_ltr_ooui)
                 binding.viewPageTitle.text = getString(R.string.talk_footer_view_article)
             }
-            binding.viewPageContent.text = StringUtil.fromHtml(StringUtil.removeNamespace(pageTitle.displayText))
+            binding.viewPageContent.text = StringUtil.fromHtml(StringUtil.removeNamespace(viewModel.pageTitle.displayText))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
@@ -23,7 +23,7 @@ import org.wikipedia.util.log.L
 import org.wikipedia.views.TalkTopicsSortOverflowView
 import org.wikipedia.watchlist.WatchlistExpiry
 
-class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : ViewModel() {
+class TalkTopicsViewModel(var pageTitle: PageTitle, private val sidePanel: Boolean) : ViewModel() {
 
     private val talkPageDao = AppDatabase.instance.talkPageSeenDao()
     private val handler = CoroutineExceptionHandler { _, throwable ->
@@ -34,8 +34,6 @@ class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : V
     }
 
     private val watchlistFunnel = WatchlistFunnel()
-    private var resolveTitleRequired = false
-    var resolvedPageTitle: PageTitle? = null
     val threadItems = mutableListOf<ThreadItem>()
     var sortedThreadItems = listOf<ThreadItem>()
     var lastRevision: MwQueryPage.Revision? = null
@@ -62,13 +60,9 @@ class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : V
     }
 
     fun loadTopics() {
-        if (pageTitle == null) {
-            return
-        }
-        val pageTitle = pageTitle?.copy()!!
-
         // Determine whether we need to resolve the PageTitle, since the calling activity might
         // have given us a non-Talk page, and we need to prepend the correct namespace.
+        var resolveTitleRequired = false
         if (pageTitle.namespace.isEmpty()) {
             pageTitle.namespace = TalkAliasData.valueFor(pageTitle.wikiSite.languageCode)
         } else if (pageTitle.isUserPage) {
@@ -115,17 +109,17 @@ class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : V
 
             isWatched = watchStatus.watched
             hasWatchlistExpiry = watchStatus.hasWatchlistExpiry()
-            resolvedPageTitle = pageTitle
 
             uiState.value = UiState.LoadTopic(pageTitle, threadItems)
         }
     }
 
+    fun updatePageTitle(pageTitle: PageTitle) {
+        this.pageTitle = pageTitle.copy()
+        loadTopics()
+    }
+
     fun undoSave(newRevisionId: Long, undoneSubject: CharSequence, undoneBody: CharSequence) {
-        if (pageTitle == null) {
-            return
-        }
-        val pageTitle = pageTitle!!
         viewModelScope.launch(editHandler) {
             val token = withContext(Dispatchers.IO) {
                 CsrfTokenClient.getToken(pageTitle.wikiSite).blockingFirst()
@@ -158,10 +152,6 @@ class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : V
     }
 
     fun subscribeTopic(commentName: String, subscribed: Boolean) {
-        if (pageTitle == null) {
-            return
-        }
-        val pageTitle = pageTitle!!
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable -> L.e(throwable) }) {
             val token = withContext(Dispatchers.IO) {
                 CsrfTokenClient.getToken(pageTitle.wikiSite).blockingFirst()
@@ -206,19 +196,11 @@ class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : V
     }
 
     suspend fun isSubscribed(commentName: String): Boolean {
-        if (pageTitle == null) {
-            return false
-        }
-        val pageTitle = pageTitle!!
         val response = ServiceFactory.get(pageTitle.wikiSite).getTalkPageTopicSubscriptions(commentName)
         return response.subscriptions[commentName] == 1
     }
 
     fun watchOrUnwatch(expiry: WatchlistExpiry, unwatch: Boolean) {
-        if (pageTitle == null) {
-            return
-        }
-        val pageTitle = pageTitle!!
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable -> L.e(throwable) }) {
             withContext(Dispatchers.IO) {
                 if (expiry != WatchlistExpiry.NEVER) {
@@ -256,10 +238,10 @@ class TalkTopicsViewModel(var pageTitle: PageTitle?, var sidePanel: Boolean) : V
         }
     }
 
-    class Factory(private val pageTitle: PageTitle?, private val sidePanel: Boolean = false) : ViewModelProvider.Factory {
+    class Factory(private val pageTitle: PageTitle, private val sidePanel: Boolean = false) : ViewModelProvider.Factory {
         @Suppress("unchecked_cast")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return TalkTopicsViewModel(pageTitle, sidePanel) as T
+            return TalkTopicsViewModel(pageTitle.copy(), sidePanel) as T
         }
     }
 


### PR DESCRIPTION
Pardon the size of this follow-up, but this nails down a few inconsistencies that have bothered me for a while:

* The `pageTitle` object in TalkTopicsViewModel should always be nonnull, which simplifies everything.
* The `pageTitle` object in TalkTopicsViewModel should never be modified by external sources.
* TalkTopicsActivity should not have its own copy of `pageTitle`, and should always reference it from the ViewModel.
* Offload nullability state to the `viewModel` object maintained by SidePanelHandler, so that the viewModel can always have a nonnull PageTitle.
