### PR TITLE
Tweak size of tooltip arrow.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -191,7 +191,7 @@ object FeedbackUtil {
             setArrowDrawableResource(R.drawable.ic_tooltip_arrow_up)
             setArrowPositionRules(ArrowPositionRules.ALIGN_ANCHOR)
             setArrowOrientationRules(ArrowOrientationRules.ALIGN_ANCHOR)
-            setArrowSize(24)
+            setArrowSize(16)
             setMarginLeft(8)
             setMarginRight(8)
             setMarginTop(if (aboveOrBelow) 0 else topOrBottomMargin)


### PR DESCRIPTION
This shall be the new size of the arrow for all tooltips. This creates a more understated arrow, and is a better choice for certain harder-to-reach spots, such as the overflow button.