### PR TITLE
Minor design tweaks in editing screen.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -135,8 +135,17 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback {
 
     private val syntaxButtonCallback = object : WikiTextKeyboardView.Callback {
         override fun onPreviewLink(title: String) {
-            bottomSheetPresenter.show(supportFragmentManager,
-                    LinkPreviewDialog.newInstance(HistoryEntry(PageTitle(title, pageTitle.wikiSite), HistoryEntry.SOURCE_INTERNAL_LINK), null))
+            val dialog = LinkPreviewDialog.newInstance(HistoryEntry(PageTitle(title, pageTitle.wikiSite), HistoryEntry.SOURCE_INTERNAL_LINK), null)
+            bottomSheetPresenter.show(supportFragmentManager, dialog)
+            binding.root.post {
+                dialog.dialog?.setOnDismissListener {
+                    if (!isDestroyed) {
+                        binding.root.postDelayed({
+                            DeviceUtil.showSoftKeyboard(binding.editSectionText)
+                        }, 200)
+                    }
+                }
+            }
         }
 
         override fun onRequestInsertMedia() {

--- a/app/src/main/res/layout/view_wikitext_keyboard.xml
+++ b/app/src/main/res/layout/view_wikitext_keyboard.xml
@@ -54,6 +54,13 @@
             app:buttonImage="@drawable/ic_redo_themed_24dp" />
 
         <org.wikipedia.views.WikitextKeyboardButtonView
+            android:id="@+id/wikitext_button_insert_media"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:buttonHint="@string/wikitext_insert_media"
+            app:buttonImage="@drawable/ic_image_themed_24dp" />
+
+        <org.wikipedia.views.WikitextKeyboardButtonView
             android:id="@+id/wikitext_button_link"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -61,11 +68,11 @@
             app:buttonImage="@drawable/ic_link_black_24dp" />
 
         <org.wikipedia.views.WikitextKeyboardButtonView
-            android:id="@+id/wikitext_button_insert_media"
+            android:id="@+id/wikitext_button_preview_link"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:buttonHint="@string/wikitext_insert_media"
-            app:buttonImage="@drawable/ic_image_themed_24dp" />
+            app:buttonHint="@string/wikitext_preview_link"
+            app:buttonImage="@drawable/ic_visibility_24" />
 
         <org.wikipedia.views.WikitextKeyboardButtonView
             android:id="@+id/wikitext_button_template"
@@ -80,13 +87,6 @@
             android:layout_height="wrap_content"
             app:buttonHint="@string/wikitext_reference"
             app:buttonImage="@drawable/ic_oojs_ui_icon_reference" />
-
-        <org.wikipedia.views.WikitextKeyboardButtonView
-            android:id="@+id/wikitext_button_preview_link"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:buttonHint="@string/wikitext_preview_link"
-            app:buttonImage="@drawable/ic_visibility_24" />
 
     </LinearLayout>
 


### PR DESCRIPTION
* Rearrange the order of a couple of icons.
* Explicitly show the keyboard after dismissing a link preview.

https://phabricator.wikimedia.org/T313223#8313690
(no need for Design review, just merge and review via Alpha)