### PR TITLE
Fix showing contributions from all namespaces.

### DIFF
--- a/app/src/main/java/org/wikipedia/usercontrib/UserContribListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/usercontrib/UserContribListViewModel.kt
@@ -107,7 +107,9 @@ class UserContribListViewModel(bundle: Bundle) : ViewModel() {
                     return LoadResult.Page(emptyList(), null, null)
                 }
 
-                val nsFilter = UserContribFilterActivity.NAMESPACE_LIST.filter { !Prefs.userContribFilterExcludedNs.contains(it) }.joinToString("|")
+                val nsFilter = if (Prefs.userContribFilterExcludedNs.isEmpty()) "" else
+                    UserContribFilterActivity.NAMESPACE_LIST.filter { !Prefs.userContribFilterExcludedNs.contains(it) }.joinToString("|")
+
                 val response = ServiceFactory.get(wikiSite).getUserContrib(userName, 500, nsFilter.ifEmpty { null }, null, params.key)
                 val contribs = response.query?.userContributions!!
 


### PR DESCRIPTION
When selecting contributions from "all" namespaces to be shown, it should really be from _all_ namespaces, instead of the four namespaces we offer for filtering.

https://phabricator.wikimedia.org/T325130