### PR TITLE
Update Glide to 4.13.2.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -169,7 +169,7 @@ dependencies {
 
     String okHttpVersion = '4.8.1'
     String retrofitVersion = '2.9.0'
-    String glideVersion = '4.11.0'
+    String glideVersion = '4.13.2'
     String mockitoVersion = '3.4.0'
     String leakCanaryVersion = '2.8.1'
     String kotlinCoroutinesVersion = '1.3.9'


### PR DESCRIPTION
https://github.com/bumptech/glide/releases/tag/v4.13.2