### PR TITLE
Introduce a single-WebView activity.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -306,6 +306,10 @@
             android:name=".diff.ArticleEditDetailsActivity" />
 
         <activity
+            android:name=".activity.SingleWebViewActivity"
+            android:theme="@style/AppTheme.ActionBar" />
+
+        <activity
             android:name=".page.customize.CustomizeToolbarActivity"
             android:label="@string/customize_toolbar_title"
             android:theme="@style/AppTheme.ActionBar"/>

--- a/app/src/main/java/org/wikipedia/activity/SingleWebViewActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/SingleWebViewActivity.kt
@@ -1,0 +1,87 @@
+package org.wikipedia.activity
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.core.view.isVisible
+import org.wikipedia.WikipediaApp
+import org.wikipedia.databinding.ActivitySingleWebViewBinding
+import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.okhttp.OkHttpWebViewClient
+import org.wikipedia.page.LinkHandler
+import org.wikipedia.page.PageTitle
+import org.wikipedia.page.PageViewModel
+
+class SingleWebViewActivity : BaseActivity() {
+    private lateinit var binding: ActivitySingleWebViewBinding
+    private lateinit var blankLinkHandler: LinkHandler
+    private lateinit var targetUrl: String
+    val blankModel = PageViewModel()
+
+    @SuppressLint("SetJavaScriptEnabled")
+    public override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivitySingleWebViewBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        supportActionBar?.title = ""
+
+        targetUrl = intent.getStringExtra(EXTRA_URL)!!
+        blankLinkHandler = EditLinkHandler(this, WikipediaApp.instance.wikiSite)
+
+        binding.webView.settings.javaScriptEnabled = true
+        binding.webView.settings.mediaPlaybackRequiresUserGesture = false
+        binding.webView.webViewClient = object : OkHttpWebViewClient() {
+            override val model get() = blankModel
+            override val linkHandler get() = blankLinkHandler
+
+            override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                super.onPageStarted(view, url, favicon)
+                binding.progressBar.isVisible = true
+            }
+
+            override fun onPageFinished(view: WebView?, url: String?) {
+                super.onPageFinished(view, url)
+                binding.progressBar.isVisible = false
+            }
+        }
+
+        if (savedInstanceState == null) {
+            binding.webView.loadUrl(targetUrl)
+        }
+    }
+
+    override fun onDestroy() {
+        binding.webView.clearAllListeners()
+        (binding.webView.parent as ViewGroup).removeView(binding.webView)
+        super.onDestroy()
+    }
+
+    override fun onBackPressed() {
+        if (binding.webView.canGoBack()) {
+            binding.webView.goBack()
+            return
+        }
+        super.onBackPressed()
+    }
+
+    inner class EditLinkHandler constructor(context: Context, override var wikiSite: WikiSite) : LinkHandler(context) {
+        override fun onPageLinkClicked(anchor: String, linkText: String) { }
+        override fun onInternalLinkClicked(title: PageTitle) { }
+        override fun onMediaLinkClicked(title: PageTitle) { }
+        override fun onDiffLinkClicked(title: PageTitle, revisionId: Long) { }
+    }
+
+    companion object {
+        const val EXTRA_URL = "url"
+
+        fun newIntent(context: Context, url: String): Intent {
+            return Intent(context, SingleWebViewActivity::class.java)
+                    .putExtra(EXTRA_URL, url)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_single_web_view.xml
+++ b/app/src/main/res/layout/activity_single_web_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/paper_color">
+
+    <org.wikipedia.views.ObservableWebView
+        android:id="@+id/webView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progressBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"/>
+
+</FrameLayout>


### PR DESCRIPTION
...for use in Fundraising or Vanishing purposes, in place of a CustomTab activity.

This is because a WebView that's under our control can pass through our network layer and inherit our cookies, allowing the user to maintain their session between the native environment and the WebView.

This can be merged now, since this new activity is not yet used from anywhere.