### PR TITLE
Adding timeSpent to end event

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -23,7 +23,7 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
     }
 
     fun articleDescriptionEditingEnd(context: Context) {
-        log(context, composeGroupString() + ".timeSpentMs:${timer.elapsedMillis}.end")
+        log(context, composeGroupString() + ".end.timeSpentMs:${timer.elapsedMillis}")
     }
 
     fun logAttempt(context: Context, finalDescription: String, wasChosen: Boolean, wasModified: Boolean, title: PageTitle) {


### PR DESCRIPTION
Adding this back just in case @JTannerWMF  wants to get an estimate on timeSpent for all edits: published and unpublished.