### PR TITLE
Fix edit date display in page history.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.kt
@@ -5,6 +5,9 @@ import kotlinx.serialization.Serializable
 import org.wikipedia.dataclient.page.Protection
 import org.wikipedia.gallery.ImageInfo
 import org.wikipedia.page.Namespace
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 @Serializable
 class MwQueryPage {
@@ -95,6 +98,10 @@ class MwQueryPage {
         val parsedcomment: String = ""
 
         var diffSize = 0
+
+        val localDateTime: LocalDateTime by lazy {
+            LocalDateTime.ofInstant(Instant.parse(timeStamp), ZoneId.systemDefault())
+        }
 
         fun getContentFromSlot(slot: String): String {
             return slots?.get(slot)?.content.orEmpty()

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -67,10 +67,10 @@ class EditHistoryListViewModel(bundle: Bundle) : ViewModel() {
         }.map {
             EditHistoryItem(it)
         }.insertSeparators { before, after ->
-            val dateBefore = if (before != null) DateUtil.getShortDateString(DateUtil.iso8601DateParse(before.item.timeStamp)) else ""
-            val dateAfter = if (after != null) DateUtil.getShortDateString(DateUtil.iso8601DateParse(after.item.timeStamp)) else ""
-            if (dateAfter.isNotEmpty() && dateAfter != dateBefore) {
-                EditHistorySeparator(dateAfter)
+            val dateBefore = before?.item?.localDateTime?.toLocalDate()
+            val dateAfter = after?.item?.localDateTime?.toLocalDate()
+            if (dateAfter != null && dateAfter != dateBefore) {
+                EditHistorySeparator(DateUtil.getShortDateString(dateAfter))
             } else {
                 null
             }


### PR DESCRIPTION
Display the date in the user's current time zone instead of the UTC date in an article's edit history. Related to #3721.