### PR TITLE
Remove unnecessary explicit IO dispatching from coroutines.

### DIFF
--- a/app/src/main/java/org/wikipedia/categories/CategoryDialogViewModel.kt
+++ b/app/src/main/java/org/wikipedia/categories/CategoryDialogViewModel.kt
@@ -6,9 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.page.PageTitle
 import org.wikipedia.util.Resource
@@ -26,15 +24,13 @@ class CategoryDialogViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             categoriesData.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                val response = ServiceFactory.get(pageTitle.wikiSite).getCategories(pageTitle.prefixedText)
-                val titles = response.query?.pages?.map { page ->
-                    PageTitle(page.title, pageTitle.wikiSite).also {
-                        it.displayText = page.displayTitle(pageTitle.wikiSite.languageCode)
-                    }
-                }.orEmpty()
-                categoriesData.postValue(Resource.Success(titles))
-            }
+            val response = ServiceFactory.get(pageTitle.wikiSite).getCategories(pageTitle.prefixedText)
+            val titles = response.query?.pages?.map { page ->
+                PageTitle(page.title, pageTitle.wikiSite).also {
+                    it.displayText = page.displayTitle(pageTitle.wikiSite.languageCode)
+                }
+            }.orEmpty()
+            categoriesData.postValue(Resource.Success(titles))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -59,39 +59,37 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             revisionDetails.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                if (watchedStatus.value !is Resource.Success) {
-                    val query = ServiceFactory.get(pageTitle.wikiSite).getWatchedStatusWithRights(pageTitle.prefixedText).query!!
-                    val page = query.firstPage()!!
-                    if (pageId < 0) {
-                        pageId = page.pageId
-                    }
-                    watchedStatus.postValue(Resource.Success(page))
-                    hasRollbackRights = query.userInfo?.rights?.contains("rollback") == true
-                    rollbackRights.postValue(Resource.Success(hasRollbackRights))
+            if (watchedStatus.value !is Resource.Success) {
+                val query = ServiceFactory.get(pageTitle.wikiSite).getWatchedStatusWithRights(pageTitle.prefixedText).query!!
+                val page = query.firstPage()!!
+                if (pageId < 0) {
+                    pageId = page.pageId
                 }
-                if (revisionIdFrom >= 0) {
-                    val responseFrom = async { ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsWithInfo(pageId.toString(), 2, revisionIdFrom) }
-                    val responseTo = async { ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsWithInfo(pageId.toString(), 2, revisionIdTo) }
-                    val pageTo = responseTo.await().query?.firstPage()!!
-                    revisionFrom = responseFrom.await().query?.firstPage()!!.revisions[0]
-                    revisionTo = pageTo.revisions[0]
-                    canGoForward = revisionTo!!.revId < pageTo.lastrevid
-                } else {
-                    val response = ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsWithInfo(pageId.toString(), 2, revisionIdTo)
-                    val page = response.query?.firstPage()!!
-                    val revisions = page.revisions
-                    revisionTo = revisions[0]
-                    canGoForward = revisions[0].revId < page.lastrevid
-                    revisionFrom = revisions.getOrNull(1)
-                }
-
-                revisionToId = revisionTo!!.revId
-                revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
-
-                revisionDetails.postValue(Resource.Success(Unit))
-                getDiffText(revisionFromId, revisionToId)
+                watchedStatus.postValue(Resource.Success(page))
+                hasRollbackRights = query.userInfo?.rights?.contains("rollback") == true
+                rollbackRights.postValue(Resource.Success(hasRollbackRights))
             }
+            if (revisionIdFrom >= 0) {
+                val responseFrom = async { ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsWithInfo(pageId.toString(), 2, revisionIdFrom) }
+                val responseTo = async { ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsWithInfo(pageId.toString(), 2, revisionIdTo) }
+                val pageTo = responseTo.await().query?.firstPage()!!
+                revisionFrom = responseFrom.await().query?.firstPage()!!.revisions[0]
+                revisionTo = pageTo.revisions[0]
+                canGoForward = revisionTo!!.revId < pageTo.lastrevid
+            } else {
+                val response = ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsWithInfo(pageId.toString(), 2, revisionIdTo)
+                val page = response.query?.firstPage()!!
+                val revisions = page.revisions
+                revisionTo = revisions[0]
+                canGoForward = revisions[0].revId < page.lastrevid
+                revisionFrom = revisions.getOrNull(1)
+            }
+
+            revisionToId = revisionTo!!.revId
+            revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
+
+            revisionDetails.postValue(Resource.Success(Unit))
+            getDiffText(revisionFromId, revisionToId)
         }
     }
 
