### PR TITLE
Fix API call for retrieving parsed messages with arguments.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -170,7 +170,7 @@ interface Service {
     @get:GET(MW_API_PREFIX + "action=streamconfigs&format=json&constraints=destination_event_service=eventgate-analytics-external")
     val streamConfigs: Observable<MwStreamConfigsResponse>
 
-    @GET(MW_API_PREFIX + "action=query&meta=allmessages")
+    @GET(MW_API_PREFIX + "action=query&meta=allmessages&amenableparser=1")
     suspend fun getMessages(
             @Query("ammessages") messages: String,
             @Query("amargs") args: String?


### PR DESCRIPTION
This API call has another special parameter that enables the parser to actually parse the wikitext of the message, which will expand templates and magic words.

https://phabricator.wikimedia.org/T317504