### PR TITLE
Whoops: fix breadcrumbs serialization.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
@@ -14,11 +14,14 @@ import org.wikipedia.util.log.L
 @SerialName("/analytics/mobile_apps/android_breadcrumbs_event/1.0.0")
 class BreadCrumbLogEvent(
         private val screen_name: String,
-        private val action: String,
-        private val app_primary_language_code: String = WikipediaApp.instance.languageState.appLanguageCode
+        private val action: String
 ) : MobileAppsEvent(STREAM_NAME) {
 
+    // Do NOT join the declaration and assignment to these fields, or they won't be serialized correctly.
+    private val app_primary_language_code: String
+
     init {
+        app_primary_language_code = WikipediaApp.instance.languageState.appLanguageCode
         L.d(">>> $screen_name.$action")
     }
 


### PR DESCRIPTION
[facepalm] In my refactoring of breadcrumbs, I joined the declaration and assignment of a field, which we cannot do because of how these events are serialized.

(If declaration and assignment are joined, that field will not be serialized for some reason.)