### PR TITLE
Only logged in users should be included in the experiment

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
@@ -10,6 +10,7 @@ import org.wikipedia.R
 import org.wikipedia.activity.SingleFragmentActivity
 import org.wikipedia.analytics.eventplatform.ABTest.Companion.GROUP_1
 import org.wikipedia.analytics.eventplatform.MachineGeneratedArticleDescriptionsAnalyticsHelper
+import org.wikipedia.auth.AccountUtil
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.PageActivity
@@ -35,8 +36,8 @@ class DescriptionEditActivity : SingleFragmentActivity<DescriptionEditFragment>(
         val action = intent.getSerializableExtra(Constants.INTENT_EXTRA_ACTION) as Action
         val pageTitle = intent.getParcelableExtra<PageTitle>(EXTRA_TITLE)!!
 
-        MachineGeneratedArticleDescriptionsAnalyticsHelper.isUserInExperiment = (action == Action.ADD_DESCRIPTION &&
-                pageTitle.description.isNullOrEmpty() &&
+        MachineGeneratedArticleDescriptionsAnalyticsHelper.isUserInExperiment = (AccountUtil.isLoggedIn &&
+                action == Action.ADD_DESCRIPTION && pageTitle.description.isNullOrEmpty() &&
                 SuggestedArticleDescriptionsDialog.availableLanguages.contains(pageTitle.wikiSite.languageCode))
 
         val shouldShowAIOnBoarding = MachineGeneratedArticleDescriptionsAnalyticsHelper.isUserInExperiment &&

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -44,7 +44,6 @@ import org.wikipedia.suggestededits.SuggestedEditsSurvey
 import org.wikipedia.suggestededits.SuggestionsActivity
 import org.wikipedia.util.*
 import org.wikipedia.util.log.L
-import org.wikipedia.views.SuggestedArticleDescriptionsDialog
 import java.io.IOException
 import java.lang.Runnable
 import java.util.*
@@ -221,8 +220,7 @@ class DescriptionEditFragment : Fragment() {
         binding.fragmentDescriptionEditView.updateInfoText()
 
         binding.fragmentDescriptionEditView.isSuggestionButtonEnabled =
-                AccountUtil.isLoggedIn && SuggestedArticleDescriptionsDialog.availableLanguages.contains(pageTitle.wikiSite.languageCode) &&
-                action == DescriptionEditActivity.Action.ADD_DESCRIPTION && pageTitle.description.isNullOrEmpty() &&
+                MachineGeneratedArticleDescriptionsAnalyticsHelper.isUserInExperiment &&
                 MachineGeneratedArticleDescriptionsAnalyticsHelper.abcTest.group != GROUP_1
 
         if (binding.fragmentDescriptionEditView.isSuggestionButtonEnabled) {

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -221,7 +221,7 @@ class DescriptionEditFragment : Fragment() {
         binding.fragmentDescriptionEditView.updateInfoText()
 
         binding.fragmentDescriptionEditView.isSuggestionButtonEnabled =
-                SuggestedArticleDescriptionsDialog.availableLanguages.contains(pageTitle.wikiSite.languageCode) &&
+                AccountUtil.isLoggedIn && SuggestedArticleDescriptionsDialog.availableLanguages.contains(pageTitle.wikiSite.languageCode) &&
                 action == DescriptionEditActivity.Action.ADD_DESCRIPTION && pageTitle.description.isNullOrEmpty() &&
                 MachineGeneratedArticleDescriptionsAnalyticsHelper.abcTest.group != GROUP_1
 


### PR DESCRIPTION
For the below scenario:

1. User is not logged in
2. Stumbles upon an article without a description
3. Enters the edit description screen

User will get put into group 0 - no suggestions or 1 - non-blp - and never in 2, because without them being logged in, we cannot find their edit count.

Since this alters the experiment, @JTannerWMF wants the gate to be tightened to logged in users.
