### PR TITLE
Send correct parameters to Metrics Platform AgentData.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
@@ -10,8 +10,8 @@ import java.time.Duration
 object MetricsPlatform {
     private val agentData = AgentData(
         WikipediaApp.instance.appInstallID,
-        "mobile app",
-        "android"
+        "android",
+        "app"
     )
 
     private val clientData = ClientData(


### PR DESCRIPTION
The existing parameters were incorrect (didn't match required enum values), and were resulting in server errors.