### PR TITLE
Fix duplication of reading list pages when syncing.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
@@ -422,7 +422,7 @@ class ReadingListSyncAdapter : JobIntentService() {
     private fun createOrUpdatePage(listForPage: ReadingList,
                                    remotePage: RemoteReadingListEntry) {
         val remoteTitle = pageTitleFromRemoteEntry(remotePage)
-        var localPage = listForPage.pages.find { ReadingListPage.toPageTitle(it) == remoteTitle }
+        var localPage = listForPage.pages.find { ReadingListPage.toPageTitle(it).matches(remoteTitle) }
         var updateOnly = localPage != null
 
         if (localPage == null) {
@@ -447,7 +447,7 @@ class ReadingListSyncAdapter : JobIntentService() {
     }
 
     private fun deletePageByTitle(listForPage: ReadingList, title: PageTitle) {
-        var localPage = listForPage.pages.find { ReadingListPage.toPageTitle(it) == title }
+        var localPage = listForPage.pages.find { ReadingListPage.toPageTitle(it).matches(title) }
         if (localPage == null) {
             localPage = AppDatabase.instance.readingListPageDao().getPageByTitle(listForPage, title)
             if (localPage == null) {


### PR DESCRIPTION
Once again we're bitten by incorrect usage of the equals operator `==` when comparing `PageTitle` objects. This should not be used, and instead we should use the `.matches()` function.
This is because the `displayTitle` field could change between different instances of `PageTitle`, but the actual page that it represents is the same.

https://phabricator.wikimedia.org/T318319