### PR TITLE
Update "delete-tag-and-release' library to v0.2.1 for Github action

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,7 +35,7 @@ jobs:
       run: git rev-parse HEAD > app/build/outputs/apk/alpha/release/rev-hash.txt
     - name: Rename APK to universal
       run: mv app/build/outputs/apk/alpha/release/app-alpha-release-signed.apk app/build/outputs/apk/alpha/release/app-alpha-universal-release.apk
-    - uses: dev-drprasad/delete-tag-and-release@v0.1.2
+    - uses: dev-drprasad/delete-tag-and-release@v0.2.1
       name: Delete latest alpha tag
       with:
         delete_release: false


### PR DESCRIPTION
It is showing "Error: Unable to resolve action `dev-drprasad/delete-tag-and-release@v0.1.2`, unable to find version `v0.1.2`" on the `main` branch.