### PR TITLE
Don't prepopulate ping message when replying on same user's talk page.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -150,7 +150,7 @@ class TalkReplyActivity : BaseActivity(), LinkPreviewDialog.Callback, UserMentio
             binding.replySubjectLayout.isVisible = false
             binding.replyInputView.textInputLayout.hint = getString(R.string.talk_reply_hint)
             binding.talkScrollContainer.fullScroll(View.FOCUS_DOWN)
-            binding.replyInputView.maybePrepopulateUserName()
+            binding.replyInputView.maybePrepopulateUserName(AccountUtil.userName.orEmpty(), viewModel.pageTitle)
             binding.talkScrollContainer.post {
                 if (!isDestroyed) {
                     binding.replyInputView.editText.requestFocus()

--- a/app/src/main/java/org/wikipedia/views/UserMentionInputView.kt
+++ b/app/src/main/java/org/wikipedia/views/UserMentionInputView.kt
@@ -16,9 +16,10 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
-import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.ViewUserMentionInputBinding
 import org.wikipedia.dataclient.ServiceFactory
+import org.wikipedia.page.PageTitle
+import org.wikipedia.util.StringUtil
 import java.util.concurrent.TimeUnit
 
 class UserMentionInputView : LinearLayout, UserMentionEditText.Listener {
@@ -75,10 +76,11 @@ class UserMentionInputView : LinearLayout, UserMentionEditText.Listener {
         }
     }
 
-    fun maybePrepopulateUserName() {
+    fun maybePrepopulateUserName(currentUserName: String, currentPageTitle: PageTitle) {
         if (binding.inputEditText.text.isNullOrEmpty() && userNameHints.isNotEmpty()) {
             val candidateName = userNameHints.first()
-            if (candidateName != AccountUtil.userName) {
+            if (candidateName != currentUserName &&
+                    StringUtil.addUnderscores(candidateName.lowercase()) != StringUtil.addUnderscores(currentPageTitle.text.lowercase())) {
                 binding.inputEditText.prepopulateUserName(candidateName)
             }
         }


### PR DESCRIPTION
When you reply to a comment on a user's talk page, which was written by that same user, we don't need to prepopulate the @-ping, since that user will get a notification anyway.