### PR TITLE
Enable local description editing for Test Wiki.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -276,7 +276,7 @@ class DescriptionEditFragment : Fragment() {
     private fun shouldWriteToLocalWiki(): Boolean {
         return (action == DescriptionEditActivity.Action.ADD_DESCRIPTION ||
                 action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION) &&
-                wikiUsesLocalDescriptions(pageTitle.wikiSite.languageCode)
+                DescriptionEditUtil.wikiUsesLocalDescriptions(pageTitle.wikiSite.languageCode)
     }
 
     private inner class EditViewCallback : DescriptionEditView.Callback {
@@ -551,10 +551,6 @@ class DescriptionEditFragment : Fragment() {
                         ARG_ACTION to action,
                         Constants.INTENT_EXTRA_INVOKE_SOURCE to source)
             }
-        }
-
-        fun wikiUsesLocalDescriptions(lang: String): Boolean {
-            return lang == "en"
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditLicenseView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditLicenseView.kt
@@ -41,7 +41,7 @@ class DescriptionEditLicenseView constructor(context: Context, attrs: AttributeS
 
     fun buildLicenseNotice(arg: String, lang: String? = null) {
         if ((arg == ARG_NOTICE_ARTICLE_DESCRIPTION || arg == ARG_NOTICE_DEFAULT) &&
-                DescriptionEditFragment.wikiUsesLocalDescriptions(lang.orEmpty())) {
+                DescriptionEditUtil.wikiUsesLocalDescriptions(lang.orEmpty())) {
             binding.licenseText.text = StringUtil.fromHtml(context.getString(R.string.edit_save_action_license_logged_in,
                     context.getString(R.string.terms_of_use_url),
                     context.getString(R.string.cc_by_sa_3_url)))

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditUtil.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditUtil.kt
@@ -7,8 +7,12 @@ object DescriptionEditUtil {
     private const val DESCRIPTION_SOURCE_LOCAL = "local"
     private const val DESCRIPTION_SOURCE_WIKIDATA = "central"
 
+    fun wikiUsesLocalDescriptions(lang: String): Boolean {
+        return lang == "en" || lang == "test"
+    }
+
     fun isEditAllowed(page: Page): Boolean {
-        return if (page.title.wikiSite.languageCode == "en") {
+        return if (wikiUsesLocalDescriptions(page.title.wikiSite.languageCode)) {
             // For English Wikipedia, allow editing the description for all articles, since the
             // edit will go directly into the article instead of Wikidata.
             true


### PR DESCRIPTION
This will make description editing on TestWiki articles behave more like English Wikipedia, where descriptions will be written to the article instead of Wikidata.
This will have the benefit of being able to test the Captcha workflow on TestWiki, by adding a description that is known to trigger captcha.

https://phabricator.wikimedia.org/T331027