### PR TITLE
Ability to thank contributors without navigating to diff view

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
@@ -161,11 +161,11 @@ class MwQueryResult {
         @SerialName("new") private val isNew = false
         @SerialName("anon") val isAnon = false
         @SerialName("old_revid") private val oldRevid: Long = 0
-        private val pageid = 0
         private val timestamp: String? = null
         private val comment: String? = null
         private val minor = false
         private val bot = false
+        val pageId = 0
         val revid: Long = 0
         val ns = 0
         val title: String = ""

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -452,7 +452,8 @@ class EditHistoryListActivity : BaseActivity() {
                 UserTalkPopupHelper.show(this@EditHistoryListActivity, bottomSheetPresenter,
                         PageTitle(UserAliasData.valueFor(viewModel.pageTitle.wikiSite.languageCode),
                                 revision.user, viewModel.pageTitle.wikiSite), revision.isAnon, v,
-                        Constants.InvokeSource.DIFF_ACTIVITY, HistoryEntry.SOURCE_EDIT_DIFF_DETAILS)
+                    Constants.InvokeSource.DIFF_ACTIVITY, HistoryEntry.SOURCE_EDIT_DIFF_DETAILS,
+                    revisionId = revision.revId, pageId = viewModel.pageId)
             }
         }
 

--- a/app/src/main/java/org/wikipedia/talk/UserTalkPopupHelper.kt
+++ b/app/src/main/java/org/wikipedia/talk/UserTalkPopupHelper.kt
@@ -2,14 +2,23 @@ package org.wikipedia.talk
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.app.AlertDialog
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuPopupHelper
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.wikipedia.Constants
 import org.wikipedia.R
+import org.wikipedia.analytics.eventplatform.EditHistoryInteractionEvent
+import org.wikipedia.dataclient.ServiceFactory
+import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.Namespace
@@ -18,21 +27,24 @@ import org.wikipedia.page.PageTitle
 import org.wikipedia.page.linkpreview.LinkPreviewDialog
 import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.usercontrib.UserContribListActivity