@@ -105,21 +103,19 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             revisionDetails.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                val response = ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsAscending(null, pageId.toString(), 2, revisionIdFrom)
-                val page = response.query?.firstPage()!!
-                val revisions = page.revisions
+            val response = ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsAscending(null, pageId.toString(), 2, revisionIdFrom)
+            val page = response.query?.firstPage()!!
+            val revisions = page.revisions
 
-                revisionFrom = revisions[0]
-                revisionTo = revisions.getOrElse(1) { revisions.first() }
-                canGoForward = revisions.size > 1 && revisions[1].revId < page.lastrevid
+            revisionFrom = revisions[0]
+            revisionTo = revisions.getOrElse(1) { revisions.first() }
+            canGoForward = revisions.size > 1 && revisions[1].revId < page.lastrevid
 
-                revisionToId = revisionTo!!.revId
-                revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
+            revisionToId = revisionTo!!.revId
+            revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
 
-                revisionDetails.postValue(Resource.Success(Unit))
-                getDiffText(revisionFromId, revisionToId)
-            }
+            revisionDetails.postValue(Resource.Success(Unit))
+            getDiffText(revisionFromId, revisionToId)
         }
     }
 
@@ -130,19 +126,17 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             diffText.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                if (pageTitle.wikiSite.uri.authority == Uri.parse(Service.WIKIDATA_URL).authority) {
-                    // For the special case of Wikidata we return a blank Revision object, since the
-                    // Rest API in Wikidata cannot render diffs properly yet.
-                    // TODO: wait until Wikidata API returns diffs correctly
-                    singleRevisionText.postValue(Resource.Success(Revision()))
-                } else if (oldRevisionId > 0) {
-                    diffText.postValue(Resource.Success(ServiceFactory.getCoreRest(pageTitle.wikiSite).getDiff(oldRevisionId, newRevisionId)))
-                } else {
-                    singleRevisionText.postValue(Resource.Success(ServiceFactory.getCoreRest(pageTitle.wikiSite).getRevision(newRevisionId)))
-                }
-                diffRevisionId = newRevisionId
+            if (pageTitle.wikiSite.uri.authority == Uri.parse(Service.WIKIDATA_URL).authority) {
+                // For the special case of Wikidata we return a blank Revision object, since the
+                // Rest API in Wikidata cannot render diffs properly yet.
+                // TODO: wait until Wikidata API returns diffs correctly
+                singleRevisionText.postValue(Resource.Success(Revision()))
+            } else if (oldRevisionId > 0) {
+                diffText.postValue(Resource.Success(ServiceFactory.getCoreRest(pageTitle.wikiSite).getDiff(oldRevisionId, newRevisionId)))
+            } else {
+                singleRevisionText.postValue(Resource.Success(ServiceFactory.getCoreRest(pageTitle.wikiSite).getRevision(newRevisionId)))
             }
+            diffRevisionId = newRevisionId
         }
     }
 
@@ -150,10 +144,8 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             thankStatus.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                val token = ServiceFactory.get(wikiSite).getToken().query?.csrfToken()
-                thankStatus.postValue(Resource.Success(ServiceFactory.get(wikiSite).postThanksToRevision(revisionId, token!!)))
-            }
+            val token = ServiceFactory.get(wikiSite).getToken().query?.csrfToken()
+            thankStatus.postValue(Resource.Success(ServiceFactory.get(wikiSite).postThanksToRevision(revisionId, token!!)))
         }
     }
 
@@ -161,18 +153,16 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             watchResponse.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                val token = ServiceFactory.get(pageTitle.wikiSite).getWatchToken().query?.watchToken()
-                val response = ServiceFactory.get(pageTitle.wikiSite)
-                        .watch(if (unwatch) 1 else null, null, pageTitle.prefixedText, expiry.expiry, token!!)
+            val token = ServiceFactory.get(pageTitle.wikiSite).getWatchToken().query?.watchToken()
+            val response = ServiceFactory.get(pageTitle.wikiSite)
+                    .watch(if (unwatch) 1 else null, null, pageTitle.prefixedText, expiry.expiry, token!!)
 
