### PR TITLE
 Updated to latest revision id for MobileWikiAppLinkPreview

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/LinkPreviewFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/LinkPreviewFunnel.kt
@@ -33,7 +33,7 @@ class LinkPreviewFunnel(app: WikipediaApp, private val source: Int) : TimedFunne
 
     companion object {
         private const val SCHEMA_NAME = "MobileWikiAppLinkPreview"
-        private const val REV_ID = 18531254
+        private const val REV_ID = 23808516
         private const val PROD_LINK_PREVIEW_VERSION = 3
     }
 }


### PR DESCRIPTION
The change was reverted, but I just made this update to stay at the latest rev id.