### PR TITLE
Configure Metrics Platform parameters more explicitly.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
@@ -4,6 +4,7 @@ import org.wikimedia.metrics_platform.MetricsClient
 import org.wikimedia.metrics_platform.context.AgentData
 import org.wikimedia.metrics_platform.context.ClientData
 import org.wikipedia.WikipediaApp
+import java.time.Duration
 
 object MetricsPlatform {
     private val agentData = AgentData(
@@ -19,5 +20,9 @@ object MetricsPlatform {
         WikipediaApp.instance.wikiSite.authority()
     )
 
-    val client: MetricsClient = MetricsClient.builder(clientData).build()
+    val client: MetricsClient = MetricsClient.builder(clientData)
+        .eventQueueCapacity(256)
+        .streamConfigFetchInterval(Duration.ofHours(12))
+        .sendEventsInterval(Duration.ofSeconds(30))
+        .build()
 }

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
@@ -4,6 +4,7 @@ import org.wikimedia.metrics_platform.MetricsClient
 import org.wikimedia.metrics_platform.context.AgentData
 import org.wikimedia.metrics_platform.context.ClientData
 import org.wikipedia.WikipediaApp
+import org.wikipedia.settings.Prefs
 import java.time.Duration
 
 object MetricsPlatform {
@@ -21,7 +22,7 @@ object MetricsPlatform {
     )
 
     val client: MetricsClient = MetricsClient.builder(clientData)
-        .eventQueueCapacity(256)
+        .eventQueueCapacity(Prefs.analyticsQueueSize)
         .streamConfigFetchInterval(Duration.ofHours(12))
         .sendEventsInterval(Duration.ofSeconds(30))
         .build()


### PR DESCRIPTION
This is just for us to have more explicit control of the timing and capacity of the Metrics Platform logic.
(In particular, the default Stream Config fetch delay in the library is 30 seconds, which is much too frequent.)