### PR TITLE
Fix CreateAccount captcha handling broken by recent API changes.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
@@ -64,7 +64,7 @@ class MwQueryResult {
     }
 
     fun captchaId(): String? {
-        return amInfo?.requests?.find { "CaptchaAuthenticationRequest" == it.id }?.fields?.get("captchaId")?.value
+        return amInfo?.requests?.find { it.id.orEmpty().contains("CaptchaAuthenticationRequest") }?.fields?.get("captchaId")?.value
     }
 
     fun getUserResponse(userName: String): UserInfo? {


### PR DESCRIPTION
It looks like there were some recent changes to the backend API that are breaking our account creation flow, in particular our Captcha handling.

We expect the `authmanagerinfo` structure to contain an object with an id of `CaptchaAuthenticationRequest`, but now the id has become `MediaWiki\Extension\ConfirmEdit\Auth\CaptchaAuthenticationRequest`, which we don't account for. This PR will account for both variations.

To be investigated more fully later.

https://phabricator.wikimedia.org/T316403