### PR TITLE
Fix: show article summary when editing description from a long-press action

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -173,7 +173,8 @@ class DescriptionEditFragment : Fragment() {
 
     private fun loadPageSummaryIfNeeded(savedInstanceState: Bundle?) {
         binding.fragmentDescriptionEditView.showProgressBar(true)
-        if ((invokeSource == InvokeSource.PAGE_ACTIVITY || invokeSource == InvokeSource.PAGE_EDIT_PENCIL) && sourceSummary?.extractHtml.isNullOrEmpty()) {
+        if ((invokeSource == InvokeSource.PAGE_ACTIVITY || invokeSource == InvokeSource.PAGE_EDIT_PENCIL ||
+                    invokeSource == InvokeSource.PAGE_EDIT_HIGHLIGHT) && sourceSummary?.extractHtml.isNullOrEmpty()) {
             editingAllowed = false
             binding.fragmentDescriptionEditView.setEditAllowed(false)
             binding.fragmentDescriptionEditView.showProgressBar(true)


### PR DESCRIPTION
If we long press on the article description and click "Edit here", the article summary view will not show up in the edit article description screen.