### PR TITLE
Follow-up to insert images into wikitext.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -177,11 +177,15 @@ class EditSectionActivity : BaseActivity() {
             }
         }
         binding.editKeyboardOverlay.editText = binding.editSectionText
-        binding.editKeyboardOverlay.pageTitle = pageTitle
-        binding.editKeyboardOverlay.activityResultLauncher = requestInsertMedia
-        binding.editKeyboardOverlay.callback = WikiTextKeyboardView.Callback {
-            bottomSheetPresenter.show(supportFragmentManager,
-                    LinkPreviewDialog.newInstance(HistoryEntry(PageTitle(it, pageTitle.wikiSite), HistoryEntry.SOURCE_INTERNAL_LINK), null))
+        binding.editKeyboardOverlay.callback = object : WikiTextKeyboardView.Callback {
+            override fun onPreviewLink(title: String) {
+                bottomSheetPresenter.show(supportFragmentManager,
+                        LinkPreviewDialog.newInstance(HistoryEntry(PageTitle(title, pageTitle.wikiSite), HistoryEntry.SOURCE_INTERNAL_LINK), null))
+            }
+
+            override fun onRequestInsertMedia() {
+                requestInsertMedia.launch(InsertMediaActivity.newIntent(this@EditSectionActivity, pageTitle.prefixedText))
+            }
         }
         binding.editSectionText.setOnClickListener { finishActionMode() }
         updateTextSize()

--- a/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaActivity.kt
@@ -256,11 +256,11 @@ class InsertMediaActivity : BaseActivity() {
 
     private inner class InsertMediaDiffCallback : DiffUtil.ItemCallback<MediaSearchResult>() {
         override fun areItemsTheSame(oldItem: MediaSearchResult, newItem: MediaSearchResult): Boolean {
-            return oldItem.pageTitle.prefixedText == newItem.pageTitle.prefixedText && oldItem.pageTitle.namespace == newItem.pageTitle.namespace
+            return oldItem == newItem
         }
 
         override fun areContentsTheSame(oldItem: MediaSearchResult, newItem: MediaSearchResult): Boolean {
-            return areItemsTheSame(oldItem, newItem)
+            return oldItem.pageTitle.prefixedText == newItem.pageTitle.prefixedText && oldItem.pageTitle.namespace == newItem.pageTitle.namespace
         }
     }
 

--- a/app/src/main/java/org/wikipedia/edit/insertmedia/MediaSearchResult.kt
+++ b/app/src/main/java/org/wikipedia/edit/insertmedia/MediaSearchResult.kt
@@ -1,9 +1,7 @@
 package org.wikipedia.edit.insertmedia
 
-import kotlinx.serialization.Serializable
 import org.wikipedia.gallery.ImageInfo
 import org.wikipedia.page.PageTitle
 
-@Serializable
-data class MediaSearchResult(val pageTitle: PageTitle,
-                             val imageInfo: ImageInfo?)
+class MediaSearchResult(val pageTitle: PageTitle,
+                        val imageInfo: ImageInfo?)

--- a/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.kt
+++ b/app/src/main/java/org/wikipedia/views/WikiTextKeyboardView.kt
@@ -1,27 +1,22 @@
 package org.wikipedia.views
 
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.inputmethod.InputConnection
 import android.widget.FrameLayout
-import androidx.activity.result.ActivityResultLauncher
 import org.wikipedia.databinding.ViewWikitextKeyboardBinding
 import org.wikipedia.edit.SyntaxHighlightableEditText
-import org.wikipedia.edit.insertmedia.InsertMediaActivity
-import org.wikipedia.page.PageTitle
 
 class WikiTextKeyboardView : FrameLayout {
-    fun interface Callback {
+    interface Callback {
         fun onPreviewLink(title: String)
+        fun onRequestInsertMedia()
     }
 
     private val binding = ViewWikitextKeyboardBinding.inflate(LayoutInflater.from(context), this, true)
-    var activityResultLauncher: ActivityResultLauncher<Intent>? = null
     var callback: Callback? = null
-    var pageTitle: PageTitle? = null
     var editText: SyntaxHighlightableEditText? = null
 
     constructor(context: Context) : super(context)
@@ -72,9 +67,7 @@ class WikiTextKeyboardView : FrameLayout {
         }
 
         binding.wikitextButtonInsertMedia.setOnClickListener {
-            pageTitle?.let {
-                activityResultLauncher?.launch(InsertMediaActivity.newIntent(context, it.prefixedText))
-            }
+            callback?.onRequestInsertMedia()
         }
 
         binding.wikitextButtonPreviewLink.setOnClickListener {

--- a/app/src/main/res/layout/item_insert_media.xml
+++ b/app/src/main/res/layout/item_insert_media.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <LinearLayout


### PR DESCRIPTION
* Remove `ActivityResultLauncher` logic from WikiTextKeyboardView. This is a component that shouldn't have too much knowledge of who is using it and what PageTitle it's operating on. This is now changed to a callback method.
* Add background ripple effect when tapping to select image items.
* The `MediaSearchResult` class doesn't need to be serializable, and doesn't need to be a `data class`.