### PR TITLE
Improve/fix error handling when posting DiscussionTools edits.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/discussiontools/DiscussionToolsEditResponse.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/discussiontools/DiscussionToolsEditResponse.kt
@@ -2,9 +2,10 @@ package org.wikipedia.dataclient.discussiontools
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.wikipedia.dataclient.mwapi.MwResponse
 
 @Serializable
-class DiscussionToolsEditResponse {
+class DiscussionToolsEditResponse : MwResponse() {
     @SerialName("discussiontoolsedit") val result: EditResult? = null
 
     @Serializable


### PR DESCRIPTION
When an edit to a Talk page fails (e.g. if your IP address is blocked, and so on), we're currently showing "Unknown error occurred", because we're not correctly accounting for errors in our model class.

By making the `DiscussionToolsEditResponse` object inherit from `MwResponse`, we will automatically get the functionality of parsing errors and throwing the correct exception when an error is returned.