### PR TITLE
Improve deserialization of editnotices.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwVisualEditorResponse.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwVisualEditorResponse.kt
@@ -1,6 +1,10 @@
 package org.wikipedia.dataclient.mwapi
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import org.wikipedia.json.JsonUtil
 
 @Serializable
 class MwVisualEditorResponse : MwResponse() {
@@ -8,6 +12,10 @@ class MwVisualEditorResponse : MwResponse() {
 
     @Serializable
     class VisualEditorData {
-        val notices: Map<String, String>? = null
+        private val notices: JsonElement? = null
+
+        fun getEditNotices(): Map<String, String>? {
+            return if (notices != null && notices is JsonObject) JsonUtil.json.decodeFromJsonElement(notices) else null
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -545,7 +545,7 @@ class EditSectionActivity : BaseActivity() {
                         editNotices.clear()
                         // Populate edit notices, but filter out anonymous edit warnings, since
                         // we show that type of warning ourselves when previewing.
-                        editNotices.addAll(it.visualeditor?.notices.orEmpty()
+                        editNotices.addAll(it.visualeditor?.getEditNotices().orEmpty()
                                 .filterKeys { key -> key.startsWith("editnotice") }
                                 .values.filter { str -> StringUtil.fromHtml(str).trim().isNotEmpty() })
                         invalidateOptionsMenu()


### PR DESCRIPTION
When an article doesn't have any editnotices, the structure is received as an empty array `[]` instead of an empty object `{}`, which is a weird MediaWiki convention of sending empty elements. This was throwing off our deserializer, and was causing an error to be printed in the log.
(This did not impact the presentation of edit notices.)