### PR TITLE
Support exporting history to csv

### DIFF
--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.kt
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.kt
@@ -47,7 +47,6 @@ import org.wikipedia.views.DefaultViewHolder
 import org.wikipedia.views.PageItemView
 import org.wikipedia.views.SwipeableItemTouchHelperCallback
 import org.wikipedia.views.WikiCardView
-import java.io.File
 
 class HistoryFragment : Fragment(), BackPressedHandler {
     interface Callback {
@@ -311,7 +310,7 @@ class HistoryFragment : Fragment(), BackPressedHandler {
             }
             exportHistoryButton.setOnClickListener {
                 if (context != null) {
-                    lifecycleScope.launch{
+                    lifecycleScope.launch {
                         withContext(Dispatchers.IO) {
                             val jsonified = exportHistoryToJSON()
                             if (!jsonified.isNullOrEmpty()) {
@@ -324,8 +323,7 @@ class HistoryFragment : Fragment(), BackPressedHandler {
                             }
                         }
                     }
-                }
-                else {
+                } else {
                     Toast.makeText(context, "Failed to open file to export data.", Toast.LENGTH_LONG).show()
                 }
             }

--- a/app/src/main/java/org/wikipedia/history/db/HistoryEntryDao.kt
+++ b/app/src/main/java/org/wikipedia/history/db/HistoryEntryDao.kt
@@ -31,6 +31,9 @@ interface HistoryEntryDao {
         deleteBy(entry.authority, entry.lang, entry.namespace, entry.apiTitle)
     }
 
+    @Query("SELECT * FROM HistoryEntry ORDER BY timestamp DESC")
+    suspend fun getAll(): List<HistoryEntry>
+
     @Transaction
     suspend fun upsertWithTimeSpent(entry: HistoryEntry, timeSpent: Int) {
         val curEntry = findEntryBy(entry.authority, entry.lang, entry.apiTitle)

--- a/app/src/main/java/org/wikipedia/util/ShareUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ShareUtil.kt
@@ -74,13 +74,11 @@ object ShareUtil {
         return context.getString(R.string.feed_featured_image_share_subject) + " | " + getFeedCardDateString(age)
     }
 
-    fun shareJSON(context: Context, json: String, filename: String, subject: String)
-    {
+    fun shareJSON(context: Context, json: String, filename: String, subject: String) {
         val uri = getUriFromFile(context, processJSONForSharing(context, json, filename))
         if (uri == null) {
             displayShareErrorMessage(context)
-        }
-        else {
+        } else {
             val intent = buildFileShareIntent(context, subject, "application/json", uri)
             context.startActivity(intent)
         }
@@ -93,8 +91,7 @@ object ShareUtil {
                 context.resources.getString(R.string.image_share_via))
     }
 
-    private fun buildFileShareIntent(context: Context, subject: String, mime: String, uri: Uri): Intent?
-    {
+    private fun buildFileShareIntent(context: Context, subject: String, mime: String, uri: Uri): Intent? {
         val intent = createFileShareIntent(subject, mime, uri)
         return getIntentChooser(context, intent, "Share via")
     }
@@ -116,8 +113,7 @@ object ShareUtil {
         return FileUtil.writeToFile(bytes, File(shareFolder, cleanFileName(imageFileName)))
     }
 
-    private fun processJSONForSharing(context: Context, json: String, filename: String): File?
-    {
+    private fun processJSONForSharing(context: Context, json: String, filename: String): File? {
         val shareFolder = getClearShareFolder(context) ?: return null
         shareFolder.mkdirs()
         val file = File(shareFolder, filename)

--- a/app/src/main/java/org/wikipedia/util/ShareUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ShareUtil.kt
@@ -74,14 +74,14 @@ object ShareUtil {
         return context.getString(R.string.feed_featured_image_share_subject) + " | " + getFeedCardDateString(age)
     }
 
-    fun shareCSV(context: Context, csvFile: File, subject: String)
+    fun shareJSON(context: Context, json: String, filename: String, subject: String)
     {
-        val uri = getUriFromFile(context, csvFile)
+        val uri = getUriFromFile(context, processJSONForSharing(context, json, filename))
         if (uri == null) {
             displayShareErrorMessage(context)
         }
         else {
-            val intent = buildFileShareIntent(context, subject, "text/csv", uri)
+            val intent = buildFileShareIntent(context, subject, "application/json", uri)
             context.startActivity(intent)
         }
     }
@@ -114,6 +114,16 @@ object ShareUtil {
         shareFolder.mkdirs()
         val bytes = FileUtil.compressBmpToJpg(bmp)
         return FileUtil.writeToFile(bytes, File(shareFolder, cleanFileName(imageFileName)))
+    }
+
+    private fun processJSONForSharing(context: Context, json: String, filename: String): File?
+    {
+        val shareFolder = getClearShareFolder(context) ?: return null
+        shareFolder.mkdirs()
+        val file = File(shareFolder, filename)
+        file.createNewFile()
+        file.writeText(json)
+        return file
     }
 
     private fun createImageShareIntent(subject: String, text: String, uri: Uri): Intent {

--- a/app/src/main/java/org/wikipedia/util/ShareUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ShareUtil.kt
@@ -74,11 +74,29 @@ object ShareUtil {
         return context.getString(R.string.feed_featured_image_share_subject) + " | " + getFeedCardDateString(age)
     }
 
+    fun shareCSV(context: Context, csvFile: File, subject: String)
+    {
+        val uri = getUriFromFile(context, csvFile)
+        if (uri == null) {
+            displayShareErrorMessage(context)
+        }
+        else {
+            val intent = buildFileShareIntent(context, subject, "text/csv", uri)
+            context.startActivity(intent)
+        }
+    }
+
     private fun buildImageShareChooserIntent(context: Context, subject: String,
                                              text: String, uri: Uri): Intent? {
         val shareIntent = createImageShareIntent(subject, text, uri)
         return getIntentChooser(context, shareIntent,
                 context.resources.getString(R.string.image_share_via))
+    }
+
+    private fun buildFileShareIntent(context: Context, subject: String, mime: String, uri: Uri): Intent?
+    {
+        val intent = createFileShareIntent(subject, mime, uri)
+        return getIntentChooser(context, intent, "Share via")
     }
 
     private fun getUriFromFile(context: Context, file: File?): Uri? {
@@ -104,6 +122,13 @@ object ShareUtil {
                 .putExtra(Intent.EXTRA_TEXT, text)
                 .putExtra(Intent.EXTRA_STREAM, uri)
                 .setType("image/jpeg")
+    }
+
+    private fun createFileShareIntent(subject: String, mime: String, uri: Uri): Intent {
+        return Intent(Intent.ACTION_SEND)
+            .putExtra(Intent.EXTRA_SUBJECT, subject)
+            .putExtra(Intent.EXTRA_STREAM, uri)
+            .setType(mime)
     }
 
     private fun displayOnCatchMessage(caught: Throwable, context: Context) {

--- a/app/src/main/res/layout/view_history_header_with_search.xml
+++ b/app/src/main/res/layout/view_history_header_with_search.xml
@@ -36,6 +36,18 @@
             android:textStyle="bold" />
 
         <ImageView
+            android:id="@+id/history_export"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/actionBarItemBackground"
+            android:clickable="true"
+            android:contentDescription="@string/history_export"
+            android:focusable="true"
+            android:scaleType="centerInside"
+            app:srcCompat="@drawable/ic_share"
+            app:tint="?attr/material_theme_secondary_color" />
+
+        <ImageView
             android:id="@+id/history_filter"
             android:layout_width="48dp"
             android:layout_height="48dp"

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1301,4 +1301,5 @@
   <string name="reading_list_share_message_v2">Message that is sent to a recipient when sharing a reading list.</string>
   <string name="reading_list_share_survey_title">Title for dialog box that leads to a survey about sharing reading lists.</string>
   <string name="reading_list_share_survey_body">Message body for dialog box that leads to a survey about sharing reading lists.</string>
+  <string name="history_export">Tooltip to show on button to export list of viewed articles.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1351,6 +1351,7 @@
     <string name="media_playback_error">Error playing media.</string>
     <string name="user_contrib_menu_label">Contributions</string>
     <string name="user_contrib_filter_activity_title">Filter contributions</string>
+    <string name="history_export">Export History</string>
 
     <!-- Shareable reading lists -->
     <string name="shareable_reading_lists_import_dialog_title">Import shared reading list</string>


### PR DESCRIPTION
On the "Search" section, the application shows the history of the pages the user has viewed. The history view supports filtering and deleting.

In this commit, we add a new option to "export" the history via a csv file. The CSV file contains all the data from the history table. After the file is created, the user is prompted on how they want to share the file.

Bug: [T249340](https://phabricator.wikimedia.org/T249340)