### PR TITLE
Fix: Do not assign group to users not in experiment

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -104,7 +104,7 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
     }
 
     private fun composeGroupString(): String {
-        if(!isUserInExperiment){
+        if (!isUserInExperiment) {
             return ""
         }
         return "$MACHINE_GEN_DESC_SUGGESTIONS.group:${abcTest.group}.experienced:${Prefs.suggestedEditsMachineGeneratedDescriptionsIsExperienced}"

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -104,6 +104,9 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
     }
 
     private fun composeGroupString(): String {
+        if(!isUserInExperiment){
+            return ""
+        }
         return "$MACHINE_GEN_DESC_SUGGESTIONS.group:${abcTest.group}.experienced:${Prefs.suggestedEditsMachineGeneratedDescriptionsIsExperienced}"
     }
 


### PR DESCRIPTION
When users are not logged in, the .start event inadvertently triggered group assignment in all cases. This check is to fix the issue of accidental assignment.