### PR TITLE
Fix: use uselang for entityterms API in testwiki

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
@@ -18,6 +18,7 @@ import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.descriptions.DescriptionEditActivity
 import org.wikipedia.descriptions.DescriptionEditActivity.Action
+import org.wikipedia.language.LanguageUtil
 import org.wikipedia.page.PageTitle
 import org.wikipedia.suggestededits.PageSummaryForEdit
 import org.wikipedia.suggestededits.SuggestedEditsImageTagEditActivity
@@ -97,7 +98,7 @@ class FilePageFragment : Fragment(), FilePageView.Callback {
         binding.filePageView.visibility = View.GONE
         binding.progressBar.visibility = View.VISIBLE
 
-        disposables.add(ServiceFactory.get(Constants.commonsWikiSite).getImageInfoWithEntityTerms(pageTitle.prefixedText, pageTitle.wikiSite.languageCode, pageTitle.wikiSite.languageCode)
+        disposables.add(ServiceFactory.get(Constants.commonsWikiSite).getImageInfoWithEntityTerms(pageTitle.prefixedText, pageTitle.wikiSite.languageCode, LanguageUtil.convertToUselangIfNeeded(pageTitle.wikiSite.languageCode))
                 .subscribeOn(Schedulers.io())
                 .flatMap {
                     // set image caption to pageTitle description

--- a/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
+++ b/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
@@ -6,6 +6,7 @@ import org.wikipedia.Constants
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.dataclient.wikidata.Claims
+import org.wikipedia.language.LanguageUtil
 
 object ImageTagsProvider {
     fun getImageTagsObservable(pageId: Int, langCode: String): Observable<Map<String, List<String>>> {
@@ -17,7 +18,7 @@ object ImageTagsProvider {
                     if (ids.isNullOrEmpty()) {
                         Observable.just(MwQueryResponse())
                     } else {
-                        ServiceFactory.get(Constants.wikidataWikiSite).getWikidataEntityTerms(ids.joinToString(separator = "|"), langCode)
+                        ServiceFactory.get(Constants.wikidataWikiSite).getWikidataEntityTerms(ids.joinToString(separator = "|"), LanguageUtil.convertToUselangIfNeeded(langCode))
                     }
                 }
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/org/wikipedia/language/LanguageUtil.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguageUtil.kt
@@ -136,4 +136,8 @@ object LanguageUtil {
                 language == "fr" && (StringUtils.equalsAny(first, "le", "la", "les", "un", "une", "des") ||
                 first.startsWith("l'")))
     }
+
+    fun convertToUselangIfNeeded(languageCode: String): String {
+        return if (languageCode == "test") "uselang" else languageCode
+    }
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -32,6 +32,7 @@ import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_IMAGE_TAGS
+import org.wikipedia.language.LanguageUtil
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.suggestededits.provider.EditingSuggestionsProvider
@@ -164,7 +165,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
         ViewUtil.loadImage(binding.imageView, ImageUrlUtil.getUrlForPreferredSize(page!!.imageInfo()!!.thumbUrl, Constants.PREFERRED_CARD_THUMBNAIL_SIZE))
 
         disposables.add(
-                ServiceFactory.get(Constants.commonsWikiSite).getWikidataEntityTerms(page!!.title, callback().getLangCode())
+                ServiceFactory.get(Constants.commonsWikiSite).getWikidataEntityTerms(page!!.title, LanguageUtil.convertToUselangIfNeeded(callback().getLangCode()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { response ->

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -31,6 +31,7 @@ import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 import org.wikipedia.diff.ArticleEditDetailsActivity
+import org.wikipedia.language.LanguageUtil
 import org.wikipedia.page.PageTitle
 import org.wikipedia.userprofile.Contribution.Companion.EDIT_TYPE_ARTICLE_DESCRIPTION
 import org.wikipedia.userprofile.Contribution.Companion.EDIT_TYPE_GENERIC
@@ -477,7 +478,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
                     contribution.wikiSite.languageCode).subscribeOn(Schedulers.io()),
                     if (contribution.qNumber.isEmpty()) Observable.just(contribution.qNumber) else (
                             ServiceFactory.get(Constants.wikidataWikiSite)
-                                .getWikidataEntityTerms(contribution.qNumber, contribution.wikiSite.languageCode)
+                                .getWikidataEntityTerms(contribution.qNumber, LanguageUtil.convertToUselangIfNeeded(contribution.wikiSite.languageCode))
                                 .subscribeOn(Schedulers.io())
                                 .flatMap { response ->
                                     var label = contribution.qNumber


### PR DESCRIPTION
https://phabricator.wikimedia.org/T318738

It looks like the `entityterms` API in Commons does not properly support `test` wiki, which also affects the function in SE image tags.