### PR TITLE
Fix/improve parsing of Dates in talk thread topics.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/discussiontools/ThreadItem.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/discussiontools/ThreadItem.kt
@@ -43,7 +43,13 @@ class ThreadItem(
         }
 
     @IgnoredOnParcel @Transient val date = try {
-        DateUtil.iso8601DateParse(timestamp)
+        if (timestamp.contains("T")) {
+            // Assume a ISO 8601 timestamp
+            DateUtil.iso8601DateParse(timestamp)
+        } else {
+            // Assume a DB timestamp
+            DateUtil.dbDateParse(timestamp)
+        }
     } catch (e: Exception) {
         e.printStackTrace()
         null


### PR DESCRIPTION
When we parse Talk topics, we expect the timestamp to be in ISO 8601 format, but actually sometimes it's formatted in the db format, which is causing us to fail to parse the date.

For example in the `Talk:Darjeeling` page, the dates are not parsed, and are not appearing correctly in our Talk screen.

This patch will handle both types of timestamps automatically.