### PR TITLE
Handle valid page link in the FilePage properly

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -16,9 +16,13 @@ import org.wikipedia.Constants.PREFERRED_GALLERY_IMAGE_SIZE
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.databinding.ViewFilePageBinding
+import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.descriptions.DescriptionEditActivity
+import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.LinkMovementMethodExt
+import org.wikipedia.page.PageActivity
+import org.wikipedia.page.PageTitle
 import org.wikipedia.suggestededits.PageSummaryForEdit
 import org.wikipedia.util.ImageUrlUtil
 import org.wikipedia.util.ResourceUtil
@@ -191,7 +195,13 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
         binding.detailsContainer.addView(view)
     }
 
-    private val movementMethod = LinkMovementMethodExt { url: String ->
-        UriUtil.handleExternalLink(context, Uri.parse(UriUtil.resolveProtocolRelativeUrl(url)))
+    private val movementMethod = LinkMovementMethodExt { url ->
+        val uri = Uri.parse(UriUtil.resolveProtocolRelativeUrl(url))
+        if (UriUtil.isValidPageLink(uri)) {
+            val entry = HistoryEntry(PageTitle.titleForUri(uri, WikiSite(uri)), HistoryEntry.SOURCE_FILE_PAGE)
+            context.startActivity(PageActivity.newIntentForNewTab(context, entry, entry.title))
+        } else {
+            UriUtil.handleExternalLink(context, Uri.parse(UriUtil.resolveProtocolRelativeUrl(url)))
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/history/HistoryEntry.kt
+++ b/app/src/main/java/org/wikipedia/history/HistoryEntry.kt
@@ -93,5 +93,6 @@ class HistoryEntry(
         const val SOURCE_CATEGORY = 36
         const val SOURCE_ARCHIVED_TALK = 37
         const val SOURCE_USER_CONTRIB = 38
+        const val SOURCE_FILE_PAGE = 39
     }
 }


### PR DESCRIPTION
Currently, in the `FilePageFragment`, we always open the links in the descriptions on an external browser, even if the links are valid page links.

Steps to reproduce:
1. Search "The Sting" in `en.wiki`
2. Click on the lead image and go to the image page.
3. Scroll down to the Author section and click on the "Universal Pictures" link.