### PR TITLE
Fix/improve "edit here" selection.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -16,7 +16,6 @@ import androidx.core.net.toUri
 import androidx.core.os.postDelayed
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
-import androidx.core.view.postDelayed
 import androidx.core.widget.doAfterTextChanged
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -638,11 +637,7 @@ class EditSectionActivity : BaseActivity() {
         }
         binding.editSectionText.post {
             binding.editSectionScroll.fullScroll(View.FOCUS_DOWN)
-            binding.editSectionText.postDelayed(500) {
-                if (!isDestroyed) {
-                    StringUtil.highlightEditText(binding.editSectionText, sectionWikitext!!, highlightText)
-                }
-            }
+            StringUtil.highlightEditText(binding.editSectionText, sectionWikitext!!, highlightText)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -126,21 +126,23 @@ object StringUtil {
     }
 
     fun highlightEditText(editText: EditText, parentText: String, highlightText: String) {
-        val words = highlightText.split("\\s+".toRegex()).toTypedArray()
+        val words = highlightText.split("\\s".toRegex()).filter { it.isNotBlank() }
         var pos = 0
+        var firstPos = 0
         for (word in words) {
             pos = parentText.indexOf(word, pos)
             if (pos == -1) {
                 break
+            } else if (firstPos == 0) {
+                firstPos = pos
             }
         }
         if (pos == -1) {
             pos = parentText.indexOf(words.last())
+            firstPos = pos
         }
         if (pos >= 0) {
-            // TODO: Programmatic selection doesn't seem to work with RTL content...
-            editText.setSelection(pos, pos + words.last().length)
-            editText.performLongClick()
+            editText.setSelection(firstPos, pos + words.last().length)
         }
     }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T318039

The recent update that changes our `SyntaxHighlightableEditText` to inherit from the platform `EditText` seems to have altered its behavior when programmatically highlighting a selection.