### PR TITLE
Fix: show 24 hours format in revision history compare toolbar

### DIFF
--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -169,11 +169,11 @@ class EditHistoryListActivity : BaseActivity() {
     private fun updateCompareStateItems() {
         binding.compareFromCard.isVisible = viewModel.selectedRevisionFrom != null
         if (viewModel.selectedRevisionFrom != null) {
-            binding.compareFromText.text = DateUtil.getShortDayWithTimeString(this, viewModel.selectedRevisionFrom!!.timeStamp)
+            binding.compareFromText.text = DateUtil.getShortDayWithTimeString(viewModel.selectedRevisionFrom!!.timeStamp)
         }
         binding.compareToCard.isVisible = viewModel.selectedRevisionTo != null
         if (viewModel.selectedRevisionTo != null) {
-            binding.compareToText.text = DateUtil.getShortDayWithTimeString(this, viewModel.selectedRevisionTo!!.timeStamp)
+            binding.compareToText.text = DateUtil.getShortDayWithTimeString(viewModel.selectedRevisionTo!!.timeStamp)
         }
         enableCompareButton(binding.compareConfirmButton, viewModel.selectedRevisionFrom != null && viewModel.selectedRevisionTo != null)
     }

--- a/app/src/main/java/org/wikipedia/util/DateUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.kt
@@ -94,9 +94,8 @@ object DateUtil {
         return getDateStringWithSkeletonPattern(date, datePattern)
     }
 
-    fun getShortDayWithTimeString(context: Context, dateStr: String): String {
-        val datePattern = if (DateFormat.is24HourFormat(context)) "MMM d HH:mm" else "MMM d hh:mm a"
-        return getDateStringWithSkeletonPattern(iso8601DateParse(dateStr), datePattern)
+    fun getShortDayWithTimeString(dateStr: String): String {
+        return getDateStringWithSkeletonPattern(iso8601DateParse(dateStr), "MMM d HH:mm")
     }
 
     fun getTimeAndDateString(context: Context, date: Date): String {


### PR DESCRIPTION
The button overlaps the compare button on the right.
<img src="https://user-images.githubusercontent.com/2435576/189461692-63f91bb2-ce8c-4b32-b010-01f31895f104.jpg" width="480" />
