### PR TITLE
Follow-up to registerForActivityResult in description editing.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -103,7 +103,7 @@ class DescriptionEditFragment : Fragment() {
         Prefs.isSuggestedEditsReactivationPassStageOne = false
         SuggestedEditsFunnel.get().success(action)
         binding.fragmentDescriptionEditView.setSaveState(false)
-        if (Prefs.showDescriptionEditSuccessPrompt && invokeSource == InvokeSource.PAGE_ACTIVITY) {
+        if (Prefs.showDescriptionEditSuccessPrompt && invokeSource != InvokeSource.SUGGESTED_EDITS) {
             editSuccessLauncher.launch(DescriptionEditSuccessActivity.newIntent(requireContext(), invokeSource))
             Prefs.showDescriptionEditSuccessPrompt = false
         } else {


### PR DESCRIPTION
As it is currently, there's actually no way to invoke the "Success" activity after adding/editing a description, because we now have different `invokeSource` constants from the Edit Pencil and the Add Description CTA.
The original intention was to show the Success screen only when editing a description from within the PageActivity (i.e. NOT from suggested edits), so let's just do it that way.