+import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.ResourceUtil
+import org.wikipedia.util.log.L
 
 @SuppressLint("RestrictedApi")
 object UserTalkPopupHelper {
 
     fun show(activity: AppCompatActivity, bottomSheetPresenter: ExclusiveBottomSheetPresenter,
              title: PageTitle, anon: Boolean, anchorView: View,
-             invokeSource: Constants.InvokeSource, historySource: Int) {
+             invokeSource: Constants.InvokeSource, historySource: Int, revisionId: Long? = null, pageId: Int? = null) {
         val pos = IntArray(2)
         anchorView.getLocationInWindow(pos)
-        show(activity, bottomSheetPresenter, title, anon, pos[0], pos[1], invokeSource, historySource)
+        show(activity, bottomSheetPresenter, title, anon, pos[0], pos[1], invokeSource, historySource, revisionId = revisionId, pageId = pageId)
     }
 
     fun show(activity: AppCompatActivity, bottomSheetPresenter: ExclusiveBottomSheetPresenter,
              title: PageTitle, anon: Boolean, x: Int, y: Int, invokeSource: Constants.InvokeSource,
-             historySource: Int, showContribs: Boolean = true) {
+             historySource: Int, showContribs: Boolean = true, revisionId: Long? = null, pageId: Int? = null) {
         if (title.namespace() == Namespace.USER_TALK || title.namespace() == Namespace.TALK) {
             activity.startActivity(TalkTopicsActivity.newIntent(activity, title, invokeSource))
         } else if (title.namespace() == Namespace.USER) {
@@ -42,7 +54,8 @@ object UserTalkPopupHelper {
             anchorView.y = (y - rootView.top).toFloat()
             (rootView as ViewGroup).addView(anchorView)
 
-            val helper = getPopupHelper(activity, title, anon, anchorView, invokeSource, historySource, showContribs)
+            val helper = getPopupHelper(activity, title, anon, anchorView, invokeSource, historySource,
+                showContribs, revisionId = revisionId, pageId = pageId)
             helper.setOnDismissListener {
                 rootView.removeView(anchorView)
             }
@@ -54,9 +67,40 @@ object UserTalkPopupHelper {
         }
     }
 
+    private fun showThankDialog(activity: Activity, title: PageTitle, revisionId: Long, pageId: Int) {
+        val parent = FrameLayout(activity)
+        val editHistoryInteractionEvent =
+            EditHistoryInteractionEvent(title.wikiSite.dbName(), pageId)
+        val dialog: AlertDialog =
+            AlertDialog.Builder(activity).setView(parent).setPositiveButton(R.string.thank_dialog_positive_button_text) { _, _ ->
+                    revisionId?.let { sendThanks(activity, title.wikiSite, revisionId, title, editHistoryInteractionEvent) }
+                }.setNegativeButton(R.string.thank_dialog_negative_button_text) { _, _ ->
+                    editHistoryInteractionEvent.logThankCancel()
+                }.create()
+        dialog.layoutInflater.inflate(R.layout.view_thank_dialog, parent)
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(ResourceUtil.getThemedColor(activity, R.attr.secondary_text_color))
+        }
+        dialog.show()
+    }
+
+    private fun sendThanks(activity: Activity, wikiSite: WikiSite, revisionId: Long?, title: PageTitle,
+                           editHistoryInteractionEvent: EditHistoryInteractionEvent) {
+        CoroutineScope(Dispatchers.Default).launch(CoroutineExceptionHandler { _, throwable ->
+            L.e(throwable)
+            editHistoryInteractionEvent.logThankFail()
+        }) {
+            val token = ServiceFactory.get(wikiSite).getToken().query?.csrfToken()
+            ServiceFactory.get(wikiSite).postThanksToRevision(revisionId!!, token!!)
+            FeedbackUtil.showMessage(activity, activity.getString(R.string.thank_success_message, title.text))
+            editHistoryInteractionEvent.logThankSuccess()
+        }
+    }
+
     private fun getPopupHelper(activity: Activity, title: PageTitle, anon: Boolean,
                                anchorView: View, invokeSource: Constants.InvokeSource,
-                               historySource: Int, showContribs: Boolean = true): MenuPopupHelper {
+                               historySource: Int, showContribs: Boolean = true,
+                               revisionId: Long? = null, pageId: Int? = null): MenuPopupHelper {
         val builder = MenuBuilder(activity)
         activity.menuInflater.inflate(R.menu.menu_user_talk_popup, builder)
         builder.setCallback(object : MenuBuilder.Callback {
@@ -73,6 +117,9 @@ object UserTalkPopupHelper {
                     R.id.menu_user_contributions_page -> {
                         activity.startActivity(UserContribListActivity.newIntent(activity, title.text))
                     }
+                    R.id.menu_user_thank -> {
+                        pageId?.let { showThankDialog(activity, title, revisionId!!, pageId) }
+                    }
                 }
                 return true
             }
@@ -82,6 +129,7 @@ object UserTalkPopupHelper {
 
         builder.findItem(R.id.menu_user_profile_page).isVisible = !anon
         builder.findItem(R.id.menu_user_contributions_page).isVisible = showContribs
+        builder.findItem(R.id.menu_user_thank).isVisible = revisionId != null
         val helper = MenuPopupHelper(activity, builder, anchorView)
         helper.setForceShowIcon(true)
         return helper

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
@@ -341,7 +341,7 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
     override fun onUserClick(item: MwQueryResult.WatchlistItem, view: View) {
         UserTalkPopupHelper.show(requireActivity() as AppCompatActivity, bottomSheetPresenter,
                 PageTitle(UserAliasData.valueFor(item.wiki!!.languageCode), item.user, item.wiki!!),
-                !AccountUtil.isLoggedIn, view, Constants.InvokeSource.WATCHLIST_ACTIVITY, HistoryEntry.SOURCE_WATCHLIST)
+                !AccountUtil.isLoggedIn, view, Constants.InvokeSource.WATCHLIST_ACTIVITY, HistoryEntry.SOURCE_WATCHLIST, revisionId = item.revid, pageId = item.pageId)
     }
 
     companion object {

--- a/app/src/main/res/menu/menu_user_talk_popup.xml
+++ b/app/src/main/res/menu/menu_user_talk_popup.xml
@@ -17,4 +17,9 @@
         android:icon="@drawable/ic_icon_user_contributions_ooui"
         app:iconTint="?attr/secondary_text_color"
         android:title="@string/menu_option_view_user_contributions" />
+    <item
+        android:id="@+id/menu_user_thank"
+        android:icon="@drawable/ic_heart_24"
+        app:iconTint="?attr/secondary_text_color"
+        android:title="@string/thank_label" />
 </menu>


### PR DESCRIPTION
**Phab:** https://phabricator.wikimedia.org/T317698

Since thanking users for edits is a feature promoting positivity, this commit brings it to a more visible surface, on the edits screen and watchList screen.
Data tracking is wired to it as well.