### PR TITLE
Follow-up to latency logging.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/SessionFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/SessionFunnel.kt
@@ -88,7 +88,7 @@ class SessionFunnel(app: WikipediaApp) : Funnel(app, SCHEMA_NAME, REVISION) {
                 "totalPages", sessionData.totalPages,
                 "pageLoadLatency", sessionData.getPageLatency(),
                 "languages", JsonUtil.encodeToString(app.languageState.appLanguageCodes),
-                "apiMode", 1
+                "apiMode", 2
         )
     }
 

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
@@ -51,7 +51,7 @@ abstract class OkHttpWebViewClient : WebViewClient() {
                 WikipediaApp.instance.sessionFunnel.pageFetchStart()
             }
             val rsp = request(request)
-            if (rsp.networkResponse != null && rsp.cacheResponse == null && shouldLogLatency) {
+            if (rsp.networkResponse != null && shouldLogLatency) {
                 WikipediaApp.instance.sessionFunnel.pageFetchEnd()
             }
             response = if (CONTENT_TYPE_OGG == rsp.header(HEADER_CONTENT_TYPE) ||


### PR DESCRIPTION
* Bump the `apiMode` field to 2.
* I don't think we actually need to check for `cacheResponse == null`, since if we have a nonnull `networkResponse`, it definitely means that a network transaction was made, and we want to log the latency of it.