### PR TITLE
Jump to the target position without animation in TalkTopicActivity

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -38,6 +38,7 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.staticdata.UserAliasData
 import org.wikipedia.util.*
 import org.wikipedia.views.SearchActionProvider
+import org.wikipedia.views.ViewUtil
 
 class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
     private lateinit var binding: ActivityTalkTopicBinding
@@ -294,7 +295,7 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
             if (position >= 0) {
                 binding.talkRecyclerView.post {
                     if (!isDestroyed) {
-                        binding.talkRecyclerView.scrollToPosition(position)
+                        ViewUtil.jumpToPositionWithoutAnimation(binding.talkRecyclerView, position)
                         threadAdapter.notifyItemChanged(position)
                     }
                 }

--- a/app/src/main/java/org/wikipedia/views/ViewUtil.kt
+++ b/app/src/main/java/org/wikipedia/views/ViewUtil.kt
@@ -12,6 +12,7 @@ import android.view.*
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.MultiTransformation
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
@@ -25,7 +26,6 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DimenUtil.roundedDpToPx
 import org.wikipedia.util.ResourceUtil.getThemedColor
 import org.wikipedia.util.WhiteBackgroundTransformation
-import java.util.*
 
 object ViewUtil {
     private val CENTER_CROP_ROUNDED_CORNERS = MultiTransformation(CenterCrop(), WhiteBackgroundTransformation(), RoundedCorners(roundedDpToPx(2f)))
@@ -98,5 +98,14 @@ object ViewUtil {
             }
         }
         return null
+    }
+
+    fun jumpToPositionWithoutAnimation(recyclerView: RecyclerView, position: Int) {
+        recyclerView.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                recyclerView.scrollToPosition(position)
+                recyclerView.viewTreeObserver.removeOnGlobalLayoutListener(this)
+            }
+        })
     }
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T318829#8357986

Just found a solution that we can apply the `viewTreeObserver` before scrolling and remove it after scrolling.