### PR TITLE
Add marginEnd to the talk topics footer

### DIFF
--- a/app/src/main/res/layout/view_talk_topics_footer.xml
+++ b/app/src/main/res/layout/view_talk_topics_footer.xml
@@ -55,7 +55,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:text="@string/talk_footer_about_this_talk_page"
+                android:text="@string/talk_footer_view_edit_history"
+                android:layout_marginEnd="16dp"
                 android:textColor="?attr/secondary_text_color"/>
 
         </LinearLayout>
@@ -100,6 +101,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:text="@string/view_user_page"
+                android:layout_marginEnd="16dp"
                 android:textColor="?attr/secondary_text_color"/>
 
         </LinearLayout>


### PR DESCRIPTION
The content will touch the edge of the footer if we have a really long article title or edited by an anonymous IP editor 