### PR TITLE
Convert remaining Fragments to use MenuProvider.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureFragment.kt
@@ -2,7 +2,9 @@ package org.wikipedia.feed.configure
 
 import android.os.Bundle
 import android.view.*
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -25,7 +27,7 @@ import org.wikipedia.views.DefaultViewHolder
 import org.wikipedia.views.DrawableItemDecoration
 import java.util.*
 
-class ConfigureFragment : Fragment(), ConfigureItemView.Callback {
+class ConfigureFragment : Fragment(), MenuProvider, ConfigureItemView.Callback {
 
     private var _binding: FragmentFeedConfigureBinding? = null
     private val binding get() = _binding!!
@@ -37,6 +39,7 @@ class ConfigureFragment : Fragment(), ConfigureItemView.Callback {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentFeedConfigureBinding.inflate(inflater, container, false)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         setupRecyclerView()
         funnel = FeedConfigureFunnel(WikipediaApp.instance, WikipediaApp.instance.wikiSite,
@@ -74,11 +77,6 @@ class ConfigureFragment : Fragment(), ConfigureItemView.Callback {
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
-    }
-
     override fun onPause() {
         super.onPause()
         FeedContentType.saveState()
@@ -92,11 +90,11 @@ class ConfigureFragment : Fragment(), ConfigureItemView.Callback {
         super.onDestroyView()
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_feed_configure, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.menu_feed_configure, menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_feed_configure_select_all -> {
                 FeedContentType.values().map { it.isEnabled = true }
@@ -117,7 +115,7 @@ class ConfigureFragment : Fragment(), ConfigureItemView.Callback {
                 touch()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
@@ -179,7 +179,7 @@ class ReadingListFragment : Fragment(), MenuProvider, ReadingListItemActionsDial
                 }
                 true
             }
-            else -> true
+            else -> false
         }
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
@@ -11,7 +11,9 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.view.ActionMode
 import androidx.core.os.bundleOf
 import androidx.core.view.MenuItemCompat
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -49,7 +51,7 @@ import org.wikipedia.util.*
 import org.wikipedia.views.*
 import org.wikipedia.views.MultiSelectActionModeCallback.Companion.isTagType
 
-class ReadingListFragment : Fragment(), ReadingListItemActionsDialog.Callback {
+class ReadingListFragment : Fragment(), MenuProvider, ReadingListItemActionsDialog.Callback {
 
     private var _binding: FragmentReadingListBinding? = null
     private val binding get() = _binding!!
@@ -84,17 +86,13 @@ class ReadingListFragment : Fragment(), ReadingListItemActionsDialog.Callback {
         touchCallback = SwipeableItemTouchHelperCallback(requireContext())
         ItemTouchHelper(touchCallback).attachToRecyclerView(binding.readingListRecyclerView)
         readingListId = requireArguments().getLong(ReadingListActivity.EXTRA_READING_LIST_ID)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         setToolbar()
         setHeaderView()
         setRecyclerView()
         setSwipeRefreshView()
         disposables.add(WikipediaApp.instance.bus.subscribe(EventBusConsumer()))
         return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
     }
 
     override fun onResume() {
@@ -110,15 +108,14 @@ class ReadingListFragment : Fragment(), ReadingListItemActionsDialog.Callback {
         super.onDestroyView()
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_reading_list, menu)
         if (showOverflowMenu) {
             inflater.inflate(R.menu.menu_reading_list_item, menu)
         }
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
+    override fun onPrepareMenu(menu: Menu) {
         val sortByNameItem = menu.findItem(R.id.menu_sort_by_name)
         val sortByRecentItem = menu.findItem(R.id.menu_sort_by_recent)
         val sortMode = Prefs.getReadingListPageSortMode(ReadingList.SORT_BY_NAME_ASC)
@@ -142,7 +139,7 @@ class ReadingListFragment : Fragment(), ReadingListItemActionsDialog.Callback {
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_search_lists -> {
                 appCompatActivity.startSupportActionMode(searchActionModeCallback)
@@ -182,7 +179,7 @@ class ReadingListFragment : Fragment(), ReadingListItemActionsDialog.Callback {
                 }
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> true
         }
     }
 

--- a/app/src/main/java/org/wikipedia/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/wikipedia/settings/SettingsFragment.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.view.View
+import androidx.core.view.MenuProvider
+import androidx.lifecycle.Lifecycle
 import androidx.preference.SwitchPreferenceCompat
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.functions.Consumer
@@ -14,25 +17,22 @@ import org.wikipedia.events.ReadingListsEnabledStatusEvent
 import org.wikipedia.events.ReadingListsNoLongerSyncedEvent
 import org.wikipedia.settings.DeveloperSettingsActivity.Companion.newIntent
 
-class SettingsFragment : PreferenceLoaderFragment() {
+class SettingsFragment : PreferenceLoaderFragment(), MenuProvider {
     private lateinit var preferenceLoader: SettingsPreferenceLoader
     private val disposables = CompositeDisposable()
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         disposables.add(WikipediaApp.instance.bus.subscribe(EventBusConsumer()))
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         // TODO: Kick off a sync of reading lists, which will call back to us whether lists
         // are enabled or not. (Not sure if this is necessary yet.)
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onDestroyView() {
+        super.onDestroyView()
         disposables.clear()
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        setHasOptionsMenu(true)
     }
 
     override fun loadPreferences() {
@@ -52,23 +52,21 @@ class SettingsFragment : PreferenceLoaderFragment() {
         requireActivity().invalidateOptionsMenu()
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.menu_settings, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.menu_settings, menu)
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
+    override fun onPrepareMenu(menu: Menu) {
         prepareDeveloperSettingsMenuItem(menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.developer_settings -> {
                 launchDeveloperSettingsActivity()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.kt
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.kt
@@ -9,7 +9,9 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.core.os.bundleOf
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -28,7 +30,7 @@ import org.wikipedia.views.DefaultViewHolder
 import org.wikipedia.views.MultiSelectActionModeCallback
 import java.util.*
 
-class WikipediaLanguagesFragment : Fragment(), WikipediaLanguagesItemView.Callback {
+class WikipediaLanguagesFragment : Fragment(), MenuProvider, WikipediaLanguagesItemView.Callback {
     private var _binding: FragmentWikipediaLanguagesBinding? = null
     private val binding get() = _binding!!
     private lateinit var itemTouchHelper: ItemTouchHelper
@@ -49,14 +51,10 @@ class WikipediaLanguagesFragment : Fragment(), WikipediaLanguagesItemView.Callba
         invokeSource = requireActivity().intent.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as InvokeSource
         initialLanguageList = JsonUtil.encodeToString(app.languageState.appLanguageCodes).orEmpty()
         funnel = AppLanguageSettingsFunnel()
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         prepareWikipediaLanguagesList()
         setupRecyclerView()
         return binding.root
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        setHasOptionsMenu(true)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -80,21 +78,21 @@ class WikipediaLanguagesFragment : Fragment(), WikipediaLanguagesItemView.Callba
         super.onDestroyView()
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_wikipedia_languages, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.menu_wikipedia_languages, menu)
         if (app.languageState.appLanguageCodes.size <= 1) {
             val overflowMenu = menu.getItem(0)
             overflowMenu.isVisible = false
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_wikipedia_languages_remove -> {
                 beginRemoveLanguageMode()
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
@@ -10,7 +10,9 @@ import android.view.View.VISIBLE
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.core.os.bundleOf
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.widget.ViewPager2
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -34,7 +36,7 @@ import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.log.L
 import org.wikipedia.views.PositionAwareFragmentStateAdapter
 
-class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsItemFragment.Callback {
+class SuggestedEditsCardsFragment : Fragment(), MenuProvider, SuggestedEditsItemFragment.Callback {
     private var _binding: FragmentSuggestedEditsCardsBinding? = null
     private val binding get() = _binding!!
 
@@ -90,7 +92,7 @@ class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsItemFragment.Callb
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         setInitialUiState()
         binding.cardsViewPager.offscreenPageLimit = 2
         binding.cardsViewPager.registerOnPageChangeCallback(viewPagerListener) // addOnPageChangeListener(viewPagerListener)
@@ -124,12 +126,12 @@ class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsItemFragment.Callb
         maybeShowOnboarding()
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_suggested_edits, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.menu_suggested_edits, menu)
         ResourceUtil.setMenuItemTint(requireContext(), menu.findItem(R.id.menu_help), R.attr.colorAccent)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_help -> {
                 when (action) {
@@ -143,7 +145,7 @@ class SuggestedEditsCardsFragment : Fragment(), SuggestedEditsItemFragment.Callb
                 }
                 true
             }
-            else -> super.onOptionsItemSelected(item)
+            else -> false
         }
     }
 


### PR DESCRIPTION
I believe there are no more deprecation warnings about MenuProvider. (Old-style optionsMenu functions in Activity classes are not yet deprecated, and probably shouldn't be changed yet.)