### PR TITLE
Fix/improve tracking of latency on page loads.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/SessionData.kt
+++ b/app/src/main/java/org/wikipedia/analytics/SessionData.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.util.MathUtil
+import java.util.concurrent.TimeUnit
 
 @Serializable
 class SessionData {
@@ -46,7 +47,7 @@ class SessionData {
     }
 
     fun addPageLatency(pageLatency: Long) {
-        this.pageLatency.addSample(pageLatency)
+        this.pageLatency.addSample(TimeUnit.NANOSECONDS.toMillis(pageLatency))
     }
 
     fun addPageFromBack() {

--- a/app/src/main/java/org/wikipedia/analytics/SessionFunnel.kt
+++ b/app/src/main/java/org/wikipedia/analytics/SessionFunnel.kt
@@ -60,11 +60,11 @@ class SessionFunnel(app: WikipediaApp) : Funnel(app, SCHEMA_NAME, REVISION) {
     }
 
     fun pageFetchStart() {
-        pageLoadStartTime = System.currentTimeMillis()
+        pageLoadStartTime = System.nanoTime()
     }
 
     fun pageFetchEnd() {
-        sessionData.addPageLatency(System.currentTimeMillis() - pageLoadStartTime)
+        sessionData.addPageLatency(System.nanoTime() - pageLoadStartTime)
     }
 
     private fun hasTimedOut(): Boolean {


### PR DESCRIPTION
We're currently using `System.currentTimeMillis()` for tracking the latency of page loads, which is actually not the appropriate thing to use in this case.
The `currentTimeMillis()` function gives us the "current time" of the device, which can actually change at any moment:
- The device's clock might have drifted a bit, and suddenly receives an updated date/time from GPS or the network.
- The user moves from one time zone into another.
- The user changes the date/time on the device manually.

A much more appropriate function for measuring an "elapsed" time is the `nanoTime()` function, which gives the total nanoseconds of uptime for the current VM.

(Note that we should not be changing all instances of `currentTimeMillis()` into `nanoTime()`, since there are cases where `currentTimeMillis()` is more appropriate.)