### PR TITLE
Fix search execution when entering from intent.

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -267,7 +267,7 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
                 return@postDelayed
             }
             searchResultsFragment.startSearch(term, force)
-        }, if (invokeSource == InvokeSource.VOICE) VOICE_SEARCH_DELAY_MILLIS else 0)
+        }, if (invokeSource == InvokeSource.VOICE || invokeSource == InvokeSource.INTENT_SHARE || invokeSource == InvokeSource.INTENT_PROCESS_TEXT) INTENT_DELAY_MILLIS else 0)
     }
 
     private fun openSearch() {
@@ -363,7 +363,7 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
         private const val ARG_QUERY = "lastQuery"
         private const val PANEL_RECENT_SEARCHES = 0
         private const val PANEL_SEARCH_RESULTS = 1
-        private const val VOICE_SEARCH_DELAY_MILLIS = 500L
+        private const val INTENT_DELAY_MILLIS = 500L
         const val RESULT_LANG_CHANGED = 1
         const val LANG_BUTTON_TEXT_SIZE_LARGER = 12
         const val LANG_BUTTON_TEXT_SIZE_MEDIUM = 10


### PR DESCRIPTION
I believe this broke because of us updating `SearchResultsFragment` to use a ViewModel, while the main `SearchFragment` itself doesn't yet use a ViewModel, and so there may be some clashes of lifecycle events.

https://phabricator.wikimedia.org/T335139