### PR TITLE
Fix: use displayText to search images in InsertMedia screen

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -184,7 +184,7 @@ class EditSectionActivity : BaseActivity() {
             }
 
             override fun onRequestInsertMedia() {
-                requestInsertMedia.launch(InsertMediaActivity.newIntent(this@EditSectionActivity, pageTitle.prefixedText))
+                requestInsertMedia.launch(InsertMediaActivity.newIntent(this@EditSectionActivity, pageTitle.displayText))
             }
         }
         binding.editSectionText.setOnClickListener { finishActionMode() }
@@ -536,7 +536,9 @@ class EditSectionActivity : BaseActivity() {
                         val firstPage = response.query?.firstPage()!!
                         val rev = firstPage.revisions[0]
 
-                        pageTitle = PageTitle(firstPage.title, pageTitle.wikiSite)
+                        pageTitle = PageTitle(firstPage.title, pageTitle.wikiSite).apply {
+                            this.displayText = pageTitle.displayText
+                        }
                         sectionWikitext = rev.content
                         currentRevision = rev.revId
 

--- a/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaViewModel.kt
@@ -14,7 +14,7 @@ import org.wikipedia.util.StringUtil
 
 class InsertMediaViewModel(bundle: Bundle) : ViewModel() {
 
-    var searchQuery = StringUtil.removeUnderscores(bundle.getString(InsertMediaActivity.EXTRA_SEARCH_QUERY)!!)
+    var searchQuery = StringUtil.removeHTMLTags(StringUtil.removeUnderscores(bundle.getString(InsertMediaActivity.EXTRA_SEARCH_QUERY)!!))
     val originalSearchQuery = searchQuery
     var selectedImage: MediaSearchResult? = null
     var imagePosition = IMAGE_POSITION_RIGHT


### PR DESCRIPTION
This will solve the language variant issue when entering the `InsertMediaActivity` for the first time.

Steps to reproduce:
1. Go to `Elizabeth II` in en.wiki
2. Change the language to `zh-hant`
3. Edit the article and click on the insert media icon
4. You will see `伊丽莎白二世` (`zh-hans`) instead of `伊莉莎白二世` (`zh-hant`)