### PR TITLE
Move MP logging to Pre-prod

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
@@ -28,7 +28,7 @@ open class MetricsEvent {
     )
 
     protected fun submitEvent(eventName: String, customData: Map<String, Any>, pageData: PageData? = null) {
-        if (ReleaseUtil.isPreBetaRelease && Prefs.isEventLoggingEnabled) {
+        if (ReleaseUtil.isPreProdRelease && Prefs.isEventLoggingEnabled) {
             MetricsPlatform.client.submitMetricsEvent(
                 EVENT_NAME_BASE + eventName,
                 getClientData(pageData),


### PR DESCRIPTION
Moving Article interaction logging to Metrics Platform to beta, in order to collect more data.