### PR TITLE
Update ReadingListsFunnel, prelude to share/export lists.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/ReadingListsFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/ReadingListsFunnel.kt
@@ -48,6 +48,46 @@ class ReadingListsFunnel : Funnel(WikipediaApp.instance, SCHEMA_NAME, REV_ID) {
         log("action", "deleteitem", "itemcount", list.pages.size, "listcount", listCount)
     }
 
+    fun logShareList(list: ReadingList) {
+        log("action", "share", "itemcount", list.pages.size)
+    }
+
+    fun logExportLists(listCount: Int) {
+        log("action", "export", "listcount", listCount)
+    }
+
+    fun logImportStart() {
+        log("action", "import_start")
+    }
+
+    fun logImportCancel(listCount: Int) {
+        log("action", "import_cancel", "listcount", listCount)
+    }
+
+    fun logImportFinish(listCount: Int) {
+        log("action", "import_finish", "listcount", listCount)
+    }
+
+    fun logReceiveStart() {
+        log("action", "receive_start")
+    }
+
+    fun logReceivePreview(list: ReadingList) {
+        log("action", "receive_preview", "itemcount", list.pages.size)
+    }
+
+    fun logReceiveCancel(list: ReadingList) {
+        log("action", "receive_cancel", "itemcount", list.pages.size)
+    }
+
+    fun logReceiveFinish(list: ReadingList) {
+        log("action", "receive_finish", "itemcount", list.pages.size)
+    }
+
+    fun logSurveyShown() {
+        log("action", "survey_shown")
+    }
+
     override fun preprocessData(eventData: JSONObject): JSONObject {
         preprocessData(eventData, "synced", Prefs.isReadingListSyncEnabled)
         return super.preprocessData(eventData)
@@ -57,6 +97,6 @@ class ReadingListsFunnel : Funnel(WikipediaApp.instance, SCHEMA_NAME, REV_ID) {
 
     companion object {
         private const val SCHEMA_NAME = "MobileWikiAppReadingLists"
-        private const val REV_ID = 20339451
+        private const val REV_ID = 24010884
     }
 }


### PR DESCRIPTION
This makes the necessary additions to the `ReadingListsFunnel`, so that it could be used by both Sharing and Exporting feature branches independently.

https://phabricator.wikimedia.org/T321949