### PR TITLE
Update a few dependencies and remove Jetifier.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,8 +178,8 @@ dependencies {
     String kotlinCoroutinesVersion = '1.3.9'
     String firebaseMessagingVersion = '23.1.1'
     String mlKitVersion = '17.0.4'
-    String roomVersion = "2.4.3"
-    String espressoVersion = '3.5.0'
+    String roomVersion = "2.5.0"
+    String espressoVersion = '3.5.1'
     String serialization_version = '1.4.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
@@ -260,9 +260,9 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-web:$espressoVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
-    androidTestImplementation "android.arch.persistence.room:testing:1.1.1"
+    androidTestImplementation "androidx.room:room-testing:$roomVersion"
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.7.21'
     repositories {
         google()
         mavenCentral()
@@ -8,9 +8,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.14'
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-        classpath "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:$kotlin_version-1.0.6"
+        classpath 'com.google.gms:google-services:4.3.14'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M


### PR DESCRIPTION
* Update Room to 2.5.0. https://developer.android.com/jetpack/androidx/releases/room#2.5.0
* Update kotlin to 1.7.21.
* Update espresso to 3.5.1.
* Remove unnecessary `Jetifier` option, which will speed up builds.
* Remove unused dependency on `ksp`.