### PR TITLE
Improve positioning and state of "customize toolbar" tooltip.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -79,6 +79,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
     private val listDialogDismissListener = DialogInterface.OnDismissListener { pageFragment.updateBookmarkAndMenuOptionsFromDao() }
     private val isCabOpen get() = currentActionModes.isNotEmpty()
     private var exclusiveTooltipRunnable: Runnable? = null
+    private var isTooltipShowing = false
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -121,11 +122,12 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
             TabActivity.captureFirstTabBitmap(pageFragment.containerView, pageFragment.title?.prefixedText.orEmpty())
             startActivityForResult(TabActivity.newIntentFromPageActivity(this), Constants.ACTIVITY_REQUEST_BROWSE_TABS)
         }
-        toolbarHideHandler = ViewHideHandler(binding.pageToolbarContainer, null, Gravity.TOP)
+        toolbarHideHandler = ViewHideHandler(binding.pageToolbarContainer, null, Gravity.TOP) { isTooltipShowing }
         FeedbackUtil.setButtonLongPressToast(binding.pageToolbarButtonNotifications, binding.pageToolbarButtonTabs, binding.pageToolbarButtonShowOverflowMenu)
         binding.pageToolbarButtonShowOverflowMenu.setOnClickListener {
             pageFragment.showOverflowMenu(it)
             pageFragment.articleInteractionEvent?.logMoreClick()
+            Prefs.showOneTimeCustomizeToolbarTooltip = false
         }
 
         binding.pageToolbarButtonNotifications.setColor(ResourceUtil.getThemedColor(this, R.attr.toolbar_icon_color))
@@ -669,20 +671,20 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
             FeedbackUtil.getTooltip(
                 this,
                 getString(R.string.theme_chooser_menu_item_short_tooltip),
-                arrowAnchorPadding = -DimenUtil.roundedDpToPx(6f),
-                topOrBottomMargin = -12,
+                arrowAnchorPadding = -DimenUtil.roundedDpToPx(7f),
+                topOrBottomMargin = 0,
                 aboveOrBelow = true,
                 autoDismiss = false,
                 showDismissButton = true
             ).apply {
                 setOnBalloonDismissListener {
                     Prefs.showOneTimeCustomizeToolbarTooltip = false
-                    Prefs.toolbarTooltipVisible = false
+                    isTooltipShowing = false
                 }
                 BreadCrumbLogEvent.logTooltipShown(this@PageActivity, binding.pageToolbarButtonShowOverflowMenu)
                 showAlignBottom(binding.pageToolbarButtonShowOverflowMenu)
                 setCurrentTooltip(this)
-                Prefs.toolbarTooltipVisible = true
+                isTooltipShowing = true
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -204,7 +204,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
             }
         }
 
-        bottomBarHideHandler = ViewHideHandler(binding.pageActionsTabLayout, null, Gravity.BOTTOM, updateElevation = false)
+        bottomBarHideHandler = ViewHideHandler(binding.pageActionsTabLayout, null, Gravity.BOTTOM, updateElevation = false) { false }
         bottomBarHideHandler.setScrollView(webView)
         bottomBarHideHandler.enabled = Prefs.readingFocusModeEnabled
 

--- a/app/src/main/java/org/wikipedia/page/ViewHideHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/ViewHideHandler.kt
@@ -3,7 +3,6 @@ package org.wikipedia.page
 import android.view.Gravity
 import android.view.View
 import org.wikipedia.R
-import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DimenUtil.dpToPx
 import org.wikipedia.util.DimenUtil.getDimension
 import org.wikipedia.views.ObservableWebView
@@ -14,7 +13,8 @@ import org.wikipedia.views.ViewAnimations.ensureTranslationY
 class ViewHideHandler(private val hideableView: View,
                       private val anchoredView: View?,
                       private val gravity: Int,
-                      private val updateElevation: Boolean = true) :
+                      private val updateElevation: Boolean = true,
+                      private val shouldAlwaysShow: () -> Boolean) :
         ObservableWebView.OnScrollChangeListener, OnUpOrCancelMotionEventListener, OnDownMotionEventListener, ObservableWebView.OnClickListener {
 
     private lateinit var webView: ObservableWebView
@@ -38,7 +38,7 @@ class ViewHideHandler(private val hideableView: View,
         if (!enabled) {
             return
         }
-        if (gravity == Gravity.TOP && Prefs.toolbarTooltipVisible) {
+        if (gravity == Gravity.TOP && shouldAlwaysShow()) {
             ensureDisplayed()
             return
         }

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -594,10 +594,6 @@ object Prefs {
         get() = PrefsIoUtil.getString(R.string.preference_key_edit_history_filter_type, null).orEmpty()
         set(value) = PrefsIoUtil.setString(R.string.preference_key_edit_history_filter_type, value)
 
-    var toolbarTooltipVisible
-        get() = PrefsIoUtil.getBoolean(R.string.preference_key_toolbar_tooltip_visible, false)
-        set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_toolbar_tooltip_visible, value)
-
     var talkTopicExpandOrCollapseByDefault
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_talk_topic_expand_all, true)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_talk_topic_expand_all, value)

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -136,7 +136,6 @@
     <string name="preference_key_talk_topics_sort_mode">talkTopicsSortMode</string>
     <string name="preference_key_reading_focus_mode">readingFocusMode</string>
     <string name="preference_key_edit_history_filter_type">editHistoryFilterType</string>
-    <string name="preference_key_toolbar_tooltip_visible">toolbarTooltipVisible</string>
     <string name="preference_key_talk_topic_expand_all">talkTopicExpandAll</string>
     <string name="preference_key_onboarding_survey_shown">onboardingSurveyShown</string>
 </resources>


### PR DESCRIPTION
* Shift the tooltip arrow a little further, so that it aligns as close as possible with the overflow button. It's still not perfect on all devices, but better.
* Explicitly disable the tooltip once the user taps the overflow menu.
* No longer abuse Prefs to communicate state between the activity and `ViewHideHandler`, and instead use a lambda.

https://phabricator.wikimedia.org/T312523