### PR TITLE
[UI] Use "wrap_content" width for the search lang tab view instead of the hardcoded value

### DIFF
--- a/app/src/main/res/layout/view_custom_language_tab.xml
+++ b/app/src/main/res/layout/view_custom_language_tab.xml
@@ -9,10 +9,12 @@
     <TextView
         android:id="@+id/language_code"
         style="@style/TextViewCentered"
-        android:layout_width="24dp"
+        android:layout_width="wrap_content"
         android:layout_height="24dp"
         android:background="@drawable/lang_button_shape_border"
         android:fontFamily="sans-serif-medium"
+        android:minWidth="24dp"
+        android:paddingHorizontal="2dp"
         android:textAllCaps="true"
         android:textColor="?attr/secondary_color"
         android:textSize="12sp" />


### PR DESCRIPTION
A simple change to fix a UI of Lang Tab view in Search. Language codes with more than 2 characters won't fit into the Tab view.

--

Before:

![Screenshot_20230627_223354](https://github.com/wikimedia/apps-android-wikipedia/assets/1822584/d49d2b54-e068-42cd-b865-9dc6c8fd128c)

After:

![Screenshot_20230627_223720](https://github.com/wikimedia/apps-android-wikipedia/assets/1822584/940df717-5fa9-44cc-a20e-258dc39c531f)

![Screenshot_20230627_225231](https://github.com/wikimedia/apps-android-wikipedia/assets/1822584/400bdcf8-46a7-405c-a1d6-7fd42e7dd710)
