### PR TITLE
Update to AppCompat 1.5.0, and add example of using MenuProvider.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -185,7 +185,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version"
 
     implementation "com.google.android.material:material:1.6.1"
-    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation "androidx.core:core-ktx:1.8.0"
     implementation "androidx.browser:browser:1.4.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
@@ -5,7 +5,9 @@ import android.view.*
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -38,7 +40,8 @@ import org.wikipedia.util.log.L
 import org.wikipedia.views.NotificationButtonView
 import java.util.*
 
-class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistItemView.Callback, WatchlistLanguagePopupView.Callback {
+class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistItemView.Callback,
+        WatchlistLanguagePopupView.Callback, MenuProvider {
     private var _binding: FragmentWatchlistBinding? = null
 
     private lateinit var notificationButtonView: NotificationButtonView
@@ -62,6 +65,7 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         binding.watchlistRefreshView.setColorSchemeResources(ResourceUtil.getThemedAttributeId(requireContext(), R.attr.colorAccent))
         binding.watchlistRefreshView.setOnRefreshListener { fetchWatchlist(true) }
@@ -75,23 +79,17 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
         funnel.logOpenWatchlist()
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        setHasOptionsMenu(true)
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         disposables.clear()
         _binding = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_watchlist, menu)
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
+    override fun onPrepareMenu(menu: Menu) {
         menu.findItem(R.id.menu_change_language).isVisible = WikipediaApp.instance.languageState.appLanguageCodes.size > 1
 
         val notificationMenuItem = menu.findItem(R.id.menu_notifications)
@@ -113,14 +111,14 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
         updateNotificationDot(false)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_change_language -> {
                 val overflowView = WatchlistLanguagePopupView(requireContext())
                 overflowView.show(ActivityCompat.requireViewById(requireActivity(), R.id.menu_change_language), this)
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 


### PR DESCRIPTION
The old ways of menu handling are deprecated and need to be replaced with `MenuProvider` interfaces, for some reason. This PR provides an example of upgrading a fragment from old-style menu handling to the new style.

https://developer.android.com/jetpack/androidx/releases/appcompat#1.5.0