### PR TITLE
Further improve room.schemaLocation declaration.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'kotlin-kapt'
     id 'kotlin-parcelize'
     id 'kotlinx-serialization'
-    id 'com.google.devtools.ksp'
 }
 
 // Copy the signing.properties.sample file to ~/.sign/signing.properties and adjust the values.
@@ -43,8 +42,10 @@ android {
 
         vectorDrawables.useSupportLibrary = true
 
-        ksp {
-            arg("room.schemaLocation", "$projectDir/schemas".toString())
+        kapt {
+            arguments {
+                arg("room.schemaLocation", "$projectDir/schemas".toString())
+            }
         }
 
         signingConfig signingConfigs.debug
@@ -53,12 +54,6 @@ android {
         buildConfigField "String", "META_WIKI_BASE_URI", '"https://meta.wikimedia.org"'
         buildConfigField "String", "EVENTGATE_ANALYTICS_EXTERNAL_BASE_URI", '"https://intake-analytics.wikimedia.org"'
         buildConfigField "String", "EVENTGATE_LOGGING_EXTERNAL_BASE_URI", '"https://intake-logging.wikimedia.org"'
-
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
-            }
-        }
     }
 
     testOptions {


### PR DESCRIPTION
This is a much more complete solution than the previous PR. This updates the `schemaLocation` to be provided via `kapt`, allowing us to remove the weird `ksp` dependency.