### PR TITLE
Coroutinize user contribution stats.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -347,10 +347,10 @@ interface Service {
     ): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query&prop=pageviews")
-    fun getPageViewsForTitles(@Query("titles") titles: String): Observable<MwQueryResponse>
+    suspend fun getPageViewsForTitles(@Query("titles") titles: String): MwQueryResponse
 
-    @get:GET(MW_API_PREFIX + "action=query&meta=wikimediaeditortaskscounts|userinfo&uiprop=groups|blockinfo|editcount|latestcontrib")
-    val editorTaskCounts: Observable<MwQueryResponse>
+    @GET(MW_API_PREFIX + "action=query&meta=wikimediaeditortaskscounts|userinfo&uiprop=groups|blockinfo|editcount|latestcontrib")
+    suspend fun getEditorTaskCounts(): MwQueryResponse
 
     @FormUrlEncoded
     @POST(MW_API_PREFIX + "action=rollback")
@@ -389,7 +389,7 @@ interface Service {
     ): Observable<Claims>
 
     @GET(MW_API_PREFIX + "action=wbgetentities&props=descriptions|labels|sitelinks")
-    fun getWikidataLabelsAndDescriptions(@Query("ids") idList: String): Observable<Entities>
+    suspend fun getWikidataLabelsAndDescriptions(@Query("ids") idList: String): Entities
 
     @POST(MW_API_PREFIX + "action=wbsetclaim&errorlang=uselang")
     @FormUrlEncoded

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.kt
@@ -24,12 +24,12 @@ class MwQueryResult {
     @SerialName("allusers") val allUsers: List<UserInfo>? = null
     @SerialName("globaluserinfo") val globalUserInfo: UserInfo? = null
 
-    private val redirects: MutableList<Redirect>? = null
-    private val converted: MutableList<ConvertedTitle>? = null
+    private val redirects: List<Redirect>? = null
+    private val converted: List<ConvertedTitle>? = null
     private val tokens: Tokens? = null
     private val echomarkread: MarkReadResponse? = null
     val users: List<UserInfo>? = null
-    val pages: MutableList<MwQueryPage>? = null
+    val pages: List<MwQueryPage>? = null
     val echomarkseen: MarkReadResponse? = null
     val notifications: NotificationList? = null
     val watchlist: List<WatchlistItem> = emptyList()
@@ -75,7 +75,7 @@ class MwQueryResult {
         return users?.find { StringUtil.capitalize(userName) == it.name }
     }
 
-    fun langLinks(): MutableList<PageTitle> {
+    fun langLinks(): List<PageTitle> {
         val result = mutableListOf<PageTitle>()
         if (pages.isNullOrEmpty()) {
             return result

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
@@ -5,6 +5,10 @@ import android.os.Parcelable
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.wikipedia.Constants
 import org.wikipedia.WikipediaApp
@@ -47,7 +51,11 @@ class SuggestedEditsFeedClient : FeedClient {
         if (age == 0) {
             // In the background, fetch the user's latest contribution stats, so that we can update whether the
             // Suggested Edits feature is paused or disabled, the next time the feed is refreshed.
-            UserContribStats.getEditCountsObservable().subscribe()
+            CoroutineScope(Dispatchers.Main).launch {
+                withContext(Dispatchers.IO) {
+                    UserContribStats.verifyEditCountsAndPauseState()
+                }
+            }
         }
 
         if (UserContribStats.isDisabled() || UserContribStats.maybePauseAndGetEndDate() != null) {

--- a/app/src/main/java/org/wikipedia/language/LangLinksViewModel.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksViewModel.kt
@@ -35,7 +35,7 @@ class LangLinksViewModel(bundle: Bundle) : ViewModel() {
             languageEntries.postValue(Resource.Error(throwable))
         }) {
             val response = ServiceFactory.get(pageTitle.wikiSite).getLangLinks(pageTitle.prefixedText)
-            val langLinks = response.query!!.langLinks()
+            val langLinks = response.query!!.langLinks().toMutableList()
             updateLanguageEntriesSupported(langLinks)
             sortLanguageEntriesByMru(langLinks)
             languageEntries.postValue(Resource.Success(langLinks))

--- a/app/src/main/java/org/wikipedia/search/SearchResults.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResults.kt
@@ -6,9 +6,9 @@ import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.dataclient.mwapi.MwQueryResponse
 
 @Serializable
-data class SearchResults constructor(var results: MutableList<SearchResult> = ArrayList(),
+data class SearchResults constructor(var results: MutableList<SearchResult> = mutableListOf(),
                                      var continuation: MwQueryResponse.Continuation? = null) {
-    constructor(pages: MutableList<MwQueryPage>, wiki: WikiSite, continuation: MwQueryResponse.Continuation?) : this() {
+    constructor(pages: List<MwQueryPage>, wiki: WikiSite, continuation: MwQueryResponse.Continuation?) : this() {
         // Sort the array based on the "index" property
         results.addAll(pages.sortedBy { it.index }.map { SearchResult(it, wiki) })
         this.continuation = continuation

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragmentViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragmentViewModel.kt
@@ -3,12 +3,10 @@ package org.wikipedia.suggestededits
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
@@ -57,11 +55,12 @@ class SuggestedEditsTasksFragmentViewModel : ViewModel() {
             val homeSiteCall = async { ServiceFactory.get(WikipediaApp.instance.wikiSite).getUserContributions(AccountUtil.userName!!, 10, null) }
             val commonsCall = async { ServiceFactory.get(Constants.commonsWikiSite).getUserContributions(AccountUtil.userName!!, 10, null) }
             val wikidataCall = async { ServiceFactory.get(Constants.wikidataWikiSite).getUserContributions(AccountUtil.userName!!, 10, null) }
-            val editCountsCall = withContext(Dispatchers.IO) { UserContribStats.getEditCountsObservable().blockingSingle() }
+            val editCountsCall = async { UserContribStats.verifyEditCountsAndPauseState() }
 
             val homeSiteResponse = homeSiteCall.await()
             val commonsResponse = commonsCall.await()
             val wikidataResponse = wikidataCall.await()
+            editCountsCall.await()
 
             homeSiteResponse.query?.userInfo?.let {
                 if (it.isBlocked) {
@@ -100,9 +99,7 @@ class SuggestedEditsTasksFragmentViewModel : ViewModel() {
             )
             revertSeverity = UserContribStats.getRevertSeverity()
 
-            withContext(Dispatchers.IO) {
-                totalPageviews = UserContribStats.getPageViewsObservable(wikidataResponse).blockingSingle()
-            }
+            totalPageviews = UserContribStats.getPageViews(wikidataResponse)
 
             _uiState.value = UiState.Success()
         }


### PR DESCRIPTION
This refactors our `UserContribStats` functions to become `suspend` functions, and no longer rely on rxjava.
This will indirectly benefit transitioning to IP masking.