### PR TITLE
Properly use custom FileProvider class.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -327,7 +327,7 @@
             android:label="@string/insert_media_title"/>
 
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name=".WikipediaFileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/app/src/main/java/org/wikipedia/WikipediaFileProvider.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaFileProvider.kt
@@ -1,0 +1,12 @@
+package org.wikipedia
+
+import androidx.core.content.FileProvider
+
+/**
+ * According to the documentation:
+ * "It is possible to use FileProvider directly instead of extending it. However, this is not
+ * reliable and will causes (sic) crashes on some devices."
+ * https://developer.android.com/reference/androidx/core/content/FileProvider
+ */
+class WikipediaFileProvider : FileProvider(R.xml.file_paths) {
+}

--- a/app/src/main/java/org/wikipedia/WikipediaFileProvider.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaFileProvider.kt
@@ -8,5 +8,4 @@ import androidx.core.content.FileProvider
  * reliable and will causes (sic) crashes on some devices."
  * https://developer.android.com/reference/androidx/core/content/FileProvider
  */
-class WikipediaFileProvider : FileProvider(R.xml.file_paths) {
-}
+class WikipediaFileProvider : FileProvider(R.xml.file_paths)


### PR DESCRIPTION
According to the documentation it's bad practice to declare the base `androidx.core.content.FileProvider` in our manifest. Instead it should always be a subclass, even if the subclass doesn't do anything special.