### PR TITLE
Follow-up to Image Tags exit warning.

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagEditActivity.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagEditActivity.kt
@@ -21,7 +21,7 @@ import org.wikipedia.util.ResourceUtil
 class SuggestedEditsImageTagEditActivity : BaseActivity(), SuggestedEditsItemFragment.Callback {
 
     private lateinit var binding: ActivitySuggestedEditsFeedCardImageTagsBinding
-    private var suggestedEditsImageTagsFragment: SuggestedEditsImageTagsFragment? = null
+    private lateinit var suggestedEditsImageTagsFragment: SuggestedEditsImageTagsFragment
     var page: MwQueryPage? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -34,11 +34,11 @@ class SuggestedEditsImageTagEditActivity : BaseActivity(), SuggestedEditsItemFra
         supportActionBar!!.title = getString(R.string.suggested_edits_tag_images)
         setImageZoomHelper()
 
-        suggestedEditsImageTagsFragment = supportFragmentManager.findFragmentById(R.id.imageTagFragment) as SuggestedEditsImageTagsFragment?
-        suggestedEditsImageTagsFragment?.invokeSource = intent.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as Constants.InvokeSource
+        suggestedEditsImageTagsFragment = supportFragmentManager.findFragmentById(R.id.imageTagFragment) as SuggestedEditsImageTagsFragment
+        suggestedEditsImageTagsFragment.invokeSource = intent.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as Constants.InvokeSource
 
-        binding.addContributionButton.setOnClickListener { suggestedEditsImageTagsFragment!!.publish() }
-        binding.addContributionLandscapeImage.setOnClickListener { suggestedEditsImageTagsFragment!!.publish() }
+        binding.addContributionButton.setOnClickListener { suggestedEditsImageTagsFragment.publish() }
+        binding.addContributionLandscapeImage.setOnClickListener { suggestedEditsImageTagsFragment.publish() }
         maybeShowOnboarding()
     }
 
