### PR TITLE
Fix searching for keywords within displayTitles.

### DIFF
--- a/app/src/main/java/org/wikipedia/history/db/HistoryEntryWithImageDao.kt
+++ b/app/src/main/java/org/wikipedia/history/db/HistoryEntryWithImageDao.kt
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.search.SearchResult
 import org.wikipedia.search.SearchResults
+import org.wikipedia.util.StringUtil
 import java.text.DateFormat
 import java.util.*
 
@@ -33,6 +34,7 @@ interface HistoryEntryWithImageDao {
             .replace("%", "\\%").replace("_", "\\_")
 
         val entries = findEntriesBySearchTerm("%$normalizedQuery%")
+                .filter { StringUtil.fromHtml(it.displayTitle).toString().lowercase().contains(normalizedQuery) }
 
         return if (entries.isEmpty()) SearchResults()
         else SearchResults(entries.take(3).map { SearchResult(toHistoryEntry(it).title, SearchResult.SearchResultType.HISTORY) }.toMutableList())

--- a/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
@@ -13,6 +13,7 @@ import org.wikipedia.readinglist.sync.ReadingListSyncAdapter
 import org.wikipedia.savedpages.SavedPageSyncService
 import org.wikipedia.search.SearchResult
 import org.wikipedia.search.SearchResults
+import org.wikipedia.util.StringUtil
 import java.util.*
 
 @Dao
@@ -145,7 +146,8 @@ interface ReadingListPageDao {
         normalizedQuery = normalizedQuery.replace("\\", "\\\\")
             .replace("%", "\\%").replace("_", "\\_")
 
-        val pages = findPageBySearchTerm("%$normalizedQuery%").filter { it.accentAndCaseInvariantTitle().contains(normalizedQuery) }
+        val pages = findPageBySearchTerm("%$normalizedQuery%")
+                .filter { StringUtil.fromHtml(it.accentAndCaseInvariantTitle()).contains(normalizedQuery) }
 
         return if (pages.isEmpty()) SearchResults()
         else SearchResults(pages.take(2).map {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -31,8 +31,7 @@ import org.wikipedia.readinglist.LongPressMenu
 import org.wikipedia.readinglist.database.ReadingListPage
 import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
 import org.wikipedia.util.ResourceUtil.getThemedColorStateList
-import org.wikipedia.util.StringUtil.boldenKeywordText
-import org.wikipedia.util.StringUtil.fromHtml
+import org.wikipedia.util.StringUtil
 import org.wikipedia.views.DefaultViewHolder
 import org.wikipedia.views.GoneIfEmptyTextView
 import org.wikipedia.views.ViewUtil.formatLangButton
@@ -177,7 +176,7 @@ class SearchResultsFragment : Fragment() {
             }
             WikipediaApp.instance.tabList.forEach { tab ->
                 tab.backStackPositionTitle?.let {
-                    if (it.displayText.lowercase(Locale.getDefault()).contains(term.lowercase(Locale.getDefault()))) {
+                    if (StringUtil.fromHtml(it.displayText).toString().lowercase(Locale.getDefault()).contains(term.lowercase(Locale.getDefault()))) {
                         resultList.add(SearchResult(it, SearchResult.SearchResultType.TAB_LIST))
                         return
                     }
@@ -214,7 +213,7 @@ class SearchResultsFragment : Fragment() {
 
     private fun handleSuggestion(suggestion: String?) {
         if (suggestion != null) {
-            binding.searchSuggestion.text = fromHtml("<u>" +
+            binding.searchSuggestion.text = StringUtil.fromHtml("<u>" +
                     getString(R.string.search_did_you_mean, suggestion) + "</u>")
             binding.searchSuggestion.tag = suggestion
             binding.searchSuggestion.visibility = View.VISIBLE
@@ -451,7 +450,7 @@ class SearchResultsFragment : Fragment() {
             }
 
             // highlight search term within the text
-            boldenKeywordText(pageTitleText, pageTitle.displayText, currentSearchTerm)
+            StringUtil.boldenKeywordText(pageTitleText, pageTitle.displayText, currentSearchTerm)
             searchResultItemImage.visibility = if (pageTitle.thumbUrl.isNullOrEmpty()) if (type === SearchResult.SearchResultType.SEARCH) View.GONE else View.INVISIBLE else View.VISIBLE
             loadImageWithRoundedCorners(searchResultItemImage, pageTitle.thumbUrl)
 

--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -150,14 +150,12 @@ object StringUtil {
     fun boldenKeywordText(textView: TextView, parentText: String, searchQuery: String?) {
         var parentTextStr = parentText
         val startIndex = indexOf(parentTextStr, searchQuery)
-        if (startIndex >= 0) {
+        if (startIndex >= 0 && !isIndexInsideHtmlTag(parentTextStr, startIndex)) {
             parentTextStr = (parentTextStr.substring(0, startIndex) + "<strong>" +
                     parentTextStr.substring(startIndex, startIndex + searchQuery!!.length) + "</strong>" +
                     parentTextStr.substring(startIndex + searchQuery.length))
-            textView.text = fromHtml(parentTextStr)
-        } else {
-            textView.text = parentTextStr
         }
+        textView.text = fromHtml(parentTextStr)
     }
 
     fun highlightAndBoldenText(textView: TextView, input: String?, shouldBolden: Boolean, highlightColor: Int) {
@@ -175,6 +173,15 @@ object StringUtil {
             }
             textView.text = spannableString
         }
+    }
+
+    private fun isIndexInsideHtmlTag(text: String, index: Int): Boolean {
+        var tagStack = 0
+        for (i in text.indices) {
+            if (text[i] == '<') { tagStack++ } else if (text[i] == '>') { tagStack-- }
+            if (i == index) { break }
+        }
+        return tagStack > 0
     }
 
     // case insensitive indexOf, also more lenient with similar chars, like chars with accents


### PR DESCRIPTION
This fixes a few long-standing bugs in our logic of searching PageTitles based on the `displayTitle` field.

* We allow the `displayTitle` to contain HTML tags, which is good, because we want the title to be rich-text, with italics, bold, etc. The problem is that the displayTitle could also contain other tags that we need to ignore, such as `<style class=...>`.
* Another issue emerges when searching through displayTitles. If we search for the word "class", it will return titles with the tag `<style class=...>` in them, so we need to pre-process the title before searching.
* And one last issue is **boldening** keywords within titles, which we do by injecting a `<strong>` tag around the keyword. To do this correctly, we need to detect whether the keyword is already inside an HTML tag, and only inject the `<strong>` tag if the keyword is not inside another tag.

https://phabricator.wikimedia.org/T322826