### PR TITLE
Fix: add additional logic to check empty statements in Entities object

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/wikidata/Entities.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/wikidata/Entities.kt
@@ -1,8 +1,11 @@
 package org.wikipedia.dataclient.wikidata
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
 import org.wikipedia.dataclient.mwapi.MwResponse
+import org.wikipedia.json.JsonUtil
 
 @Serializable
 class Entities : MwResponse() {
@@ -22,9 +25,17 @@ class Entities : MwResponse() {
         val labels: Map<String, Label> = emptyMap()
         val descriptions: Map<String, Label> = emptyMap()
         val sitelinks: Map<String, SiteLink> = emptyMap()
-        val statements: Map<String, List<Claims.Claim>> = emptyMap()
+        val statements: JsonElement? = null
         val missing: JsonElement? = null
         val lastRevId: Long = 0
+
+        fun getStatements(): Map<String, List<Claims.Claim>> {
+            return if (statements != null && statements !is JsonArray) {
+                JsonUtil.json.decodeFromJsonElement(statements)
+            } else {
+                emptyMap()
+            }
+        }
     }
 
     @Serializable

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -551,7 +551,7 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.Callback, GalleryItemF
             ) { entities, protectionInfoRsp ->
                 val captions = entities.first?.labels?.values?.associate { it.language to it.value }.orEmpty()
                 item.mediaInfo!!.captions = captions
-                val depicts = ImageTagsProvider.getDepictsClaims(entities.first?.statements.orEmpty())
+                val depicts = ImageTagsProvider.getDepictsClaims(entities.first?.getStatements().orEmpty())
                 Pair(protectionInfoRsp.query?.isEditProtected == true, depicts.size)
             }.subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
@@ -114,7 +114,7 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
                 }
                 .flatMap { pair ->
                     val labelMap = pair.first.first?.labels?.values?.associate { v -> v.language to v.value }.orEmpty()
-                    val depicts = ImageTagsProvider.getDepictsClaims(pair.first.first?.statements.orEmpty())
+                    val depicts = ImageTagsProvider.getDepictsClaims(pair.first.first?.getStatements().orEmpty())
                     captionSourcePageTitle = PageTitle(imageTitle, WikiSite(Service.COMMONS_URL, it.wikiSite.languageCode))
                     captionSourcePageTitle!!.description = labelMap[it.wikiSite.languageCode]
                     imagePage = pair.second.query?.firstPage()


### PR DESCRIPTION
https://phabricator.wikimedia.org/T320617

The empty `statements` will return an empty list `[]` instead of `{}`, which causes the parsing error. 