-                lastWatchExpiry = expiry
-                if (watchlistExpiryChanged && unwatch) {
-                    watchlistExpiryChanged = false
-                }
-
-                watchResponse.postValue(Resource.Success(response))
+            lastWatchExpiry = expiry
+            if (watchlistExpiryChanged && unwatch) {
+                watchlistExpiryChanged = false
             }
+
+            watchResponse.postValue(Resource.Success(response))
         }
     }
 
@@ -180,15 +170,13 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             undoEditResponse.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                val msgResponse = ServiceFactory.get(title.wikiSite).getMessages("undo-summary", "$revisionId|$user")
-                val undoMessage = msgResponse.query?.allmessages?.find { it.name == "undo-summary" }?.content
-                val summary = if (undoMessage != null) "$undoMessage $comment" else comment
-                val token = ServiceFactory.get(title.wikiSite).getToken().query!!.csrfToken()!!
-                val undoResponse = ServiceFactory.get(title.wikiSite).postUndoEdit(title.prefixedText, summary,
-                        null, token, revisionId, if (revisionIdAfter > 0) revisionIdAfter else null)
-                undoEditResponse.postValue(Resource.Success(undoResponse))
-            }
+            val msgResponse = ServiceFactory.get(title.wikiSite).getMessages("undo-summary", "$revisionId|$user")
+            val undoMessage = msgResponse.query?.allmessages?.find { it.name == "undo-summary" }?.content
+            val summary = if (undoMessage != null) "$undoMessage $comment" else comment
+            val token = ServiceFactory.get(title.wikiSite).getToken().query!!.csrfToken()!!
+            val undoResponse = ServiceFactory.get(title.wikiSite).postUndoEdit(title.prefixedText, summary,
+                    null, token, revisionId, if (revisionIdAfter > 0) revisionIdAfter else null)
+            undoEditResponse.postValue(Resource.Success(undoResponse))
         }
     }
 
