### PR TITLE
Fix obscure potential crash during language initialization.

### DIFF
--- a/app/src/main/java/org/wikipedia/language/AppLanguageState.kt
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageState.kt
@@ -145,5 +145,11 @@ class AppLanguageState(context: Context) {
                 addAppLanguageCode(systemLanguageCode)
             }
         }
+        if (_appLanguageCodes.isEmpty()) {
+            // If the language list is still empty, add the fallback language.
+            // This is for devices that have very nonstandard language configurations, or
+            // variants of languages that we don't support yet.
+            addAppLanguageCode(AppLanguageLookUpTable.FALLBACK_LANGUAGE_CODE)
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/language/AppLanguageState.kt
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageState.kt
@@ -149,7 +149,7 @@ class AppLanguageState(context: Context) {
             // If the language list is still empty, add the fallback language.
             // This is for devices that have very nonstandard language configurations, or
             // variants of languages that we don't support yet.
-            addAppLanguageCode(AppLanguageLookUpTable.FALLBACK_LANGUAGE_CODE)
+            addAppLanguageCode(systemLanguageCode)
         }
     }
 }


### PR DESCRIPTION
This is extremely rare, but possible on devices that have a very nonstandard language configuration that might throw us off.