### PR TITLE
Revert "Use Files methods in OfflineCacheInterceptor. (#3874)"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,7 +182,7 @@ dependencies {
     String espressoVersion = '3.5.1'
     String serialization_version = '1.4.0'
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.2'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"


### PR DESCRIPTION
This reverts #3874 by @Isira-Seneviratne, since it's causing sporadic crashes on a subset of devices in our Beta track.
The `desugar_jdk_libs_nio` library is _not mature enough_ for us to use. We do not need it.