### PR TITLE
Remove an unnecessary space from a message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -617,7 +617,7 @@
     <string name="reading_list_delete_lists_dialog_delete_button_text">Delete</string>
     <string name="reading_list_activity_title">Reading list: %s</string>
     <string name="reading_list_notification_title">Reading list(s) exported</string>
-    <string name="reading_list_notification_text"> %d Reading list(s) have been exported as \'reading_lists export.json\' to your downloads folder</string>
+    <string name="reading_list_notification_text">%d Reading list(s) have been exported as \'reading_lists export.json\' to your downloads folder</string>
     <string name="reading_list_notification_detailed_text">Reading lists have been exported to \'reading_lists_export.json\'</string>
     <string name="reading_lists_action_menu_export_lists">Export</string>
     <string name="reading_lists_import_file_picker_title">Choose the file to import</string>


### PR DESCRIPTION
The space appears in the beginning of the message, which is unusual, because messages usually don't begin with whitespace. It may also cause issue when exporting from translatewiki.

If the space is intentional, then I guess this can be closed without merging, but the reason for the space's presence there should be documented.

Thanks :)