### PR TITLE
Fix/update snackbar styles.

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,9 +15,7 @@
         <item name="actionBarStyle">@style/ToolbarStyle</item>
         <item name="popupTheme">@style/ToolbarPopupTheme</item>
         <item name="actionModeStyle">@style/ActionModeStyle</item>
-        <item name="snackbarStyle">@style/SnackbarStyle</item>
-        <item name="snackbarTextViewStyle">@style/H3.Button.SnackbarTextView</item>
-        <item name="snackbarButtonStyle">@style/SnackbarButtonStyle</item>
+        <item name="snackbarTextViewStyle">@style/SnackbarTextView</item>
 
         <item name="autoCompleteTextViewStyle">@style/SearchViewEditTextStyle</item>
         <item name="android:listViewStyle">@style/ListView</item>
@@ -135,14 +133,6 @@
         <item name="android:textStyle">normal</item>
     </style>
 
-    <style name="H3.Button.SnackbarTextView">
-        <item name="android:maxLines">10</item>
-        <item name="android:paddingTop">0dp</item>
-        <item name="android:paddingBottom">0dp</item>
-        <item name="android:paddingStart">0dp</item>
-        <item name="android:paddingEnd">12dp</item>
-    </style>
-
     <style name="H3.Article">
         <item name="android:fontFamily">serif</item>
         <item name="android:textStyle">normal</item>
@@ -184,6 +174,16 @@
 
     <style name="P.MaterialListTitle">
         <item name="android:textColor">?attr/primary_color</item>
+    </style>
+
+    <style name="SnackbarTextView">
+        <item name="android:textColor">@color/gray200</item>
+        <item name="android:maxLines">10</item>
+        <item name="lineHeight">26sp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
+        <item name="android:paddingStart">4dp</item>
+        <item name="android:paddingEnd">8dp</item>
     </style>
 
     <style name="Chip">
@@ -658,15 +658,6 @@
     <style name="LongPressAlertDialogStyle" parent="AlertDialogStyle">
         <item name="android:backgroundTint">?attr/paper_color</item>
         <item name="android:background">?attr/paper_color</item>
-    </style>
-
-    <style name="SnackbarStyle" parent="Widget.MaterialComponents.Snackbar">
-        <item name="android:paddingStart">16dp</item>
-        <item name="android:paddingEnd">4dp</item>
-    </style>
-
-    <style name="SnackbarButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
-        <item name="android:paddingEnd">8dp</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This is to follow up on the big color consolidation, and it looks like Snackbars got a bit broken, showing slightly incorrect colors and typeface.
This brings our Snackbars back to their correct state before the consolidation.