### PR TITLE
Fix playback of timestamped WebM videos.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
@@ -47,7 +47,8 @@ abstract class OkHttpWebViewClient : WebViewClient() {
         var response: WebResourceResponse
         try {
             val rsp = request(request)
-            response = if (CONTENT_TYPE_OGG == rsp.header(HEADER_CONTENT_TYPE)) {
+            response = if (CONTENT_TYPE_OGG == rsp.header(HEADER_CONTENT_TYPE) ||
+                    CONTENT_TYPE_WEBM == rsp.header(HEADER_CONTENT_TYPE)) {
                 rsp.close()
                 return super.shouldInterceptRequest(view, request)
             } else {
@@ -133,6 +134,7 @@ abstract class OkHttpWebViewClient : WebViewClient() {
     companion object {
         private const val HEADER_CONTENT_TYPE = "content-type"
         private const val CONTENT_TYPE_OGG = "application/ogg"
+        private const val CONTENT_TYPE_WEBM = "video/webm"
         private val SUPPORTED_SCHEMES = listOf("http", "https")
     }
 }


### PR DESCRIPTION
For embedded videos that begin with a nonzero timestamp, there seems to be a problem with the way we're intercepting Web requests from the WebView and passing them through OkHttp.

This will add a special case (which we're already doing for OGG files) to no longer intercept loading WebM videos.

https://phabricator.wikimedia.org/T309105