### PR TITLE
Use Java 10 URLEncoder and URLDecoder methods.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ static def computeVersionName(versionCode, label) {
     return "2.7.${versionCode}-${label}-${(new Date()).format('yyyy-MM-dd')}"
 }
 
-final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_8
+final JavaVersion JAVA_VERSION = JavaVersion.VERSION_11
 
 android {
     compileSdkVersion 33
@@ -182,7 +182,7 @@ dependencies {
     String espressoVersion = '3.5.1'
     String serialization_version = '1.4.0'
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.0'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -14,9 +14,9 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.page.PageTitle
 import org.wikipedia.staticdata.UserAliasData
 import org.wikipedia.util.log.L
-import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 object UriUtil {
     const val LOCAL_URL_SETTINGS = "#settings"
@@ -29,25 +29,19 @@ object UriUtil {
         return try {
             // Force decoding of plus sign, since the built-in decode() function will replace
             // plus sign with space.
-            URLDecoder.decode(url.replace("+", "%2B"), "UTF-8")
+            URLDecoder.decode(url.replace("+", "%2B"), StandardCharsets.UTF_8)
         } catch (e: IllegalArgumentException) {
             // Swallow IllegalArgumentException (can happen with malformed encoding), and just
             // return the original string.
             L.d("URL decoding failed. String was: $url")
             url
-        } catch (e: UnsupportedEncodingException) {
-            throw RuntimeException(e)
         }
     }
 
     fun encodeURL(url: String): String {
-        return try {
-            // Before returning, explicitly convert plus signs to encoded spaces, since URLEncoder
-            // does that for some reason.
-            URLEncoder.encode(url, "UTF-8").replace("+", "%20")
-        } catch (e: UnsupportedEncodingException) {
-            throw RuntimeException(e)
-        }
+        // Before returning, explicitly convert plus signs to encoded spaces, since URLEncoder
+        // does that for some reason.
+        return URLEncoder.encode(url, StandardCharsets.UTF_8).replace("+", "%20")
     }
 
     fun visitInExternalBrowser(context: Context, uri: Uri) {


### PR DESCRIPTION
Use the new [`URLEncoder.encode(String, Charset)`](https://developer.android.com/reference/java/net/URLEncoder#encode(java.lang.String,%20java.nio.charset.Charset)) and [`URLDecoder.decode(String, Charset)`](https://developer.android.com/reference/java/net/URLDecoder#decode(java.lang.String,%20java.nio.charset.Charset)) methods introduced in Java 10 / Android API level 33.