### PR TITLE
Fix the issue of showing incorrect language variants in an article title

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -103,7 +103,7 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=info|description&inprop=varianttitles|displaytitle&redirects=1")
     fun getInfoByPageId(@Query("pageids") pageIds: String): Observable<MwQueryResponse>
 
-    @GET(MW_API_PREFIX + "action=query&prop=description|pageimages&redirects=1")
+    @GET(MW_API_PREFIX + "action=query&prop=info|description|pageimages&inprop=varianttitles|displaytitle&redirects=1")
     suspend fun getPageTitlesByPageId(@Query("pageids") pageIds: String): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query")

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsImportHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsImportHelper.kt
@@ -31,7 +31,8 @@ object ReadingListsImportHelper {
                     page.displayTitle(wikiSite.languageCode),
                     page.title,
                     page.description,
-                    page.thumbUrl()
+                    page.thumbUrl(),
+                    lang = wikiSite.languageCode
                 )
                 listPages.add(readingListPage)
             }


### PR DESCRIPTION
We should request the `info` along with `inprop=varianttitles|displaytitle` in order to save a proper title from different language variants and also save the correct language code in the database.