### PR TITLE
Correctly respect user option to add edited pages to watchlist.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -444,6 +444,10 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched")
     suspend fun getWatchedStatus(@Query("titles") titles: String): MwQueryResponse
 
+    @Headers("Cache-Control: no-cache")
+    @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched&meta=userinfo&uiprop=options")
+    suspend fun getWatchedStatusWithUserOptions(@Query("titles") titles: String): MwQueryResponse
+
     @get:GET(MW_API_PREFIX + "action=query&list=watchlist&wllimit=500&wlallrev=1&wlprop=ids|title|flags|comment|parsedcomment|timestamp|sizes|user|loginfo")
     @get:Headers("Cache-Control: no-cache")
     val watchlist: Observable<MwQueryResponse>

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.kt
@@ -20,6 +20,7 @@ class UserInfo : BlockInfo() {
     val rights: List<String> = emptyList()
     @SerialName("cancreate") val canCreate: Boolean = false
     @SerialName("cancreateerror") private val canCreateError: List<MwServiceError>? = null
+    val options: Options? = null
 
     val error get() = canCreateError?.get(0)?.title.orEmpty()
     val hasBlockError get() = error.contains("block")
@@ -47,4 +48,9 @@ class UserInfo : BlockInfo() {
             }
             return date
         }
+
+    @Serializable
+    class Options {
+        @SerialName("watchdefault") val watchDefault: Int = 0
+    }
 }

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryFragment.kt
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryFragment.kt
@@ -124,9 +124,10 @@ class EditSummaryFragment : Fragment() {
                 L.e(throwable)
             }) {
                 withContext(Dispatchers.IO) {
-                    val page = ServiceFactory.get(title.wikiSite)
-                        .getWatchedStatus(title.prefixedText).query?.firstPage()!!
-                    binding.watchPageCheckBox.isChecked = page.watched
+                    val query = ServiceFactory.get(title.wikiSite)
+                        .getWatchedStatusWithUserOptions(title.prefixedText).query!!
+                    binding.watchPageCheckBox.isChecked = query.firstPage()!!.watched ||
+                            query.userInfo?.options?.watchDefault == 1
                 }
             }
         } else {


### PR DESCRIPTION
There's a user preference (settable on Desktop) that allows you to "Add pages and files I edit to my watchlist".
This is exposed via the `userinfo` API, and we can automatically check the box to "Watch" a page that is being edited, if we see that this preference is set.

https://phabricator.wikimedia.org/T331503

Surprisingly, we don't do any checking of any user options at all, so this also lays the groundwork (serialization logic) for checking other user options.