### PR TITLE
Improve/fix detection of voice input capability.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,9 @@
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="https" />
         </intent>
+        <intent>
+            <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -2,10 +2,13 @@ package org.wikipedia
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.os.Build
 import android.os.Handler
+import android.speech.RecognizerIntent
 import android.text.TextUtils
 import android.view.Window
 import android.webkit.WebView
@@ -126,6 +129,16 @@ class WikipediaApp : Application() {
 
     val isAnyActivityResumed
         get() = activityLifecycleHandler.isAnyActivityResumed
+
+    val voiceRecognitionAvailable by lazy {
+        try {
+            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+            packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY).isNotEmpty()
+        } catch (e: Exception) {
+            L.e(e)
+            false
+        }
+    }
 
     init {
         instance = this

--- a/app/src/main/java/org/wikipedia/feed/searchbar/SearchCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/searchbar/SearchCardView.kt
@@ -1,10 +1,11 @@
 package org.wikipedia.feed.searchbar
 
 import android.content.Context
-import android.speech.SpeechRecognizer
 import android.view.LayoutInflater
 import android.view.View
+import androidx.core.view.isVisible
 import org.wikipedia.R
+import org.wikipedia.WikipediaApp
 import org.wikipedia.databinding.ViewSearchBarBinding
 import org.wikipedia.feed.view.DefaultFeedCardView
 import org.wikipedia.util.FeedbackUtil
@@ -23,6 +24,6 @@ class SearchCardView(context: Context) : DefaultFeedCardView<SearchCard>(context
 
         binding.searchContainer.setOnClickListener { callback?.onSearchRequested(it) }
         binding.voiceSearchButton.setOnClickListener { callback?.onVoiceSearchRequested() }
-        binding.voiceSearchButton.visibility = if (SpeechRecognizer.isRecognitionAvailable(context)) VISIBLE else GONE
+        binding.voiceSearchButton.isVisible = WikipediaApp.instance.voiceRecognitionAvailable
     }
 }


### PR DESCRIPTION
On certain devices we are not properly detecting whether voice recognition services are available. This can lead to a situation where we display the "microphone" icon in the Search bar, but when you tap the icon nothing happens, or an error is shown.

This will change to detecting voice input capability explicitly by querying intent handlers, instead of querying the SpeechRecognizer object, which is a slightly different thing.
