### PR TITLE
Fix potential crash when fetching suggested edit stats for Feed.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsFeedClient.kt
@@ -53,7 +53,12 @@ class SuggestedEditsFeedClient : FeedClient {
             // Suggested Edits feature is paused or disabled, the next time the feed is refreshed.
             CoroutineScope(Dispatchers.Main).launch {
                 withContext(Dispatchers.IO) {
-                    UserContribStats.verifyEditCountsAndPauseState()
+                    try {
+                        UserContribStats.verifyEditCountsAndPauseState()
+                    } catch (e: Exception) {
+                        // Log the exception; will retry next time the feed is refreshed.
+                        L.e(e)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fixes a very obscure potential crash when scrolling down the Feed when logged in (towards the Suggested Edits card). We make a request that fetches your contribution stats, and if that request fails with an error, we don't actually handle the exception.