### PR TITLE
Fix crash when tapping certain Settings items.

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/PreferenceMultiLine.kt
+++ b/app/src/main/java/org/wikipedia/settings/PreferenceMultiLine.kt
@@ -43,7 +43,7 @@ class PreferenceMultiLine : Preference {
 
     @SuppressLint("RestrictedApi")
     override fun performClick() {
-        BreadCrumbLogEvent.logSettingsSelection(context, key)
+        BreadCrumbLogEvent.logSettingsSelection(context, if (!key.isNullOrEmpty()) key else title.toString())
         super.performClick()
     }
 }


### PR DESCRIPTION
(Issue caught by TSG during regression testing!)
Certain Settings items, specifically the ones at the bottom that lead to an external link, don't have a `key` associated with them. Since the breadcrumbs logger expects a nonnull key, it causes a crash.