### PR TITLE
Fix/improve thumbnail URL transforming for certain URLs.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/ImageUrlUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ImageUrlUtil.kt
@@ -2,12 +2,12 @@ package org.wikipedia.util
 
 object ImageUrlUtil {
 
-    private val WIDTH_IN_IMAGE_URL_REGEX = """(\d+)px-""".toPattern()
+    private val WIDTH_IN_IMAGE_URL_REGEX = """/(page\d+-)?(\d+)(px-)""".toPattern()
 
     fun getUrlForPreferredSize(original: String, size: Int): String {
         val matcher = WIDTH_IN_IMAGE_URL_REGEX.matcher(original)
-        return if (matcher.find() && matcher.group(1)!!.toInt() != size) {
-            matcher.replaceAll("${size}px-")
+        return if (matcher.find() && matcher.group(2)!!.toInt() != size) {
+            matcher.replaceFirst("/${matcher.group(1).orEmpty()}$size$3")
         } else {
             original
         }

--- a/app/src/test/java/org/wikipedia/util/ImageUriUtilTest.kt
+++ b/app/src/test/java/org/wikipedia/util/ImageUriUtilTest.kt
@@ -34,4 +34,10 @@ class ImageUriUtilTest {
         MatcherAssert.assertThat(ImageUrlUtil.getUrlForPreferredSize("https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Dehnungsmethoden_DrKlee.pdf/page1-320px-Dehnungsmethoden_DrKlee.pdf.jpg", 1280),
             Matchers.`is`("https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Dehnungsmethoden_DrKlee.pdf/page1-1280px-Dehnungsmethoden_DrKlee.pdf.jpg"))
     }
+
+    @Test
+    fun testUrlForPagedSizeStringWithPxInName() {
+        MatcherAssert.assertThat(ImageUrlUtil.getUrlForPreferredSize("https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Lossy-page1-2658px-Nelson%27s_Pillar%2C_Sackville-Street%2C_Dublin_RMG_PU3914_%28cropped%29.jpg/492px-Lossy-page1-2658px-Nelson%27s_Pillar%2C_Sackville-Street%2C_Dublin_RMG_PU3914_%28cropped%29.jpg", 640),
+            Matchers.`is`("https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Lossy-page1-2658px-Nelson%27s_Pillar%2C_Sackville-Street%2C_Dublin_RMG_PU3914_%28cropped%29.jpg/640px-Lossy-page1-2658px-Nelson%27s_Pillar%2C_Sackville-Street%2C_Dublin_RMG_PU3914_%28cropped%29.jpg"))
+    }
 }


### PR DESCRIPTION
Notice that in today's featured article ("Nelson's Pillar") the lead image is broken.
This is because our regex for getting the appropriate thumbnail width is failing for this particular image, because the image filename itself contains a "px"-size as part of the name, which trips up the regex and produces an invalid URL.

This fixes and hardens our regex to catch both regular images from Commons, as well as paged documents such as PDF and Tiff files.