### PR TITLE
Radically improve performance of wikitext editor.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -54,7 +54,6 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.util.*
 import org.wikipedia.util.log.L
 import org.wikipedia.views.EditNoticesDialog
-import org.wikipedia.views.ViewAnimations
 import org.wikipedia.views.ViewUtil
 import org.wikipedia.views.WikiTextKeyboardView
 import java.io.IOException
@@ -124,7 +123,7 @@ class EditSectionActivity : BaseActivity() {
         sectionAnchor = intent.getStringExtra(EXTRA_SECTION_ANCHOR)
         textToHighlight = intent.getStringExtra(EXTRA_HIGHLIGHT_TEXT)
         supportActionBar?.title = ""
-        syntaxHighlighter = SyntaxHighlighter(this, binding.editSectionText)
+        syntaxHighlighter = SyntaxHighlighter(this, binding.editSectionText, binding.editSectionScroll)
         binding.editSectionScroll.isSmoothScrollingEnabled = false
         captchaHandler = CaptchaHandler(this, pageTitle.wikiSite, binding.captchaContainer.root,
                 binding.editSectionText, "", null)
@@ -473,7 +472,7 @@ class EditSectionActivity : BaseActivity() {
             }
 
             override fun onDestroyActionMode(mode: ActionMode) {
-                binding.editSectionText.clearMatches(syntaxHighlighter)
+                syntaxHighlighter.clearSearchQueryInfo()
                 binding.editSectionText.setSelection(binding.editSectionText.selectionStart,
                         binding.editSectionText.selectionStart)
             }
@@ -513,9 +512,11 @@ class EditSectionActivity : BaseActivity() {
 
     private fun fetchSectionText() {
         if (sectionWikitext == null) {
+            showProgressBar(true)
             disposables.add(ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, if (sectionID >= 0) sectionID else null)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
+                    .doOnTerminate { showProgressBar(false) }
                     .subscribe({ response ->
                         val firstPage = response.query?.firstPage()!!
                         val rev = firstPage.revisions[0]
@@ -533,10 +534,9 @@ class EditSectionActivity : BaseActivity() {
                         }
                         displaySectionText()
                         maybeShowEditSourceDialog()
-                    }) { throwable ->
-                        showProgressBar(false)
-                        showError(throwable)
-                        L.e(throwable)
+                    }) {
+                        showError(it)
+                        L.e(it)
                     })
             disposables.add(ServiceFactory.get(pageTitle.wikiSite).getVisualEditorMetadata(pageTitle.prefixedText)
                     .subscribeOn(Schedulers.io())
@@ -554,9 +554,7 @@ class EditSectionActivity : BaseActivity() {
                         } else {
                             maybeShowEditNoticesTooltip()
                         }
-                    }, {
-                        L.e(it)
-                    }))
+                    }, { L.e(it) }))
         } else {
             displaySectionText()
         }
