### PR TITLE
Follow-up to Watchlist ViewModel.

### DIFF
--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
@@ -6,6 +6,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.view.MenuProvider
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -134,6 +135,7 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
         binding.watchlistEmptyContainer.visibility = View.GONE
         binding.watchlistRecyclerView.visibility = View.GONE
         binding.watchlistErrorView.visibility = View.GONE
+        binding.watchlistProgressBar.isVisible = !binding.watchlistRefreshView.isRefreshing
     }
 
     private fun onSuccess() {

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
@@ -54,7 +54,8 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         binding.watchlistRefreshView.setColorSchemeResources(ResourceUtil.getThemedAttributeId(requireContext(), R.attr.colorAccent))
-        binding.watchlistRefreshView.setOnRefreshListener { fetchWatchlist(true) }
+        binding.watchlistRefreshView.setOnRefreshListener { viewModel.fetchWatchlist() }
+        binding.watchlistErrorView.retryClickListener = View.OnClickListener { viewModel.fetchWatchlist() }
 
         binding.watchlistRecyclerView.layoutManager = LinearLayoutManager(requireContext())
 
@@ -64,13 +65,12 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
         lifecycleScope.launchWhenStarted {
             viewModel.uiState.collect {
                 when (it) {
+                    is WatchlistViewModel.UiState.Loading -> onLoading()
                     is WatchlistViewModel.UiState.Success -> onSuccess()
                     is WatchlistViewModel.UiState.Error -> onError(it.throwable)
                 }
             }
         }
-
-        fetchWatchlist(false)
     }
 
     override fun onDestroyView() {
@@ -130,37 +130,22 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
         viewModel.displayLanguages = WikipediaApp.instance.languageState.appLanguageCodes.filterNot { Prefs.watchlistDisabledLanguages.contains(it) }
     }
 
-    private fun fetchWatchlist(refreshing: Boolean) {
+    private fun onLoading() {
         binding.watchlistEmptyContainer.visibility = View.GONE
         binding.watchlistRecyclerView.visibility = View.GONE
         binding.watchlistErrorView.visibility = View.GONE
-
-        if (!AccountUtil.isLoggedIn) {
-            return
-        }
-
-        if (viewModel.displayLanguages.isEmpty()) {
-            binding.watchlistEmptyContainer.visibility = View.VISIBLE
-            binding.watchlistProgressBar.visibility = View.GONE
-            return
-        }
-
-        if (!refreshing) {
-            binding.watchlistProgressBar.visibility = View.VISIBLE
-        }
-
-        if (refreshing) {
-            viewModel.fetchWatchlist()
-        }
     }
 
     private fun onSuccess() {
+        binding.watchlistErrorView.visibility = View.GONE
         binding.watchlistRefreshView.isRefreshing = false
         binding.watchlistProgressBar.visibility = View.GONE
         onUpdateList()
     }
 
     private fun onError(t: Throwable) {
+        binding.watchlistRefreshView.isRefreshing = false
+        binding.watchlistProgressBar.visibility = View.GONE
         binding.watchlistErrorView.setError(t)
         binding.watchlistErrorView.visibility = View.VISIBLE
     }
@@ -272,7 +257,7 @@ class WatchlistFragment : Fragment(), WatchlistHeaderView.Callback, WatchlistIte
 
     override fun onLanguageChanged() {
         updateDisplayLanguages()
-        fetchWatchlist(true)
+        viewModel.fetchWatchlist()
     }
 
     override fun onItemClick(item: MwQueryResult.WatchlistItem) {

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistViewModel.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistViewModel.kt
@@ -56,6 +56,7 @@ class WatchlistViewModel : ViewModel() {
     }
 
     fun fetchWatchlist() {
+        _uiState.value = UiState.Loading()
         viewModelScope.launch(handler) {
             watchlistItems = mutableListOf()
             displayLanguages.map { language ->
@@ -69,12 +70,13 @@ class WatchlistViewModel : ViewModel() {
                 }
             }.awaitAll()
             watchlistItems.sortByDescending { it.date }
-            _uiState.value = UiState.Success(watchlistItems)
+            _uiState.value = UiState.Success()
         }
     }
 
     open class UiState {
-        data class Success(val watchlistItem: List<MwQueryResult.WatchlistItem>) : UiState()
-        data class Error(val throwable: Throwable) : UiState()
+        class Loading : UiState()
+        class Success : UiState()
+        class Error(val throwable: Throwable) : UiState()
     }
 }


### PR DESCRIPTION
* Remove unnecessary `fetch` call inside `viewCreated()`.
* Introduce a `Loading` UI state, for complete consistency in the spirit of ViewModel usage.
* Hooked up the Retry button in the ErrorView.