### PR TITLE
Send the receive_start event every time we trigger an import

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -556,7 +556,6 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
 
     private fun maybeShowImportReadingListsNewInstallDialog() {
         if (!Prefs.importReadingListsNewInstallDialogShown) {
-            ReadingListsFunnel().logReceiveStart()
             AlertDialog.Builder(requireContext())
                 .setTitle(R.string.shareable_reading_lists_new_install_dialog_title)
                 .setMessage(R.string.shareable_reading_lists_new_install_dialog_content)

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsImportHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsImportHelper.kt
@@ -3,6 +3,7 @@ package org.wikipedia.readinglist
 import android.content.Context
 import android.util.Base64
 import org.wikipedia.R
+import org.wikipedia.analytics.ReadingListsFunnel
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.json.JsonUtil
@@ -14,6 +15,7 @@ import java.util.*
 object ReadingListsImportHelper {
 
     suspend fun importReadingLists(context: Context, encodedJson: String): ReadingList {
+        ReadingListsFunnel().logReceiveStart()
         val readingListData = getExportedReadingLists(encodedJson)
         val listTitle = readingListData?.name.orEmpty().ifEmpty { context.getString(R.string.shareable_reading_lists_new_imported_list_title) }
         val listDescription = readingListData?.description.orEmpty().ifEmpty { DateUtil.getTimeAndDateString(context, Date()) }


### PR DESCRIPTION
The receive_start event was hidden inside the logic to show dialog for fresh installs. We need this event every time we trigger an import.