### PR TITLE
Follow-up to search results ViewModel

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -352,7 +352,7 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
         searchLanguageCode = selectedLanguageCode
         searchResultsFragment.setLayoutDirection(searchLanguageCode)
         recentSearchesFragment.onLangCodeChanged()
-        startSearch(query, true)
+        startSearch(query, false)
     }
 
     override fun onLanguageButtonClicked() {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -103,7 +103,7 @@ class SearchResultsFragment : Fragment() {
     }
 
     fun startSearch(term: String?, force: Boolean) {
-        if (!force && viewModel.searchTerm == term) {
+        if (!force && viewModel.searchTerm == term && viewModel.languageCode == searchLanguageCode) {
             return
         }
 


### PR DESCRIPTION
* Achieve total concurrency for all local searching (tabs / reading lists / history
* Don't force reloading all results upon language change, since this causes searches to be reloaded upon screen rotation.
* Correctly deduplicate local vs. network results.