### PR TITLE
Fix detection and display of coffee-roll talk topics.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -450,7 +450,6 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
         const val EXTRA_TOPIC_ID = "topicId"
         const val EXTRA_REPLY_ID = "replyId"
         const val EXTRA_SEARCH_QUERY = "searchQuery"
-        const val HEADER_LEVEL = 99
 
         fun newIntent(context: Context,
                       pageTitle: PageTitle,
@@ -473,7 +472,7 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
         }
 
         fun isHeaderTemplate(item: ThreadItem?): Boolean {
-            return item?.headingLevel == HEADER_LEVEL
+            return item?.headingLevel == 0 && item.id.isEmpty()
         }
     }
 }


### PR DESCRIPTION
We were detecting a "coffee-roll" section based on if the `headingLevel` is equal to 99. Apparently this was actually unintentional from the Editing team, and was changed to 0. This is a more consistent way to detect a coffee roll section.