### PR TITLE
Fix gradle warning about Room schema location.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,12 @@ android {
         buildConfigField "String", "META_WIKI_BASE_URI", '"https://meta.wikimedia.org"'
         buildConfigField "String", "EVENTGATE_ANALYTICS_EXTERNAL_BASE_URI", '"https://intake-analytics.wikimedia.org"'
         buildConfigField "String", "EVENTGATE_LOGGING_EXTERNAL_BASE_URI", '"https://intake-logging.wikimedia.org"'
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
+            }
+        }
     }
 
     testOptions {


### PR DESCRIPTION
The Room annotation processor wants the schema directory to be specified explicitly. This simply gives it the current schema location where the schemas already exist.