### PR TITLE
Fix kapt compilation of Glide module.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'com.google.gms.google-services'
     id 'kotlin-android'
+    id 'kotlin-kapt'
     id 'kotlin-parcelize'
     id 'kotlinx-serialization'
     id 'com.google.devtools.ksp'
@@ -206,7 +207,7 @@ dependencies {
 
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     implementation "com.github.bumptech.glide:okhttp3-integration:$glideVersion"
-    ksp("com.github.bumptech.glide:compiler:$glideVersion")
+    kapt "com.github.bumptech.glide:compiler:$glideVersion"
 
     implementation "com.squareup.okhttp3:logging-interceptor:$okHttpVersion"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"


### PR DESCRIPTION
This is now the proper way to make sure that our `OkHttpGlideModule` is compiled and included properly.