### PR TITLE
Fix: hide descriptions button conditionally for group1 users

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -258,6 +258,9 @@ class DescriptionEditFragment : Fragment() {
                     analyticsHelper.displayOrderList = listOfNotNull(firstSuggestion, secondSuggestion)
                     binding.fragmentDescriptionEditView.showSuggestedDescriptionsButton(firstSuggestion, secondSuggestion)
                     analyticsHelper.logSuggestionsShown(requireContext(), pageTitle)
+                } else {
+                    binding.fragmentDescriptionEditView.isSuggestionButtonEnabled = false
+                    binding.fragmentDescriptionEditView.updateSuggestedDescriptionsButtonVisibility()
                 }
             }
         }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -415,8 +415,10 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
         binding.suggestedDescButton.chipIcon = CircularProgressDrawable(ResourceUtil.getThemedColor(context, R.attr.primary_color), 1).also { it.start() }
     }
 
-    private fun updateSuggestedDescriptionsButtonVisibility() {
-        binding.suggestedDescButton.isVisible = binding.viewDescriptionEditTextLayout.error.isNullOrEmpty() && isSuggestionButtonEnabled
+     fun updateSuggestedDescriptionsButtonVisibility() {
+        binding.root.post {
+            binding.suggestedDescButton.isVisible = binding.viewDescriptionEditTextLayout.error.isNullOrEmpty() && isSuggestionButtonEnabled
+        }
     }
 
     fun showSuggestedDescriptionsButton(firstSuggestion: String, secondSuggestion: String?) {


### PR DESCRIPTION
In cases where group1 users see blp articles, the spinners shows endlessly.
This fix hides the spinner once blp check is done

**Phab:** https://phabricator.wikimedia.org/T333733#8765947