### PR TITLE
Convert all AlertDialogs to Material3 dialogs.

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -12,10 +12,10 @@ import android.view.MenuItem
 import android.view.MotionEvent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.ColorInt
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.pm.ShortcutManagerCompat
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.skydoves.balloon.Balloon
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.disposables.Disposable
@@ -210,7 +210,7 @@ abstract class BaseActivity : AppCompatActivity() {
     private fun maybeShowLoggedOutInBackgroundDialog() {
         if (Prefs.loggedOutInBackground) {
             Prefs.loggedOutInBackground = false
-            AlertDialog.Builder(this)
+            MaterialAlertDialogBuilder(this)
                     .setCancelable(false)
                     .setTitle(R.string.logged_out_in_background_title)
                     .setMessage(R.string.logged_out_in_background_dialog)
@@ -255,7 +255,7 @@ abstract class BaseActivity : AppCompatActivity() {
             if (event is NetworkConnectEvent) {
                 SavedPageSyncService.enqueue()
             } else if (event is SplitLargeListsEvent) {
-                AlertDialog.Builder(this@BaseActivity)
+                MaterialAlertDialogBuilder(this@BaseActivity)
                         .setMessage(getString(R.string.split_reading_list_message, SiteInfoClient.maxPagesPerReadingList))
                         .setPositiveButton(R.string.reading_list_split_dialog_ok_button_text, null)
                         .show()

--- a/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.kt
+++ b/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.kt
@@ -9,8 +9,8 @@ import android.text.TextWatcher
 import android.util.Patterns
 import android.view.KeyEvent
 import android.view.View
-import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doOnTextChanged
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -230,7 +230,7 @@ class CreateAccountActivity : BaseActivity() {
                 binding.createAccountEmail.error = getString(R.string.create_account_email_error)
                 return
             }
-            ValidateResult.NO_EMAIL -> AlertDialog.Builder(this)
+            ValidateResult.NO_EMAIL -> MaterialAlertDialogBuilder(this)
                     .setCancelable(false)
                     .setTitle(R.string.email_recommendation_dialog_title)
                     .setMessage(StringUtil.fromHtml(resources.getString(R.string.email_recommendation_dialog_message)))

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -425,7 +425,7 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
             binding.suggestedDescButton.chipIcon = AppCompatResources.getDrawable(context, R.drawable.ic_robot_24)
         }
         binding.suggestedDescButton.setOnClickListener {
-            SuggestedArticleDescriptionsDialog(context, firstSuggestion, secondSuggestion, pageTitle, callback!!.getAnalyticsHelper()) { suggestion ->
+            SuggestedArticleDescriptionsDialog(context as Activity, firstSuggestion, secondSuggestion, pageTitle, callback!!.getAnalyticsHelper()) { suggestion ->
                 binding.viewDescriptionEditText.setText(suggestion)
                 binding.viewDescriptionEditText.setSelection(binding.viewDescriptionEditText.text?.length ?: 0)
                 callback?.getAnalyticsHelper()?.logSuggestionChosen(context, suggestion, pageTitle)

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.diff
 
-import android.app.AlertDialog
 import android.content.res.ColorStateList
 import android.graphics.Rect
 import android.os.Bundle
@@ -20,6 +19,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.EditHistoryInteractionEvent
@@ -396,7 +396,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
 
     private fun showThankDialog() {
         val parent = FrameLayout(requireContext())
-        val dialog: AlertDialog = AlertDialog.Builder(activity)
+        val dialog = MaterialAlertDialogBuilder(requireActivity())
                 .setView(parent)
                 .setPositiveButton(R.string.thank_dialog_positive_button_text) { _, _ ->
                     viewModel.sendThanks(viewModel.pageTitle.wikiSite, viewModel.revisionToId)
@@ -406,10 +406,6 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
                 }
                 .create()
         dialog.layoutInflater.inflate(R.layout.view_thank_dialog, parent)
-        dialog.setOnShowListener {
-            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
-                    .setTextColor(ResourceUtil.getThemedColor(requireContext(), R.attr.placeholder_color))
-        }
         dialog.show()
     }
 
@@ -424,7 +420,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     }
 
     private fun showRollbackDialog() {
-        AlertDialog.Builder(requireActivity())
+        MaterialAlertDialogBuilder(requireActivity())
             .setMessage(R.string.revision_rollback_dialog_title)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 binding.progressBar.isVisible = true

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -12,13 +12,13 @@ import android.text.TextWatcher
 import android.view.*
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.net.toUri
 import androidx.core.os.postDelayed
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
@@ -397,15 +397,14 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback {
     }
 
     private fun showRetryDialog(t: Throwable) {
-        val retryDialog = AlertDialog.Builder(this@EditSectionActivity)
+        MaterialAlertDialogBuilder(this@EditSectionActivity)
                 .setTitle(R.string.dialog_message_edit_failed)
                 .setMessage(t.localizedMessage)
                 .setPositiveButton(R.string.dialog_message_edit_failed_retry) { dialog, _ ->
                     editTokenThenSave
                     dialog.dismiss()
                 }
-                .setNegativeButton(R.string.dialog_message_edit_failed_cancel) { dialog, _ -> dialog.dismiss() }.create()
-        retryDialog.show()
+                .setNegativeButton(R.string.dialog_message_edit_failed_cancel) { dialog, _ -> dialog.dismiss() }.show()
     }
 
     /**
@@ -423,7 +422,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback {
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({ response: MwParseResponse -> showError(MwException(MwServiceError(code, response.text))) }) { showError(it) })
         } else if ("editconflict" == code) {
-            AlertDialog.Builder(this@EditSectionActivity)
+            MaterialAlertDialogBuilder(this@EditSectionActivity)
                     .setTitle(R.string.edit_conflict_title)
                     .setMessage(R.string.edit_conflict_message)
                     .setPositiveButton(R.string.edit_conflict_dialog_ok_button_text, null)
@@ -664,7 +663,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback {
         val binding = DialogWithCheckboxBinding.inflate(layoutInflater)
         binding.dialogMessage.text = StringUtil.fromHtml(getString(R.string.talk_edit_disclaimer))
         binding.dialogMessage.movementMethod = movementMethod
-        AlertDialog.Builder(this@EditSectionActivity)
+        MaterialAlertDialogBuilder(this@EditSectionActivity)
             .setView(binding.root)
             .setPositiveButton(R.string.onboarding_got_it) { dialog, _ -> dialog.dismiss() }
             .setOnDismissListener {
@@ -724,7 +723,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback {
         setNavigationBarColor(ResourceUtil.getThemedColor(this, android.R.attr.colorBackground))
         DeviceUtil.hideSoftKeyboard(this)
         if (sectionTextModified) {
-            val alert = AlertDialog.Builder(this)
+            val alert = MaterialAlertDialogBuilder(this)
             alert.setMessage(getString(R.string.edit_abandon_confirm))
             alert.setPositiveButton(getString(R.string.edit_abandon_confirm_yes)) { dialog, _ ->
                 dialog.dismiss()

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.kt
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.kt
@@ -7,9 +7,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
-import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.bridge.CommunicationBridge
 import org.wikipedia.bridge.CommunicationBridge.CommunicationBridgeListener
@@ -163,7 +163,7 @@ class EditPreviewFragment : Fragment(), CommunicationBridgeListener, ReferenceDi
          */
         private fun showLeavingEditDialogue(runnable: Runnable) {
             // Ask the user if they really meant to leave the edit workflow
-            val leavingEditDialog = AlertDialog.Builder(requireActivity())
+            MaterialAlertDialogBuilder(requireActivity())
                 .setMessage(R.string.dialog_message_leaving_edit)
                 .setPositiveButton(R.string.dialog_message_leaving_edit_leave) { dialog, _: Int ->
                     // They meant to leave; close dialogue and run specified action
@@ -171,8 +171,7 @@ class EditPreviewFragment : Fragment(), CommunicationBridgeListener, ReferenceDi
                     runnable.run()
                 }
                 .setNegativeButton(R.string.dialog_message_leaving_edit_stay, null)
-                .create()
-            leavingEditDialog.show()
+                .show()
         }
 
         @Suppress("UNUSED_PARAMETER")

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
@@ -7,9 +7,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.BackPressedHandler
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
@@ -134,7 +134,7 @@ class FeedFragment : Fragment(), BackPressedHandler {
         if (app.languageState.appLanguageCodes.contains(AppLanguageLookUpTable.TRADITIONAL_CHINESE_LANGUAGE_CODE) &&
             app.languageState.appLanguageCodes.contains(AppLanguageLookUpTable.SIMPLIFIED_CHINESE_LANGUAGE_CODE) &&
             Prefs.shouldShowRemoveChineseVariantPrompt) {
-            AlertDialog.Builder(requireActivity())
+            MaterialAlertDialogBuilder(requireActivity())
                 .setTitle(R.string.dialog_of_remove_chinese_variants_from_app_lang_title)
                 .setMessage(R.string.dialog_of_remove_chinese_variants_from_app_lang_text)
                 .setPositiveButton(R.string.dialog_of_remove_chinese_variants_from_app_lang_edit) { _, _ -> showLanguagesActivity(InvokeSource.LANG_VARIANT_DIALOG) }
@@ -336,7 +336,7 @@ class FeedFragment : Fragment(), BackPressedHandler {
             val view = ConfigureItemLanguageDialogView(requireContext())
             val tempDisabledList = ArrayList(contentType.langCodesDisabled)
             view.setContentType(adapter.langList, tempDisabledList)
-            AlertDialog.Builder(requireContext())
+            MaterialAlertDialogBuilder(requireContext())
                 .setView(view)
                 .setTitle(contentType.titleId)
                 .setPositiveButton(R.string.feed_lang_selection_dialog_ok_button_text) { _, _ ->
@@ -345,7 +345,6 @@ class FeedFragment : Fragment(), BackPressedHandler {
                     refresh()
                 }
                 .setNegativeButton(R.string.feed_lang_selection_dialog_cancel_button_text, null)
-                .create()
                 .show()
         }
     }

--- a/app/src/main/java/org/wikipedia/feed/configure/ConfigureItemView.kt
+++ b/app/src/main/java/org/wikipedia/feed/configure/ConfigureItemView.kt
@@ -5,8 +5,8 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.databinding.ItemFeedContentTypeBinding
@@ -60,7 +60,7 @@ class ConfigureItemView(context: Context) : FrameLayout(context) {
         val view = ConfigureItemLanguageDialogView(context)
         val tempDisabledList = contentType.langCodesDisabled.toMutableList()
         view.setContentType(adapter.langList, tempDisabledList)
-        AlertDialog.Builder(context)
+        MaterialAlertDialogBuilder(context)
             .setView(view)
             .setTitle(contentType.titleId)
             .setPositiveButton(R.string.customize_lang_selection_dialog_ok_button_text) { _, _ ->
@@ -72,7 +72,6 @@ class ConfigureItemView(context: Context) : FrameLayout(context) {
                 binding.feedContentTypeCheckbox.isChecked = atLeastOneEnabled
             }
             .setNegativeButton(R.string.customize_lang_selection_dialog_cancel_button_text, null)
-            .create()
             .show()
     }
 

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -14,11 +14,11 @@ import android.view.Gravity
 import android.view.View
 import android.widget.FrameLayout
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -237,7 +237,7 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.Callback, GalleryItemF
         }
         val isProtected = v.tag != null && v.tag as Boolean
         if (isProtected) {
-            AlertDialog.Builder(this)
+            MaterialAlertDialogBuilder(this)
                 .setCancelable(false)
                 .setTitle(R.string.page_protected_can_not_edit_title)
                 .setMessage(R.string.page_protected_can_not_edit)

--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.kt
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.history
 
-import android.app.AlertDialog
 import android.content.Context
 import android.graphics.Typeface
 import android.os.Bundle
@@ -22,6 +21,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -294,11 +294,11 @@ class HistoryFragment : Fragment(), BackPressedHandler {
             }
             clearHistoryButton.setOnClickListener {
                 if (selectedEntries.size == 0) {
-                    AlertDialog.Builder(requireContext())
+                    MaterialAlertDialogBuilder(requireContext())
                             .setTitle(R.string.dialog_title_clear_history)
                             .setMessage(R.string.dialog_message_clear_history)
                             .setPositiveButton(R.string.dialog_message_clear_history_yes) { _, _ -> onClearHistoryClick() }
-                            .setNegativeButton(R.string.dialog_message_clear_history_no, null).create().show()
+                            .setNegativeButton(R.string.dialog_message_clear_history_no, null).show()
                 } else {
                     deleteSelectedPages()
                 }

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -16,12 +16,12 @@ import android.speech.RecognizerIntent
 import android.util.Pair
 import android.view.*
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.functions.Consumer
 import org.wikipedia.BackPressedHandler
@@ -554,7 +554,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     private fun maybeShowImportReadingListsNewInstallDialog() {
         if (!Prefs.importReadingListsNewInstallDialogShown) {
             ReadingListsSharingAnalyticsHelper.logReceiveStart(requireContext())
-            AlertDialog.Builder(requireContext())
+            MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.shareable_reading_lists_new_install_dialog_title)
                 .setMessage(R.string.shareable_reading_lists_new_install_dialog_content)
                 .setNegativeButton(R.string.shareable_reading_lists_new_install_dialog_got_it, null)

--- a/app/src/main/java/org/wikipedia/page/AnnouncementDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/AnnouncementDialog.kt
@@ -1,9 +1,10 @@
 package org.wikipedia.page
 
-import android.app.AlertDialog
 import android.content.Context
 import android.net.Uri
 import android.widget.ScrollView
+import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.Constants
 import org.wikipedia.feed.announcement.Announcement
 import org.wikipedia.feed.announcement.AnnouncementCard
@@ -16,7 +17,12 @@ import org.wikipedia.settings.SettingsActivity
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
 import org.wikipedia.util.UriUtil
 
-class AnnouncementDialog internal constructor(context: Context, val announcement: Announcement) : AlertDialog(context), AnnouncementCardView.Callback {
+class AnnouncementDialog internal constructor(
+    context: Context,
+    val announcement: Announcement
+) : MaterialAlertDialogBuilder(context), AnnouncementCardView.Callback {
+
+    private var dialog: AlertDialog? = null
 
     init {
         val scrollView = ScrollView(context)
@@ -26,6 +32,11 @@ class AnnouncementDialog internal constructor(context: Context, val announcement
         scrollView.addView(cardView)
         scrollView.isVerticalScrollBarEnabled = true
         setView(scrollView)
+    }
+
+    override fun show(): AlertDialog {
+        dialog = super.show()
+        return dialog!!
     }
 
     override fun onAnnouncementPositiveAction(card: Card, uri: Uri) {
@@ -49,6 +60,6 @@ class AnnouncementDialog internal constructor(context: Context, val announcement
 
     private fun dismissDialog() {
         Prefs.announcementShownDialogs = setOf(announcement.id)
-        dismiss()
+        dialog?.dismiss()
     }
 }

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -9,11 +9,11 @@ import android.os.Bundle
 import android.view.*
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.view.*
 import androidx.preference.PreferenceManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.functions.Consumer
 import org.wikipedia.Constants
@@ -666,11 +666,10 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
     }
 
     private fun showDescriptionEditRevertDialog(qNumber: String) {
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
             .setTitle(R.string.notification_reverted_title)
             .setView(DescriptionEditRevertHelpView(this, qNumber))
             .setPositiveButton(R.string.reverted_edit_dialog_ok_button_text, null)
-            .create()
             .show()
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -12,7 +12,6 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.widget.LinearLayout
-import androidx.appcompat.app.AlertDialog
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.animation.doOnEnd
 import androidx.core.app.ActivityCompat
@@ -23,6 +22,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textview.MaterialTextView
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Completable
@@ -1125,7 +1125,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     fun verifyBeforeEditingDescription(text: String?, invokeSource: InvokeSource) {
         page?.let {
             if (!AccountUtil.isLoggedIn && Prefs.totalAnonDescriptionsEdited >= resources.getInteger(R.integer.description_max_anon_edits)) {
-                AlertDialog.Builder(requireActivity())
+                MaterialAlertDialogBuilder(requireActivity())
                     .setMessage(R.string.description_edit_anon_limit)
                     .setPositiveButton(R.string.page_editing_login) { _, _ ->
                         startActivity(LoginActivity.newIntent(requireContext(), LoginActivity.SOURCE_EDIT))

--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
@@ -7,10 +7,10 @@ import android.os.Bundle
 import android.view.*
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.view.drawToBitmap
 import androidx.core.view.isVisible
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.mrapp.android.tabswitcher.Animation
 import de.mrapp.android.tabswitcher.TabSwitcher
 import de.mrapp.android.tabswitcher.TabSwitcherDecorator
@@ -156,14 +156,14 @@ class TabActivity : BaseActivity() {
             }
             R.id.menu_close_all_tabs -> {
                 if (app.tabList.isNotEmpty()) {
-                    AlertDialog.Builder(this).run {
+                    MaterialAlertDialogBuilder(this).run {
                         setMessage(R.string.close_all_tabs_confirm)
                         setPositiveButton(R.string.close_all_tabs_confirm_yes) { _, _ ->
                             binding.tabSwitcher.clear()
                             cancelled = false
                         }
                         setNegativeButton(R.string.close_all_tabs_confirm_no, null)
-                        create().show()
+                        .show()
                     }
                 }
                 true

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -5,7 +5,7 @@ import android.content.DialogInterface
 import android.icu.text.ListFormatter
 import android.os.Build
 import android.text.Spanned
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.*
 import org.apache.commons.lang3.StringUtils
 import org.wikipedia.Constants.InvokeSource
@@ -85,14 +85,13 @@ object ReadingListBehaviorsUtil {
             return
         }
         if (showDialog) {
-            AlertDialog.Builder(activity)
+            MaterialAlertDialogBuilder(activity)
                     .setMessage(activity.getString(R.string.reading_list_delete_confirm, readingList.title))
                     .setPositiveButton(R.string.reading_list_delete_dialog_ok_button_text) { _, _ ->
                         AppDatabase.instance.readingListDao().deleteList(readingList)
                         AppDatabase.instance.readingListPageDao().markPagesForDeletion(readingList, readingList.pages, false)
                         callback.onCompleted() }
                     .setNegativeButton(R.string.reading_list_delete_dialog_cancel_button_text, null)
-                    .create()
                     .show()
         } else {
             AppDatabase.instance.readingListDao().deleteList(readingList)
@@ -102,7 +101,7 @@ object ReadingListBehaviorsUtil {
     }
 
     fun deleteReadingLists(activity: Activity, readingLists: List<ReadingList>, callback: Callback) {
-        AlertDialog.Builder(activity)
+        MaterialAlertDialogBuilder(activity)
             .setTitle(R.string.reading_list_delete_lists_confirm_dialog_title)
             .setMessage(activity.resources.getQuantityString(R.plurals.reading_list_delete_lists_confirm_dialog_message, readingLists.size, readingLists.size))
             .setPositiveButton(R.string.reading_list_delete_lists_dialog_delete_button_text) { _, _ ->
@@ -261,13 +260,12 @@ object ReadingListBehaviorsUtil {
                 val pages = withContext(dispatcher) { AppDatabase.instance.readingListPageDao().getAllPageOccurrences(ReadingListPage.toPageTitle(page)) }
                 val lists = withContext(dispatcher) { AppDatabase.instance.readingListDao().getListsFromPageOccurrences(pages) }
                 if (lists.size > 1) {
-                    val dialog = AlertDialog.Builder(activity)
+                    MaterialAlertDialogBuilder(activity)
                             .setTitle(R.string.reading_list_confirm_remove_article_from_offline_title)
                             .setMessage(getConfirmToggleOfflineMessage(activity, page, lists))
                             .setPositiveButton(R.string.reading_list_confirm_remove_article_from_offline) { _, _ -> toggleOffline(activity, page, callback) }
                             .setNegativeButton(R.string.reading_list_remove_from_offline_cancel_button_text, null)
-                            .create()
-                    dialog.show()
+                            .show()
                 } else {
                     toggleOffline(activity, page, callback)
                 }
@@ -312,7 +310,7 @@ object ReadingListBehaviorsUtil {
     }
 
     private fun showMobileDataWarningDialog(activity: Activity, listener: DialogInterface.OnClickListener) {
-        AlertDialog.Builder(activity)
+        MaterialAlertDialogBuilder(activity)
                 .setTitle(R.string.dialog_title_download_only_over_wifi)
                 .setMessage(R.string.dialog_text_download_only_over_wifi)
                 .setPositiveButton(R.string.dialog_title_download_only_over_wifi_allow, listener)

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
@@ -24,6 +24,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.functions.Consumer
@@ -457,7 +458,7 @@ class ReadingListFragment : Fragment(), MenuProvider, ReadingListItemActionsDial
                 }
             })
 
-            previewSaveDialog = AlertDialog.Builder(requireContext())
+            previewSaveDialog = MaterialAlertDialogBuilder(requireContext())
                 .setPositiveButton(R.string.reading_lists_preview_save_dialog_save) { _, _ ->
                     it.pages.clear()
                     it.pages.addAll(savedPages)

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListSyncBehaviorDialogs.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListSyncBehaviorDialogs.kt
@@ -1,7 +1,7 @@
 package org.wikipedia.readinglist
 
 import android.app.Activity
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.databinding.DialogWithCheckboxBinding
@@ -18,7 +18,7 @@ object ReadingListSyncBehaviorDialogs {
     private var PROMPT_LOGIN_TO_SYNC_DIALOG_SHOWING = false
 
     fun detectedRemoteTornDownDialog(activity: Activity) {
-        AlertDialog.Builder(activity)
+        MaterialAlertDialogBuilder(activity)
                 .setCancelable(false)
                 .setTitle(R.string.reading_list_turned_sync_off_dialog_title)
                 .setMessage(R.string.reading_list_turned_sync_off_dialog_text)
@@ -34,7 +34,7 @@ object ReadingListSyncBehaviorDialogs {
         val binding = DialogWithCheckboxBinding.inflate(activity.layoutInflater)
         binding.dialogMessage.text = StringUtil.fromHtml(activity.getString(R.string.reading_list_prompt_turned_sync_on_dialog_text))
         binding.dialogMessage.movementMethod = LinkMovementMethodExt { _ -> showAndroidAppFAQ(activity) }
-        AlertDialog.Builder(activity)
+        MaterialAlertDialogBuilder(activity)
                 .setCancelable(false)
                 .setTitle(R.string.reading_list_prompt_turned_sync_on_dialog_title)
                 .setView(binding.root)
@@ -54,7 +54,7 @@ object ReadingListSyncBehaviorDialogs {
         val binding = DialogWithCheckboxBinding.inflate(activity.layoutInflater)
         binding.dialogMessage.text = StringUtil.fromHtml(activity.getString(R.string.reading_lists_login_reminder_text_with_link))
         binding.dialogMessage.movementMethod = LinkMovementMethodExt { _ -> showAndroidAppFAQ(activity) }
-        AlertDialog.Builder(activity)
+        MaterialAlertDialogBuilder(activity)
                 .setCancelable(false)
                 .setTitle(R.string.reading_list_login_reminder_title)
                 .setView(binding.root)

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsReceiveSurveyHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsReceiveSurveyHelper.kt
@@ -3,7 +3,7 @@ package org.wikipedia.readinglist
 import android.app.Activity
 import android.content.Context
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.ReadingListsSharingAnalyticsHelper
@@ -39,7 +39,7 @@ object ReadingListsReceiveSurveyHelper {
     private fun showSurveyDialog(activity: Activity) {
         Prefs.readingListReceiveSurveyDialogShown = true
 
-        val dialog = AlertDialog.Builder(activity)
+        val dialog = MaterialAlertDialogBuilder(activity)
                 .setTitle(activity.getString(R.string.reading_list_share_survey_title))
                 .setMessage(StringUtil.fromHtml(activity.getString(R.string.reading_list_share_survey_body) +
                         "<br/><br/><small><a href=\"${getLanguageSpecificPrivacyPolicyUrl()}\">" +

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsShareSurveyHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsShareSurveyHelper.kt
@@ -3,7 +3,7 @@ package org.wikipedia.readinglist
 import android.app.Activity
 import android.content.Context
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.ReadingListsSharingAnalyticsHelper
@@ -39,7 +39,7 @@ object ReadingListsShareSurveyHelper {
     private fun showSurveyDialog(activity: Activity) {
         Prefs.readingListShareSurveyDialogShown = true
 
-        val dialog = AlertDialog.Builder(activity)
+        val dialog = MaterialAlertDialogBuilder(activity)
                 .setTitle(activity.getString(R.string.reading_list_share_survey_title))
                 .setMessage(StringUtil.fromHtml(activity.getString(R.string.reading_list_share_survey_body) +
                         "<br/><br/><small><a href=\"${getLanguageSpecificPrivacyPolicyUrl()}\">" +

--- a/app/src/main/java/org/wikipedia/readinglist/RemoveFromReadingListsDialog.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/RemoveFromReadingListsDialog.kt
@@ -1,7 +1,7 @@
 package org.wikipedia.readinglist
 
 import android.content.Context
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.readinglist.database.ReadingList
@@ -30,7 +30,7 @@ class RemoveFromReadingListsDialog(private val listsContainingPage: List<Reading
 
     private fun showDialog(context: Context, callback: Callback?) {
         val selectedLists = BooleanArray(listsContainingPage.size)
-        AlertDialog.Builder(context)
+        MaterialAlertDialogBuilder(context)
             .setTitle(R.string.reading_list_remove_from_lists)
             .setPositiveButton(R.string.reading_list_remove_list_dialog_ok_button_text) { _, _ ->
                 val newLists = (listsContainingPage zip selectedLists.asIterable())
@@ -48,7 +48,6 @@ class RemoveFromReadingListsDialog(private val listsContainingPage: List<Reading
             .setMultiChoiceItems(listsContainingPage.map { it.title }.toTypedArray(), selectedLists) { _, which, checked ->
                 selectedLists[which] = checked
             }
-            .create()
             .show()
     }
 }

--- a/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.kt
@@ -5,13 +5,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isInvisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.*
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -47,7 +47,7 @@ class RecentSearchesFragment : Fragment() {
         _binding = FragmentSearchRecentBinding.inflate(inflater, container, false)
 
         binding.recentSearchesDeleteButton.setOnClickListener {
-            AlertDialog.Builder(requireContext())
+            MaterialAlertDialogBuilder(requireContext())
                     .setMessage(getString(R.string.clear_recent_searches_confirm))
                     .setPositiveButton(getString(R.string.clear_recent_searches_confirm_yes)) { _, _ ->
                         lifecycleScope.launch(coroutineExceptionHandler) {
@@ -58,7 +58,7 @@ class RecentSearchesFragment : Fragment() {
                         }
                     }
                     .setNegativeButton(getString(R.string.clear_recent_searches_confirm_no), null)
-                    .create().show()
+                    .show()
         }
         binding.addLanguagesButton.setOnClickListener { onAddLangButtonClick() }
         binding.recentSearchesRecycler.layoutManager = LinearLayoutManager(requireActivity())

--- a/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.kt
+++ b/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.kt
@@ -1,9 +1,9 @@
 package org.wikipedia.settings
 
 import android.content.DialogInterface
-import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
@@ -79,7 +79,7 @@ internal class DeveloperSettingsPreferenceLoader(fragment: PreferenceFragmentCom
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({ summary: PageSummary ->
-                        AlertDialog.Builder(activity)
+                        MaterialAlertDialogBuilder(activity)
                                 .setTitle(fromHtml(summary.displayTitle))
                                 .setMessage(fromHtml(summary.extract))
                                 .setPositiveButton("Go") { _: DialogInterface, _: Int ->
@@ -90,7 +90,7 @@ internal class DeveloperSettingsPreferenceLoader(fragment: PreferenceFragmentCom
                                 .show()
                     }
                     ) { throwable: Throwable ->
-                        AlertDialog.Builder(activity)
+                        MaterialAlertDialogBuilder(activity)
                                 .setMessage(throwable.message)
                                 .setPositiveButton(android.R.string.ok, null)
                                 .show()
@@ -103,7 +103,7 @@ internal class DeveloperSettingsPreferenceLoader(fragment: PreferenceFragmentCom
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({ (_, second) ->
-                        AlertDialog.Builder(activity)
+                        MaterialAlertDialogBuilder(activity)
                                 .setTitle(fromHtml(second.displayTitle))
                                 .setMessage(fromHtml(second.description))
                                 .setPositiveButton("Go") { _: DialogInterface, _: Int ->
@@ -114,7 +114,7 @@ internal class DeveloperSettingsPreferenceLoader(fragment: PreferenceFragmentCom
                                 .show()
                     }
                     ) { throwable: Throwable ->
-                        AlertDialog.Builder(activity)
+                        MaterialAlertDialogBuilder(activity)
                                 .setMessage(throwable.message)
                                 .setPositiveButton(android.R.string.ok, null)
                                 .show()

--- a/app/src/main/java/org/wikipedia/settings/LogoutPreference.kt
+++ b/app/src/main/java/org/wikipedia/settings/LogoutPreference.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.Button
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
@@ -30,7 +30,7 @@ class LogoutPreference : Preference {
         holder.itemView.findViewById<TextView>(R.id.accountName).text = AccountUtil.userName
         holder.itemView.findViewById<Button>(R.id.logoutButton).setOnClickListener { view ->
             activity?.let {
-                AlertDialog.Builder(it)
+                MaterialAlertDialogBuilder(it)
                     .setMessage(R.string.logout_prompt)
                     .setNegativeButton(R.string.logout_dialog_cancel_button_text, null)
                     .setPositiveButton(R.string.preference_title_logout) { _, _ ->

--- a/app/src/main/java/org/wikipedia/settings/SettingsPreferenceLoader.kt
+++ b/app/src/main/java/org/wikipedia/settings/SettingsPreferenceLoader.kt
@@ -2,10 +2,10 @@ package org.wikipedia.settings
 
 import android.content.DialogInterface
 import android.content.Intent
-import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -73,7 +73,7 @@ internal class SettingsPreferenceLoader(fragment: PreferenceFragmentCompat) : Ba
                     (preference as SwitchPreferenceCompat).isChecked = true
                     ReadingListSyncAdapter.setSyncEnabledWithSetup()
                 } else {
-                    AlertDialog.Builder(activity)
+                    MaterialAlertDialogBuilder(activity)
                             .setTitle(activity.getString(R.string.preference_dialog_of_turning_off_reading_list_sync_title, AccountUtil.userName))
                             .setMessage(activity.getString(R.string.preference_dialog_of_turning_off_reading_list_sync_text, AccountUtil.userName))
                             .setPositiveButton(R.string.reading_lists_confirm_remote_delete_yes, DeleteRemoteListsYesListener(preference))
@@ -81,7 +81,7 @@ internal class SettingsPreferenceLoader(fragment: PreferenceFragmentCompat) : Ba
                             .show()
                 }
             } else {
-                AlertDialog.Builder(activity)
+                MaterialAlertDialogBuilder(activity)
                         .setTitle(R.string.reading_list_preference_login_to_enable_sync_dialog_title)
                         .setMessage(R.string.reading_list_preference_login_to_enable_sync_dialog_text)
                         .setPositiveButton(R.string.reading_list_preference_login_to_enable_sync_dialog_login

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.kt
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.*
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.core.os.bundleOf
@@ -15,6 +14,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
@@ -322,7 +322,7 @@ class WikipediaLanguagesFragment : Fragment(), MenuProvider, WikipediaLanguagesI
 
     fun showRemoveLanguagesDialog() {
         if (selectedCodes.size > 0) {
-            AlertDialog.Builder(requireActivity()).let {
+            MaterialAlertDialogBuilder(requireActivity()).let {
                 if (selectedCodes.size < wikipediaLanguages.size) {
                     it
                     .setTitle(resources.getQuantityString(R.plurals.wikipedia_languages_remove_dialog_title, selectedCodes.size))

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -8,10 +8,10 @@ import android.text.TextWatcher
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
 import androidx.core.util.lruCache
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.activity.BaseActivity
@@ -292,7 +292,7 @@ class TalkReplyActivity : BaseActivity(), LinkPreviewDialog.Callback, UserMentio
         setResult(RESULT_BACK_FROM_TOPIC)
         if (viewModel.isNewTopic && (!binding.replySubjectText.text.isNullOrEmpty() ||
                     !binding.replyInputView.editText.text.isNullOrEmpty())) {
-            AlertDialog.Builder(this)
+            MaterialAlertDialogBuilder(this)
                 .setCancelable(false)
                 .setTitle(R.string.talk_new_topic_exit_dialog_title)
                 .setMessage(R.string.talk_new_topic_exit_dialog_message)

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.talk
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -16,6 +15,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.activity.BaseActivity
@@ -321,7 +321,7 @@ class TalkTopicActivity : BaseActivity(), LinkPreviewDialog.Callback {
             if (AccountUtil.isLoggedIn) {
                 viewModel.toggleSubscription()
             } else {
-                AlertDialog.Builder(this@TalkTopicActivity)
+                MaterialAlertDialogBuilder(this@TalkTopicActivity)
                     .setTitle(R.string.talk_login_to_subscribe_dialog_title)
                     .setMessage(R.string.talk_login_to_subscribe_dialog_content)
                     .setPositiveButton(R.string.login_join_wikipedia) { _, _ ->

--- a/app/src/main/java/org/wikipedia/talk/UserTalkPopupHelper.kt
+++ b/app/src/main/java/org/wikipedia/talk/UserTalkPopupHelper.kt
@@ -2,7 +2,6 @@ package org.wikipedia.talk
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.app.AlertDialog
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
@@ -10,6 +9,7 @@ import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuPopupHelper
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,7 +28,6 @@ import org.wikipedia.page.linkpreview.LinkPreviewDialog
 import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.usercontrib.UserContribListActivity
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.log.L
 
 @SuppressLint("RestrictedApi")
@@ -69,7 +68,7 @@ object UserTalkPopupHelper {
         val parent = FrameLayout(activity)
         val editHistoryInteractionEvent = EditHistoryInteractionEvent(title.wikiSite.dbName(), pageId)
         val dialog =
-            AlertDialog.Builder(activity)
+            MaterialAlertDialogBuilder(activity)
                 .setView(parent)
                 .setPositiveButton(R.string.thank_dialog_positive_button_text) { _, _ ->
                     sendThanks(activity, title.wikiSite, revisionId, title, editHistoryInteractionEvent)
@@ -79,9 +78,6 @@ object UserTalkPopupHelper {
                 }
                 .create()
         dialog.layoutInflater.inflate(R.layout.view_thank_dialog, parent)
-        dialog.setOnShowListener {
-            dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(ResourceUtil.getThemedColor(activity, R.attr.placeholder_color))
-        }
         dialog.show()
     }
 

--- a/app/src/main/java/org/wikipedia/views/EditNoticesDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/EditNoticesDialog.kt
@@ -1,7 +1,7 @@
 package org.wikipedia.views
 
 import android.annotation.SuppressLint
-import android.content.Context
+import android.app.Activity
 import android.net.Uri
 import android.view.View
 import android.view.ViewGroup
@@ -9,6 +9,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.databinding.DialogEditNoticesBinding
 import org.wikipedia.dataclient.WikiSite
@@ -23,10 +24,11 @@ import org.wikipedia.util.log.L
 class EditNoticesDialog constructor(
         val wikiSite: WikiSite,
         val editNotices: List<String>,
-        context: Context
-) : AlertDialog(context) {
+        activity: Activity
+) : MaterialAlertDialogBuilder(activity) {
 
-    private val binding = DialogEditNoticesBinding.inflate(layoutInflater)
+    private val binding = DialogEditNoticesBinding.inflate(activity.layoutInflater)
+    private var dialog: AlertDialog? = null
 
     private val movementMethod = LinkMovementMethodExt { urlStr ->
         L.v("Link clicked was $urlStr")
@@ -35,7 +37,7 @@ class EditNoticesDialog constructor(
 
     init {
         setView(binding.root)
-        binding.editNoticeCloseButton.setOnClickListener { dismiss() }
+        binding.editNoticeCloseButton.setOnClickListener { dialog?.dismiss() }
 
         binding.editNoticeRecycler.adapter = EditNoticesAdapter()
         binding.editNoticeRecycler.layoutManager = LinearLayoutManager(context)
@@ -43,6 +45,11 @@ class EditNoticesDialog constructor(
 
         binding.editNoticeCheckbox.isChecked = Prefs.autoShowEditNotices
         binding.editNoticeCheckbox.setOnCheckedChangeListener { _, isChecked -> Prefs.autoShowEditNotices = isChecked }
+    }
+
+    override fun show(): AlertDialog {
+        dialog = super.show()
+        return dialog!!
     }
 
     private inner class EditNoticesAdapter : RecyclerView.Adapter<DefaultViewHolder>() {

--- a/app/src/main/java/org/wikipedia/views/SuggestedArticleDescriptionsDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/SuggestedArticleDescriptionsDialog.kt
@@ -1,28 +1,28 @@
 package org.wikipedia.views
 
-import android.content.Context
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
+import android.app.Activity
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.analytics.eventplatform.MachineGeneratedArticleDescriptionsAnalyticsHelper
 import org.wikipedia.databinding.DialogArticleDescriptionsBinding
 import org.wikipedia.page.PageTitle
 
 class SuggestedArticleDescriptionsDialog(
-    context: Context,
+    activity: Activity,
     firstSuggestion: String,
     secondSuggestion: String?,
     private val pageTitle: PageTitle,
     private val analyticsHelper: MachineGeneratedArticleDescriptionsAnalyticsHelper,
     callback: Callback
-) : AlertDialog(context) {
+) : MaterialAlertDialogBuilder(activity) {
 
     fun interface Callback {
         fun onSuggestionClicked(suggestion: String)
     }
 
-    private val binding = DialogArticleDescriptionsBinding.inflate(layoutInflater)
+    private val binding = DialogArticleDescriptionsBinding.inflate(activity.layoutInflater)
+    private var dialog: AlertDialog? = null
     private var suggestionChosen = false
 
     init {
@@ -30,26 +30,25 @@ class SuggestedArticleDescriptionsDialog(
         binding.firstSuggestion.text = firstSuggestion
         binding.secondSuggestionLayout.isVisible = secondSuggestion != null
         secondSuggestion?.let { binding.secondSuggestion.text = it }
-        window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
-        binding.closeButton.setOnClickListener { dismiss() }
+        binding.closeButton.setOnClickListener { dialog?.dismiss() }
         binding.firstSuggestion.setOnClickListener {
             callback.onSuggestionClicked(binding.firstSuggestion.text.toString())
             suggestionChosen = true
-            dismiss()
+            dialog?.dismiss()
         }
         binding.secondSuggestion.setOnClickListener {
             callback.onSuggestionClicked(binding.secondSuggestion.text.toString())
             suggestionChosen = true
-            dismiss()
+            dialog?.dismiss()
         }
 
         binding.firstSuggestionFlag.setOnClickListener {
-            SuggestedArticleDescriptionsReportDialog(context, binding.firstSuggestion.text.toString(), pageTitle, analyticsHelper) { dismiss() }.show()
+            SuggestedArticleDescriptionsReportDialog(activity, binding.firstSuggestion.text.toString(), pageTitle, analyticsHelper) { dialog?.dismiss() }.show()
         }
 
         binding.secondSuggestionFlag.setOnClickListener {
-            SuggestedArticleDescriptionsReportDialog(context, binding.secondSuggestion.text.toString(), pageTitle, analyticsHelper) { dismiss() }.show()
+            SuggestedArticleDescriptionsReportDialog(activity, binding.secondSuggestion.text.toString(), pageTitle, analyticsHelper) { dialog?.dismiss() }.show()
         }
 
         setOnDismissListener {
@@ -57,6 +56,11 @@ class SuggestedArticleDescriptionsDialog(
                 analyticsHelper.logSuggestionsDismissed(context, pageTitle)
             }
         }
+    }
+
+    override fun show(): AlertDialog {
+        dialog = super.show()
+        return dialog!!
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/views/SuggestedArticleDescriptionsReportDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/SuggestedArticleDescriptionsReportDialog.kt
@@ -1,10 +1,8 @@
 package org.wikipedia.views
 
 import android.app.Activity
-import android.content.Context
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.MachineGeneratedArticleDescriptionsAnalyticsHelper
 import org.wikipedia.databinding.DialogDescriptionSuggestionReportBinding
@@ -12,41 +10,51 @@ import org.wikipedia.page.PageTitle
 import org.wikipedia.util.FeedbackUtil
 
 class SuggestedArticleDescriptionsReportDialog(
-    context: Context,
+    activity: Activity,
     suggestion: String,
     private val pageTitle: PageTitle,
     private val analyticsHelper: MachineGeneratedArticleDescriptionsAnalyticsHelper,
     callback: Callback
-) : AlertDialog(context) {
+) : MaterialAlertDialogBuilder(activity) {
 
     fun interface Callback {
         fun onReportClick()
     }
 
     private var reported = false
-    private val binding = DialogDescriptionSuggestionReportBinding.inflate(layoutInflater)
+    private val binding = DialogDescriptionSuggestionReportBinding.inflate(activity.layoutInflater)
+    private var dialog: AlertDialog? = null
 
     init {
         setView(binding.root)
-        window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-        binding.reportButton.setOnClickListener {
+
+        setPositiveButton(context.getString(R.string.suggested_edits_report_suggestion)) { _, _ ->
             if (getReportReasons().isNotEmpty()) {
                 analyticsHelper.logSuggestionReported(context, suggestion, getReportReasons(), pageTitle)
                 FeedbackUtil.makeSnackbar(context as Activity, context.getString(R.string.suggested_edits_suggestion_report_submitted)).show()
                 callback.onReportClick()
                 reported = true
-                dismiss()
+                dialog?.dismiss()
             }
         }
+
+        setNegativeButton(context.getString(R.string.text_input_dialog_cancel_button_text)) { _, _ ->
+            dialog?.dismiss()
+        }
+
         binding.suggestionReportOther.setEndIconOnClickListener {
             binding.suggestionReportOther.editText?.text?.clear()
         }
-        binding.cancelButton.setOnClickListener { dismiss() }
         setOnDismissListener {
             if (!reported) {
                 analyticsHelper.logReportDialogDismissed(context)
             }
         }
+    }
+
+    override fun show(): AlertDialog {
+        dialog = super.show()
+        return dialog!!
     }
 
     private fun getReportReasons(): List<String> {

--- a/app/src/main/res/drawable/dialog_16dp_radius_background.xml
+++ b/app/src/main/res/drawable/dialog_16dp_radius_background.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid
-        android:color="?attr/paper_color"/>
-    <corners
-        android:radius="16dp" />
-
-</shape>

--- a/app/src/main/res/layout/dialog_article_descriptions.xml
+++ b/app/src/main/res/layout/dialog_article_descriptions.xml
@@ -1,107 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="24dp"
-    android:background="@drawable/dialog_16dp_radius_background"
     android:paddingStart="20dp"
     android:paddingEnd="4dp"
     android:paddingTop="12dp"
     android:paddingBottom="12dp"
+    android:orientation="vertical"
     android:clipChildren="false"
     android:clipToPadding="false">
 
     <LinearLayout
-        android:id="@+id/descriptionsContainer"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:fontFamily="sans-serif"
+            android:gravity="center"
+            android:text="@string/suggested_edits_article_descriptions_dialog_title"
+            android:textColor="?attr/primary_color"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/closeButton"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/dialog_close_description"
+            android:padding="12dp"
+            app:srcCompat="@drawable/ic_close_black_24dp"
+            app:tint="?attr/primary_color" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:orientation="vertical">
+        android:gravity="center_vertical">
 
-        <LinearLayout
-            android:layout_width="match_parent"
+        <com.google.android.material.chip.Chip
+            android:id="@+id/firstSuggestion"
+            style="@style/Chip.Accessible"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical">
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center"
+            android:padding="8dp" />
 
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:fontFamily="sans-serif"
-                android:gravity="center"
-                android:text="@string/suggested_edits_article_descriptions_dialog_title"
-                android:textColor="?attr/primary_color"
-                android:textSize="20sp"
-                android:textStyle="bold" />
-
-            <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/closeButton"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/dialog_close_description"
-                android:padding="12dp"
-                app:srcCompat="@drawable/ic_close_black_24dp"
-                app:tint="?attr/primary_color" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:clipChildren="false"
-            android:clipToPadding="false"
-            android:gravity="center_vertical">
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/firstSuggestion"
-                style="@style/Chip.Accessible"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:background="?attr/selectableItemBackground"
-                android:gravity="center"
-                android:padding="8dp" />
-
-            <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/firstSuggestionFlag"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/article_header_edit_description"
-                android:padding="16dp"
-                app:srcCompat="@drawable/ic_report_flag"
-                app:tint="?attr/primary_color" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/secondSuggestionLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="12dp"
-            android:clipToPadding="false"
-            android:gravity="center_vertical">
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/secondSuggestion"
-                style="@style/Chip.Accessible"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:background="?attr/selectableItemBackground"
-                android:padding="8dp" />
-
-            <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/secondSuggestionFlag"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:padding="16dp"
-                app:srcCompat="@drawable/ic_report_flag"
-                app:tint="?attr/primary_color" />
-        </LinearLayout>
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/firstSuggestionFlag"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/article_header_edit_description"
+            android:padding="16dp"
+            app:srcCompat="@drawable/ic_report_flag"
+            app:tint="?attr/primary_color" />
     </LinearLayout>
-</FrameLayout>
+
+    <LinearLayout
+        android:id="@+id/secondSuggestionLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="12dp"
+        android:clipToPadding="false"
+        android:gravity="center_vertical">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/secondSuggestion"
+            style="@style/Chip.Accessible"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackground"
+            android:padding="8dp" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/secondSuggestionFlag"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:padding="16dp"
+            app:srcCompat="@drawable/ic_report_flag"
+            app:tint="?attr/primary_color" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_description_suggestion_report.xml
+++ b/app/src/main/res/layout/dialog_description_suggestion_report.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_margin="24dp"
-    android:background="@drawable/dialog_16dp_radius_background"
     android:orientation="vertical"
     android:padding="24dp">
 
@@ -99,59 +98,31 @@
         android:layout_height="1dp"
         android:background="?attr/border_color" />
 
-    <FrameLayout
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/suggestionReportOther"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="7dp"
-        android:paddingBottom="7dp">
+        android:layout_marginTop="8dp"
+        android:gravity="start"
+        android:hint="@string/edit_summary_tag_other"
+        android:textAlignment="viewStart"
+        app:endIconDrawable="@drawable/chip_close_button_dark"
+        app:endIconMode="custom"
+        app:endIconTint="?attr/placeholder_color"
+        app:errorTextAppearance="@style/TextInputLayoutErrorTextAppearance">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/suggestionReportOther"
+        <org.wikipedia.views.PlainPasteEditText
+            android:id="@+id/suggestionReportOtherEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:gravity="start"
-            android:hint="@string/edit_summary_tag_other"
-            android:textAlignment="viewStart"
-            app:endIconDrawable="@drawable/chip_close_button_dark"
-            app:endIconMode="custom"
-            app:endIconTint="?attr/placeholder_color"
-            app:errorTextAppearance="@style/TextInputLayoutErrorTextAppearance">
+            android:imeOptions="flagNoExtractUi|actionDone"
+            android:inputType="textMultiLine"
+            android:lineSpacingExtra="6sp"
+            android:maxLength="@integer/description_max_chars"
+            android:textSize="16sp">
 
-            <org.wikipedia.views.PlainPasteEditText
-                android:id="@+id/suggestionReportOtherEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:imeOptions="flagNoExtractUi|actionDone"
-                android:inputType="textMultiLine"
-                android:lineSpacingExtra="6sp"
-                android:maxLength="@integer/description_max_chars"
-                android:textSize="16sp">
+            <requestFocus />
+        </org.wikipedia.views.PlainPasteEditText>
+    </com.google.android.material.textfield.TextInputLayout>
 
-                <requestFocus />
-            </org.wikipedia.views.PlainPasteEditText>
-        </com.google.android.material.textfield.TextInputLayout>
-    </FrameLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end">
-
-        <TextView
-            android:id="@+id/cancelButton"
-            style="@style/AlertDialogButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="24dp"
-            android:text="@string/text_input_dialog_cancel_button_text" />
-
-        <TextView
-            android:id="@+id/reportButton"
-            style="@style/AlertDialogButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/suggested_edits_report_suggestion"
-            android:textColor="?attr/colorAccent" />
-    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_with_checkbox.xml
+++ b/app/src/main/res/layout/dialog_with_checkbox.xml
@@ -8,7 +8,7 @@
 
     <org.wikipedia.views.AppTextView
         android:id="@+id/dialog_message"
-        style="@style/P.DialogText"
+        style="@style/P.DialogBody"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
@@ -16,7 +16,7 @@
 
     <CheckBox
         android:id="@+id/dialog_checkbox"
-        style="@style/P.DialogText"
+        style="@style/P.DialogBody"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"

--- a/app/src/main/res/layout/view_card_announcement.xml
+++ b/app/src/main/res/layout/view_card_announcement.xml
@@ -55,7 +55,8 @@
                 style="@style/FlatButton.Small"
                 android:layout_marginEnd="8dp"
                 app:iconSize="20dp"
-                app:iconTint="?attr/progressive_color"/>
+                app:iconTint="?attr/progressive_color"
+                tools:text="Lorem ipsum"/>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/view_announcement_action_negative"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,7 +20,7 @@
         <item name="android:listViewStyle">@style/ListView</item>
         <item name="android:textViewStyle">@style/RtlAwareTextView</item>
 
-        <item name="alertDialogTheme">@style/AlertDialogStyle</item>
+        <item name="materialAlertDialogTheme">@style/AlertDialogTheme</item>
         <item name="materialButtonStyle">@style/Widget.MaterialComponents.Button.TextButton</item>
         <item name="maxActionInlineWidth">@dimen/snackbar_action_inline_max_dimen</item>
         <item name="textInputStyle">@style/TextInputLayoutStyle</item>
@@ -105,7 +105,11 @@
         <item name="lineHeight">24sp</item>
     </style>
 
-    <style name="H2.DialogTitleStyle">
+    <style name="H2.DialogTitle" parent="MaterialAlertDialog.Material3.Title.Text">
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">20sp</item>
+        <item name="lineHeight">28sp</item>
         <item name="android:textColor">?attr/primary_color</item>
         <item name="android:layout_marginBottom">5dp</item>
     </style>
@@ -173,7 +177,10 @@
         <item name="lineHeight">28sp</item>
     </style>
 
-    <style name="P.DialogText">
+    <style name="P.DialogBody" parent="MaterialAlertDialog.Material3.Body.Text">
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:textSize">16sp</item>
+        <item name="lineHeight">24sp</item>
         <item name="android:textColor">?attr/secondary_color</item>
     </style>
 
@@ -582,13 +589,11 @@
         <item name="android:dropDownVerticalOffset">@dimen/popup_menu_drop_down_vertical_offset</item>
     </style>
 
-    <style name="AlertDialogStyle" parent="ThemeOverlay.Material3.MaterialAlertDialog">
-        <item name="backgroundTint">?attr/paper_color</item>
-        <item name="android:textColorPrimary">?attr/secondary_color</item>
-        <item name="android:windowTitleStyle">@style/H2.DialogTitleStyle</item>
-        <item name="android:textAppearanceMedium">@style/H2</item>
-        <item name="textColorAlertDialogListItem">?attr/secondary_color</item>
-        <item name="android:lineSpacingExtra">@dimen/dialog_line_spacing_extra</item>
+    <style name="AlertDialogTheme" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="colorSurface">?attr/paper_color</item>
+        <item name="elevationOverlayEnabled">false</item>
+        <item name="materialAlertDialogTitleTextStyle">@style/H2.DialogTitle</item>
+        <item name="materialAlertDialogBodyTextStyle">@style/P.DialogBody</item>
     </style>
 
     <style name="SnackbarStyle" parent="Widget.Material3.Snackbar">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,8 +21,6 @@
         <item name="android:textViewStyle">@style/RtlAwareTextView</item>
 
         <item name="alertDialogTheme">@style/AlertDialogStyle</item>
-        <!-- Theme for dialog after long pressing on internal links -->
-        <item name="android:alertDialogTheme">@style/LongPressAlertDialogStyle</item>
         <item name="materialButtonStyle">@style/Widget.MaterialComponents.Button.TextButton</item>
         <item name="maxActionInlineWidth">@dimen/snackbar_action_inline_max_dimen</item>
         <item name="textInputStyle">@style/TextInputLayoutStyle</item>
@@ -37,7 +35,7 @@
         <item name="android:textColorTertiary">?attr/placeholder_color</item>
         <item name="android:textColorHint">?attr/placeholder_color</item>
 
-        <item name="colorPrimary">?attr/placeholder_color</item>
+        <item name="colorPrimary">?attr/progressive_color</item>
         <item name="colorAccent">?attr/progressive_color</item>
         <item name="colorError">?attr/destructive_color</item>
 
@@ -297,21 +295,6 @@
         <item name="android:visibility">gone</item>
         <item name="android:layout_marginStart">-48dp</item>
         <item name="actionModeCloseDrawable">@drawable/ic_arrow_back_black_24dp</item>
-    </style>
-
-    <style name="AlertDialogButtonStyle" parent="Widget.Material3.Button.TextButton.Dialog">
-        <item name="android:textAlignment">textEnd</item>
-        <item name="android:minWidth">0dp</item>
-        <item name="android:paddingStart">16dp</item>
-        <item name="android:paddingEnd">16dp</item>
-    </style>
-
-    <style name="NegativeButtonStyle" parent="AlertDialogButtonStyle">
-        <item name="android:textColor">?attr/progressive_color</item>
-    </style>
-
-    <style name="PositiveButtonStyle" parent="AlertDialogButtonStyle">
-        <item name="android:textColor">?attr/progressive_color</item>
     </style>
 
     <style name="TabToolbarTheme" parent="@style/ThemeOverlay.Material3.ActionBar">
@@ -599,20 +582,13 @@
         <item name="android:dropDownVerticalOffset">@dimen/popup_menu_drop_down_vertical_offset</item>
     </style>
 
-    <style name="AlertDialogStyle" parent="ThemeOverlay.Material3.Dialog.Alert">
-        <item name="android:colorBackground">?attr/paper_color</item>
+    <style name="AlertDialogStyle" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="backgroundTint">?attr/paper_color</item>
         <item name="android:textColorPrimary">?attr/secondary_color</item>
         <item name="android:windowTitleStyle">@style/H2.DialogTitleStyle</item>
         <item name="android:textAppearanceMedium">@style/H2</item>
-        <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
-        <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
         <item name="textColorAlertDialogListItem">?attr/secondary_color</item>
         <item name="android:lineSpacingExtra">@dimen/dialog_line_spacing_extra</item>
-    </style>
-
-    <style name="LongPressAlertDialogStyle" parent="AlertDialogStyle">
-        <item name="android:backgroundTint">?attr/paper_color</item>
-        <item name="android:background">?attr/paper_color</item>
     </style>
 
     <style name="SnackbarStyle" parent="Widget.Material3.Snackbar">


### PR DESCRIPTION
(to be merged into the Material3 branch)
This converts all our usages of `AlertDialog` to the newer `MaterialAlertDialogBuilder`, which automatically inherits Material3 styles.