### PR TITLE
Remove unused callback from ArchivedTalkPagesActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/ArchivedTalkPagesActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/ArchivedTalkPagesActivity.kt
@@ -35,7 +35,7 @@ import org.wikipedia.views.DrawableItemDecoration
 import org.wikipedia.views.PageItemView
 import org.wikipedia.views.WikiErrorView
 
-class ArchivedTalkPagesActivity : BaseActivity(), LinkPreviewDialog.Callback {
+class ArchivedTalkPagesActivity : BaseActivity() {
     private lateinit var binding: ActivityArchivedTalkPagesBinding
 
     private val archivedTalkPagesAdapter = ArchivedTalkPagesAdapter()
@@ -44,7 +44,6 @@ class ArchivedTalkPagesActivity : BaseActivity(), LinkPreviewDialog.Callback {
     private val archivedTalkPagesConcatAdapter = archivedTalkPagesAdapter.withLoadStateHeaderAndFooter(archivedTalkPagesLoadHeader, archivedTalkPagesLoadFooter)
 
     private val itemCallback = ItemCallback()
-    private val bottomSheetPresenter = ExclusiveBottomSheetPresenter()
     private val viewModel: ArchivedTalkPagesViewModel by viewModels { ArchivedTalkPagesViewModel.Factory(intent.extras!!) }
 
     public override fun onCreate(savedInstanceState: Bundle?) {
@@ -86,23 +85,6 @@ class ArchivedTalkPagesActivity : BaseActivity(), LinkPreviewDialog.Callback {
         }
         RichTextUtil.removeUnderlinesFromLinks(binding.toolbarTitle)
         FeedbackUtil.setButtonLongPressToast(binding.toolbarTitle)
-    }
-
-    override fun onLinkPreviewLoadPage(title: PageTitle, entry: HistoryEntry, inNewTab: Boolean) {
-        startActivity(if (inNewTab) PageActivity.newIntentForNewTab(this, entry, entry.title) else PageActivity.newIntentForCurrentTab(this, entry, entry.title, false))
-    }
-
-    override fun onLinkPreviewCopyLink(title: PageTitle) {
-        ClipboardUtil.setPlainText(this, text = title.uri)
-        FeedbackUtil.showMessage(this, R.string.address_copied)
-    }
-
-    override fun onLinkPreviewAddToList(title: PageTitle) {
-        bottomSheetPresenter.showAddToListDialog(supportFragmentManager, title, InvokeSource.LINK_PREVIEW_MENU)
-    }
-
-    override fun onLinkPreviewShareLink(title: PageTitle) {
-        ShareUtil.shareText(this, title)
     }
 
     private inner class LoadingItemAdapter(private val retry: () -> Unit) : LoadStateAdapter<LoadingViewHolder>() {

--- a/app/src/main/java/org/wikipedia/talk/ArchivedTalkPagesActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/ArchivedTalkPagesActivity.kt
@@ -23,11 +23,9 @@ import org.wikipedia.R
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.databinding.ActivityArchivedTalkPagesBinding
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
-import org.wikipedia.page.linkpreview.LinkPreviewDialog
 import org.wikipedia.readinglist.database.ReadingList
 import org.wikipedia.richtext.RichTextUtil
 import org.wikipedia.util.*


### PR DESCRIPTION
We are not using the `LinkPreviewDialog` in the `ArchivedTalkPagesActivity` and the callback should be removed. 