### PR TITLE
Add info links to article call to action(s)

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -212,6 +212,7 @@ class DescriptionEditFragment : Fragment() {
         }
         binding.fragmentDescriptionEditView.showProgressBar(false)
         binding.fragmentDescriptionEditView.setEditAllowed(editingAllowed)
+        binding.fragmentDescriptionEditView.updateInfoText()
     }
 
     private fun callback(): Callback? {

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -90,8 +90,8 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
         }
 
         binding.learnMoreButton.setOnClickListener {
-            UriUtil.visitInExternalBrowser(context, Uri.parse(WikipediaApp.instance.getString(if (action == DescriptionEditActivity.Action.ADD_DESCRIPTION
-                || action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION) R.string.description_edit_description_learn_more_url
+            UriUtil.visitInExternalBrowser(context, Uri.parse(WikipediaApp.instance.getString(if (action == DescriptionEditActivity.Action.ADD_DESCRIPTION ||
+                action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION) R.string.description_edit_description_learn_more_url
             else R.string.description_edit_image_caption_learn_more_url)))
         }
     }
@@ -389,9 +389,9 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
 
     fun updateInfoText() {
         binding.learnMoreButton.text =
-            if (action == DescriptionEditActivity.Action.ADD_DESCRIPTION || action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION)
-                context.getString(R.string.description_edit_learn_more)
-            else {context.getString(R.string.description_edit_image_caption_learn_more)}
+            if (action == DescriptionEditActivity.Action.ADD_DESCRIPTION ||
+                action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION) context.getString(R.string.description_edit_learn_more)
+            else context.getString(R.string.description_edit_image_caption_learn_more)
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -3,6 +3,7 @@ package org.wikipedia.descriptions
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.net.Uri
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.inputmethod.EditorInfo
@@ -86,6 +87,12 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
                 return@setOnEditorActionListener true
             }
             false
+        }
+
+        binding.learnMoreButton.setOnClickListener {
+            UriUtil.visitInExternalBrowser(context, Uri.parse(WikipediaApp.instance.getString(if (action == DescriptionEditActivity.Action.ADD_DESCRIPTION
+                || action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION) R.string.description_edit_description_learn_more_url
+            else R.string.description_edit_image_caption_learn_more_url)))
         }
     }
 
@@ -378,6 +385,13 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
             isLanguageWrong = true
             enqueueValidateText()
         }
+    }
+
+    fun updateInfoText() {
+        binding.learnMoreButton.text =
+            if (action == DescriptionEditActivity.Action.ADD_DESCRIPTION || action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION)
+                context.getString(R.string.description_edit_learn_more)
+            else {context.getString(R.string.description_edit_image_caption_learn_more)}
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.kt
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.kt
@@ -10,7 +10,6 @@ import android.webkit.WebView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
-import io.reactivex.rxjava3.disposables.CompositeDisposable
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.EditFunnel
@@ -44,7 +43,6 @@ class EditPreviewFragment : Fragment(), CommunicationBridgeListener, ReferenceDi
     private lateinit var otherTag: EditSummaryTag
     private lateinit var funnel: EditFunnel
     private val summaryTags = mutableListOf<EditSummaryTag>()
-    private val disposables = CompositeDisposable()
     private val bottomSheetPresenter = ExclusiveBottomSheetPresenter()
     val isActive get() = binding.editPreviewContainer.visibility == View.VISIBLE
 
@@ -186,7 +184,7 @@ class EditPreviewFragment : Fragment(), CommunicationBridgeListener, ReferenceDi
         bridge.addListener("reference") { _, messagePayload ->
             (JsonUtil.decodeFromString<PageReferences>(messagePayload.toString()))?.let {
                 references = it
-                if (!references.referencesGroup.isNullOrEmpty()) {
+                if (references.referencesGroup.isNotEmpty()) {
                     bottomSheetPresenter.show(childFragmentManager, ReferenceDialog())
                 }
             }
@@ -194,7 +192,6 @@ class EditPreviewFragment : Fragment(), CommunicationBridgeListener, ReferenceDi
     }
 
     override fun onDestroyView() {
-        disposables.clear()
         binding.editPreviewWebview.clearAllListeners()
         (binding.editPreviewWebview.parent as ViewGroup).removeView(binding.editPreviewWebview)
         bridge.cleanup()

--- a/app/src/main/res/layout/view_description_edit.xml
+++ b/app/src/main/res/layout/view_description_edit.xml
@@ -180,6 +180,23 @@
                         </com.google.android.material.textfield.TextInputLayout>
                     </FrameLayout>
 
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/learnMoreButton"
+                        style="@style/FlatButton.Small.Transparent"
+                        android:layout_width="match_parent"
+                        android:layout_marginStart="12dp"
+                        android:fontFamily="sans-serif"
+                        android:letterSpacing="0"
+                        android:text="@string/description_edit_learn_more"
+                        android:textAlignment="viewStart"
+                        android:textAllCaps="false"
+                        android:textColor="?attr/colorAccent"
+                        android:textSize="16sp"
+                        app:icon="@drawable/ic_open_in_new_black_24px"
+                        app:iconGravity="end"
+                        app:iconPadding="12dp"
+                        app:iconSize="16dp"
+                        app:iconTint="?attr/colorAccent" />
                 </LinearLayout>
             </ScrollView>
 

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1213,4 +1213,8 @@
   <string name="revision_initial_none">Label shown when showing a diff of the first revision of an article (when there is no previous revision to compare with).</string>
   <string name="archive_empty">Error shown when the current page does not have subpages.</string>
   <string name="media_playback_error">Error shown when the selected media could not be played.</string>
+  <string name="description_edit_learn_more">Label text for information about article descriptions.</string>
+  <string name="description_edit_image_caption_learn_more">Label text for information about Image Captions.</string>
+  <string name="description_edit_description_learn_more_url">URL that points to a page on mediawiki that contains guidelines for writing article descriptions.</string>
+  <string name="description_edit_image_caption_learn_more_url">URL that points to a page on mediawiki that contains guidelines for writing Image captions.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -807,6 +807,10 @@
     <string name="description_edit_license_notice"><![CDATA[By changing the article description, I agree to the <a href="%1$s">Terms of Use</a> and to irrevocably release my contributions under the <a href="%2$s">Creative Commons CC0</a> license.]]></string>
     <string name="description_edit_helper_text_lowercase_warning">usually begin with a lowercase letter</string>
     <string name="description_edit_voice_input_description">Voice input</string>
+    <string name="description_edit_learn_more">Learn more about article descriptions</string>
+    <string name="description_edit_image_caption_learn_more">Learn more about Image Captions</string>
+    <string name="description_edit_description_learn_more_url">https://www.mediawiki.org/wiki/Wikimedia_Apps/Suggested_edits#Article_descriptions</string>
+    <string name="description_edit_image_caption_learn_more_url">https://www.mediawiki.org/wiki/Wikimedia_Apps/Suggested_edits#Image_captions</string>
 
     <string name="description_too_short">The text is too short.</string>
     <string name="description_ends_with_punctuation">The text must not end with punctuation.</string>


### PR DESCRIPTION
Added info links to editing vies to provide guidance to users while adding article descriptions or image captions from article CTA. Also available when editing from Suggested edits.
**Phab:** https://phabricator.wikimedia.org/T315702