### PR TITLE
Follow-up to reading lists MEP, and enhance Breadcrumbs overall.

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -107,11 +107,6 @@ abstract class BaseActivity : AppCompatActivity() {
         Prefs.localClassName = localClassName
     }
 
-    override fun onResumeFragments() {
-        super.onResumeFragments()
-        BreadCrumbLogEvent.logScreenShown(this)
-    }
-
     override fun onDestroy() {
         unregisterReceiver(networkStateReceiver)
         disposables.dispose()
@@ -129,6 +124,7 @@ abstract class BaseActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         WikipediaApp.instance.appSessionEvent.touchSession()
+        BreadCrumbLogEvent.logScreenShown(this)
 
         // allow this activity's exclusive bus methods to override any existing ones.
         unregisterExclusiveBusMethods()

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
@@ -1,10 +1,12 @@
 package org.wikipedia.analytics.eventplatform
 
 import android.content.Context
+import android.view.MenuItem
 import android.view.View
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.appcompat.widget.SwitchCompat
+import androidx.fragment.app.Fragment
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.wikipedia.WikipediaApp
@@ -43,13 +45,18 @@ class BreadCrumbLogEvent(
             EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context), str))
         }
 
+        fun logClick(context: Context, item: MenuItem) {
+            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context),
+                context.resources.getResourceEntryName(item.itemId) + ".click"))
+        }
+
         fun logLongClick(context: Context, view: View) {
             val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
             EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context), "$viewReadableName.longclick"))
         }
 
-        fun logScreenShown(context: Context) {
-            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context), "show"))
+        fun logScreenShown(context: Context, fragment: Fragment? = null) {
+            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context, fragment), "show"))
         }
 
         fun logBackPress(context: Context) {
@@ -70,16 +77,6 @@ class BreadCrumbLogEvent(
             val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
             val str = "$viewReadableName." + (view as TextView).text
             EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context), str))
-        }
-
-        fun logMenuItemSelection(context: Context, view: View?, addDialogLogString: String? = null) {
-            addDialogLogString?.let {
-                EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context), addDialogLogString))
-                return
-            }
-            view?.let {
-                EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context), BreadCrumbViewUtil.getReadableNameForView(view)))
-            }
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbViewUtil.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbViewUtil.kt
@@ -66,8 +66,8 @@ object BreadCrumbViewUtil {
         }
     }
 
