### PR TITLE
Fix: make sure showing article title and search bar when receiving 500 error code in EditHistoryListActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -142,9 +142,9 @@ class EditHistoryListActivity : BaseActivity() {
                     editHistoryInteractionEvent = EditHistoryInteractionEvent(viewModel.pageTitle.wikiSite.dbName(), viewModel.pageId)
                     editHistoryInteractionEvent?.logShowHistory()
                 }
-                editHistoryStatsAdapter.notifyItemChanged(0)
-                editHistorySearchBarAdapter.notifyItemChanged(0)
             }
+            editHistoryStatsAdapter.notifyItemChanged(0)
+            editHistorySearchBarAdapter.notifyItemChanged(0)
         }
 
         lifecycleScope.launch {
@@ -348,6 +348,8 @@ class EditHistoryListActivity : BaseActivity() {
             val statsFlowValue = viewModel.editHistoryStatsData.value
             if (statsFlowValue is Resource.Success) {
                 view.setup(viewModel.pageTitle, statsFlowValue.data)
+            } else {
+                view.setup(viewModel.pageTitle, null)
             }
         }
     }
@@ -367,23 +369,23 @@ class EditHistoryListActivity : BaseActivity() {
         }
 
         fun bindItem() {
-            val statsFlowValue = viewModel.editHistoryStatsData.value
-            if (statsFlowValue is Resource.Success) {
-                binding.root.setCardBackgroundColor(
-                    ResourceUtil.getThemedColor(this@EditHistoryListActivity, R.attr.color_group_22)
-                )
 
-                itemView.setOnClickListener {
-                    startSearchActionMode()
-                }
+            binding.filterByButton.isVisible = viewModel.editHistoryStatsData.value is Resource.Success
 
-                binding.filterByButton.setOnClickListener {
-                    showFilterOverflowMenu()
-                }
+            binding.root.setCardBackgroundColor(
+                ResourceUtil.getThemedColor(this@EditHistoryListActivity, R.attr.color_group_22)
+            )
 
-                FeedbackUtil.setButtonLongPressToast(binding.filterByButton)
-                binding.root.isVisible = true
+            itemView.setOnClickListener {
+                startSearchActionMode()
             }
+
+            binding.filterByButton.setOnClickListener {
+                showFilterOverflowMenu()
+            }
+
+            FeedbackUtil.setButtonLongPressToast(binding.filterByButton)
+            binding.root.isVisible = true
         }
 
         private fun updateFilterCount() {

--- a/app/src/main/java/org/wikipedia/views/EditHistoryStatsView.kt
+++ b/app/src/main/java/org/wikipedia/views/EditHistoryStatsView.kt
@@ -29,26 +29,27 @@ class EditHistoryStatsView constructor(context: Context, attrs: AttributeSet? = 
         setPadding(padding, 0, padding, 0)
     }
 
-    fun setup(pageTitle: PageTitle, editHistoryStats: EditHistoryListViewModel.EditHistoryStats) {
+    fun setup(pageTitle: PageTitle, editHistoryStats: EditHistoryListViewModel.EditHistoryStats?) {
         binding.articleTitleView.text = StringUtil.fromHtml(context.getString(R.string.page_edit_history_activity_title,
                 "<a href=\"#\">${pageTitle.displayText}</a>"))
         RichTextUtil.removeUnderlinesFromLinks(binding.articleTitleView)
-        val timestamp = editHistoryStats.revision.timeStamp
-        if (timestamp.isNotBlank()) {
-            val createdYear = DateUtil.getYearOnlyDateString(DateUtil.iso8601DateParse(timestamp))
-            val calendar = Calendar.getInstance()
-            val today = DateUtil.getShortDateString(calendar.time)
-            calendar.add(Calendar.YEAR, -1)
-            val lastYear = DateUtil.getShortDateString(calendar.time)
-            binding.editCountsView.text = context.resources.getQuantityString(R.plurals.page_edit_history_article_edits_since_year,
-                    editHistoryStats.allEdits.count, editHistoryStats.allEdits.count, createdYear)
-            binding.statsGraphView.setData(editHistoryStats.metrics.map { it.edits.toFloat() })
-            binding.statsGraphView.contentDescription = context.getString(R.string.page_edit_history_metrics_content_description, lastYear, today)
-            FeedbackUtil.setButtonLongPressToast(binding.statsGraphView)
-
-            binding.articleTitleView.movementMethod = LinkMovementMethodExt { _ ->
-                context.startActivity(PageActivity.newIntentForNewTab(context, HistoryEntry(pageTitle, HistoryEntry.SOURCE_EDIT_HISTORY), pageTitle))
+        editHistoryStats?.let { stats ->
+            val timestamp = stats.revision.timeStamp
+            if (timestamp.isNotBlank()) {
+                val createdYear = DateUtil.getYearOnlyDateString(DateUtil.iso8601DateParse(timestamp))
+                val calendar = Calendar.getInstance()
+                val today = DateUtil.getShortDateString(calendar.time)
+                calendar.add(Calendar.YEAR, -1)
+                val lastYear = DateUtil.getShortDateString(calendar.time)
+                binding.editCountsView.text = context.resources.getQuantityString(R.plurals.page_edit_history_article_edits_since_year,
+                    stats.allEdits.count, stats.allEdits.count, createdYear)
+                binding.statsGraphView.setData(stats.metrics.map { it.edits.toFloat() })
+                binding.statsGraphView.contentDescription = context.getString(R.string.page_edit_history_metrics_content_description, lastYear, today)
+                FeedbackUtil.setButtonLongPressToast(binding.statsGraphView)
             }
+        }
+        binding.articleTitleView.movementMethod = LinkMovementMethodExt { _ ->
+            context.startActivity(PageActivity.newIntentForNewTab(context, HistoryEntry(pageTitle, HistoryEntry.SOURCE_EDIT_HISTORY), pageTitle))
         }
     }
 }


### PR DESCRIPTION
Steps to reproduce:
1. Go to [Elizabeth II](https://en.wikipedia.org/wiki/Elizabeth_II)
2. Click on Edit history

You'll see the blank in the edit stats and no article title, that's because the following API returns HTTP 500:
https://en.wikipedia.org/w/rest.php/v1/page/Elizabeth_II/history/counts/editors

This PR hides the graph data and also the filter button since there are no numbers will be displayed in the components.