@@ -196,11 +184,9 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             rollbackResponse.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                val rollbackToken = ServiceFactory.get(title.wikiSite).getToken("rollback").query!!.rollbackToken()!!
-                val rollbackPostResponse = ServiceFactory.get(title.wikiSite).postRollback(title.prefixedText, null, user, rollbackToken)
-                rollbackResponse.postValue(Resource.Success(rollbackPostResponse))
-            }
+            val rollbackToken = ServiceFactory.get(title.wikiSite).getToken("rollback").query!!.rollbackToken()!!
+            val rollbackPostResponse = ServiceFactory.get(title.wikiSite).postRollback(title.prefixedText, null, user, rollbackToken)
+            rollbackResponse.postValue(Resource.Success(rollbackPostResponse))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryFragment.kt
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryFragment.kt
@@ -18,9 +18,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.chip.Chip
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.R
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.FragmentPreviewSummaryBinding
@@ -123,12 +121,10 @@ class EditSummaryFragment : Fragment() {
             lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
                 L.e(throwable)
             }) {
-                withContext(Dispatchers.IO) {
-                    val query = ServiceFactory.get(title.wikiSite)
-                        .getWatchedStatusWithUserOptions(title.prefixedText).query!!
-                    binding.watchPageCheckBox.isChecked = query.firstPage()!!.watched ||
-                            query.userInfo?.options?.watchDefault == 1
-                }
+                val query = ServiceFactory.get(title.wikiSite)
+                    .getWatchedStatusWithUserOptions(title.prefixedText).query!!
+                binding.watchPageCheckBox.isChecked = query.firstPage()!!.watched ||
+                        query.userInfo?.options?.watchDefault == 1
             }
         } else {
             binding.watchPageCheckBox.isEnabled = false

--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.kt
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.kt
@@ -29,7 +29,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import org.wikipedia.BackPressedHandler
 import org.wikipedia.Constants
 import org.wikipedia.R
@@ -144,9 +143,7 @@ class HistoryFragment : Fragment(), BackPressedHandler {
     private fun onClearHistoryClick() {
         lifecycleScope.launch {
             try {
-                withContext(Dispatchers.IO) {
-                    AppDatabase.instance.historyEntryDao().deleteAll()
-                }
+                AppDatabase.instance.historyEntryDao().deleteAll()
             } finally {
                 reloadHistoryItems()
             }
@@ -196,9 +193,9 @@ class HistoryFragment : Fragment(), BackPressedHandler {
 
     private fun deleteSelectedPages() {
         val selectedEntryList = mutableListOf<HistoryEntry>()
-        for (entry in selectedEntries) {
-            selectedEntryList.add(entry)
-            runBlocking(Dispatchers.IO) {
+        selectedEntryList.addAll(selectedEntries)
+        runBlocking(Dispatchers.IO) {
+            for (entry in selectedEntries) {
                 AppDatabase.instance.historyEntryDao().delete(entry)
             }
         }
@@ -213,9 +210,9 @@ class HistoryFragment : Fragment(), BackPressedHandler {
         val message = if (entries.size == 1) getString(R.string.history_item_deleted, entries[0].title.displayText) else getString(R.string.history_items_deleted, entries.size)
         val snackbar = FeedbackUtil.makeSnackbar(requireActivity(), message)
         snackbar.setAction(R.string.history_item_delete_undo) {
-            lifecycleScope.launch(Dispatchers.IO) {
+            lifecycleScope.launch(Dispatchers.Main) {
                 AppDatabase.instance.historyEntryDao().insert(entries)
-                withContext(Dispatchers.Main) { reloadHistoryItems() }
+                reloadHistoryItems()
             }
         }
         snackbar.show()

--- a/app/src/main/java/org/wikipedia/language/LangLinksViewModel.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksViewModel.kt
@@ -34,13 +34,11 @@ class LangLinksViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             languageEntries.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                val response = ServiceFactory.get(pageTitle.wikiSite).getLangLinks(pageTitle.prefixedText)
-                val langLinks = response.query!!.langLinks()
-                updateLanguageEntriesSupported(langLinks)
-                sortLanguageEntriesByMru(langLinks)
-                languageEntries.postValue(Resource.Success(langLinks))
-            }
+            val response = ServiceFactory.get(pageTitle.wikiSite).getLangLinks(pageTitle.prefixedText)
+            val langLinks = response.query!!.langLinks()
+            updateLanguageEntriesSupported(langLinks)
+            sortLanguageEntriesByMru(langLinks)
+            languageEntries.postValue(Resource.Success(langLinks))
         }
     }
 
@@ -48,11 +46,9 @@ class LangLinksViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             languageEntries.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                val summary = ServiceFactory.getRest(title.wikiSite).getPageSummary(null, title.prefixedText)
-                title.displayText = summary.displayTitle
-                languageEntryVariantUpdate.postValue(Resource.Success(Unit))
-            }
+            val summary = ServiceFactory.getRest(title.wikiSite).getPageSummary(null, title.prefixedText)
+            title.displayText = summary.displayTitle
+            languageEntryVariantUpdate.postValue(Resource.Success(Unit))
         }
     }
 
@@ -60,11 +56,9 @@ class LangLinksViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             L.e(throwable)
         }) {
-            withContext(Dispatchers.IO) {
-                val siteMatrix = ServiceFactory.get(WikipediaApp.instance.wikiSite).getSiteMatrix()
-                val sites = SiteMatrix.getSites(siteMatrix)
-                siteListData.postValue(Resource.Success(sites))
-            }
+            val siteMatrix = ServiceFactory.get(WikipediaApp.instance.wikiSite).getSiteMatrix()
+            val sites = SiteMatrix.getSites(siteMatrix)
+            siteListData.postValue(Resource.Success(sites))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/language/LanguagesListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguagesListViewModel.kt
@@ -5,9 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.apache.commons.lang3.StringUtils
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -36,11 +34,9 @@ class LanguagesListViewModel : ViewModel() {
 
     private fun fetchData() {
         viewModelScope.launch(handler) {
-            withContext(Dispatchers.IO) {
-                val siteMatrix = ServiceFactory.get(WikipediaApp.instance.wikiSite).getSiteMatrix()
-                val sites = SiteMatrix.getSites(siteMatrix)
-                siteListData.postValue(Resource.Success(sites))
-            }
+            val siteMatrix = ServiceFactory.get(WikipediaApp.instance.wikiSite).getSiteMatrix()
+            val sites = SiteMatrix.getSites(siteMatrix)
+            siteListData.postValue(Resource.Success(sites))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/notifications/NotificationViewModel.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationViewModel.kt
@@ -3,11 +3,9 @@ package org.wikipedia.notifications
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.NotificationInteractionEvent
@@ -38,9 +36,7 @@ class NotificationViewModel : ViewModel() {
 
     init {
         viewModelScope.launch(handler) {
-            withContext(Dispatchers.IO) {
-                dbNameMap = notificationRepository.fetchUnreadWikiDbNames()
-            }
+            dbNameMap = notificationRepository.fetchUnreadWikiDbNames()
         }
     }
 
@@ -132,9 +128,7 @@ class NotificationViewModel : ViewModel() {
     fun fetchAndSave() {
         viewModelScope.launch(handler) {
             if (WikipediaApp.instance.isOnline) {
-                withContext(Dispatchers.IO) {
-                    currentContinueStr = notificationRepository.fetchAndSave(delimitedWikiList(), "read|!read", currentContinueStr)
-                }
+                currentContinueStr = notificationRepository.fetchAndSave(delimitedWikiList(), "read|!read", currentContinueStr)
             }
             collectionNotifications()
         }
@@ -186,9 +180,7 @@ class NotificationViewModel : ViewModel() {
             .map {
                 it.read = if (markUnread) null else Date().toString()
                 viewModelScope.launch(handler) {
-                    withContext(Dispatchers.IO) {
-                        notificationRepository.updateNotification(it)
-                    }
+                    notificationRepository.updateNotification(it)
                     collectionNotifications()
                 }
             }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -29,9 +29,7 @@ import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.float
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -539,9 +537,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     private fun addTimeSpentReading(timeSpentSec: Int) {
         model.curEntry?.let {
             lifecycleScope.launch(CoroutineExceptionHandler { _, throwable -> L.e(throwable) }) {
-                withContext(Dispatchers.IO) {
-                    AppDatabase.instance.historyEntryDao().upsertWithTimeSpent(it, timeSpentSec)
-                }
+                AppDatabase.instance.historyEntryDao().upsertWithTimeSpent(it, timeSpentSec)
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -9,7 +9,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
@@ -199,9 +198,7 @@ class PageFragmentLoadState(private var model: PageViewModel,
 
     private fun checkAnonNotifications(title: PageTitle) {
         CoroutineScope(Dispatchers.Main).launch {
-            val response = withContext(Dispatchers.IO) {
-                ServiceFactory.get(title.wikiSite).getLastModified(UserTalkAliasData.valueFor(title.wikiSite.languageCode) + ":" + Prefs.lastAnonUserWithMessages)
-            }
+            val response = ServiceFactory.get(title.wikiSite).getLastModified(UserTalkAliasData.valueFor(title.wikiSite.languageCode) + ":" + Prefs.lastAnonUserWithMessages)
             if (AnonymousNotificationHelper.anonTalkPageHasRecentMessage(response, title)) {
                 fragment.showAnonNotification()
             }

--- a/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
@@ -211,7 +211,7 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
             val section = getItem(position)
             val sectionHeading = newConvertView!!.findViewById<TextView>(R.id.page_toc_item_text)
             val sectionBullet = newConvertView.findViewById<View>(R.id.page_toc_item_bullet)
-            sectionHeading.text = StringUtil.fromHtml(section.title)
+            sectionHeading.text = StringUtil.fromHtml(StringUtil.removeStyleTags(section.title))
             var textSize = TOC_SUBSECTION_TEXT_SIZE
             when {
                 section.isLead -> {

--- a/app/src/main/java/org/wikipedia/readinglist/LongPressMenu.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/LongPressMenu.kt
@@ -12,7 +12,6 @@ import androidx.appcompat.widget.PopupMenu
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.database.AppDatabase
@@ -41,11 +40,9 @@ class LongPressMenu(private val anchorView: View, private val existsInAnyList: B
     fun show(entry: HistoryEntry?) {
         entry?.let {
             CoroutineScope(Dispatchers.Main).launch {
-                listsContainingPage = withContext(Dispatchers.IO) {
-                    AppDatabase.instance.readingListDao().getListsFromPageOccurrences(
+                listsContainingPage = AppDatabase.instance.readingListDao().getListsFromPageOccurrences(
                         AppDatabase.instance.readingListPageDao().getAllPageOccurrences(it.title)
                     )
-                }
                 if (!anchorView.isAttachedToWindow) {
                     return@launch
                 }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
@@ -325,9 +325,7 @@ class ReadingListFragment : Fragment(), MenuProvider, ReadingListItemActionsDial
                 // In this case, there's nothing for us to do, so just bail from the activity.
                 requireActivity().finish()
             }) {
-                val list = withContext(Dispatchers.IO) {
-                    AppDatabase.instance.readingListDao().getListById(readingListId, true)
-                }
+                val list = AppDatabase.instance.readingListDao().getListById(readingListId, true)
                 binding.readingListSwipeRefresh.isRefreshing = false
                 readingList = list
                 readingList?.let {

--- a/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.kt
@@ -51,9 +51,7 @@ class RecentSearchesFragment : Fragment() {
                     .setMessage(getString(R.string.clear_recent_searches_confirm))
                     .setPositiveButton(getString(R.string.clear_recent_searches_confirm_yes)) { _, _ ->
                         lifecycleScope.launch(coroutineExceptionHandler) {
-                            withContext(Dispatchers.IO) {
-                                AppDatabase.instance.recentSearchDao().deleteAll()
-                            }
+                            AppDatabase.instance.recentSearchDao().deleteAll()
                             updateList()
                         }
                     }
@@ -118,17 +116,13 @@ class RecentSearchesFragment : Fragment() {
         if (!namespaceMap.containsKey(langCode)) {
             val map = mutableMapOf<Namespace, String>()
             namespaceMap[langCode] = map
-            withContext(Dispatchers.IO) {
-                nsMap = ServiceFactory.get(WikiSite.forLanguageCode(langCode)).getPageNamespaceWithSiteInfo(null).query?.namespaces.orEmpty()
-                namespaceHints.forEach {
-                    map[it] = nsMap[it.code().toString()]?.name.orEmpty()
-                }
+            nsMap = ServiceFactory.get(WikiSite.forLanguageCode(langCode)).getPageNamespaceWithSiteInfo(null).query?.namespaces.orEmpty()
+            namespaceHints.forEach {
+                map[it] = nsMap[it.code().toString()]?.name.orEmpty()
             }
         }
 
-        withContext(Dispatchers.IO) {
-            searches = AppDatabase.instance.recentSearchDao().getRecentSearches()
-        }
+        searches = AppDatabase.instance.recentSearchDao().getRecentSearches()
 
         recentSearchList.clear()
         recentSearchList.addAll(searches)
@@ -157,9 +151,7 @@ class RecentSearchesFragment : Fragment() {
 
         override fun onSwipe() {
             lifecycleScope.launch(coroutineExceptionHandler) {
-                withContext(Dispatchers.IO) {
-                    AppDatabase.instance.recentSearchDao().delete(recentSearch)
-                }
+                AppDatabase.instance.recentSearchDao().delete(recentSearch)
                 updateList()
             }
         }

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -15,9 +15,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
@@ -331,9 +329,7 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
     private fun addRecentSearch(title: String?) {
         if (!title.isNullOrBlank()) {
             lifecycleScope.launch(CoroutineExceptionHandler { _, throwable -> throwable.printStackTrace() }) {
-                withContext(Dispatchers.IO) {
-                    AppDatabase.instance.recentSearchDao().insertRecentSearch(RecentSearch(text = title))
-                }
+                AppDatabase.instance.recentSearchDao().insertRecentSearch(RecentSearch(text = title))
                 recentSearchesFragment.updateList()
             }
         }

--- a/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
@@ -95,19 +95,15 @@ class SearchResultsViewModel : ViewModel() {
                         if (langCode == languageCode) {
                             resultsCount?.add(0)
                         } else {
-                            val prefixSearchResponse = withContext(Dispatchers.IO) {
-                                ServiceFactory.get(WikiSite.forLanguageCode(langCode))
+                            val prefixSearchResponse = ServiceFactory.get(WikiSite.forLanguageCode(langCode))
                                     .prefixSearch(searchTerm, params.loadSize, 0)
-                            }
                             var countResultSize = 0
                             prefixSearchResponse.query?.pages?.let {
                                 countResultSize = it.size
                             }
                             if (countResultSize == 0) {
-                                val fullTextSearchResponse = withContext(Dispatchers.IO) {
-                                    ServiceFactory.get(WikiSite.forLanguageCode(langCode))
+                                val fullTextSearchResponse = ServiceFactory.get(WikiSite.forLanguageCode(langCode))
                                         .fullTextSearch(searchTerm, null, params.loadSize, null)
-                                }
                                 countResultSize = fullTextSearchResponse.query?.pages?.size ?: 0
                             }
                             resultsCount?.add(countResultSize)

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicHolder.kt
@@ -10,7 +10,6 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.databinding.ItemTalkTopicBinding
@@ -125,9 +124,7 @@ class TalkTopicHolder internal constructor(
 
     private fun showOverflowMenu(anchorView: View) {
         CoroutineScope(Dispatchers.Main).launch {
-            val subscribed = withContext(Dispatchers.IO) {
-                viewModel.isSubscribed(threadItem.name)
-            }
+            val subscribed = viewModel.isSubscribed(threadItem.name)
             threadItem.subscribed = subscribed
             TalkTopicsActionsOverflowView(context).show(anchorView, threadItem, object : TalkTopicsActionsOverflowView.Callback {
                 override fun markAsReadClick() {

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
@@ -75,10 +75,8 @@ class TalkTopicsViewModel(var pageTitle: PageTitle, private val sidePanel: Boole
 
         viewModelScope.launch(handler) {
             if (resolveTitleRequired) {
-                val siteInfoResponse = withContext(Dispatchers.IO) {
-                    ServiceFactory.get(pageTitle.wikiSite).getPageNamespaceWithSiteInfo(pageTitle.prefixedText,
+                val siteInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getPageNamespaceWithSiteInfo(pageTitle.prefixedText,
                         OfflineCacheInterceptor.SAVE_HEADER_SAVE, pageTitle.wikiSite.languageCode, UriUtil.encodeURL(pageTitle.prefixedText))
-                }
                 resolveTitleRequired = false
                 siteInfoResponse.query?.namespaces?.let { namespaces ->
                     siteInfoResponse.query?.firstPage()?.let { page ->
@@ -95,20 +93,16 @@ class TalkTopicsViewModel(var pageTitle: PageTitle, private val sidePanel: Boole
                 }
             }
 
-            val discussionToolsInfoResponse = async {
-                ServiceFactory.get(pageTitle.wikiSite).getTalkPageTopics(pageTitle.prefixedText,
+            val discussionToolsInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getTalkPageTopics(pageTitle.prefixedText,
                     OfflineCacheInterceptor.SAVE_HEADER_SAVE, pageTitle.wikiSite.languageCode, UriUtil.encodeURL(pageTitle.prefixedText))
-            }
 
             threadItems.clear()
-            threadItems.addAll(discussionToolsInfoResponse.await().pageInfo?.threads ?: emptyList())
+            threadItems.addAll(discussionToolsInfoResponse.pageInfo?.threads ?: emptyList())
             sortAndFilterThreadItems()
 
             if (WikipediaApp.instance.isOnline) {
-                val watchStatus = withContext(Dispatchers.Default) {
-                    if (!sidePanel) ServiceFactory.get(pageTitle.wikiSite)
+                val watchStatus = if (!sidePanel) ServiceFactory.get(pageTitle.wikiSite)
                         .getWatchedStatus(pageTitle.prefixedText).query?.firstPage()!! else MwQueryPage()
-                }
                 isWatched = watchStatus.watched
                 hasWatchlistExpiry = watchStatus.hasWatchlistExpiry()
             }
@@ -208,23 +202,21 @@ class TalkTopicsViewModel(var pageTitle: PageTitle, private val sidePanel: Boole
 
     fun watchOrUnwatch(expiry: WatchlistExpiry, unwatch: Boolean) {
         viewModelScope.launch(actionHandler) {
-            withContext(Dispatchers.IO) {
-                val token = ServiceFactory.get(pageTitle.wikiSite).getWatchToken().query?.watchToken()
-                val response = ServiceFactory.get(pageTitle.wikiSite)
-                    .watch(if (unwatch) 1 else null, null, pageTitle.prefixedText, expiry.expiry, token!!)
+            val token = ServiceFactory.get(pageTitle.wikiSite).getWatchToken().query?.watchToken()
+            val response = ServiceFactory.get(pageTitle.wikiSite)
+                .watch(if (unwatch) 1 else null, null, pageTitle.prefixedText, expiry.expiry, token!!)
 
-                lastWatchExpiry = expiry
-                if (watchlistExpiryChanged && unwatch) {
-                    watchlistExpiryChanged = false
-                }
+            lastWatchExpiry = expiry
+            if (watchlistExpiryChanged && unwatch) {
+                watchlistExpiryChanged = false
+            }
 
-                response.getFirst()?.let {
-                    isWatched = it.watched
-                    hasWatchlistExpiry = lastWatchExpiry != WatchlistExpiry.NEVER
-                    // We have to send values to the object, even if we use the variables from ViewModel.
-                    // Otherwise the status will not be updated in the activity since the values in the object remains the same.
-                    uiState.value = UiState.DoWatch(isWatched, hasWatchlistExpiry)
-                }
+            response.getFirst()?.let {
+                isWatched = it.watched
+                hasWatchlistExpiry = lastWatchExpiry != WatchlistExpiry.NEVER
+                // We have to send values to the object, even if we use the variables from ViewModel.
+                // Otherwise the status will not be updated in the activity since the values in the object remains the same.
+                uiState.value = UiState.DoWatch(isWatched, hasWatchlistExpiry)
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/usercontrib/UserContribListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/usercontrib/UserContribListViewModel.kt
@@ -7,10 +7,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.paging.*
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.Service
@@ -82,13 +80,11 @@ class UserContribListViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             L.e(throwable)
         }) {
-            withContext(Dispatchers.IO) {
-                val messageName = "project-localized-name-${wikiSite.dbName()}"
-                val query = ServiceFactory.get(wikiSite).userInfoWithMessages(userName, messageName).query
+            val messageName = "project-localized-name-${wikiSite.dbName()}"
+            val query = ServiceFactory.get(wikiSite).userInfoWithMessages(userName, messageName).query
 
-                userContribStatsData.postValue(Resource.Success(UserContribStats(query?.users!![0].editCount,
-                        query.users[0].registrationDate, query.allmessages.orEmpty().getOrNull(0)?.content.orEmpty().ifEmpty { wikiSite.dbName() })))
-            }
+            userContribStatsData.postValue(Resource.Success(UserContribStats(query?.users!![0].editCount,
+                    query.users[0].registrationDate, query.allmessages.orEmpty().getOrNull(0)?.content.orEmpty().ifEmpty { wikiSite.dbName() })))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/util/ShareUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ShareUtil.kt
@@ -55,7 +55,7 @@ object ShareUtil {
 
     fun shareImage(context: Context, bmp: Bitmap,
                    imageFileName: String, subject: String, text: String) {
-        CoroutineScope(Dispatchers.Default).launch(CoroutineExceptionHandler { _, msg ->
+        CoroutineScope(Dispatchers.Main).launch(CoroutineExceptionHandler { _, msg ->
             run {
                 displayOnCatchMessage(msg, context)
             }

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistViewModel.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistViewModel.kt
@@ -75,13 +75,12 @@ class WatchlistViewModel : ViewModel() {
             watchlistItems = mutableListOf()
             displayLanguages.map { language ->
                 async {
-                    withContext(Dispatchers.IO) {
-                        ServiceFactory.get(WikiSite.forLanguageCode(language))
-                            .getWatchlist(latestRevisions(), showCriteriaString(), showTypesString())
-                    }.query?.watchlist?.map {
-                        it.wiki = WikiSite.forLanguageCode(language)
-                        watchlistItems.add(it)
-                    }
+                    ServiceFactory.get(WikiSite.forLanguageCode(language))
+                        .getWatchlist(latestRevisions(), showCriteriaString(), showTypesString())
+                        .query?.watchlist?.map {
+                            it.wiki = WikiSite.forLanguageCode(language)
+                            watchlistItems.add(it)
+                        }
                 }
             }.awaitAll()
             watchlistItems.sortByDescending { it.date }


### PR DESCRIPTION
When making Retrofit or Room calls from within a coroutine, it is not necessary to wrap it in an explicit `withContext(Dispatchers.IO) { }` block, since Retrofit and Room automatically provide main-safe `suspend` functions.

Pardon the size of this PR, but it's literally just removing a bunch of outer `withContext(Dispatchers.IO) {` calls that are redundant. Note the reduction in code size.