### PR TITLE
Extend survey dates for Reading Lists by 30 days.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsReceiveSurveyHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsReceiveSurveyHelper.kt
@@ -57,7 +57,7 @@ object ReadingListsReceiveSurveyHelper {
     }
 
     private fun fallsWithinDateRange(): Boolean {
-        val endTime = GregorianCalendar(2022, Calendar.DECEMBER, 30)
+        val endTime = GregorianCalendar(2023, Calendar.APRIL, 17)
         return Calendar.getInstance().timeInMillis < endTime.timeInMillis
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsShareSurveyHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsShareSurveyHelper.kt
@@ -57,7 +57,7 @@ object ReadingListsShareSurveyHelper {
     }
 
     private fun fallsWithinDateRange(): Boolean {
-        val endTime = GregorianCalendar(2022, Calendar.DECEMBER, 30)
+        val endTime = GregorianCalendar(2023, Calendar.APRIL, 17)
         return Calendar.getInstance().timeInMillis < endTime.timeInMillis
     }
 


### PR DESCRIPTION
This extends the surveys by 30 days after our projected release date of Mar 15, plus a couple extra days to allow for some uptake of the new app version.