@@ -51,13 +51,11 @@ class SuggestedEditsImageTagEditActivity : BaseActivity(), SuggestedEditsItemFra
     }
 
     override fun updateActionButton() {
-        if (suggestedEditsImageTagsFragment != null) {
-            binding.addContributionLandscapeImage.setBackgroundColor(ResourceUtil.getThemedColor(this, R.attr.progressive_color))
-            binding.addContributionButton.isEnabled = suggestedEditsImageTagsFragment!!.publishEnabled()
-            binding.addContributionLandscapeImage.isEnabled = suggestedEditsImageTagsFragment!!.publishEnabled()
-            binding.addContributionButton.alpha = if (suggestedEditsImageTagsFragment!!.publishEnabled()) 1f else 0.5f
-            binding.addContributionLandscapeImage.alpha = if (suggestedEditsImageTagsFragment!!.publishEnabled()) 1f else 0.5f
-        }
+        binding.addContributionLandscapeImage.setBackgroundColor(ResourceUtil.getThemedColor(this, R.attr.progressive_color))
+        binding.addContributionButton.isEnabled = suggestedEditsImageTagsFragment.publishEnabled()
+        binding.addContributionLandscapeImage.isEnabled = suggestedEditsImageTagsFragment.publishEnabled()
+        binding.addContributionButton.alpha = if (suggestedEditsImageTagsFragment.publishEnabled()) 1f else 0.5f
+        binding.addContributionLandscapeImage.alpha = if (suggestedEditsImageTagsFragment.publishEnabled()) 1f else 0.5f
 
         if (DimenUtil.isLandscape(this)) {
             binding.addContributionButton.visibility = GONE
@@ -85,11 +83,10 @@ class SuggestedEditsImageTagEditActivity : BaseActivity(), SuggestedEditsItemFra
     }
 
     override fun onBackPressed() {
-        if (suggestedEditsImageTagsFragment != null && suggestedEditsImageTagsFragment?.atLeastOneTagChecked()!!) {
-            SuggestedEditsImageTagsFragment.getExitWarningDialog(this).show()
-        } else {
-            super.onBackPressed()
+        if (!suggestedEditsImageTagsFragment.onBackPressed()) {
+            return
         }
+        super.onBackPressed()
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -1,7 +1,5 @@
 package org.wikipedia.suggestededits
 
-import android.app.Activity
-import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.Typeface
@@ -248,19 +246,18 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
         return chip
     }
 
-    companion object {
-        fun newInstance(): SuggestedEditsItemFragment {
-            return SuggestedEditsImageTagsFragment()
+    override fun onBackPressed(): Boolean {
+        if (!atLeastOneTagChecked()) {
+            return true
         }
-
-        fun getExitWarningDialog(context: Context): MaterialAlertDialogBuilder {
-            return MaterialAlertDialogBuilder(context)
-                .setCancelable(false)
-                .setTitle(R.string.talk_new_topic_exit_dialog_title)
-                .setMessage(R.string.suggested_edits_image_tags_exit_dialog_message)
-                .setPositiveButton(R.string.edit_abandon_confirm_yes) { _, _ -> (context as Activity).finish() }
-                .setNegativeButton(R.string.edit_abandon_confirm_no, null)
-        }
+        MaterialAlertDialogBuilder(requireActivity())
+            .setCancelable(false)
+            .setTitle(R.string.talk_new_topic_exit_dialog_title)
+            .setMessage(R.string.suggested_edits_image_tags_exit_dialog_message)
+            .setPositiveButton(R.string.edit_abandon_confirm_yes) { _, _ -> requireActivity().finish() }
+            .setNegativeButton(R.string.edit_abandon_confirm_no, null)
+            .show()
+        return false
     }
 
     override fun onClick(v: View?) {
@@ -457,7 +454,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
         }
     }
 
-    fun atLeastOneTagChecked(): Boolean {
+    private fun atLeastOneTagChecked(): Boolean {
         return binding.tagsChipGroup.children.filterIsInstance<Chip>().any { it.isChecked }
     }
 
@@ -474,5 +471,11 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
 
     private fun callback(): Callback {
         return FragmentUtil.getCallback(this, Callback::class.java)!!
+    }
+
+    companion object {
+        fun newInstance(): SuggestedEditsItemFragment {
+            return SuggestedEditsImageTagsFragment()
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsItemFragment.kt
@@ -39,4 +39,8 @@ abstract class SuggestedEditsItemFragment : Fragment() {
     }
 
     open fun publish() {}
+
+    open fun onBackPressed(): Boolean {
+        return true
+    }
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestionsActivity.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestionsActivity.kt
@@ -15,22 +15,19 @@ import org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTI
 import org.wikipedia.suggestededits.SuggestedEditsCardsFragment.Companion.newInstance
 
 class SuggestionsActivity : SingleFragmentActivity<SuggestedEditsCardsFragment>() {
-    private var suggestedEditsImageTagsFragment: SuggestedEditsImageTagsFragment? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         supportActionBar!!.title = getActionBarTitle(intent.getSerializableExtra(INTENT_EXTRA_ACTION) as Action)
-        suggestedEditsImageTagsFragment = supportFragmentManager.findFragmentById(R.id.imageTagFragment) as SuggestedEditsImageTagsFragment?
         setImageZoomHelper()
     }
 
     override fun onBackPressed() {
-        if (fragment.topBaseChild() is SuggestedEditsImageTagsFragment && (fragment.topBaseChild() as SuggestedEditsImageTagsFragment).atLeastOneTagChecked()) {
-                SuggestedEditsImageTagsFragment.getExitWarningDialog(this).show()
-        } else {
-            super.onBackPressed()
+        if (fragment.topBaseChild()?.onBackPressed() == false) {
+            return
         }
+        super.onBackPressed()
     }
 
     override fun createFragment(): SuggestedEditsCardsFragment {


### PR DESCRIPTION
This confines the responsibility of showing the popup dialog entirely to the specific `SuggestedEditsImageTagsFragment`, and abstracts away the `onBackPressed` handler to the superclass.