### PR TITLE
Fix potential minor crash when drawing Tab bitmap.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
@@ -319,8 +319,10 @@ class TabActivity : BaseActivity() {
         fun captureFirstTabBitmap(view: View, title: String) {
             clearFirstTabBitmap()
             try {
-                FIRST_TAB_BITMAP = view.drawToBitmap(Bitmap.Config.RGB_565)
-                FIRST_TAB_BITMAP_TITLE = title
+                if (view.isLaidOut) {
+                    FIRST_TAB_BITMAP = view.drawToBitmap(Bitmap.Config.RGB_565)
+                    FIRST_TAB_BITMAP_TITLE = title
+                }
             } catch (e: OutOfMemoryError) {
                 // don't worry about it
             }


### PR DESCRIPTION
This is an extremely minor crash that is occasionally observed in Play Store logs.