### PR TITLE
Remove TODO in LangLinksActivity since it has been resoloved

### DIFF
--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
@@ -254,7 +254,6 @@ class LangLinksActivity : BaseActivity() {
             if (canonicalName.isNullOrEmpty() || languageCode == app.languageState.systemLanguageCode) {
                 nonLocalizedLanguageNameTextView.visibility = View.GONE
             } else {
-                // TODO: Fix an issue when app language is zh-hant, the subtitle in zh-hans will display in English
                 nonLocalizedLanguageNameTextView.text = canonicalName
                 nonLocalizedLanguageNameTextView.visibility = View.VISIBLE
             }


### PR DESCRIPTION
The subtitle now shows in the correct language variant.