### PR TITLE
Fix possible crash due to off-by-one error in wikitext editor.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/SyntaxHighlightableEditText.kt
+++ b/app/src/main/java/org/wikipedia/edit/SyntaxHighlightableEditText.kt
@@ -145,7 +145,7 @@ class SyntaxHighlightableEditText : EditText {
         }
 
         // handle the case of the last line, which doesn't end with a newline char.
-        var j = lineCount - 1
+        var j = lineCount - 2
         while (j >= 0 && !lineContainsNewlineChar[j]) { j-- }
         renderedLineBeginsActualLine[j + 1] = true
 


### PR DESCRIPTION
The crash can occur if you go into the wikitext editor and add empty line(s) at the end of the text box.