### PR TITLE
Improve parsing and handling of diff links.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/LinkHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.kt
@@ -85,7 +85,7 @@ abstract class LinkHandler(protected val context: Context) : JSEventListener, Ur
                 onPageLinkClicked(uri.fragment!!, linkText)
             }
             !uri.getQueryParameter("title").isNullOrEmpty() && !uri.getQueryParameter("diff").isNullOrEmpty() && supportedAuthority -> {
-                onDiffLinkClicked(PageTitle(uri.getQueryParameter("title"), site), uri.getQueryParameter("diff")!!.toLong())
+                onDiffLinkClicked(PageTitle(uri.getQueryParameter("title"), site), uri.getQueryParameter("diff")?.toLongOrNull() ?: -1)
             }
             else -> {
                 onExternalLinkClicked(uri)

--- a/app/src/main/java/org/wikipedia/page/LinkHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.kt
@@ -85,7 +85,12 @@ abstract class LinkHandler(protected val context: Context) : JSEventListener, Ur
                 onPageLinkClicked(uri.fragment!!, linkText)
             }
             !uri.getQueryParameter("title").isNullOrEmpty() && !uri.getQueryParameter("diff").isNullOrEmpty() && supportedAuthority -> {
-                onDiffLinkClicked(PageTitle(uri.getQueryParameter("title"), site), uri.getQueryParameter("diff")?.toLongOrNull() ?: -1)
+                val diffAttr = uri.getQueryParameter("diff").orEmpty()
+                var diffRev = diffAttr.toLongOrNull() ?: -1
+                if (diffAttr == "next" || diffAttr == "prev") {
+                    diffRev = uri.getQueryParameter("oldid")?.toLongOrNull() ?: -1
+                }
+                onDiffLinkClicked(PageTitle(uri.getQueryParameter("title"), site), diffRev)
             }
             else -> {
                 onExternalLinkClicked(uri)


### PR DESCRIPTION
* This fixes a very obscure potential crash stemming from certain diff links.
* This also expands the types of diff links that can be handled by our `LinkHandler` and our Diff activity.

Our code was previously assuming that diff links always have a `diff=` attribute that equals the revision ID to diff against, like this:

https://en.wikipedia.org/w/index.php?title=User%3ADmitry_Brant%2Fsandbox&diff=1139503514&oldid=1132602357

But in fact, the `diff=` attribute can contain certain keywords, like `cur`, `prev`, and `next`:

https://en.wikipedia.org/w/index.php?title=User:Dmitry_Brant/sandbox&diff=cur&oldid=1139503514

These can now be handled by our code.