### PR TITLE
Follow-up to WebView in link preview.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.page.linkpreview
 
-import android.annotation.SuppressLint
 import android.app.ActivityOptions
 import android.content.DialogInterface
 import android.content.Intent
@@ -251,11 +250,10 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
         }
     }
 
-    @SuppressLint("RequiresFeature")
     private fun setPreviewContents(contents: LinkPreviewContents) {
         if (!contents.extract.isNullOrEmpty()) {
             binding.linkPreviewExtractWebview.setBackgroundColor(Color.TRANSPARENT)
-            val colorHex = Integer.toHexString(ResourceUtil.getThemedColor(requireContext(), android.R.attr.textColorPrimary)).substring(2)
+            val colorHex = ResourceUtil.colorToCssString(ResourceUtil.getThemedColor(requireContext(), android.R.attr.textColorPrimary))
             binding.linkPreviewExtractWebview.loadDataWithBaseURL(null, "${JavaScriptActionHandler.getCssStyles(pageTitle.wikiSite)}<div style=\"line-height: 150%; color: #$colorHex\">${contents.extract}</div>", "text/html", "UTF-8", null)
         }
         contents.title.thumbUrl?.let {

--- a/app/src/main/java/org/wikipedia/util/ResourceUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ResourceUtil.kt
@@ -65,6 +65,10 @@ object ResourceUtil {
         MenuItemCompat.setIconTintList(item, getThemedColorStateList(context, colorAttr))
     }
 
+    fun colorToCssString(@ColorInt color: Int): String {
+        return String.format("%08x", (color shl 8) or ((color shr 24) and 0xff))
+    }
+
     @ColorInt
     fun lightenColor(@ColorInt color: Int): Int {
         return ColorUtils.blendARGB(color, Color.WHITE, 0.3f)


### PR DESCRIPTION
* Improve conversion of `ColorInt` resource to CSS color, preserving opacity.