### PR TITLE
Crash fix: Do not log api info for group 0 users

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -27,12 +27,12 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
     }
 
     fun logAttempt(context: Context, finalDescription: String, wasChosen: Boolean, wasModified: Boolean, title: PageTitle) {
-        log(context, composeLogString(title) + ".attempt:$finalDescription ${getSuggestionOrderString(wasChosen, wasModified)}" +
+        log(context, composeLogString(title) + ".attempt:$finalDescription${getSuggestionOrderString(wasChosen, wasModified)}" +
                 ".timeSpentMs:${timer.elapsedMillis}")
     }
 
     fun logSuccess(context: Context, finalDescription: String, wasChosen: Boolean, wasModified: Boolean, title: PageTitle, revId: Long) {
-        log(context, composeLogString(title) + ".success:$finalDescription ${getSuggestionOrderString(wasChosen, wasModified)}" +
+        log(context, composeLogString(title) + ".success:$finalDescription${getSuggestionOrderString(wasChosen, wasModified)}" +
                     ".timeSpentMs:${timer.elapsedMillis}.revId:$revId")
     }
 

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.wikipedia.WikipediaApp
+import org.wikipedia.analytics.eventplatform.ABTest.Companion.GROUP_1
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.page.PageTitle
@@ -27,15 +28,22 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
     }
 
     fun logAttempt(context: Context, finalDescription: String, wasChosen: Boolean, wasModified: Boolean, title: PageTitle) {
-        log(context, composeLogString(title) + ".attempt:$finalDescription" +
-                ".suggestion1:${encode(apiOrderList.first())}" + (if (apiOrderList.size > 1) ".suggestion2:${encode(apiOrderList.last())}" else "") +
-                getOrderString(wasChosen, chosenSuggestion) + ".modified:$wasModified.timeSpentMs:${timer.elapsedMillis}")
+        log(context, composeLogString(title) + ".attempt:$finalDescription ${getSuggestionOrderString(wasChosen, wasModified)}" +
+                ".timeSpentMs:${timer.elapsedMillis}")
     }
 
     fun logSuccess(context: Context, finalDescription: String, wasChosen: Boolean, wasModified: Boolean, title: PageTitle, revId: Long) {
-        log(context, composeLogString(title) + ".success:$finalDescription" +
-                ".suggestion1:${encode(apiOrderList.first())}" + (if (apiOrderList.size > 1) ".suggestion2:${encode(apiOrderList.last())}" else "") +
-                getOrderString(wasChosen, chosenSuggestion) + ".modified:$wasModified.timeSpentMs:${timer.elapsedMillis}.revId:$revId")
+        log(context, composeLogString(title) + ".success:$finalDescription ${getSuggestionOrderString(wasChosen, wasModified)}" +
+                    ".timeSpentMs:${timer.elapsedMillis}.revId:$revId")
+    }
+
+    private fun getSuggestionOrderString(wasChosen: Boolean, wasModified: Boolean): String {
+       return if (abcTest.group == GROUP_1) {
+           ""
+       } else {
+           ".suggestion1:${encode(apiOrderList.first())}" + (if (apiOrderList.size > 1) ".suggestion2:${encode(apiOrderList.last())}" else "") +
+                   getOrderString(wasChosen, chosenSuggestion) + ".modified:$wasModified"
+       }
     }
 
     fun logSuggestionsReceived(context: Context, isBlp: Boolean, title: PageTitle) {

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.wikipedia.WikipediaApp
-import org.wikipedia.analytics.eventplatform.ABTest.Companion.GROUP_1
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.page.PageTitle
@@ -38,7 +37,7 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
     }
 
     private fun getSuggestionOrderString(wasChosen: Boolean, wasModified: Boolean): String {
-       return if (abcTest.group == GROUP_1) {
+       return if (apiOrderList.isEmpty() || displayOrderList.isEmpty()) {
            ""
        } else {
            ".suggestion1:${encode(apiOrderList.first())}" + (if (apiOrderList.size > 1) ".suggestion2:${encode(apiOrderList.last())}" else "") +


### PR DESCRIPTION
This crash is because users being in group0 which doesn't receive api response, and hence attempting to access the list objects produces a crash.

**Crash:**
https://play.google.com/console/u/0/developers/6169333749249604352/app/4972092403490495074/vitals/crashes/a09ba6c2234facc96fd131a793b0ffb9/details?installedFrom=PLAY_STORE&days=28&versionCode=50435