### PR TITLE
Add logic to de-duplicate and fix consistency of reading lists.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -471,7 +471,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         dismissBottomSheet()
         val historyEntry = HistoryEntry(title, HistoryEntry.SOURCE_INTERNAL_LINK)
 
-        if (title.matches(model.title) && !title.fragment.isNullOrEmpty()) {
+        if (title == model.title && !title.fragment.isNullOrEmpty()) {
             scrollToSection(title.fragment!!)
             return
         }
@@ -502,7 +502,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     private fun selectedTabPosition(title: PageTitle): Int {
         return app.tabList.firstOrNull { it.backStackPositionTitle != null &&
-                title.matches(it.backStackPositionTitle) }?.let { app.tabList.indexOf(it) } ?: -1
+                title == it.backStackPositionTitle }?.let { app.tabList.indexOf(it) } ?: -1
     }
 
     private fun openInNewTab(title: PageTitle, entry: HistoryEntry, position: Int, openFromExistingTab: Boolean = false) {
@@ -950,7 +950,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     fun loadPage(title: PageTitle, entry: HistoryEntry, pushBackStack: Boolean, squashBackstack: Boolean, isRefresh: Boolean = false) {
         // is the new title the same as what's already being displayed?
         if (currentTab.backStack.isNotEmpty() &&
-                title.matches(currentTab.backStack[currentTab.backStackPosition].title)) {
+                title == currentTab.backStack[currentTab.backStackPosition].title) {
             if (model.page == null || isRefresh) {
                 pageFragmentLoadState.loadFromBackStack(isRefresh)
             } else if (!title.fragment.isNullOrEmpty()) {

--- a/app/src/main/java/org/wikipedia/page/PageTitle.kt
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.kt
@@ -197,11 +197,20 @@ data class PageTitle(
         )
     }
 
-    fun matches(other: PageTitle?): Boolean {
-        return other != null &&
-                other.prefixedText == prefixedText &&
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PageTitle) return false
+        return other.prefixedText == prefixedText &&
                 other.namespace == namespace &&
                 other.wikiSite.languageCode == wikiSite.languageCode
+    }
+
+    override fun hashCode(): Int {
+        var result = _namespace?.hashCode() ?: 0
+        result = 31 * result + wikiSite.languageCode.hashCode()
+        result = 31 * result + _text.hashCode()
+        result = 31 * result + (fragment?.hashCode() ?: 0)
+        return result
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
@@ -23,6 +23,9 @@ interface ReadingListPageDao {
     @Update(onConflict = OnConflictStrategy.REPLACE)
     fun updateReadingListPage(page: ReadingListPage)
 
+    @Delete
+    fun deleteReadingListPage(page: ReadingListPage)
+
     @Query("SELECT * FROM ReadingListPage")
     fun getAllPages(): List<ReadingListPage>
 

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
@@ -463,7 +463,7 @@ class ReadingListSyncAdapter : JobIntentService() {
     }
 
     private fun deletePageByTitle(listForPage: ReadingList, title: PageTitle) {
-        var localPage = listForPage.pages.find { ReadingListPage.toPageTitle(it).matches(title) }
+        var localPage = listForPage.pages.find { ReadingListPage.toPageTitle(it) == title }
         if (localPage == null) {
             localPage = AppDatabase.instance.readingListPageDao().getPageByTitle(listForPage, title)
             if (localPage == null) {

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
@@ -239,8 +239,24 @@ class ReadingListSyncAdapter : JobIntentService() {
             }
 
             // Do any remote pages need to be deleted?
-            val pageIdsToDelete = mutableListOf<String>()
+            val pageIdsToDelete = mutableSetOf<String>()
             pageIdsToDelete.addAll(pageIdsDeleted)
+
+            // Determine if any articles need to be de-duplicated (because of bugs in previous sync inconsistencies)
+            if (syncEverything) {
+                allLocalLists.forEach { list ->
+                    val distinct = list.pages.distinctBy { pageTitleFromRemoteEntry(remoteEntryFromLocalPage(it)) }
+                    val toRemove = list.pages.toMutableSet()
+                    toRemove.removeAll(distinct.toSet())
+                    if (toRemove.isNotEmpty()) {
+                        toRemove.forEach {
+                            AppDatabase.instance.readingListPageDao().deleteReadingListPage(it)
+                        }
+                        pageIdsToDelete.addAll(createIdsForDeletion(list, toRemove))
+                    }
+                }
+            }
+
             for (id in pageIdsToDelete) {
                 L.d("Deleting remote page id $id")
                 val listAndPageId = id.split(":").toTypedArray()
@@ -495,11 +511,12 @@ class ReadingListSyncAdapter : JobIntentService() {
             manualSync()
         }
 
+        fun createIdsForDeletion(list: ReadingList, pages: Set<ReadingListPage>): Set<String> {
+            return if (list.remoteId <= 0) emptySet() else pages.map { it.remoteId }.filter { it > 0 }.map { "${list.remoteId}:$it" }.toSet()
+        }
+
         fun manualSyncWithDeletePages(list: ReadingList, pages: List<ReadingListPage>) {
-            if (list.remoteId <= 0) {
-                return
-            }
-            val ids = pages.map { it.remoteId }.filter { it > 0 }.map { "${list.remoteId}:$it" }.toSet()
+            val ids = createIdsForDeletion(list, pages.toSet())
             if (ids.isNotEmpty()) {
                 Prefs.addReadingListPagesDeletedIds(ids)
                 manualSync()

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
@@ -438,7 +438,7 @@ class ReadingListSyncAdapter : JobIntentService() {
     private fun createOrUpdatePage(listForPage: ReadingList,
                                    remotePage: RemoteReadingListEntry) {
         val remoteTitle = pageTitleFromRemoteEntry(remotePage)
-        var localPage = listForPage.pages.find { ReadingListPage.toPageTitle(it).matches(remoteTitle) }
+        var localPage = listForPage.pages.find { ReadingListPage.toPageTitle(it) == remoteTitle }
         var updateOnly = localPage != null
 
         if (localPage == null) {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -332,7 +332,7 @@ class SearchResultsFragment : Fragment() {
 
     private fun displayResults(results: List<SearchResult>) {
         for (newResult in results) {
-            val res = totalResults.find { newResult.pageTitle.matches(it.pageTitle) }
+            val res = totalResults.find { newResult.pageTitle == it.pageTitle }
             if (res == null) {
                 totalResults.add(newResult)
             } else if (!newResult.pageTitle.description.isNullOrEmpty()) {

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -79,7 +79,7 @@
     <string name="preference_key_reading_lists_deleted_ids">readingListsDeletedIds</string>
     <string name="preference_key_reading_list_pages_deleted_ids">readingListPagesDeletedIds</string>
     <string name="preference_key_show_reading_lists_sync_prompt">showReadingListsSyncPrompt</string>
-    <string name="preference_key_reading_lists_first_time_sync">readingListsFirstTimeSync</string>
+    <string name="preference_key_reading_lists_first_time_sync">readingListsFirstTimeSyncV2</string>
     <string name="preference_key_about_wikipedia_app">aboutWikipediaApp</string>
     <string name="preference_key_logout">logOut</string>
     <string name="preference_key_show_remove_chinese_variant_prompt">showRemoveChineseVariantPrompt</string>

--- a/app/src/test/java/org/wikipedia/page/PageTitleTest.java
+++ b/app/src/test/java/org/wikipedia/page/PageTitleTest.java
@@ -135,4 +135,26 @@ import static org.hamcrest.Matchers.nullValue;
         assertThat(pageTitle.getText(), is(":"));
         assertThat(pageTitle.getFragment(), nullValue());
     }
+
+    @Test public void testEquality() {
+        PageTitle title1 = new PageTitle("Test Article", WikiSite.forLanguageCode("en"));
+        PageTitle title2 = new PageTitle("Test Article", WikiSite.forLanguageCode("en"));
+        assertThat(title1.equals(title2), is(true));
+        assertThat(title2.equals(title1), is(true));
+        title2.setDisplayText("TEST ARTICLE");
+        title2.setThumbUrl("http://thumb.url");
+        title2.setExtract("Foo");
+        title2.setDescription("Bar");
+        assertThat(title1.equals(title2), is(true));
+        assertThat(title2.equals(title1), is(true));
+        title2.setNamespace("File");
+        assertThat(title1.equals(title2), is(false));
+        assertThat(title2.equals(title1), is(false));
+
+        title2 = new PageTitle("Test Article", WikiSite.forLanguageCode("ru"));
+        assertThat(title1.equals(title2), is(false));
+        assertThat(title2.equals(title1), is(false));
+
+        assertThat(title1.equals(new Object()), is(false));
+    }
 }


### PR DESCRIPTION
* Switch (back?) to using the equality `==` operator for comparing `PageTitle` objects, because I'm tired of being bitten by having to use the `matches()` function for some reason.
* Add some logic to de-duplicate reading list entries, in case they were duplicated because of some previous bugs. This should happen automatically and transparently to the user.