### PR TITLE
Return null if the timestamp if empty in ThreadItem

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/discussiontools/ThreadItem.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/discussiontools/ThreadItem.kt
@@ -43,7 +43,9 @@ class ThreadItem(
         }
 
     @IgnoredOnParcel @Transient val date = try {
-        if (timestamp.contains("T")) {
+        if (timestamp.isEmpty()) {
+            null
+        } else if (timestamp.contains("T")) {
             // Assume a ISO 8601 timestamp
             DateUtil.iso8601DateParse(timestamp)
         } else {


### PR DESCRIPTION
Not sure if it relates to this issue, but it will help to reduce the times of showing a warning message when reading the parent topic item.
https://phabricator.wikimedia.org/T327185#8638155