### PR TITLE
Remove unnecessary word from a message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1358,7 +1358,7 @@
     <string name="shareable_reading_lists_new_install_dialog_content">We noticed that a reading list has been shared with you. To view this list in this app, go back to the original message and tap the link that was shared with you again.</string>
     <string name="shareable_reading_lists_new_install_dialog_got_it">Got it</string>
     <string name="shareable_reading_lists_new_imported_list_title">Imported list</string>
-    <string name="shareable_reading_lists_new_imported_snackbar">Reading list imported successfully</string>
+    <string name="shareable_reading_lists_new_imported_snackbar">Reading list imported</string>
     <plurals name="shareable_reading_lists_import_dialog_content_articles">
         <item quantity="one">%d article</item>
         <item quantity="other">%d articles</item>


### PR DESCRIPTION
The MediaWiki convention is to aovid "successfully" in messages, as documented here:
https://www.mediawiki.org/wiki/Help:System_message#Avoid_jargon_and_slang