### PR TITLE
Fix minor inconsistencies in handling be-tarask language.

### DIFF
--- a/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.kt
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.kt
@@ -74,6 +74,8 @@ class AppLanguageLookUpTable(context: Context) {
                 name = Locale.CHINESE.getDisplayName(Locale.CHINESE)
             } else if (code == NORWEGIAN_LEGACY_LANGUAGE_CODE) {
                 name = localizedNames.getOrNull(indexOfCode(NORWEGIAN_BOKMAL_LANGUAGE_CODE))
+            } else if (code == BELARUSIAN_TARASK_LANGUAGE_CODE) {
+                name = localizedNames.getOrNull(indexOfCode(BELARUSIAN_LEGACY_LANGUAGE_CODE))
             }
         }
         return name

--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
@@ -141,8 +141,10 @@ class LangLinksActivity : BaseActivity() {
             binding.langlinkEmptyView.setEmptyText(R.string.langlinks_no_match)
             binding.langlinksRecycler.adapter = LangLinksAdapter(languageEntries,
                     languageEntries.filter {
-                        it.wikiSite.languageCode == AppLanguageLookUpTable.NORWEGIAN_LEGACY_LANGUAGE_CODE &&
-                                app.languageState.appLanguageCodes.contains(AppLanguageLookUpTable.NORWEGIAN_BOKMAL_LANGUAGE_CODE) ||
+                        (it.wikiSite.languageCode == AppLanguageLookUpTable.NORWEGIAN_LEGACY_LANGUAGE_CODE &&
+                                app.languageState.appLanguageCodes.contains(AppLanguageLookUpTable.NORWEGIAN_BOKMAL_LANGUAGE_CODE)) ||
+                                (it.wikiSite.languageCode == AppLanguageLookUpTable.BELARUSIAN_TARASK_LANGUAGE_CODE &&
+                                app.languageState.appLanguageCodes.contains(AppLanguageLookUpTable.BELARUSIAN_LEGACY_LANGUAGE_CODE)) ||
                                 app.languageState.appLanguageCodes.contains(it.wikiSite.languageCode)
                     })
             binding.langlinksRecycler.layoutManager = LinearLayoutManager(this)


### PR DESCRIPTION
We still have some annoying edge-case behavior coming from the change of the language code from `be-x-old` to `be-tarask`, which is still not consistent in API responses. We need additional special logic to handle it properly.

https://phabricator.wikimedia.org/T311877