### PR TITLE
Remove deprecated usages of capitalize().

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
@@ -9,6 +9,7 @@ import org.wikipedia.notifications.db.Notification.UnreadNotificationWikiItem
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.SiteInfo
 import org.wikipedia.util.DateUtil
+import org.wikipedia.util.StringUtil
 import java.util.*
 
 @Serializable
@@ -70,7 +71,7 @@ class MwQueryResult {
 
     fun getUserResponse(userName: String): UserInfo? {
         // MediaWiki user names are case sensitive, but the first letter is always capitalized.
-        return users?.find { userName.capitalize(Locale.getDefault()) == it?.name }
+        return users?.find { StringUtil.capitalize(userName) == it.name }
     }
 
     fun langLinks(): MutableList<PageTitle> {

--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
@@ -247,8 +247,7 @@ class LangLinksActivity : BaseActivity() {
             this.pageTitle = pageTitle
             val languageCode = pageTitle.wikiSite.languageCode
             val localizedLanguageName = app.languageState.getAppLanguageLocalizedName(languageCode)
-            localizedLanguageNameTextView.text = localizedLanguageName?.capitalize(Locale.getDefault())
-                    ?: languageCode
+            localizedLanguageNameTextView.text = StringUtil.capitalize(localizedLanguageName) ?: languageCode
             articleTitleTextView.text = StringUtil.fromHtml(pageTitle.displayText)
             val canonicalName = viewModel.getCanonicalName(languageCode)
             if (canonicalName.isNullOrEmpty() || languageCode == app.languageState.systemLanguageCode) {

--- a/app/src/main/java/org/wikipedia/language/LanguagesListActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguagesListActivity.kt
@@ -19,6 +19,7 @@ import org.wikipedia.history.SearchActionModeCallback
 import org.wikipedia.settings.languages.WikipediaLanguagesFragment
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.Resource
+import org.wikipedia.util.StringUtil
 import java.util.*
 
 class LanguagesListActivity : BaseActivity() {
@@ -206,7 +207,7 @@ class LanguagesListActivity : BaseActivity() {
         fun bindItem(listItem: LanguagesListViewModel.LanguageListItem) {
             val languageCode = listItem.code
             itemView.findViewById<TextView>(R.id.localized_language_name).text =
-                app.languageState.getAppLanguageLocalizedName(languageCode).orEmpty().capitalize(Locale.getDefault())
+                    StringUtil.capitalize(app.languageState.getAppLanguageLocalizedName(languageCode).orEmpty())
             val canonicalName = viewModel.getCanonicalName(languageCode)
             if (binding.languagesListLoadProgress.visibility != View.VISIBLE) {
                 itemView.findViewById<TextView>(R.id.language_subtitle).text =

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesItemView.kt
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesItemView.kt
@@ -14,6 +14,7 @@ import org.wikipedia.databinding.ItemWikipediaLanguageBinding
 import org.wikipedia.search.SearchFragment
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.ResourceUtil
+import org.wikipedia.util.StringUtil
 import org.wikipedia.views.ViewUtil
 import java.util.*
 
@@ -58,7 +59,7 @@ class WikipediaLanguagesItemView : LinearLayout {
     fun setContents(langCode: String, languageLocalizedName: String?, position: Int) {
         this.position = position
         binding.wikiLanguageOrder.text = (position + 1).toString()
-        binding.wikiLanguageTitle.text = languageLocalizedName.orEmpty().capitalize(Locale.getDefault())
+        binding.wikiLanguageTitle.text = StringUtil.capitalize(languageLocalizedName.orEmpty())
         binding.wikiLanguageCode.text = langCode
         val color = ResourceUtil.getThemedColorStateList(context, R.attr.color_group_63)
         binding.wikiLanguageCode.setTextColor(color)

--- a/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
+++ b/app/src/main/java/org/wikipedia/userprofile/ContributionsFragment.kt
@@ -19,7 +19,6 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
-import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.time.DateUtils
 import org.wikipedia.Constants
 import org.wikipedia.R
@@ -369,7 +368,7 @@ class ContributionsFragment : Fragment(), ContributionsHeaderView.Callback {
         val yesterday: Calendar = Calendar.getInstance()
         yesterday.add(Calendar.DAY_OF_YEAR, -1)
         return when {
-            DateUtils.isSameDay(Calendar.getInstance().time, date) -> StringUtils.capitalize(getString(R.string.view_continue_reading_card_subtitle_today))
+            DateUtils.isSameDay(Calendar.getInstance().time, date) -> StringUtil.capitalize(getString(R.string.view_continue_reading_card_subtitle_today)).orEmpty()
             DateUtils.isSameDay(yesterday.time, date) -> getString(R.string.suggested_edits_contribution_date_yesterday_text)
             else -> DateUtil.getFeedCardDateString(date)
         }

--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -23,6 +23,7 @@ import org.wikipedia.staticdata.UserAliasData
 import java.nio.charset.StandardCharsets
 import java.text.Collator
 import java.text.Normalizer
+import java.util.*
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 
@@ -251,5 +252,9 @@ object StringUtil {
 
     fun getDiffBytesText(context: Context, diffSize: Int): String {
         return context.resources.getQuantityString(R.plurals.edit_diff_bytes, diffSize.absoluteValue, if (diffSize > 0) "+$diffSize" else diffSize.toString())
+    }
+
+    fun capitalize(str: String?): String? {
+        return str?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
     }
 }


### PR DESCRIPTION
The Kotlin standard library no longer wants us to use the `capitalize()` function, and prefers us to use `replaceFirstChar{}` instead for some reason. So let's put it into a utility function.