-    fun getReadableScreenName(context: Context): String {
-        val fragName = getCurrentFragmentName(context)
+    fun getReadableScreenName(context: Context, fragment: Fragment? = null): String {
+        val fragName = if (fragment == null) getCurrentFragmentName(context) else fragment.javaClass.simpleName
         return context.javaClass.simpleName + (if (fragName.isNotEmpty()) ".$fragName" else "")
     }
 

--- a/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.kt
@@ -8,10 +8,16 @@ import androidx.annotation.StyleRes
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.wikipedia.analytics.BreadcrumbsContextHelper
+import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 
 open class ExtendedBottomSheetDialogFragment : BottomSheetDialogFragment() {
     protected fun disableBackgroundDim() {
         requireDialog().window?.setDimAmount(0f)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        BreadCrumbLogEvent.logScreenShown(requireContext(), this)
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/app/src/main/java/org/wikipedia/readinglist/AddToReadingListDialog.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/AddToReadingListDialog.kt
@@ -17,7 +17,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
-import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.databinding.DialogAddToReadingListBinding
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
@@ -60,8 +59,6 @@ open class AddToReadingListDialog : ExtendedBottomSheetDialogFragment() {
         binding.listOfLists.layoutManager = LinearLayoutManager(requireActivity())
         binding.listOfLists.adapter = adapter
         binding.createButton.setOnClickListener(createClickListener)
-        // Log a click event, but only the first time the dialog is shown.
-        logClick()
         updateLists()
         return binding.root
     }
@@ -130,10 +127,6 @@ open class AddToReadingListDialog : ExtendedBottomSheetDialogFragment() {
             return
         }
         commitChanges(readingList, titles)
-    }
-
-    open fun logClick() {
-        BreadCrumbLogEvent.logMenuItemSelection(requireActivity(), null, "add_to_reading_list from" + invokeSource.ordinal)
     }
 
     open fun commitChanges(readingList: ReadingList, titles: List<PageTitle>) {

--- a/app/src/main/java/org/wikipedia/readinglist/MoveToReadingListDialog.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/MoveToReadingListDialog.kt
@@ -14,7 +14,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
-import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.page.PageTitle
 import org.wikipedia.readinglist.database.ReadingList
@@ -32,10 +31,6 @@ class MoveToReadingListDialog : AddToReadingListDialog() {
             dismiss()
         }
         return parentView
-    }
-
-    override fun logClick() {
-        BreadCrumbLogEvent.logMenuItemSelection(requireActivity(), null, "add_to_reading_list from " + invokeSource.ordinal)
     }
 
     override fun commitChanges(readingList: ReadingList, titles: List<PageTitle>) {

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListItemView.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListItemView.kt
@@ -199,7 +199,7 @@ class ReadingListItemView : ConstraintLayout {
 
     private inner class OverflowMenuClickListener constructor(private val list: ReadingList?) : PopupMenu.OnMenuItemClickListener {
         override fun onMenuItemClick(item: MenuItem): Boolean {
-            BreadCrumbLogEvent.logMenuItemSelection(context, item.actionView)
+            BreadCrumbLogEvent.logClick(context, item)
             when (item.itemId) {
                 R.id.menu_reading_list_rename -> {
                     list?.let { callback?.onRename(it) }

--- a/app/src/main/java/org/wikipedia/views/ReadingListsOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/ReadingListsOverflowView.kt
@@ -3,10 +3,7 @@ package org.wikipedia.views
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
-import android.view.Gravity
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import android.widget.FrameLayout
 import android.widget.PopupWindow
 import androidx.core.view.isVisible
@@ -35,25 +32,27 @@ class ReadingListsOverflowView(context: Context) : FrameLayout(context) {
     init {
         binding.readingListsOverflowSelect.isVisible = ReleaseUtil.isPreBetaRelease
         binding.readingListsOverflowSortBy.setOnClickListener {
-            BreadCrumbLogEvent.logMenuItemSelection(context, it)
+            BreadCrumbLogEvent.logClick(context, it)
             dismissPopupWindowHost()
             callback?.sortByClick()
         }
         binding.readingListsOverflowCreateNewList.setOnClickListener {
-            BreadCrumbLogEvent.logMenuItemSelection(context, it)
+            BreadCrumbLogEvent.logClick(context, it)
             dismissPopupWindowHost()
             callback?.createNewListClick()
         }
         binding.readingListsOverflowImportList.setOnClickListener {
+            BreadCrumbLogEvent.logClick(context, it)
             dismissPopupWindowHost()
             callback?.importNewList()
         }
         binding.readingListsOverflowSelect.setOnClickListener {
+            BreadCrumbLogEvent.logClick(context, it)
             dismissPopupWindowHost()
             callback?.selectListClick()
         }
         binding.readingListsOverflowRefresh.setOnClickListener {
-            BreadCrumbLogEvent.logMenuItemSelection(context, it)
+            BreadCrumbLogEvent.logClick(context, it)
             dismissPopupWindowHost()
             callback?.refreshClick()
         }


### PR DESCRIPTION
* Added a breadcrumb event in the `onCreate` event of all `BottomSheetDialogs`, so that they'll be automatically logged when they're shown.
* This eliminates the need for the `logClick` function that was in the `AddToReadingListDialog`. (The `invokeSource` from that old event is also not necessary, because we have breadcrumbs leading up to it.)
* Added a general breadcrumb function for logging `MenuItem` clicks, which we can use for any menu event, until we figure out a completely generic way to log menus and other popup windows.