### PR TITLE
Stop using Summary endpoint for getting LangLinks variants.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -71,8 +71,8 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=description&redirects=1")
     fun getDescription(@Query("titles") titles: String): Observable<MwQueryResponse>
 
-    @GET(MW_API_PREFIX + "action=query&prop=info|description&inprop=varianttitles|displaytitle&redirects=1")
-    fun getInfoByPageId(@Query("pageids") pageIds: String): Observable<MwQueryResponse>
+    @GET(MW_API_PREFIX + "action=query&prop=info&inprop=varianttitles|displaytitle")
+    suspend fun getInfoByPageTitles(@Query("titles") titles: String): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query&prop=info|description|pageimages&inprop=varianttitles|displaytitle&redirects=1")
     suspend fun getPageTitlesByPageIdsOrTitles(@Query("pageids") pageIds: String? = null, @Query("titles") titles: String? = null): MwQueryResponse

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.kt
@@ -27,7 +27,7 @@ class MwQueryPage {
     private val ns = 0
     val coordinates: List<Coordinates>? = null
     private val thumbnail: Thumbnail? = null
-    private val varianttitles: Map<String, String>? = null
+    val varianttitles: Map<String, String>? = null
     private val actions: Map<String, List<MwServiceError>>? = null
     private val editintro: JsonElement? = null
 

--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
@@ -156,7 +156,7 @@ class LangLinksActivity : BaseActivity() {
     private inner class LangLinksAdapter(languageEntries: List<PageTitle>, private val appLanguageEntries: List<PageTitle>) : RecyclerView.Adapter<DefaultViewHolder>() {
         private val originalLanguageEntries = languageEntries.toMutableList()
         private val languageEntries = mutableListOf<PageTitle>()
-        private val variantTitlesToUpdate = originalLanguageEntries.filter { !WikipediaApp.instance.languageState.getDefaultLanguageCode(it.wikiSite.languageCode).isNullOrEmpty() }.toMutableList()
+        private val variantLangsToUpdate = originalLanguageEntries.mapNotNull { WikipediaApp.instance.languageState.getDefaultLanguageCode(it.wikiSite.languageCode) }.toMutableSet()
 
         private var isSearching = false
 
@@ -188,9 +188,10 @@ class LangLinksActivity : BaseActivity() {
         }
 
         override fun onBindViewHolder(holder: DefaultViewHolder, pos: Int) {
-            if (variantTitlesToUpdate.contains(languageEntries[pos])) {
-                viewModel.fetchLangVariantLink(languageEntries[pos])
-                variantTitlesToUpdate.remove(languageEntries[pos])
+            val langCode = WikipediaApp.instance.languageState.getDefaultLanguageCode(languageEntries[pos].wikiSite.languageCode)
+            if (langCode != null && variantLangsToUpdate.contains(langCode)) {
+                variantLangsToUpdate.remove(langCode)
+                viewModel.fetchLangVariantLinks(langCode, languageEntries[pos].prefixedText, originalLanguageEntries)
             }
             holder.bindItem(languageEntries[pos])
         }

--- a/app/src/main/java/org/wikipedia/language/LangLinksViewModel.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksViewModel.kt
@@ -43,12 +43,18 @@ class LangLinksViewModel(bundle: Bundle) : ViewModel() {
         }
     }
 
-    fun fetchLangVariantLink(title: PageTitle) {
+    fun fetchLangVariantLinks(langCode: String, title: String, titles: List<PageTitle>) {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             languageEntries.postValue(Resource.Error(throwable))
         }) {
-            val summary = ServiceFactory.getRest(title.wikiSite).getPageSummary(null, title.prefixedText)
-            title.displayText = summary.displayTitle
+            val response = ServiceFactory.get(WikiSite.forLanguageCode(langCode)).getInfoByPageTitles(title)
+            response.query?.firstPage()?.varianttitles?.let { variantMap ->
+                titles.forEach {
+                    variantMap[it.wikiSite.languageCode]?.let { text ->
+                        it.displayText = text
+                    }
+                }
+            }
             languageEntryVariantUpdate.postValue(Resource.Success(Unit))
         }
     }


### PR DESCRIPTION
There's a perfectly good MediaWiki API that we can use in place of (and more efficiently!) than the `page/summary` endpoint.