### PR TITLE
Final follow-up (for real!) to analytics.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -8,6 +8,7 @@ import org.wikipedia.auth.AccountUtil
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
+import org.wikipedia.util.ActiveTimer
 
 class MachineGeneratedArticleDescriptionsAnalyticsHelper {
 
@@ -15,32 +16,26 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
     var apiOrderList = emptyList<String>()
     var displayOrderList = emptyList<String>()
     private var chosenSuggestion = ""
-    private var startTime = 0L
-    private var timeSpentPerEdit = 0L
+    val timer = ActiveTimer()
+
     fun articleDescriptionEditingStart(context: Context) {
         log(context, composeGroupString() + ".start")
-        resetTimer()
-    }
-
-    private fun resetTimer() {
-        startTime = System.currentTimeMillis()
     }
 
     fun articleDescriptionEditingEnd(context: Context) {
         log(context, composeGroupString() + ".end")
-        timeSpentPerEdit = System.currentTimeMillis() - startTime
     }
 
     fun logAttempt(context: Context, finalDescription: String, wasChosen: Boolean, wasModified: Boolean, title: PageTitle) {
         log(context, composeLogString(title) + ".attempt:$finalDescription" +
                 ".suggestion1:${encode(apiOrderList.first())}" + (if (apiOrderList.size > 1) ".suggestion2.${encode(apiOrderList.last())}" else "") +
-                getOrderString(wasChosen, chosenSuggestion) + ".modified:$wasModified")
+                getOrderString(wasChosen, chosenSuggestion) + ".modified:$wasModified.timeSpentMs.${timer.elapsedMillis}")
     }
 
     fun logSuccess(context: Context, finalDescription: String, wasChosen: Boolean, wasModified: Boolean, title: PageTitle, revId: Long) {
         log(context, composeLogString(title) + ".success:$finalDescription" +
                 ".suggestion1:${encode(apiOrderList.first())}" + (if (apiOrderList.size > 1) ".suggestion2.${encode(apiOrderList.last())}" else "") +
-                getOrderString(wasChosen, chosenSuggestion) + ".modified:$wasModified.timeSpentMs.$timeSpentPerEdit.revId:$revId")
+                getOrderString(wasChosen, chosenSuggestion) + ".modified:$wasModified.timeSpentMs.${timer.elapsedMillis}.revId:$revId")
     }
 
     fun logSuggestionsReceived(context: Context, isBlp: Boolean, title: PageTitle) {

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -143,6 +143,16 @@ class DescriptionEditFragment : Fragment() {
         return binding.root
     }
 
+    override fun onPause() {
+        super.onPause()
+        analyticsHelper.timer.pause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        analyticsHelper.timer.resume()
+    }
+
     override fun onDestroyView() {
         binding.fragmentDescriptionEditView.callback = null
         _binding = null
@@ -272,16 +282,15 @@ class DescriptionEditFragment : Fragment() {
                     analyticsHelper.articleDescriptionEditingEnd(requireContext())
                 }
                 binding.fragmentDescriptionEditView.loadReviewContent(true)
+                analyticsHelper.timer.pause()
             } else {
                 binding.fragmentDescriptionEditView.setError(null)
                 binding.fragmentDescriptionEditView.setSaveState(true)
                 cancelCalls()
-                if (action == DescriptionEditActivity.Action.ADD_DESCRIPTION) {
-                    analyticsHelper.logAttempt(requireContext(),
-                        binding.fragmentDescriptionEditView.description.orEmpty(), binding.fragmentDescriptionEditView.wasSuggestionChosen,
-                        binding.fragmentDescriptionEditView.wasSuggestionModified, pageTitle
-                    )
-                }
+                analyticsHelper.logAttempt(requireContext(),
+                    binding.fragmentDescriptionEditView.description.orEmpty(), binding.fragmentDescriptionEditView.wasSuggestionChosen,
+                    binding.fragmentDescriptionEditView.wasSuggestionModified, pageTitle
+                )
                 getEditTokenThenSave()
                 EditAttemptStepEvent.logSaveAttempt(pageTitle, EditAttemptStepEvent.INTERFACE_OTHER)
             }
@@ -469,6 +478,7 @@ class DescriptionEditFragment : Fragment() {
         override fun onCancelClick() {
             if (binding.fragmentDescriptionEditView.showingReviewContent()) {
                 binding.fragmentDescriptionEditView.loadReviewContent(false)
+                analyticsHelper.timer.resume()
             } else {
                 DeviceUtil.hideSoftKeyboard(requireActivity())
                 requireActivity().onBackPressed()

--- a/app/src/main/java/org/wikipedia/util/ActiveTimer.kt
+++ b/app/src/main/java/org/wikipedia/util/ActiveTimer.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit
 class ActiveTimer {
     private var startMillis: Long = 0
     private var pauseMillis: Long = 0
+    private var isPaused = false
 
     init {
         reset()
@@ -17,12 +18,17 @@ class ActiveTimer {
 
     fun pause() {
         pauseMillis = System.currentTimeMillis()
+        isPaused = true
     }
 
     fun resume() {
-        startMillis -= System.currentTimeMillis() - pauseMillis
+        startMillis += System.currentTimeMillis() - pauseMillis
+        isPaused = false
     }
 
+    val elapsedMillis: Long
+        get() = if (isPaused) pauseMillis - startMillis else System.currentTimeMillis() - startMillis
+
     val elapsedSec: Int
-        get() = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - startMillis).toInt()
+        get() = TimeUnit.MILLISECONDS.toSeconds(elapsedMillis).toInt()
 }


### PR DESCRIPTION
* We have a perfectly good pre-made component for tracking elapsed time (`ActiveTimer`).
* This will properly `pause` and `resume` the timer precisely when we want to measure just the "editing" time of the user.
* This allows us to send the elapsed time as part of all events, and it will be uniform.
* As a bonus, this **fixes** the `ActiveTimer` class, which was actually working wrongly before.