### PR TITLE
Underpinnings for Logged-in Espresso tests using env variables.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,10 @@ android {
         buildConfigField "String", "META_WIKI_BASE_URI", '"https://meta.wikimedia.org"'
         buildConfigField "String", "EVENTGATE_ANALYTICS_EXTERNAL_BASE_URI", '"https://intake-analytics.wikimedia.org"'
         buildConfigField "String", "EVENTGATE_LOGGING_EXTERNAL_BASE_URI", '"https://intake-logging.wikimedia.org"'
+        def TEST_LOGIN_USERNAME = System.getenv('TEST_LOGIN_USERNAME')
+        def TEST_LOGIN_PASSWORD = System.getenv('TEST_LOGIN_PASSWORD')
+        buildConfigField "String", "TEST_LOGIN_USERNAME", TEST_LOGIN_USERNAME != null ? "\"${TEST_LOGIN_USERNAME}\"" : '"Foo"'
+        buildConfigField "String", "TEST_LOGIN_PASSWORD", TEST_LOGIN_PASSWORD != null ? "\"${TEST_LOGIN_PASSWORD}\"" : '"Bar"'
     }
 
     testOptions {
@@ -110,11 +114,6 @@ android {
             buildConfigField "String", "META_WIKI_BASE_URI", '"https://meta.wikimedia.beta.wmflabs.org"'
             buildConfigField "String", "EVENTGATE_ANALYTICS_EXTERNAL_BASE_URI", '"https://intake-analytics.wikimedia.beta.wmflabs.org"'
             buildConfigField "String", "EVENTGATE_LOGGING_EXTERNAL_BASE_URI", '"https://intake-logging.wikimedia.beta.wmflabs.org"'
-
-            def TEST_LOGIN_USERNAME = System.getenv('TEST_LOGIN_USERNAME')
-            def TEST_LOGIN_PASSWORD = System.getenv('TEST_LOGIN_PASSWORD')
-            buildConfigField "String", "TEST_LOGIN_USERNAME", TEST_LOGIN_USERNAME != null ? "\"${TEST_LOGIN_USERNAME}\"" : '"Foo"'
-            buildConfigField "String", "TEST_LOGIN_PASSWORD", TEST_LOGIN_PASSWORD != null ? "\"${TEST_LOGIN_PASSWORD}\"" : '"Bar"'
         }
         prod {
             versionName computeVersionName(defaultConfig.versionCode, 'r')

--- a/app/src/androidTest/java/org/wikipedia/main/LoggedInTests.kt
+++ b/app/src/androidTest/java/org/wikipedia/main/LoggedInTests.kt
@@ -12,6 +12,7 @@ import org.hamcrest.Matchers.allOf
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.wikipedia.BuildConfig
 import org.wikipedia.R
 import org.wikipedia.TestUtil
 
@@ -52,10 +53,10 @@ class LoggedInTests {
 
         // Type in an incorrect username and password
         onView(allOf(TestUtil.withGrandparent(withId(R.id.login_username_text)), withClassName(`is`("org.wikipedia.views.PlainPasteEditText"))))
-                .perform(replaceText("Foo"), closeSoftKeyboard())
+                .perform(replaceText(BuildConfig.TEST_LOGIN_USERNAME), closeSoftKeyboard())
 
         onView(allOf(TestUtil.withGrandparent(withId(R.id.login_password_input)), withClassName(`is`("org.wikipedia.views.PlainPasteEditText"))))
-                .perform(replaceText("Bar"), closeSoftKeyboard())
+                .perform(replaceText(BuildConfig.TEST_LOGIN_PASSWORD), closeSoftKeyboard())
 
         // Click the login button
         onView(withId(R.id.login_button))

--- a/app/src/androidTest/java/org/wikipedia/main/SmokeTests.kt
+++ b/app/src/androidTest/java/org/wikipedia/main/SmokeTests.kt
@@ -477,7 +477,7 @@ class SmokeTests {
         TestUtil.delay(1)
 
         // Go to Saved tab
-        onView(withId(NavTab.READING_LISTS.id())).perform(click())
+        onView(withId(NavTab.READING_LISTS.id)).perform(click())
 
         TestUtil.delay(1)
 


### PR DESCRIPTION
We will now be able to run Espresso tests where the workflow automatically logs itself in (through the LoginActivity), using credentials that are pulled from the system environment variables.

You (or an automated test system) must set the environment variables `TEST_LOGIN_USERNAME` and `TEST_LOGIN_PASSWORD` with the credentials, and they will become available as `BuildConfig` constants, ready to be used within a test that requires them.