@@ -599,7 +597,8 @@ class EditSectionActivity : BaseActivity() {
 
     private fun displaySectionText() {
         binding.editSectionText.setText(sectionWikitext)
-        ViewAnimations.crossFade(binding.viewProgressBar, binding.editSectionContainer)
+        showProgressBar(false)
+        binding.editSectionContainer.isVisible = true
         scrollToHighlight(textToHighlight)
         binding.editSectionText.isEnabled = editingAllowed
         binding.editKeyboardOverlay.isVisible = editingAllowed

--- a/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.kt
+++ b/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.kt
@@ -80,7 +80,7 @@ class FindInEditorActionProvider(private val scrollView: View,
 
     private fun scrollToCurrentResult() {
         setMatchesResults(currentResultIndex, resultPositions.size)
-        val textPosition = if (resultPositions.isEmpty()) 0 else resultPositions[currentResultIndex]
+        val textPosition = resultPositions.getOrElse(currentResultIndex) { 0 }
         textView.setSelection(textPosition, textPosition + searchQuery.orEmpty().length)
         val r = Rect()
         textView.getFocusedRect(r)

--- a/app/src/main/java/org/wikipedia/edit/SyntaxHighlightableEditText.kt
+++ b/app/src/main/java/org/wikipedia/edit/SyntaxHighlightableEditText.kt
@@ -1,7 +1,6 @@
 package org.wikipedia.edit
 
 import android.annotation.SuppressLint
-import android.content.ClipData
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
@@ -13,7 +12,6 @@ import android.text.InputType
 import android.text.Layout
 import android.text.TextPaint
 import android.util.AttributeSet
-import android.view.ContentInfo
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
@@ -23,7 +21,6 @@ import androidx.core.view.ViewCompat
 import org.wikipedia.R
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
-import org.wikipedia.util.log.L
 
 /**
  * Notice that this view inherits from the platform EditText class, instead of AppCompatEditText.
@@ -189,23 +186,6 @@ open class SyntaxHighlightableEditText : EditText {
             outAttrs.imeOptions = outAttrs.imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION.inv()
         }
         return inputConnection
-    }
-
-    override fun onReceiveContent(payload: ContentInfo): ContentInfo? {
-        var newPayload = payload
-        try {
-            // Do not allow pasting of formatted text! We do this by replacing the contents of the clip
-            // with plain text.
-            val clip = payload.clip
-            val lastClipText = clip.getItemAt(clip.itemCount - 1).coerceToText(context).toString()
-
-            newPayload = ContentInfo.Builder(payload)
-                    .setClip(ClipData.newPlainText(null, lastClipText))
-                    .build()
-        } catch (e: Exception) {
-            L.e(e)
-        }
-        return super.onReceiveContent(newPayload)
     }
 
     fun undo() {

--- a/app/src/main/java/org/wikipedia/edit/SyntaxHighlightableEditText.kt
+++ b/app/src/main/java/org/wikipedia/edit/SyntaxHighlightableEditText.kt
@@ -1,7 +1,6 @@
 package org.wikipedia.edit
 
 import android.annotation.SuppressLint
-import android.content.ClipData
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
@@ -18,9 +17,6 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.widget.EditText
-import androidx.core.view.ContentInfoCompat
-import androidx.core.view.OnReceiveContentListener
-import androidx.core.view.ViewCompat
 import org.wikipedia.R
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
@@ -33,12 +29,12 @@ import org.wikipedia.util.ResourceUtil
  * case we need to copy over any useful compatibility logic.
  */
 @SuppressLint("AppCompatCustomView")
-class SyntaxHighlightableEditText : EditText, OnReceiveContentListener {
+class SyntaxHighlightableEditText : EditText {
 
     private var prevLineCount = -1
     private val lineNumberPaint = TextPaint()
     private val lineNumberBackgroundPaint = Paint()
-    private val isRtl: Boolean
+    private val isRtl: Boolean = resources.configuration.layoutDirection == LAYOUT_DIRECTION_RTL
     private val paddingWithoutLineNumbers = DimenUtil.roundedDpToPx(8f)
     private val paddingWithLineNumbers = DimenUtil.roundedDpToPx(36f)
     private val lineNumberGapWidth = DimenUtil.roundedDpToPx(8f)
@@ -60,9 +56,6 @@ class SyntaxHighlightableEditText : EditText, OnReceiveContentListener {
     constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
 
     init {
-        // The MIME type(s) need to be set for onReceiveContent() to be called.
-        ViewCompat.setOnReceiveContentListener(this, arrayOf("text/*"), this)
-        isRtl = resources.configuration.layoutDirection == LAYOUT_DIRECTION_RTL
         applyPaddingForLineNumbers()
 
         // TODO: this is temporary, and will be controlled by a preference in the next release.
@@ -189,16 +182,6 @@ class SyntaxHighlightableEditText : EditText, OnReceiveContentListener {
             outAttrs.imeOptions = outAttrs.imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION.inv()
         }
         return inputConnection
-    }
-
-    override fun onReceiveContent(view: View, payload: ContentInfoCompat): ContentInfoCompat {
-        // Do not allow pasting of formatted text! We do this by replacing the contents of the clip
-        // with plain text.
-        val clip = payload.clip
-        val lastClipText = clip.getItemAt(clip.itemCount - 1).coerceToText(context).toString()
-        return ContentInfoCompat.Builder(payload)
-                .setClip(ClipData.newPlainText(null, lastClipText))
-                .build()
     }
 
     fun undo() {

--- a/app/src/main/java/org/wikipedia/edit/SyntaxHighlightableEditText.kt
+++ b/app/src/main/java/org/wikipedia/edit/SyntaxHighlightableEditText.kt
@@ -1,0 +1,228 @@
+package org.wikipedia.edit
+
+import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import android.os.Build
+import android.os.SystemClock
+import android.text.Editable
+import android.text.InputType
+import android.text.Layout
+import android.text.TextPaint
+import android.util.AttributeSet
+import android.view.ContentInfo
+import android.view.KeyEvent
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
+import android.widget.EditText
+import androidx.core.view.ViewCompat
+import org.wikipedia.R
+import org.wikipedia.util.DimenUtil
+import org.wikipedia.util.ResourceUtil
+import org.wikipedia.util.log.L
+
+/**
+ * Notice that this view inherits from the platform EditText class, instead of AppCompatEditText.
+ * This is because AppCompatEditText actually has very poor performance when displaying large
+ * amounts of text. Inheriting directly from the base EditText provides a vast improvement in
+ * performance, but it means we need to keep an eye on the source code of AppCompatEditText, in
+ * case we need to copy over any useful compatibility logic.
+ */
+@SuppressLint("AppCompatCustomView")
+open class SyntaxHighlightableEditText : EditText {
+
+    private var prevLineCount = -1
+    private val lineNumberPaint = TextPaint()
+    private val lineNumberBackgroundPaint = Paint()
+    private val isRtl: Boolean
+    private val paddingWithoutLineNumbers = DimenUtil.roundedDpToPx(8f)
+    private val paddingWithLineNumbers = DimenUtil.roundedDpToPx(36f)
+    private val lineNumberGapWidth = DimenUtil.roundedDpToPx(8f)
+    private var allowScrollToCursor = true
+
+    lateinit var scrollView: View
+    private lateinit var actualLineFromRenderedLine: IntArray
+
+    var inputConnection: InputConnection? = null
+
+    var showLineNumbers = false
+        set(value) {
+            field = value
+            applyPaddingForLineNumbers()
+        }
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
+
+    init {
+        // The MIME type(s) need to be set for onReceiveContent() to be called.
+        ViewCompat.setOnReceiveContentListener(this, arrayOf("text/*"), null)
+        isRtl = resources.configuration.layoutDirection == LAYOUT_DIRECTION_RTL
+        applyPaddingForLineNumbers()
+
+        // TODO: this is temporary, and will be controlled by a preference in the next release.
+        enableTypingSuggestions(false)
+
+        lineNumberPaint.isAntiAlias = true
+        lineNumberPaint.textAlign = if (isRtl) Paint.Align.LEFT else Paint.Align.RIGHT
+        lineNumberPaint.textSize = this.textSize * 0.8f
+        lineNumberPaint.color = ResourceUtil.getThemedColor(context, R.attr.material_theme_de_emphasised_color)
+        lineNumberBackgroundPaint.color = ResourceUtil.getThemedColor(context, R.attr.chip_background_color)
+    }
+
+    fun enqueueNoScrollingLayoutChange() {
+        allowScrollToCursor = false
+        postDelayed({
+            if (isAttachedToWindow) {
+                allowScrollToCursor = true
+            }
+        }, 1000)
+    }
+
+    fun enableTypingSuggestions(enabled: Boolean) {
+        inputType = EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE or
+                (if (enabled) 0 else (EditorInfo.TYPE_TEXT_FLAG_NO_SUGGESTIONS or EditorInfo.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD))
+    }
+
+    override fun bringPointIntoView(offset: Int): Boolean {
+        if (!allowScrollToCursor) {
+            return false
+        }
+        return super.bringPointIntoView(offset)
+    }
+
+    override fun onDraw(canvas: Canvas?) {
+        if (prevLineCount != lineCount) {
+            prevLineCount = lineCount
+            computeLineNumbers(prevLineCount, layout, text.toString())
+        }
+
+        if (showLineNumbers && layout != null) {
+            val wrapContent = true // TODO: make wrap content optional?
+
+            val firstLine = layout.getLineForVertical(scrollView.scrollY)
+            val lastLine = layout.getLineForVertical(scrollView.scrollY + scrollView.height)
+
+            // paint the gutter area with a slightly different color than text background.
+            val gutterRect = if (isRtl) Rect(width - paddingWithLineNumbers + lineNumberGapWidth / 2, 0, width, height) else
+                Rect(0, 0, paddingWithLineNumbers - lineNumberGapWidth / 2, height)
+            canvas?.drawRect(gutterRect, lineNumberBackgroundPaint)
+
+            // paint the line numbers, by getting each line position from the Layout.
+            var prevNum = -1
+            for (i in firstLine..lastLine) {
+                val num = actualLineFromRenderedLine[i]
+                if (!wrapContent || prevNum != num) {
+                    prevNum = num
+                    canvas?.drawText(num.toString(),
+                            (if (isRtl) width - paddingWithLineNumbers + lineNumberGapWidth else paddingWithLineNumbers - lineNumberGapWidth).toFloat(),
+                            layout.getLineBottom(i).toFloat(),
+                            lineNumberPaint)
+                }
+            }
+        }
+        super.onDraw(canvas)
+    }
+
+    private fun computeLineNumbers(lineCount: Int, layout: Layout, text: String?) {
+        val lineContainsNewlineChar = BooleanArray(lineCount)
+
+        if (text.isNullOrEmpty() || lineCount == 0) {
+            actualLineFromRenderedLine = IntArray(1)
+            actualLineFromRenderedLine[0] = 1
+            return
+        }
+
+        val renderedLineBeginsActualLine = BooleanArray(lineCount)
+        actualLineFromRenderedLine = IntArray(lineCount)
+
+        // iterate through rendered lines, and take note of ones that end with a newline char.
+        for (i in 0 until lineCount) {
+            lineContainsNewlineChar[i] = text[layout.getLineEnd(i) - 1] == '\n'
+            if (lineContainsNewlineChar[i]) {
+                var j = i - 1
+                while (j >= 0 && !lineContainsNewlineChar[j]) { j-- }
+                renderedLineBeginsActualLine[j + 1] = true
+            }
+        }
+
+        // handle the case of the last line, which doesn't end with a newline char.
+        var j = lineCount - 1
+        while (j >= 0 && !lineContainsNewlineChar[j]) { j-- }
+        renderedLineBeginsActualLine[j + 1] = true
+
+        // and build the actual mapping of rendered lines to actual lines.
+        var actualLine = 0
+        for (i in renderedLineBeginsActualLine.indices) {
+            if (renderedLineBeginsActualLine[i]) {
+                actualLine++
+            }
+            actualLineFromRenderedLine[i] = actualLine
+        }
+    }
+
+    private fun applyPaddingForLineNumbers() {
+        setPaddingRelative(if (showLineNumbers) paddingWithLineNumbers else paddingWithoutLineNumbers, paddingTop, paddingEnd, paddingBottom)
+    }
+
+    override fun getText(): Editable {
+        // A bug pre-P makes getText() crash if called before the first setText due to a cast, so
+        // retrieve the editable text.
+        return (if (Build.VERSION.SDK_INT >= 28) {
+            super.getText()
+        } else super.getEditableText()) ?: Editable.Factory.getInstance().newEditable("")
+    }
+
+    override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
+        inputConnection = super.onCreateInputConnection(outAttrs)
+
+        // For multiline EditTexts that specify a done keyboard action, unset the no carriage return
+        // flag which otherwise limits the EditText to a single line
+        val multilineInput = inputType and InputType.TYPE_TEXT_FLAG_MULTI_LINE == InputType.TYPE_TEXT_FLAG_MULTI_LINE
+        val actionDone = outAttrs.imeOptions and EditorInfo.IME_ACTION_DONE == EditorInfo.IME_ACTION_DONE
+        if (actionDone && multilineInput) {
+            outAttrs.imeOptions = outAttrs.imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION.inv()
+        }
+        return inputConnection
+    }
+
+    override fun onReceiveContent(payload: ContentInfo): ContentInfo? {
+        var newPayload = payload
+        try {
+            // Do not allow pasting of formatted text! We do this by replacing the contents of the clip
+            // with plain text.
+            val clip = payload.clip
+            val lastClipText = clip.getItemAt(clip.itemCount - 1).coerceToText(context).toString()
+
+            newPayload = ContentInfo.Builder(payload)
+                    .setClip(ClipData.newPlainText(null, lastClipText))
+                    .build()
+        } catch (e: Exception) {
+            L.e(e)
+        }
+        return super.onReceiveContent(newPayload)
+    }
+
+    fun undo() {
+        inputConnection?.let {
+            it.sendKeyEvent(KeyEvent(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
+                    KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_Z, 0, KeyEvent.META_CTRL_ON))
+            it.sendKeyEvent(KeyEvent(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
+                    KeyEvent.ACTION_UP, KeyEvent.KEYCODE_Z, 0, KeyEvent.META_CTRL_ON))
+        }
+    }
+
+    fun redo() {
+        inputConnection?.let {
+            it.sendKeyEvent(KeyEvent(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
+                    KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_Z, 0, KeyEvent.META_CTRL_ON or KeyEvent.META_SHIFT_ON))
+            it.sendKeyEvent(KeyEvent(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
+                    KeyEvent.ACTION_UP, KeyEvent.KEYCODE_Z, 0, KeyEvent.META_CTRL_ON or KeyEvent.META_SHIFT_ON))
+        }
+    }
+}

--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.kt
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.kt
@@ -2,13 +2,14 @@ package org.wikipedia.edit.richtext
 
 import android.content.Context
 import android.text.Spanned
-import android.widget.EditText
 import androidx.core.text.getSpans
+import androidx.core.widget.NestedScrollView
 import androidx.core.widget.doAfterTextChanged
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import org.wikipedia.edit.SyntaxHighlightableEditText
 import org.wikipedia.util.log.L
 import java.util.*
 import java.util.concurrent.Callable
@@ -16,13 +17,8 @@ import java.util.concurrent.TimeUnit
 
 class SyntaxHighlighter(
     private var context: Context,
-    private val textBox: EditText,
-    private var syntaxHighlightListener: OnSyntaxHighlightListener? = null
-) {
-    interface OnSyntaxHighlightListener {
-        fun syntaxHighlightResults(spanExtents: List<SpanExtents>)
-        fun findTextMatches(spanExtents: List<SpanExtents>)
-    }
+    private val textBox: SyntaxHighlightableEditText,
+    private val scrollView: NestedScrollView) {
 
     private val syntaxRules = listOf(
             SyntaxRule("{{", "}}", SyntaxRuleStyle.TEMPLATE),
@@ -37,32 +33,71 @@ class SyntaxHighlighter(
             SyntaxRule("==", "==", SyntaxRuleStyle.HEADING_LARGE),
     )
 
-    private var searchText: String? = null
-    private var selectedMatchResultPosition = 0
     private val disposables = CompositeDisposable()
     private var currentHighlightTask: SyntaxHighlightTask? = null
+    private var lastScrollY = -1
+    private val highlightOnScrollRunnable = Runnable { postHighlightOnScroll() }
+
+    private var searchQueryPositions: List<Int>? = null
+    private var searchQueryLength = 0
+    private var searchQueryPositionIndex = 0
+
+    var enabled = true
+        set(value) {
+            field = value
+            if (!value) {
+                currentHighlightTask?.cancel()
+                disposables.clear()
+                textBox.text.getSpans<SpanExtents>().forEach { textBox.text.removeSpan(it) }
+            } else {
+                runHighlightTasks(HIGHLIGHT_DELAY_MILLIS)
+            }
+        }
 
     init {
-        textBox.doAfterTextChanged { runHighlightTasks(1000) }
+        textBox.doAfterTextChanged { runHighlightTasks(HIGHLIGHT_DELAY_MILLIS * 2) }
+        textBox.scrollView = scrollView
+        postHighlightOnScroll()
     }
 
     private fun runHighlightTasks(delayMillis: Long) {
+
         currentHighlightTask?.cancel()
-        currentHighlightTask = SyntaxHighlightTask(textBox.text)
         disposables.clear()
+        if (!enabled) {
+            return
+        }
         disposables.add(Observable.timer(delayMillis, TimeUnit.MILLISECONDS)
                 .flatMap {
+                    if (textBox.layout == null) {
+                        throw IllegalArgumentException()
+                    }
+
+                    var firstVisibleLine = textBox.layout.getLineForVertical(scrollView.scrollY)
+                    if (firstVisibleLine < 0) firstVisibleLine = 0
+
+                    var lastVisibleLine = textBox.layout.getLineForVertical(scrollView.scrollY + scrollView.height)
+                    if (lastVisibleLine < firstVisibleLine) lastVisibleLine = firstVisibleLine
+                    else if (lastVisibleLine >= textBox.lineCount) lastVisibleLine = textBox.lineCount - 1
+
+                    val firstVisibleIndex = textBox.layout.getLineStart(firstVisibleLine)
+                    val lastVisibleIndex = textBox.layout.getLineEnd(lastVisibleLine)
+
+                    val textToHighlight = textBox.text.substring(firstVisibleIndex, lastVisibleIndex)
+                    currentHighlightTask = SyntaxHighlightTask(textToHighlight, firstVisibleIndex)
+
                     Observable.zip<MutableList<SpanExtents>, List<SpanExtents>, List<SpanExtents>>(Observable.fromCallable(currentHighlightTask!!),
-                            if (searchText.isNullOrEmpty()) Observable.just(emptyList())
-                            else Observable.fromCallable(SyntaxHighlightSearchMatchesTask(textBox.text, searchText!!, selectedMatchResultPosition))) { f, s ->
+                            if (searchQueryPositions.isNullOrEmpty()) Observable.just(emptyList())
+                            else Observable.fromCallable(SyntaxHighlightSearchMatchesTask(firstVisibleIndex, textToHighlight.length))) { f, s ->
                         f.addAll(s)
                         f
                     }
                 }
+                .retry(10)
                 .subscribeOn(Schedulers.computation())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ result ->
-                    syntaxHighlightListener?.syntaxHighlightResults(result)
+                    textBox.enqueueNoScrollingLayoutChange()
 
                     var time = System.currentTimeMillis()
                     val oldSpans = textBox.text.getSpans<SpanExtents>().toMutableList()
@@ -79,39 +114,40 @@ class SyntaxHighlighter(
                     }
                     oldSpans.removeAll(dupes)
 
-                    for (sp in oldSpans) {
-                        textBox.text.removeSpan(sp)
-                    }
-                    val findTextList = newSpans
-                            .onEach { textBox.text.setSpan(it, it.start, it.end, Spanned.SPAN_INCLUSIVE_INCLUSIVE) }
-                            .filter { it.syntaxRule.spanStyle == SyntaxRuleStyle.SEARCH_MATCHES } // and add our new spans
+                    oldSpans.forEach { textBox.text.removeSpan(it) }
+                    newSpans.forEach { textBox.text.setSpan(it, it.start, it.end, Spanned.SPAN_INCLUSIVE_INCLUSIVE) }
 
-                    if (!searchText.isNullOrEmpty()) {
-                        syntaxHighlightListener?.findTextMatches(findTextList)
-                    }
                     time = System.currentTimeMillis() - time
                     L.d("Took $time ms to remove ${oldSpans.size} spans and add ${newSpans.size} new.")
                 }) { L.e(it) })
     }
 
-    fun applyFindTextSyntax(searchText: String?, listener: OnSyntaxHighlightListener?) {
-        this.searchText = searchText
-        syntaxHighlightListener = listener
-        setSelectedMatchResultPosition(0)
-        runHighlightTasks(500)
-    }
-
-    fun setSelectedMatchResultPosition(selectedMatchResultPosition: Int) {
-        this.selectedMatchResultPosition = selectedMatchResultPosition
+    fun setSearchQueryInfo(searchQueryPositions: List<Int>?, searchQueryLength: Int, searchQueryPositionIndex: Int) {
+        this.searchQueryPositions = searchQueryPositions
+        this.searchQueryLength = searchQueryLength
+        this.searchQueryPositionIndex = searchQueryPositionIndex
         runHighlightTasks(0)
     }
 
+    fun clearSearchQueryInfo() {
+        setSearchQueryInfo(null, 0, 0)
+    }
+
     fun cleanup() {
+        scrollView.removeCallbacks(highlightOnScrollRunnable)
         disposables.clear()
         textBox.text.clearSpans()
     }
 
-    private inner class SyntaxHighlightTask constructor(private val text: CharSequence) : Callable<MutableList<SpanExtents>> {
+    private fun postHighlightOnScroll() {
+        if (lastScrollY != scrollView.scrollY) {
+            lastScrollY = scrollView.scrollY
+            runHighlightTasks(0)
+        }
+        scrollView.postDelayed(highlightOnScrollRunnable, HIGHLIGHT_DELAY_MILLIS)
+    }
+
+    private inner class SyntaxHighlightTask constructor(private val text: CharSequence, private val startOffset: Int) : Callable<MutableList<SpanExtents>> {
         private var cancelled = false
 
         fun cancel() {
@@ -185,36 +221,39 @@ class SyntaxHighlighter(
 
                 i++
             }
+            spansToSet.forEach {
+                it.start += startOffset
+                it.end += startOffset
+            }
             spansToSet.sortWith { a, b -> a.syntaxRule.spanStyle.compareTo(b.syntaxRule.spanStyle) }
             return spansToSet
         }
     }
 
-    private inner class SyntaxHighlightSearchMatchesTask constructor(text: CharSequence, searchText: String, private val selectedMatchResultPosition: Int) : Callable<List<SpanExtents>> {
-        private val searchText = searchText.lowercase(Locale.getDefault())
-        private val text = text.toString().lowercase(Locale.getDefault())
-
+    private inner class SyntaxHighlightSearchMatchesTask constructor(private val startOffset: Int, private val textLength: Int) : Callable<List<SpanExtents>> {
         override fun call(): List<SpanExtents> {
             val spansToSet = mutableListOf<SpanExtents>()
             val syntaxItem = SyntaxRule("", "", SyntaxRuleStyle.SEARCH_MATCHES)
-            var position = 0
-            var matches = 0
-            do {
-                position = text.indexOf(searchText, position)
-                if (position >= 0) {
-                    val newSpanInfo = if (matches == selectedMatchResultPosition) {
-                        SyntaxRuleStyle.SEARCH_MATCH_SELECTED.createSpan(context, position, syntaxItem)
-                    } else {
-                        SyntaxRuleStyle.SEARCH_MATCHES.createSpan(context, position, syntaxItem)
+
+            searchQueryPositions?.let {
+                for (i in it.indices) {
+                    if (it[i] >= startOffset && it[i] < startOffset + textLength) {
+                        val newSpanInfo = if (i == searchQueryPositionIndex) {
+                            SyntaxRuleStyle.SEARCH_MATCH_SELECTED.createSpan(context, it[i], syntaxItem)
+                        } else {
+                            SyntaxRuleStyle.SEARCH_MATCHES.createSpan(context, it[i], syntaxItem)
+                        }
+                        newSpanInfo.start = it[i]
+                        newSpanInfo.end = it[i] + searchQueryLength
+                        spansToSet.add(newSpanInfo)
                     }
-                    newSpanInfo.start = position
-                    newSpanInfo.end = position + searchText.length
-                    spansToSet.add(newSpanInfo)
-                    position += searchText.length
-                    matches++
                 }
-            } while (position >= 0)
+            }
             return spansToSet
         }
+    }
+
+    companion object {
+        const val HIGHLIGHT_DELAY_MILLIS = 500L
     }
 }

--- a/app/src/main/java/org/wikipedia/views/PlainPasteEditText.kt
+++ b/app/src/main/java/org/wikipedia/views/PlainPasteEditText.kt
@@ -2,30 +2,18 @@ package org.wikipedia.views
 
 import android.content.ClipData
 import android.content.Context
-import android.os.SystemClock
 import android.text.InputType
 import android.util.AttributeSet
-import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import androidx.core.view.ContentInfoCompat
 import androidx.core.view.ViewCompat
 import com.google.android.material.textfield.TextInputEditText
-import org.wikipedia.edit.richtext.SpanExtents
-import org.wikipedia.edit.richtext.SyntaxHighlighter
-import org.wikipedia.edit.richtext.SyntaxHighlighter.OnSyntaxHighlightListener
-import java.util.*
 
 open class PlainPasteEditText : TextInputEditText {
     interface FindListener {
         fun onFinished(activeMatchOrdinal: Int, numberOfMatches: Int, textPosition: Int, findingNext: Boolean)
     }
-
-    private val findInPageTextPositionList: MutableList<Int> = ArrayList()
-    private var findInPageCurrentTextPosition = 0
-    private var syntaxHighlighter: SyntaxHighlighter? = null
-    var inputConnection: InputConnection? = null
-    var findListener: FindListener? = null
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
@@ -48,7 +36,7 @@ open class PlainPasteEditText : TextInputEditText {
     }
 
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
-        inputConnection = super.onCreateInputConnection(outAttrs)
+        val inputConnection = super.onCreateInputConnection(outAttrs)
 
         // For multiline EditTexts that specify a done keyboard action, unset the no carriage return
         // flag which otherwise limits the EditText to a single line
@@ -58,81 +46,5 @@ open class PlainPasteEditText : TextInputEditText {
             outAttrs.imeOptions = outAttrs.imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION.inv()
         }
         return inputConnection
-    }
-
-    fun undo() {
-        inputConnection?.let {
-            it.sendKeyEvent(KeyEvent(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
-                    KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_Z, 0, KeyEvent.META_CTRL_ON))
-            it.sendKeyEvent(KeyEvent(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
-                    KeyEvent.ACTION_UP, KeyEvent.KEYCODE_Z, 0, KeyEvent.META_CTRL_ON))
-        }
-    }
-
-    fun redo() {
-        inputConnection?.let {
-            it.sendKeyEvent(KeyEvent(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
-                    KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_Z, 0, KeyEvent.META_CTRL_ON or KeyEvent.META_SHIFT_ON))
-            it.sendKeyEvent(KeyEvent(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
-                    KeyEvent.ACTION_UP, KeyEvent.KEYCODE_Z, 0, KeyEvent.META_CTRL_ON or KeyEvent.META_SHIFT_ON))
-        }
-    }
-
-    fun findInEditor(targetText: String?, syntaxHighlighter: SyntaxHighlighter) {
-        findListener?.let { listener ->
-            this.syntaxHighlighter = syntaxHighlighter
-            findInPageCurrentTextPosition = 0
-            // apply find text syntax
-            syntaxHighlighter.applyFindTextSyntax(targetText, object : OnSyntaxHighlightListener {
-                override fun syntaxHighlightResults(spanExtents: List<SpanExtents>) { }
-
-                override fun findTextMatches(spanExtents: List<SpanExtents>) {
-                    findInPageTextPositionList.clear()
-                    text?.let {
-                        findInPageTextPositionList.addAll(spanExtents.map { span -> it.getSpanStart(span) })
-                    }
-                    onFinished(false, listener)
-                }
-            })
-        }
-    }
-
-    fun findNext() {
-        find(true)
-    }
-
-    fun findPrevious() {
-        find(false)
-    }
-
-    fun findFirstOrLast(isFirst: Boolean) {
-        findListener?.let {
-            findInPageCurrentTextPosition = if (isFirst) 0 else findInPageTextPositionList.size - 1
-            onFinished(true, it)
-            syntaxHighlighter!!.setSelectedMatchResultPosition(findInPageCurrentTextPosition)
-        }
-    }
-
-    private fun find(isNext: Boolean) {
-        findListener?.let {
-            findInPageCurrentTextPosition = if (isNext) {
-                if (findInPageCurrentTextPosition == findInPageTextPositionList.size - 1) 0 else ++findInPageCurrentTextPosition
-            } else {
-                if (findInPageCurrentTextPosition == 0) findInPageTextPositionList.size - 1 else --findInPageCurrentTextPosition
-            }
-            onFinished(true, it)
-            syntaxHighlighter!!.setSelectedMatchResultPosition(findInPageCurrentTextPosition)
-        }
-    }
-
-    fun clearMatches(syntaxHighlighter: SyntaxHighlighter) {
-        findInEditor(null, syntaxHighlighter)
-    }
-
-    private fun onFinished(findingNext: Boolean, listener: FindListener) {
-        listener.onFinished(findInPageCurrentTextPosition,
-                findInPageTextPositionList.size,
-                if (findInPageTextPositionList.isEmpty()) 0 else findInPageTextPositionList[findInPageCurrentTextPosition],
-                findingNext)
     }
 }

--- a/app/src/main/java/org/wikipedia/views/PlainPasteEditText.kt
+++ b/app/src/main/java/org/wikipedia/views/PlainPasteEditText.kt
@@ -11,10 +11,6 @@ import androidx.core.view.ViewCompat
 import com.google.android.material.textfield.TextInputEditText
 
 open class PlainPasteEditText : TextInputEditText {
-    interface FindListener {
-        fun onFinished(activeMatchOrdinal: Int, numberOfMatches: Int, textPosition: Int, findingNext: Boolean)
-    }
-
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
@@ -36,8 +32,6 @@ open class PlainPasteEditText : TextInputEditText {
     }
 
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
-        val inputConnection = super.onCreateInputConnection(outAttrs)
-
         // For multiline EditTexts that specify a done keyboard action, unset the no carriage return
         // flag which otherwise limits the EditText to a single line
         val multilineInput = inputType and InputType.TYPE_TEXT_FLAG_MULTI_LINE == InputType.TYPE_TEXT_FLAG_MULTI_LINE
@@ -45,6 +39,6 @@ open class PlainPasteEditText : TextInputEditText {
         if (actionDone && multilineInput) {
             outAttrs.imeOptions = outAttrs.imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION.inv()
         }
-        return inputConnection
+        return super.onCreateInputConnection(outAttrs)
     }
 }

--- a/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.kt
+++ b/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.inputmethod.InputConnection
 import android.widget.FrameLayout
 import org.wikipedia.databinding.ViewWikitextKeyboardBinding
+import org.wikipedia.edit.SyntaxHighlightableEditText
 
 class WikiTextKeyboardView : FrameLayout {
     fun interface Callback {
@@ -15,7 +16,7 @@ class WikiTextKeyboardView : FrameLayout {
 
     private val binding = ViewWikitextKeyboardBinding.inflate(LayoutInflater.from(context), this, true)
     var callback: Callback? = null
-    var editText: PlainPasteEditText? = null
+    var editText: SyntaxHighlightableEditText? = null
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)

--- a/app/src/main/res/layout/activity_edit_section.xml
+++ b/app/src/main/res/layout/activity_edit_section.xml
@@ -14,22 +14,24 @@
         android:visibility="gone"
         tools:visibility="visible">
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:id="@+id/edit_section_scroll"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            android:scrollbars="vertical">
 
-            <org.wikipedia.views.PlainPasteEditText
+            <org.wikipedia.edit.SyntaxHighlightableEditText
                 android:id="@+id/edit_section_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginHorizontal="8dp"
                 android:fontFamily="monospace"
                 android:imeOptions="actionNone|flagNoExtractUi"
                 android:inputType="textMultiLine"
-                android:scrollbars="vertical"
                 style="@style/EditSectionTextInputLayoutStyle" />
-        </ScrollView>
+
+        </androidx.core.widget.NestedScrollView>
 
         <HorizontalScrollView
             android:id="@+id/edit_keyboard_overlay_container"


### PR DESCRIPTION
This makes our wikitext editing experience much more performant, and more usable on a wider range of devices.
There are a few key insights that led to this improvement:

1. The `androidx.appcompat` library adds a lot of extra baggage to the `AppCompatEditText` component, which actually cripples its performance with large amounts of text. Our new editing component will _no longer inherit_ from `AppCompatEditText`, and instead inherit from the base platform `EditText`. This accounts for ~**80%** of the performance issue.
2. Syntax highlighting (as well as find-in-page) uses Spans, and the longer the text, the more Spans there will be, which also impacts performance. Instead of applying syntax highlighting to the entire text every time it's updated, we will now apply syntax highlighting _only inside the currently-visible text_. This has a few tradeoffs (e.g. if you scroll very quickly, you will see un-highlighted text for a moment before it becomes highlighted; you might also see a little jumping because certain highlights affect the line height of text), but the benefits are tremendous. This accounts for another 10% of the performance issue.
3. By default the `EditText` component enables typing suggestions, which can have an impact on performance with large amounts of text, particularly on Samsung devices. We will now disable typing suggestions by default, and will provide a preference to enable them in our next update. (Typing suggestions are not very beneficial for wikitext editing anyway.)

https://phabricator.wikimedia.org/T164936