### PR TITLE
Add a monochrome icon to `launcher.xml`.

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/launcher_background"/>
     <foreground android:drawable="@drawable/launcher_foreground"/>
+    <monochrome android:drawable="@drawable/launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Android 13 adds support for themed icons - which includes the ability to have monochrome icons based on the overal system theme/wallpaper.

This change adds `launcher_foreground` as the monochrome icon.


---

Example (Alpha icon):

![Screenshot](https://user-images.githubusercontent.com/587220/188015831-fe8df940-120e-4a3b-9af0-f46e7fdf0bf1.png)


