### PR TITLE
Disable R8 full mode, and reenable minification.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,7 +95,7 @@ android {
             testProguardFiles 'test-proguard-rules.pro'
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             testProguardFiles 'test-proguard-rules.pro'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,5 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
+android.enableR8.fullMode=false
 org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M


### PR DESCRIPTION
When Android Studio upgraded the project to Gradle 8.0, it automatically enabled "full mode" in R8, which minifies the project too aggressively, stripping away things that are required at runtime. (We'll need to revisit our ProGuard rules if we want to actually enable full mode.)

This disables full mode explicitly (which is the same behavior as before gradle 8) and reenables minifying in production.