### PR TITLE
Fix swipe background of History items.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/PageItemView.kt
+++ b/app/src/main/java/org/wikipedia/views/PageItemView.kt
@@ -6,9 +6,9 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.core.widget.TextViewCompat
 import com.google.android.material.chip.Chip
@@ -21,7 +21,7 @@ import org.wikipedia.util.*
  * TODO: Use this for future RecyclerView updates where we show a list of pages
  * (e.g. History, Search, Disambiguation)
  */
-class PageItemView<T>(context: Context) : ConstraintLayout(context) {
+class PageItemView<T>(context: Context) : FrameLayout(context) {
     interface Callback<T> {
         fun onClick(item: T?)
         fun onLongClick(item: T?): Boolean
@@ -29,7 +29,7 @@ class PageItemView<T>(context: Context) : ConstraintLayout(context) {
         fun onListChipClick(readingList: ReadingList)
     }
 
-    private val binding = ItemPageListEntryBinding.inflate(LayoutInflater.from(context), this)
+    private val binding = ItemPageListEntryBinding.inflate(LayoutInflater.from(context), this, true)
     private var imageUrl: String? = null
     private var selected = false
     var callback: Callback<T?>? = null
@@ -37,8 +37,7 @@ class PageItemView<T>(context: Context) : ConstraintLayout(context) {
 
     init {
         layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        setPadding(0, DimenUtil.roundedDpToPx(16f), 0, DimenUtil.roundedDpToPx(16f))
-        setBackgroundResource(ResourceUtil.getThemedAttributeId(context, R.attr.selectableItemBackground))
+        setBackgroundColor(ResourceUtil.getThemedColor(context, R.attr.paper_color))
         isFocusable = true
         setOnClickListeners()
         DeviceUtil.setContextClickAsLongClick(this)
@@ -69,7 +68,7 @@ class PageItemView<T>(context: Context) : ConstraintLayout(context) {
         if (selected) {
             binding.pageListItemSelectedImage.visibility = VISIBLE
             binding.pageListItemImage.visibility = GONE
-            setBackgroundColor(ResourceUtil.getThemedColor(context, R.attr.background_color))
+            binding.pageListItemContainer.setBackgroundColor(ResourceUtil.getThemedColor(context, R.attr.background_color))
         } else {
             if (imageUrl.isNullOrEmpty()) {
                 binding.pageListItemImage.visibility = GONE
@@ -79,7 +78,7 @@ class PageItemView<T>(context: Context) : ConstraintLayout(context) {
                 ViewUtil.loadImageWithRoundedCorners(binding.pageListItemImage, imageUrl)
             }
             binding.pageListItemSelectedImage.visibility = GONE
-            setBackgroundResource(ResourceUtil.getThemedAttributeId(context, R.attr.selectableItemBackground))
+            binding.pageListItemContainer.setBackgroundResource(ResourceUtil.getThemedAttributeId(context, R.attr.selectableItemBackground))
         }
     }
 

--- a/app/src/main/res/layout/item_page_list_entry.xml
+++ b/app/src/main/res/layout/item_page_list_entry.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:layout_height="wrap_content"
-    tools:layout_width="match_parent"
-    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+    android:id="@+id/page_list_item_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="16dp"
+    android:paddingBottom="16dp"
+    android:background="?attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/page_list_item_title"
@@ -123,4 +126,4 @@
             app:singleLine="true"
             app:singleSelection="true" />
     </HorizontalScrollView>
-</merge>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
You might have noticed that when you go to the History (Search) tab, and try to "swipe" items to remove them, they have a weird transparency that shows the red background incorrectly.
This fixes that.