### PR TITLE
API groundwork for machine-generated descriptions.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -122,8 +122,6 @@ class DescriptionEditFragment : Fragment() {
             targetSummary = it
         }
         EditAttemptStepEvent.logInit(pageTitle, EditAttemptStepEvent.INTERFACE_OTHER)
-
-        requestSuggestion()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -201,6 +199,10 @@ class DescriptionEditFragment : Fragment() {
         binding.fragmentDescriptionEditView.showProgressBar(false)
         binding.fragmentDescriptionEditView.setEditAllowed(editingAllowed)
         binding.fragmentDescriptionEditView.updateInfoText()
+
+        if (pageTitle.description.isNullOrEmpty()) {
+            requestSuggestion()
+        }
     }
 
     private fun requestSuggestion() {

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -219,6 +219,7 @@ class DescriptionEditFragment : Fragment() {
 
                     // TODO: do something with the list of suggestions.
                     L.d("Received suggestion: " + list.first())
+                    L.d("And is it a BLP? " + response.blp)
                     //
                     //
                 }, { L.e(it) })

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -39,6 +39,7 @@ import org.wikipedia.suggestededits.SuggestedEditsSurvey
 import org.wikipedia.suggestededits.SuggestionsActivity
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 import java.io.IOException
@@ -200,7 +201,7 @@ class DescriptionEditFragment : Fragment() {
         binding.fragmentDescriptionEditView.setEditAllowed(editingAllowed)
         binding.fragmentDescriptionEditView.updateInfoText()
 
-        if (pageTitle.description.isNullOrEmpty()) {
+        if (ReleaseUtil.isPreBetaRelease && pageTitle.description.isNullOrEmpty()) {
             requestSuggestion()
         }
     }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionSuggestionResponse.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionSuggestionResponse.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 class DescriptionSuggestionResponse {
     val prediction: List<String> = emptyList()
+    val blp = false
 }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionSuggestionResponse.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionSuggestionResponse.kt
@@ -1,0 +1,8 @@
+package org.wikipedia.descriptions
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class DescriptionSuggestionResponse {
+    val prediction: List<String> = emptyList()
+}

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionSuggestionService.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionSuggestionService.kt
@@ -1,16 +1,15 @@
 package org.wikipedia.descriptions
 
-import io.reactivex.rxjava3.core.Observable
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface DescriptionSuggestionService {
     @GET("article")
-    fun getSuggestion(
+    suspend fun getSuggestion(
         @Query("lang") lang: String,
         @Query("title") title: String,
         @Query("num_beams") count: Int
-    ): Observable<DescriptionSuggestionResponse>
+    ): DescriptionSuggestionResponse
 
     companion object {
         const val API_URL = "https://ml-article-description-api.wmcloud.org/"

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionSuggestionService.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionSuggestionService.kt
@@ -1,0 +1,18 @@
+package org.wikipedia.descriptions
+
+import io.reactivex.rxjava3.core.Observable
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface DescriptionSuggestionService {
+    @GET("article")
+    fun getSuggestion(
+        @Query("lang") lang: String,
+        @Query("title") title: String,
+        @Query("num_beams") count: Int
+    ): Observable<DescriptionSuggestionResponse>
+
+    companion object {
+        const val API_URL = "https://ml-article-description-api.wmcloud.org/"
+    }
+}


### PR DESCRIPTION
@sharvaniharan This adds the API layer for getting suggested descriptions.

* Notice the `requestSuggestion()` function, which makes the API request and then provides a TODO for doing something with the received suggestion(s).
* Also notice the response contains a `blp` field, which specifies whether the given article is a BLP (biography of living person). The idea will be: showing machine-suggested descriptions for BLP articles will only be available to editors with 50+ edits.

(This is mergeable now, since it's feature-flagged for pre-beta)