### PR TITLE
Fix possible mangling of displayName in PageTitle.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageTitle.kt
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.kt
@@ -57,7 +57,7 @@ data class PageTitle(
             }
             _namespace = value
             // And prepend the new namespace onto displayText.
-            _displayText = if (value.isEmpty()) _displayText else StringUtil.removeUnderscores(value) + ":" + _displayText
+            _displayText = if (value.isEmpty() || _displayText.isNullOrEmpty()) _displayText else StringUtil.removeUnderscores(value) + ":" + _displayText
         }
 
     val isFilePage: Boolean


### PR DESCRIPTION
When setting a new Namespace on a PageTitle, we also update the `displayText`, but we should only do this if `displayText` was already non-empty, and not if it's null.

https://phabricator.wikimedia.org/T315940