### PR TITLE
Follow-up to archived talk pages.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -60,16 +60,12 @@ interface Service {
     ): Observable<MwQueryResponse>
 
     @GET(
-        MW_API_PREFIX + "action=query&redirects=" +
-                "&converttitles=&prop=description|info" +
-                "&generator=prefixsearch&gpsnamespace=0&list=search&srnamespace=0" +
-                "&inprop=varianttitles" +
-                "&srwhat=text&srinfo=suggestion&srprop=&sroffset=0&srlimit=1"
+        MW_API_PREFIX + "action=query&redirects=&converttitles=&prop=info" +
+                "&generator=prefixsearch&inprop=varianttitles"
     )
-    suspend fun searchSubPages(@Query("gpssearch") searchTerm: String?,
-                               @Query("gpslimit") maxResults: Int,
-                               @Query("gpsoffset") gsrOffset: String?,
-                               @Query("srsearch") repeat: String?): MwQueryResponse
+    suspend fun prefixSearch(@Query("gpssearch") searchTerm: String?,
+                             @Query("gpslimit") maxResults: Int,
+                             @Query("gpsoffset") gpsOffset: Int?): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query&list=allusers&auwitheditsonly=1")
     fun prefixSearchUsers(

--- a/app/src/main/java/org/wikipedia/talk/ArchivedTalkPagesViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/ArchivedTalkPagesViewModel.kt
@@ -26,7 +26,7 @@ class ArchivedTalkPagesViewModel(bundle: Bundle) : ViewModel() {
                     return LoadResult.Page(emptyList(), null, null)
                 }
                 val response = ServiceFactory.get(WikiSite.forLanguageCode(pageTitle.wikiSite.languageCode))
-                    .searchSubPages(pageTitle.prefixedText, params.loadSize, params.key?.toString().orEmpty().ifEmpty { "1" }, pageTitle.prefixedText)
+                    .prefixSearch(pageTitle.prefixedText + "/", params.loadSize, params.key)
                 if (response.query?.pages == null) {
                     return LoadResult.Page(emptyList(), null, null)
                 }


### PR DESCRIPTION
* Remove a bunch of unnecessary parameters from the API call (those are useful for a full-blown prefix search like we do in the Search box, but not necessary for this specific case).
* Explicitly add a slash `/` to the search query, because we want to search for subpages. Not including the slash can potentially return unwanted results.
* The continuation parameter (`gpsoffset`) should be `null` on the first call, and should be an integer on subsequent calls.