### PR TITLE
Underpinnings for updated Edit Notices API.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.kt
@@ -2,9 +2,13 @@ package org.wikipedia.dataclient.mwapi
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import org.wikipedia.dataclient.growthtasks.GrowthImageSuggestion
 import org.wikipedia.dataclient.page.Protection
 import org.wikipedia.gallery.ImageInfo
+import org.wikipedia.json.JsonUtil
 import org.wikipedia.page.Namespace
 import org.wikipedia.util.DateUtil
 
@@ -25,6 +29,7 @@ class MwQueryPage {
     private val thumbnail: Thumbnail? = null
     private val varianttitles: Map<String, String>? = null
     private val actions: Map<String, List<MwServiceError>>? = null
+    private val editintro: JsonElement? = null
 
     val index = 0
     var title: String = ""
@@ -74,6 +79,10 @@ class MwQueryPage {
 
     fun getErrorForAction(actionName: String): List<MwServiceError> {
         return actions?.get(actionName) ?: emptyList()
+    }
+
+    fun getEditNotices(): Map<String, String> {
+        return if (editintro != null && editintro is JsonObject) JsonUtil.json.decodeFromJsonElement(editintro) else emptyMap()
     }
 
     @Serializable


### PR DESCRIPTION
There will soon be a new API for getting edit notices directly, instead of relying indirectly on the existing visualeditor API.
This new API is not deployed to production yet, but we can start building the underpinnings regardless.

https://phabricator.wikimedia.org/T337101