### PR TITLE
Revision id update for Schema:MobileWikiAppReadingLists

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/ReadingListsFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/ReadingListsFunnel.kt
@@ -97,6 +97,6 @@ class ReadingListsFunnel : Funnel(WikipediaApp.instance, SCHEMA_NAME, REV_ID) {
 
     companion object {
         private const val SCHEMA_NAME = "MobileWikiAppReadingLists"
-        private const val REV_ID = 24010884
+        private const val REV_ID = 24051158
     }
 }


### PR DESCRIPTION
Shay had to update some descriptions which bumped the rev id. No other consequences.