### PR TITLE
Use kapt for androidx.room:room-compiler

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -222,7 +222,7 @@ dependencies {
 
     implementation("androidx.room:room-runtime:$roomVersion")
     annotationProcessor "androidx.room:room-compiler:$roomVersion"
-    ksp("androidx.room:room-compiler:$roomVersion")
+    kapt "androidx.room:room-compiler:$roomVersion"
     implementation("androidx.room:room-ktx:$roomVersion")
     implementation "androidx.room:room-rxjava3:$roomVersion"
 


### PR DESCRIPTION
While building the app, we will see the following message about use `ksp` vs `kapt`:
```
app: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'androidx.room:room-compiler:2.4.3'.
```