### PR TITLE
Introduce periodic task to clean up stale offline Talk pages.

### DIFF
--- a/app/src/main/java/org/wikipedia/offline/db/OfflineObjectDao.kt
+++ b/app/src/main/java/org/wikipedia/offline/db/OfflineObjectDao.kt
@@ -24,6 +24,9 @@ interface OfflineObjectDao {
     @Query("SELECT * FROM OfflineObject WHERE url LIKE '%/' || :urlFragment || '/%' LIMIT 1")
     fun searchForOfflineObject(urlFragment: String): OfflineObject?
 
+    @Query("SELECT * FROM OfflineObject WHERE url LIKE '%' || :urlFragment || '%'")
+    fun searchForOfflineObjects(urlFragment: String): List<OfflineObject>
+
     @Query("SELECT * FROM OfflineObject WHERE usedByStr LIKE '%|' || :id || '|%'")
     fun getFromUsedById(id: Long): List<OfflineObject>
 

--- a/app/src/main/java/org/wikipedia/recurring/DailyEventTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/DailyEventTask.kt
@@ -11,7 +11,7 @@ class DailyEventTask(context: Context) : RecurringTask() {
     override val name = context.getString(R.string.preference_key_daily_event_time_task_name)
 
     override fun shouldRun(lastRun: Date): Boolean {
-        return timeSinceLastRun(lastRun) > TimeUnit.DAYS.toMillis(1)
+        return millisSinceLastRun(lastRun) > TimeUnit.DAYS.toMillis(1)
     }
 
     override fun run(lastRun: Date) {

--- a/app/src/main/java/org/wikipedia/recurring/DailyEventTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/DailyEventTask.kt
@@ -6,33 +6,15 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.DailyStatsEvent
 import java.util.*
 import java.util.concurrent.TimeUnit
-import kotlin.math.max
-import kotlin.math.min
 
 class DailyEventTask(context: Context) : RecurringTask() {
     override val name = context.getString(R.string.preference_key_daily_event_time_task_name)
 
     override fun shouldRun(lastRun: Date): Boolean {
-        return isDailyEventDue(lastRun)
+        return timeSinceLastRun(lastRun) > TimeUnit.DAYS.toMillis(1)
     }
 
     override fun run(lastRun: Date) {
-        onDailyEvent()
-    }
-
-    private fun onDailyEvent() {
-        logDailyEventReport()
-    }
-
-    private fun logDailyEventReport() {
         DailyStatsEvent.log(WikipediaApp.instance)
-    }
-
-    private fun isDailyEventDue(lastRun: Date): Boolean {
-        return timeSinceLastDailyEvent(lastRun) > TimeUnit.DAYS.toMillis(1)
-    }
-
-    private fun timeSinceLastDailyEvent(lastRun: Date): Long {
-        return min(Int.MAX_VALUE.toLong(), max(0, absoluteTime - lastRun.time))
     }
 }

--- a/app/src/main/java/org/wikipedia/recurring/RecurringTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/RecurringTask.kt
@@ -39,7 +39,7 @@ abstract class RecurringTask {
     private val lastRunDate: Date
         get() = Date(Prefs.getLastRunTime(name))
 
-    protected fun timeSinceLastRun(lastRun: Date): Long {
+    protected fun millisSinceLastRun(lastRun: Date): Long {
         return min(Int.MAX_VALUE.toLong(), max(0, absoluteTime - lastRun.time))
     }
 }

--- a/app/src/main/java/org/wikipedia/recurring/RecurringTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/RecurringTask.kt
@@ -3,6 +3,8 @@ package org.wikipedia.recurring
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.log.L
 import java.util.*
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * Represents a task that needs to be run periodically.
@@ -36,4 +38,8 @@ abstract class RecurringTask {
         get() = System.currentTimeMillis()
     private val lastRunDate: Date
         get() = Date(Prefs.getLastRunTime(name))
+
+    protected fun timeSinceLastRun(lastRun: Date): Long {
+        return min(Int.MAX_VALUE.toLong(), max(0, absoluteTime - lastRun.time))
+    }
 }

--- a/app/src/main/java/org/wikipedia/recurring/RecurringTasksExecutor.kt
+++ b/app/src/main/java/org/wikipedia/recurring/RecurringTasksExecutor.kt
@@ -12,7 +12,8 @@ class RecurringTasksExecutor(private val app: WikipediaApp) {
         Completable.fromAction {
             val allTasks = arrayOf( // Has list of all rotating tasks that need to be run
                     RemoteConfigRefreshTask(),
-                    DailyEventTask(app)
+                    DailyEventTask(app),
+                    TalkOfflineCleanupTask(app)
             )
             for (task in allTasks) {
                 task.runIfNecessary()

--- a/app/src/main/java/org/wikipedia/recurring/TalkOfflineCleanupTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/TalkOfflineCleanupTask.kt
@@ -1,0 +1,32 @@
+package org.wikipedia.recurring
+
+import android.content.Context
+import org.wikipedia.R
+import org.wikipedia.database.AppDatabase
+import java.io.File
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class TalkOfflineCleanupTask(context: Context) : RecurringTask() {
+    override val name = context.getString(R.string.preference_key_talk_offline_cleanup_task_name)
+
+    override fun shouldRun(lastRun: Date): Boolean {
+        return timeSinceLastRun(lastRun) > CLEANUP_MAX_AGE_MILLIS
+    }
+
+    override fun run(lastRun: Date) {
+        AppDatabase.instance.offlineObjectDao()
+            .searchForOfflineObjects(CLEANUP_URL_SEARCH_KEY)
+            .filter {
+                (absoluteTime - File(it.path + ".0").lastModified()) > CLEANUP_MAX_AGE_MILLIS
+            }.forEach {
+                AppDatabase.instance.offlineObjectDao().deleteOfflineObject(it)
+                AppDatabase.instance.offlineObjectDao().deleteFilesForObject(it)
+            }
+    }
+
+    companion object {
+        private val CLEANUP_URL_SEARCH_KEY = "action=discussiontoolspageinfo"
+        private val CLEANUP_MAX_AGE_MILLIS = TimeUnit.DAYS.toMillis(7)
+    }
+}

--- a/app/src/main/java/org/wikipedia/recurring/TalkOfflineCleanupTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/TalkOfflineCleanupTask.kt
@@ -11,14 +11,14 @@ class TalkOfflineCleanupTask(context: Context) : RecurringTask() {
     override val name = context.getString(R.string.preference_key_talk_offline_cleanup_task_name)
 
     override fun shouldRun(lastRun: Date): Boolean {
-        return timeSinceLastRun(lastRun) > CLEANUP_MAX_AGE_MILLIS
+        return millisSinceLastRun(lastRun) > TimeUnit.DAYS.toMillis(CLEANUP_MAX_AGE_DAYS)
     }
 
     override fun run(lastRun: Date) {
         AppDatabase.instance.offlineObjectDao()
             .searchForOfflineObjects(CLEANUP_URL_SEARCH_KEY)
             .filter {
-                (absoluteTime - File(it.path + ".0").lastModified()) > CLEANUP_MAX_AGE_MILLIS
+                (absoluteTime - File(it.path + ".0").lastModified()) > TimeUnit.DAYS.toMillis(CLEANUP_MAX_AGE_DAYS)
             }.forEach {
                 AppDatabase.instance.offlineObjectDao().deleteOfflineObject(it)
                 AppDatabase.instance.offlineObjectDao().deleteFilesForObject(it)
@@ -26,7 +26,7 @@ class TalkOfflineCleanupTask(context: Context) : RecurringTask() {
     }
 
     companion object {
-        private val CLEANUP_URL_SEARCH_KEY = "action=discussiontoolspageinfo"
-        private val CLEANUP_MAX_AGE_MILLIS = TimeUnit.DAYS.toMillis(7)
+        private const val CLEANUP_URL_SEARCH_KEY = "action=discussiontoolspageinfo"
+        private const val CLEANUP_MAX_AGE_DAYS = 7L
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
@@ -13,7 +13,7 @@ class RemoteConfigRefreshTask : RecurringTask() {
     override val name = "remote-config-refresher"
 
     override fun shouldRun(lastRun: Date): Boolean {
-        return timeSinceLastRun(lastRun) >= RUN_INTERVAL_MILLIS
+        return millisSinceLastRun(lastRun) >= TimeUnit.DAYS.toMillis(RUN_INTERVAL_DAYS)
     }
 
     override fun run(lastRun: Date) {
@@ -33,6 +33,6 @@ class RemoteConfigRefreshTask : RecurringTask() {
 
     companion object {
         private const val REMOTE_CONFIG_URL = "https://meta.wikimedia.org/w/extensions/MobileApp/config/android.json"
-        private val RUN_INTERVAL_MILLIS = TimeUnit.DAYS.toMillis(1)
+        private const val RUN_INTERVAL_DAYS = 1L
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
@@ -13,7 +13,7 @@ class RemoteConfigRefreshTask : RecurringTask() {
     override val name = "remote-config-refresher"
 
     override fun shouldRun(lastRun: Date): Boolean {
-        return System.currentTimeMillis() - lastRun.time >= RUN_INTERVAL_MILLIS
+        return timeSinceLastRun(lastRun) >= RUN_INTERVAL_MILLIS
     }
 
     override fun run(lastRun: Date) {

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -24,6 +24,7 @@
     <string name="preference_key_mediawiki_base_uri_supports_lang_code">mediaWikiBaseUriSupportsLangCode</string>
     <string name="preference_key_retrofit_log_level">retrofitLog</string>
     <string name="preference_key_daily_event_time_task_name">dailyEventTask</string>
+    <string name="preference_key_talk_offline_cleanup_task_name">talkOfflineCleanupTask</string>
     <string name="preference_key_login_user_id_map">userIDMap</string>
     <string name="preference_key_login_groups">groups</string>
     <string name="preference_key_show_developer_settings">showDeveloperSettings</string>


### PR DESCRIPTION
This creates a new periodic task (to run every 7 days) to clean up saved offline talk pages that are older than 7 days. It works very simply by querying the DB for offline Talk responses and cross-referencing them with the state of the filesystem.
Also includes some light refactoring of the base RecurringTask class.

https://phabricator.wikimedia.org/T328677