### PR TITLE
Fix: Tooltip button style

### DIFF
--- a/app/src/main/res/layout/view_plain_text_tooltip.xml
+++ b/app/src/main/res/layout/view_plain_text_tooltip.xml
@@ -25,7 +25,9 @@
             android:id="@+id/buttonView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            style="@style/App.Button.Secondary"
+            style="@style/Widget.Material3.Button"
+            android:textColor="?attr/progressive_color"
+            android:backgroundTint="?attr/paper_color"
             android:text="@string/onboarding_got_it"
             android:visibility="gone"
             tools:visibility="visible"/>


### PR DESCRIPTION
Looks like the Material button needs to inherit its style from ` style="@style/Widget.Material3.Button"` or else it is not getting the correct width.

Before fix:
![image](https://github.com/wikimedia/apps-android-wikipedia/assets/9540770/d8f13e26-ed2f-4891-a964-20c1ab96beb5)
After:
![image](https://github.com/wikimedia/apps-android-wikipedia/assets/9540770/dd05a95a-7276-4c4a-bded-42782f3a0b6a)
