### PR TITLE
Fix lint warnings in gradle file.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,15 +11,8 @@ final File REPO_PROPS_FILE = new File('repo.properties')
 final Properties PROD_PROPS = loadProperties(PROD_PROPS_FILE)
 final Properties REPO_PROPS = loadProperties(REPO_PROPS_FILE)
 
-
-def static getDate() {
-    def date = new Date()
-    def formattedDate = date.format('yyyy-MM-dd')
-    return formattedDate
-}
-
-def computeVersionName(label) {
-    return "2.7.${android.defaultConfig.versionCode}-${label}-${date}"
+static def computeVersionName(versionCode, label) {
+    return "2.7.${versionCode}-${label}-${(new Date()).format('yyyy-MM-dd')}"
 }
 
 final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_8
@@ -109,7 +102,7 @@ android {
 
     productFlavors {
         dev {
-            versionName computeVersionName('dev')
+            versionName computeVersionName(defaultConfig.versionCode, 'dev')
             applicationIdSuffix '.dev'
             buildConfigField "String", "META_WIKI_BASE_URI", '"https://meta.wikimedia.beta.wmflabs.org"'
             buildConfigField "String", "EVENTGATE_ANALYTICS_EXTERNAL_BASE_URI", '"https://intake-analytics.wikimedia.beta.wmflabs.org"'
@@ -121,24 +114,24 @@ android {
             buildConfigField "String", "TEST_LOGIN_PASSWORD", TEST_LOGIN_PASSWORD != null ? "\"${TEST_LOGIN_PASSWORD}\"" : '"Bar"'
         }
         prod {
-            versionName computeVersionName('r')
+            versionName computeVersionName(defaultConfig.versionCode, 'r')
             signingConfig signingConfigs.prod
         }
         alpha {
-            versionName computeVersionName('alpha')
+            versionName computeVersionName(defaultConfig.versionCode, 'alpha')
             applicationIdSuffix '.alpha'
         }
         beta {
-            versionName computeVersionName('beta')
+            versionName computeVersionName(defaultConfig.versionCode, 'beta')
             applicationIdSuffix '.beta'
             signingConfig signingConfigs.prod
         }
         fdroid {
-            versionName computeVersionName('fdroid')
+            versionName computeVersionName(defaultConfig.versionCode, 'fdroid')
             signingConfig signingConfigs.prod
         }
         custom {
-            versionName computeVersionName(customChannel)
+            versionName computeVersionName(defaultConfig.versionCode, customChannel)
             // next line is for injecting a custom channel value into the custom/AndroidManifest.xml
             manifestPlaceholders = [customChannel:getProperty('customChannel').toString()]
             signingConfig signingConfigs.prod


### PR DESCRIPTION
Refactor by making `computeVersionName()` into a static function.