### PR TITLE
Fix usage of non-default / beta base URL for MediaWiki.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.kt
@@ -61,7 +61,11 @@ object ServiceFactory {
     }
 
     private fun getBasePath(wiki: WikiSite): String {
-        return Prefs.mediaWikiBaseUrl.ifEmpty { wiki.url() + "/" }
+        var path = wiki.url()
+        if (!path.endsWith("/")) {
+            path += "/"
+        }
+        return path
     }
 
     fun getRestBasePath(wiki: WikiSite): String {


### PR DESCRIPTION
For our upcoming work on IP masking, it will be very important to be able to communicate with Beta Wikipedia, because IP masking will be deployed there first.

Currently, setting a custom MediaWiki base URL (in Developer preferences) is a bit broken and inconsistent. This fixes the inconsistency.