### PR TITLE
Log remaining instruments via Metrics Platform

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -17,6 +17,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.analytics.InstallReferrerListener
 import org.wikipedia.analytics.eventplatform.AppSessionEvent
 import org.wikipedia.analytics.eventplatform.EventPlatformClient
+import org.wikipedia.analytics.metricsplatform.SessionEvent
 import org.wikipedia.appshortcuts.AppShortcuts
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.concurrency.RxBus
@@ -48,6 +49,7 @@ class WikipediaApp : Application() {
     val mainThreadHandler by lazy { Handler(mainLooper) }
     val languageState by lazy { AppLanguageState(this) }
     val appSessionEvent by lazy { AppSessionEvent() }
+    val sessionEvent by lazy { SessionEvent() }
 
     val userAgent by lazy {
         var channel = ReleaseUtil.getChannel(this)

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -75,6 +75,7 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         if (savedInstanceState == null) {
             NotificationInteractionEvent.processIntent(intent)
+            org.wikipedia.analytics.metricsplatform.NotificationInteractionEvent.processIntent(intent)
         }
 
         // Conditionally execute all recurring tasks
@@ -113,12 +114,14 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
 
     override fun onStop() {
         WikipediaApp.instance.appSessionEvent.persistSession()
+        WikipediaApp.instance.sessionEvent.persistSession()
         super.onStop()
     }
 
     override fun onResume() {
         super.onResume()
         WikipediaApp.instance.appSessionEvent.touchSession()
+        WikipediaApp.instance.sessionEvent.touchSession()
         BreadCrumbLogEvent.logScreenShown(this)
         BreadcrumbLogEvent().logScreenShown(this)
 

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -21,6 +21,7 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.BreadcrumbsContextHelper
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.analytics.eventplatform.NotificationInteractionEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.appshortcuts.AppShortcuts
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.connectivity.ConnectionStateMonitor
@@ -119,6 +120,7 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
         super.onResume()
         WikipediaApp.instance.appSessionEvent.touchSession()
         BreadCrumbLogEvent.logScreenShown(this)
+        BreadcrumbLogEvent().logScreenShown(this)
 
         // allow this activity's exclusive bus methods to override any existing ones.
         unregisterExclusiveBusMethods()
@@ -139,6 +141,7 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
     override fun onBackPressed() {
         super.onBackPressed()
         BreadCrumbLogEvent.logBackPress(this)
+        BreadcrumbLogEvent().logBackPress(this)
     }
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {

--- a/app/src/main/java/org/wikipedia/analytics/BreadcrumbsContextHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/BreadcrumbsContextHelper.kt
@@ -3,6 +3,7 @@ package org.wikipedia.analytics
 import android.view.*
 import android.widget.TextView
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.views.ViewUtil
 import kotlin.math.abs
@@ -36,8 +37,10 @@ object BreadcrumbsContextHelper {
                         } else {
                             if (touchMillis > ViewConfiguration.getLongPressTimeout()) {
                                 BreadCrumbLogEvent.logLongClick(window.context, it)
+                                BreadcrumbLogEvent().logLongClick(window.context, it)
                             } else {
                                 BreadCrumbLogEvent.logClick(window.context, it)
+                                BreadcrumbLogEvent().logClick(window.context, it)
                             }
                         }
                     }

--- a/app/src/main/java/org/wikipedia/analytics/InstallReferrerListener.kt
+++ b/app/src/main/java/org/wikipedia/analytics/InstallReferrerListener.kt
@@ -110,6 +110,11 @@ class InstallReferrerListener : InstallReferrerStateListener {
                     InstallReferrerEvent.PARAM_UTM_CAMPAIGN -> refUtmCampaign = item[1]
                     InstallReferrerEvent.PARAM_UTM_SOURCE -> refUtmSource = item[1]
                     InstallReferrerEvent.PARAM_CHANNEL -> refChannel = item[1]
+                    org.wikipedia.analytics.metricsplatform.InstallReferrerEvent.PARAM_REFERRER_URL -> refUrl = item[1]
+                    org.wikipedia.analytics.metricsplatform.InstallReferrerEvent.PARAM_UTM_MEDIUM -> refUtmMedium = item[1]
+                    org.wikipedia.analytics.metricsplatform.InstallReferrerEvent.PARAM_UTM_CAMPAIGN -> refUtmCampaign = item[1]
+                    org.wikipedia.analytics.metricsplatform.InstallReferrerEvent.PARAM_UTM_SOURCE -> refUtmSource = item[1]
+                    org.wikipedia.analytics.metricsplatform.InstallReferrerEvent.PARAM_CHANNEL -> refChannel = item[1]
                 }
             }
         } catch (e: Exception) {
@@ -120,6 +125,7 @@ class InstallReferrerListener : InstallReferrerStateListener {
         if (!refUrl.isNullOrEmpty() || !refUtmMedium.isNullOrEmpty() ||
                 !refUtmCampaign.isNullOrEmpty() || !refUtmSource.isNullOrEmpty()) {
             InstallReferrerEvent.logInstall(refUrl, refUtmMedium, refUtmCampaign, refUtmSource)
+            org.wikipedia.analytics.metricsplatform.InstallReferrerEvent.logInstall(refUrl, refUtmMedium, refUtmCampaign, refUtmSource)
         }
         if (!refUrl.isNullOrEmpty() && ShareUtil.canOpenUrlInApp(WikipediaApp.instance, refUrl)) {
             openPageFromUrl(WikipediaApp.instance, refUrl)

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.withContext
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.dataclient.ServiceFactory
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.ActiveTimer
@@ -92,6 +93,7 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
             return
         }
         EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context), logString))
+        BreadcrumbLogEvent().log(context, logString)
     }
 
     private fun getOrderString(wasChosen: Boolean, suggestion: String): String {

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/BreadcrumbEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/BreadcrumbEvent.kt
@@ -1,0 +1,79 @@
+package org.wikipedia.analytics.metricsplatform
+
+import android.content.Context
+import android.view.MenuItem
+import android.view.View
+import android.widget.Checkable
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import org.wikipedia.analytics.eventplatform.BreadCrumbViewUtil
+import org.wikipedia.settings.SettingsActivity
+import org.wikipedia.util.log.L
+
+class BreadcrumbLogEvent : MetricsEvent() {
+    fun log(context: Context, logString: String) {
+        submitEvent(BreadCrumbViewUtil.getReadableScreenName(context), logString)
+    }
+
+    fun logClick(context: Context, view: View) {
+        if (context is SettingsActivity) {
+            return
+        }
+        val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
+        val str = "$viewReadableName." + when (view) {
+            is Checkable -> if (!view.isChecked) "on" else "off"
+            else -> "click"
+        }
+        submitEvent(BreadCrumbViewUtil.getReadableScreenName(context), str)
+    }
+
+    fun logClick(context: Context, item: MenuItem) {
+        submitEvent(
+            BreadCrumbViewUtil.getReadableScreenName(context),
+            context.resources.getResourceEntryName(item.itemId) + ".click"
+        )
+    }
+
+    fun logLongClick(context: Context, view: View) {
+        val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
+        submitEvent(
+            BreadCrumbViewUtil.getReadableScreenName(context),
+            "$viewReadableName.longclick"
+        )
+    }
+
+    fun logScreenShown(context: Context, fragment: Fragment? = null) {
+        submitEvent(BreadCrumbViewUtil.getReadableScreenName(context, fragment), "show")
+    }
+
+    fun logBackPress(context: Context) {
+        submitEvent(BreadCrumbViewUtil.getReadableScreenName(context), "back")
+    }
+
+    fun logTooltipShown(context: Context, anchor: View) {
+        val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(anchor)
+        submitEvent(context.javaClass.simpleName.orEmpty(), "$viewReadableName.tooltip")
+    }
+
+    fun logSettingsSelection(context: Context, title: String, newValue: Any? = null) {
+        val str =
+            title + "." + if (newValue is Boolean) (if (newValue == true) "on" else "off") else "click"
+        submitEvent(context.javaClass.simpleName.orEmpty(), str)
+    }
+
+    fun logInputField(context: Context, view: View) {
+        val viewReadableName = BreadCrumbViewUtil.getReadableNameForView(view)
+        val str = "$viewReadableName." + (view as TextView).text
+        submitEvent(BreadCrumbViewUtil.getReadableScreenName(context), str)
+    }
+
+    private fun submitEvent(context: String, action: String) {
+        L.d(">>> metrics_platform.breadcrumbs_event.$context.$action")
+        submitEvent(
+            "breadcrumbs_event.$context",
+            mapOf(
+                "action" to action
+            )
+        )
+    }
+}

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/DailyStatsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/DailyStatsEvent.kt
@@ -1,0 +1,33 @@
+package org.wikipedia.analytics.metricsplatform
+
+import android.content.Context
+import android.content.pm.PackageManager
+import org.wikipedia.WikipediaApp
+import java.util.concurrent.TimeUnit
+
+class DailyStatsEvent : MetricsEvent() {
+    fun log(app: WikipediaApp) {
+        submitEvent(
+            "daily_stats",
+            mapOf(
+                "install_age_days" to getInstallAgeDays(app)
+            )
+        )
+    }
+
+    private fun getInstallAgeDays(context: Context): Long {
+        return TimeUnit.MILLISECONDS.toDays(getInstallAge(context))
+    }
+
+    private fun getInstallAge(context: Context): Long {
+        return System.currentTimeMillis() - getInstallTime(context)
+    }
+
+    private fun getInstallTime(context: Context): Long {
+        return try {
+            context.packageManager.getPackageInfo(context.packageName, 0).firstInstallTime
+        } catch (e: PackageManager.NameNotFoundException) {
+            throw RuntimeException(e)
+        }
+    }
+}

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/EditEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/EditEvent.kt
@@ -1,0 +1,115 @@
+package org.wikipedia.analytics.metricsplatform
+
+import org.wikimedia.metrics_platform.context.PageData
+import org.wikipedia.diff.ArticleEditDetailsViewModel
+import org.wikipedia.page.PageTitle
+import org.wikipedia.page.edithistory.EditHistoryListViewModel
+
+class EditHistoryInteractionEvent : TimedMetricsEvent {
+    private val pageData: PageData?
+
+    constructor(viewModel: ArticleEditDetailsViewModel) {
+        this.pageData = getPageData(viewModel, viewModel.revisionFromId)
+    }
+
+    constructor(viewModel: EditHistoryListViewModel) {
+        this.pageData = getPageData(viewModel)
+    }
+
+    constructor(pageTitle: PageTitle, pageId: Int, revisionId: Long) {
+        this.pageData = getPageData(pageTitle, pageId, revisionId)
+    }
+
+    fun logShowHistory() {
+        submitEvent("show_history")
+    }
+
+    fun logRevision() {
+        submitEvent("revision_view")
+    }
+
+    // User tapped 'Compare' on the edit History screen to start selecting the revisions to compare
+    fun logCompare1() {
+        submitEvent("compare1")
+    }
+
+    // User has selected a second revision and tapped the 'Compare' button, navigating them to the comparison screen
+    fun logCompare2() {
+        submitEvent("compare2")
+    }
+
+    fun logThankTry() {
+        submitEvent("thank_try")
+    }
+
+    fun logThankCancel() {
+        submitEvent("thank_cancel")
+    }
+
+    fun logThankSuccess() {
+        submitEvent("thank_success")
+    }
+
+    fun logThankFail() {
+        submitEvent("thank_fail")
+    }
+
+    fun logSearchClick() {
+        submitEvent("search_click")
+    }
+
+    fun logFilterClick() {
+        submitEvent("filter_click")
+    }
+
+    fun logFilterSelection(selection: String) {
+        submitEvent("filter_selection_" + selection)
+    }
+
+    fun logUndoTry() {
+        submitEvent("undo_try")
+    }
+
+    fun logUndoCancel() {
+        submitEvent("undo_cancel")
+    }
+
+    fun logUndoSuccess() {
+        submitEvent("undo_success")
+    }
+
+    fun logUndoFail() {
+        submitEvent("undo_fail")
+    }
+
+    fun logOlderEditChevronClick() {
+        submitEvent("older_edit_click")
+    }
+
+    fun logNewerEditChevronClick() {
+        submitEvent("newer_edit_click")
+    }
+
+    fun logShareClick() {
+        submitEvent("share_click")
+    }
+
+    fun logWatchClick() {
+        submitEvent("watch_click")
+    }
+
+    fun logUnwatchClick() {
+        submitEvent("unwatch_click")
+    }
+
+    private fun submitEvent(action: String) {
+        submitEvent(
+            "edit_history_interaction",
+            mapOf(
+                "action" to action,
+                "time_spent_ms" to timer.elapsedMillis
+            ),
+            pageData
+        )
+    }
+}

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.analytics.metricsplatform
 
+import androidx.lifecycle.ViewModel
 import org.wikimedia.metrics_platform.context.ClientData
 import org.wikimedia.metrics_platform.context.PageData
 import org.wikimedia.metrics_platform.context.PerformerData
@@ -7,9 +8,11 @@ import org.wikipedia.BuildConfig
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.EventPlatformClient
 import org.wikipedia.auth.AccountUtil
+import org.wikipedia.diff.ArticleEditDetailsViewModel
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageFragment
 import org.wikipedia.page.PageTitle
+import org.wikipedia.page.edithistory.EditHistoryListViewModel
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.ReleaseUtil
 
@@ -72,6 +75,30 @@ open class MetricsEvent {
             revisionId,
             "",
             pageTitle.wikiSite.languageCode,
+            null, null, null)
+    }
+
+    protected fun getPageData(viewModel: ArticleEditDetailsViewModel, revisionId: Long): PageData? {
+        return PageData(
+            viewModel.pageId,
+            viewModel.pageTitle.prefixedText,
+            viewModel.pageTitle.namespace().code(),
+            Namespace.of(viewModel.pageTitle.namespace().code()).toString(),
+            viewModel.revisionToId,
+            "",
+            viewModel.pageTitle.wikiSite.languageCode,
+            null, null, null)
+    }
+
+    protected fun getPageData(viewModel: EditHistoryListViewModel): PageData? {
+        return PageData(
+            viewModel.pageId,
+            viewModel.pageTitle.prefixedText,
+            viewModel.pageTitle.namespace().code(),
+            Namespace.of(viewModel.pageTitle.namespace().code()).toString(),
+            viewModel.selectedRevisionFrom?.revId,
+            "",
+            viewModel.pageTitle.wikiSite.languageCode,
             null, null, null)
     }
 

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/NotificationEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/NotificationEvent.kt
@@ -1,0 +1,128 @@
+package org.wikipedia.analytics.metricsplatform
+
+import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
+import org.wikipedia.Constants
+import org.wikipedia.WikipediaApp
+import org.wikipedia.notifications.NotificationPollBroadcastReceiver
+import org.wikipedia.notifications.db.Notification
+
+class NotificationInteractionEvent(
+    private val notification_id: Int,
+    private val notification_wiki: String,
+    private val notification_type: String,
+    private val action_rank: Int,
+    private val action_icon: String,
+    private val selection_token: String,
+    private val incoming_only: Boolean,
+    private val device_level_enabled: Boolean,
+) {
+    companion object : MetricsEvent() {
+        private const val ACTION_INCOMING = -1
+        private const val ACTION_READ_AND_ARCHIVED = 0
+        private const val ACTION_CLICKED = 10
+        private const val ACTION_DISMISSED = 11
+        const val ACTION_PRIMARY = 1
+        const val ACTION_SECONDARY = 2
+        const val ACTION_LINK_CLICKED = 3
+
+        private fun logClicked(intent: Intent) {
+            submit(
+                NotificationInteractionEvent(
+                    intent.getLongExtra(Constants.INTENT_EXTRA_NOTIFICATION_ID, 0).toInt(),
+                    WikipediaApp.instance.wikiSite.dbName(),
+                    intent.getStringExtra(Constants.INTENT_EXTRA_NOTIFICATION_TYPE).orEmpty(),
+                    NotificationInteractionEvent.ACTION_CLICKED,
+                    "",
+                    "",
+                    incoming_only = false,
+                    device_level_enabled = true
+                )
+            )
+        }
+
+        private fun logDismissed(intent: Intent) {
+            submit(
+                NotificationInteractionEvent(
+                    intent.getLongExtra(Constants.INTENT_EXTRA_NOTIFICATION_ID, 0).toInt(),
+                    WikipediaApp.instance.wikiSite.dbName(),
+                    intent.getStringExtra(Constants.INTENT_EXTRA_NOTIFICATION_TYPE).orEmpty(),
+                    NotificationInteractionEvent.ACTION_DISMISSED,
+                    "",
+                    "",
+                    incoming_only = false,
+                    device_level_enabled = true
+                )
+            )
+        }
+
+        fun logMarkRead(notification: Notification, selectionToken: Long?) {
+            submit(
+                NotificationInteractionEvent(
+                    notification.id.toInt(),
+                    notification.wiki,
+                    notification.type,
+                    NotificationInteractionEvent.ACTION_READ_AND_ARCHIVED,
+                    "",
+                    selectionToken?.toString()
+                        ?: "",
+                    incoming_only = false,
+                    device_level_enabled = true
+                )
+            )
+        }
+
+        fun logIncoming(notification: Notification, type: String?) {
+            submit(
+                NotificationInteractionEvent(
+                    notification.id.toInt(),
+                    notification.wiki,
+                    type ?: notification.type,
+                    NotificationInteractionEvent.ACTION_INCOMING,
+                    "",
+                    "",
+                    incoming_only = true,
+                    device_level_enabled = NotificationManagerCompat.from(
+                        WikipediaApp.instance
+                    ).areNotificationsEnabled()
+                )
+            )
+        }
+
+        fun logAction(notification: Notification, index: Int, link: Notification.Link) {
+            submit(
+                NotificationInteractionEvent(
+                    notification.id.toInt(), notification.wiki, notification.type, index,
+                    link.icon(), "", incoming_only = false, device_level_enabled = true
+                )
+            )
+        }
+
+        fun processIntent(intent: Intent) {
+            if (!intent.hasExtra(Constants.INTENT_EXTRA_NOTIFICATION_ID)) {
+                return
+            }
+            if (NotificationPollBroadcastReceiver.ACTION_CANCEL == intent.action) {
+                logDismissed(intent)
+            } else {
+                logClicked(intent)
+            }
+        }
+
+        fun submit(notificationEvent: NotificationInteractionEvent) {
+            submitEvent(
+                "notification_interaction",
+                mapOf(
+                    "notification_id" to notificationEvent.notification_id,
+                    "notification_wiki" to notificationEvent.notification_wiki,
+                    "notification_type" to notificationEvent.notification_type,
+                    "action_rank" to notificationEvent.action_rank,
+                    "action_icon" to notificationEvent.action_icon,
+                    "selection_token" to notificationEvent.selection_token,
+                    "incoming_only" to notificationEvent.incoming_only,
+                    "device_level_enabled" to notificationEvent.device_level_enabled
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/PreferenceEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/PreferenceEvent.kt
@@ -1,0 +1,56 @@
+package org.wikipedia.analytics.metricsplatform
+
+import org.wikipedia.Constants
+import org.wikipedia.page.action.PageActionItem
+import org.wikipedia.settings.Prefs
+import org.wikipedia.theme.Theme
+
+class AppearanceSettingInteractionEvent(private val source: Constants.InvokeSource) : MetricsEvent() {
+
+    fun logFontSizeChange(currentFontSize: Float, newFontSize: Float) {
+        submitEvent("fontSizeChange", currentFontSize.toString(), newFontSize.toString())
+    }
+
+    fun logThemeChange(currentTheme: Theme, newTheme: Theme) {
+        submitEvent("themeChange", currentTheme.tag, newTheme.tag)
+    }
+
+    fun logFontThemeChange(currentFontFamily: String?, newFontFamily: String?) {
+        submitEvent("fontThemeChange", currentFontFamily.orEmpty(), newFontFamily.orEmpty())
+    }
+
+    fun logReadingFocusMode(newValue: Boolean) {
+        submitEvent("readingFocusMode", (!newValue).toString(), newValue.toString())
+    }
+
+    private fun submitEvent(action: String, currentValue: String, newValue: String) {
+        submitEvent(
+            "app_appearance_settings_interaction",
+            mapOf(
+                "action" to action,
+                "current_value" to currentValue,
+                "new_value" to newValue,
+                "source" to source.value
+            )
+        )
+    }
+}
+
+class CustomizeToolbarEvent : TimedMetricsEvent() {
+
+    fun logCustomization(favoritesOrder: List<Int>, menuOrder: List<Int>) {
+        val source = if (Prefs.customizeToolbarMenuOrder.contains(PageActionItem.THEME.id))
+            Constants.InvokeSource.PAGE_OVERFLOW_MENU.value else Constants.InvokeSource.PAGE_ACTION_TAB.value
+
+        submitEvent(
+            "customize_toolbar_interaction",
+            mapOf(
+                "is_rfm_enabled" to Prefs.readingFocusModeEnabled,
+                "favorites_order" to favoritesOrder,
+                "menu_order" to menuOrder,
+                "time_spent_ms" to timer.elapsedMillis,
+                "source" to source
+            )
+        )
+    }
+}

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/ReferrerEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/ReferrerEvent.kt
@@ -1,0 +1,31 @@
+package org.wikipedia.analytics.metricsplatform
+
+class InstallReferrerEvent(
+    private val referrerUrl: String,
+    private val campaignId: String,
+    private val utfMedium: String,
+    private val utfCampaign: String,
+    private val utfSource: String
+) {
+
+    companion object : MetricsEvent() {
+        const val PARAM_REFERRER_URL = "referrer_url"
+        const val PARAM_UTM_MEDIUM = "utm_medium"
+        const val PARAM_UTM_CAMPAIGN = "utm_campaign"
+        const val PARAM_UTM_SOURCE = "utm_source"
+        const val PARAM_CHANNEL = "channel"
+
+        fun logInstall(referrerUrl: String?, utfMedium: String?, utfCampaign: String?, utfSource: String?) {
+            submitEvent(
+                "install_referrer_event",
+                mapOf(
+                    "referrer_url" to referrerUrl.orEmpty(),
+                    "utm_medium" to utfMedium.toString(),
+                    "utm_campaign" to utfCampaign.toString(),
+                    "utm_source" to utfSource.toString(),
+                    "campaign_id" to "android"
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/SessionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/SessionEvent.kt
@@ -1,0 +1,95 @@
+package org.wikipedia.analytics.metricsplatform
+
+import android.text.format.DateUtils
+import org.wikipedia.analytics.SessionData
+import org.wikipedia.analytics.eventplatform.EventPlatformClient
+import org.wikipedia.history.HistoryEntry
+import org.wikipedia.settings.Prefs
+
+class SessionEvent : MetricsEvent() {
+    private var sessionData: SessionData
+    private var pageLoadStartTime: Long = 0
+
+    init {
+        sessionData = Prefs.sessionData
+        if (sessionData.startTime == 0L || sessionData.lastTouchTime == 0L) {
+            // session was serialized/deserialized incorrectly, so reset it.
+            sessionData = SessionData()
+            persistSession()
+        }
+        touchSession()
+    }
+
+    /**
+     * Save the state of the current session. To be called when the main Activity is stopped,
+     * so that we don't have to save its state every time a single parameter is modified.
+     */
+    fun persistSession() {
+        Prefs.sessionData = sessionData
+    }
+
+    /**
+     * Update the timestamp for the current session. If the last-updated time is older than the
+     * defined timeout period, then consider the current session as over, and send the event!
+     */
+    fun touchSession() {
+        val now = System.currentTimeMillis()
+        if (hasTimedOut()) {
+            logSessionData()
+            // start a new session by clearing everything.
+            EventPlatformClient.AssociationController.beginNewSession()
+            sessionData = SessionData()
+            persistSession()
+        }
+        sessionData.lastTouchTime = now
+    }
+
+    fun pageViewed(entry: HistoryEntry?) {
+        touchSession()
+        sessionData.addPageViewed(entry!!)
+    }
+
+    fun backPressed() {
+        touchSession()
+        sessionData.addPageFromBack()
+    }
+
+    fun noDescription() {
+        touchSession()
+        sessionData.addPageWithNoDescription()
+    }
+
+    fun pageFetchStart() {
+        pageLoadStartTime = System.nanoTime()
+    }
+
+    fun pageFetchEnd() {
+        sessionData.addPageLatency(System.nanoTime() - pageLoadStartTime)
+    }
+
+    private fun hasTimedOut(): Boolean {
+        return System.currentTimeMillis() - sessionData.lastTouchTime > Prefs.sessionTimeout * DateUtils.MINUTE_IN_MILLIS
+    }
+
+    private fun logSessionData() {
+        val sessionLength = (sessionData.lastTouchTime - sessionData.startTime).toInt()
+        submitEvent(
+            "app_session",
+            mapOf(
+                "length_ms" to sessionLength,
+                "session_data" to sessionData
+            )
+        )
+    }
+
+    companion object {
+        /**
+         * Definition of a "session timeout", as agreed upon by the Apps and Analytics teams.
+         * (currently 30 minutes)
+         *
+         * @ToDo If/when MEP is decommissioned, replace sessionTimeout in Prefs.kt with these.
+         */
+        const val DEFAULT_SESSION_TIMEOUT = 30
+        const val MIN_SESSION_TIMEOUT = 1
+    }
+}

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/TimedMetricsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/TimedMetricsEvent.kt
@@ -3,5 +3,5 @@ package org.wikipedia.analytics.metricsplatform
 import org.wikipedia.util.ActiveTimer
 
 open class TimedMetricsEvent : MetricsEvent() {
-    protected val timer = ActiveTimer()
+    val timer = ActiveTimer()
 }

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/UserEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/UserEvent.kt
@@ -1,0 +1,106 @@
+package org.wikipedia.analytics.metricsplatform
+
+class CreateAccountEvent(private val requestSource: String) : MetricsEvent() {
+
+    fun logStart() {
+        submit("start")
+    }
+
+    fun logError(code: String?) {
+        submit("error", code.orEmpty())
+    }
+
+    fun logSuccess() {
+        submit("success")
+    }
+
+    private fun submit(action: String, errorText: String = "") {
+        submitEvent(
+            "create_account_interaction",
+            mapOf(
+                "action" to action,
+                "source" to requestSource,
+                "error_text" to errorText
+            )
+        )
+    }
+}
+
+class UserContributionEvent(val action: String) {
+    companion object : MetricsEvent() {
+        private const val STREAM_NAME = "android.user_contribution_screen"
+
+        fun logOpen() {
+            submit("open_hist")
+        }
+
+        fun logFilterDescriptions() {
+            submit("filt_desc")
+        }
+
+        fun logFilterCaptions() {
+            submit("filt_caption")
+        }
+
+        fun logFilterTags() {
+            submit("filt_tag")
+        }
+
+        fun logFilterAll() {
+            submit("filt_all")
+        }
+
+        fun logViewDescription() {
+            submit("desc_view")
+        }
+
+        fun logViewCaption() {
+            submit("caption_view")
+        }
+
+        fun logViewTag() {
+            submit("tag_view")
+        }
+
+        fun logViewMisc() {
+            submit("misc_view")
+        }
+
+        fun logNavigateDescription() {
+            submit("desc_view2")
+        }
+
+        fun logNavigateCaption() {
+            submit("caption_view2")
+        }
+
+        fun logNavigateTag() {
+            submit("tag_view2")
+        }
+
+        fun logNavigateMisc() {
+            submit("misc_view2")
+        }
+
+        fun logPaused() {
+            submit("paused")
+        }
+
+        fun logDisabled() {
+            submit("disabled")
+        }
+
+        fun logIpBlock() {
+            submit("ip_block")
+        }
+
+        private fun submit(action: String) {
+            submitEvent(
+                "user_contribution_screen",
+                mapOf(
+                    "action" to action
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.kt
+++ b/app/src/main/java/org/wikipedia/createaccount/CreateAccountActivity.kt
@@ -42,6 +42,7 @@ class CreateAccountActivity : BaseActivity() {
     private lateinit var binding: ActivityCreateAccountBinding
     private lateinit var captchaHandler: CaptchaHandler
     private lateinit var createAccountEvent: CreateAccountEvent
+    private lateinit var createAccountEventMetricsPlatform : org.wikipedia.analytics.metricsplatform.CreateAccountEvent
     private val disposables = CompositeDisposable()
     private var wiki = WikipediaApp.instance.wikiSite
     private var userNameTextWatcher: TextWatcher? = null
@@ -58,9 +59,11 @@ class CreateAccountActivity : BaseActivity() {
         NonEmptyValidator(binding.captchaContainer.captchaSubmitButton, binding.captchaContainer.captchaText)
         setClickListeners()
         createAccountEvent = CreateAccountEvent(intent.getStringExtra(LOGIN_REQUEST_SOURCE).orEmpty())
+        createAccountEventMetricsPlatform = org.wikipedia.analytics.metricsplatform.CreateAccountEvent(intent.getStringExtra(LOGIN_REQUEST_SOURCE).orEmpty())
         // Only send the editing start log event if the activity is created for the first time
         if (savedInstanceState == null) {
             createAccountEvent.logStart()
+            createAccountEventMetricsPlatform.logStart()
         }
         // Set default result to failed, so we can override if it did not
         setResult(RESULT_ACCOUNT_NOT_CREATED)
@@ -161,11 +164,13 @@ class CreateAccountActivity : BaseActivity() {
                         finishWithUserResult(response.user)
                     } else {
                         createAccountEvent.logError(StringUtil.removeStyleTags(response.message))
+                        createAccountEventMetricsPlatform.logError(StringUtil.removeStyleTags(response.message))
                         throw CreateAccountException(StringUtil.removeStyleTags(response.message))
                     }
                 }) { caught ->
                     L.e(caught.toString())
                     createAccountEvent.logError(caught.toString())
+                    createAccountEventMetricsPlatform.logError(caught.toString())
                     showProgressBar(false)
                     showError(caught)
                 })
@@ -266,6 +271,7 @@ class CreateAccountActivity : BaseActivity() {
         showProgressBar(false)
         captchaHandler.cancelCaptcha()
         createAccountEvent.logSuccess()
+        createAccountEventMetricsPlatform.logSuccess()
         DeviceUtil.hideSoftKeyboard(this@CreateAccountActivity)
         finish()
     }

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
@@ -49,10 +49,12 @@ abstract class OkHttpWebViewClient : WebViewClient() {
             val shouldLogLatency = request.url.encodedPath?.contains(RestService.PAGE_HTML_ENDPOINT) == true
             if (shouldLogLatency) {
                 WikipediaApp.instance.appSessionEvent.pageFetchStart()
+                WikipediaApp.instance.sessionEvent.pageFetchStart()
             }
             val rsp = request(request)
             if (rsp.networkResponse != null && shouldLogLatency) {
                 WikipediaApp.instance.appSessionEvent.pageFetchEnd()
+                WikipediaApp.instance.sessionEvent.pageFetchEnd()
             }
             response = if (CONTENT_TYPE_OGG == rsp.header(HEADER_CONTENT_TYPE) ||
                     CONTENT_TYPE_WEBM == rsp.header(HEADER_CONTENT_TYPE)) {

--- a/app/src/main/java/org/wikipedia/diff/UndoEditDialog.kt
+++ b/app/src/main/java/org/wikipedia/diff/UndoEditDialog.kt
@@ -11,6 +11,7 @@ import org.wikipedia.databinding.DialogUndoEditBinding
 
 class UndoEditDialog constructor(
     private val editHistoryInteractionEvent: EditHistoryInteractionEvent?,
+    private val editHistoryInteractionEventMetricsPlatform: org.wikipedia.analytics.metricsplatform.EditHistoryInteractionEvent,
     context: Context,
     callback: Callback
 ) : MaterialAlertDialogBuilder(context) {
@@ -32,6 +33,7 @@ class UndoEditDialog constructor(
 
         setNegativeButton(R.string.text_input_dialog_cancel_button_text) { _, _ ->
             editHistoryInteractionEvent?.logUndoCancel()
+            editHistoryInteractionEventMetricsPlatform.logUndoCancel()
         }
 
         binding.textInput.doOnTextChanged { text, _, _, _ ->

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -28,6 +28,7 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.analytics.eventplatform.EditAttemptStepEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.auth.AccountUtil.isLoggedIn
 import org.wikipedia.captcha.CaptchaHandler
 import org.wikipedia.captcha.CaptchaResult
@@ -332,6 +333,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback {
         )
 
         BreadCrumbLogEvent.logInputField(this, editSummaryFragment.summaryText)
+        BreadcrumbLogEvent().logInputField(this, editSummaryFragment.summaryText)
     }
 
     @Suppress("SameParameterValue")

--- a/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
+++ b/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
@@ -12,6 +12,7 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.ViewMainDrawerBinding
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
@@ -37,6 +38,7 @@ class MenuNavTabDialog : ExtendedBottomSheetDialogFragment() {
 
         binding.mainDrawerAccountContainer.setOnClickListener {
             BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerAccountContainer)
+            BreadcrumbLogEvent().logClick(requireActivity(), binding.mainDrawerAccountContainer)
             if (AccountUtil.isLoggedIn) {
                 callback()?.usernameClick()
             } else {
@@ -47,30 +49,35 @@ class MenuNavTabDialog : ExtendedBottomSheetDialogFragment() {
 
         binding.mainDrawerTalkContainer.setOnClickListener {
             BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerTalkContainer)
+            BreadcrumbLogEvent().logClick(requireActivity(), binding.mainDrawerTalkContainer)
             callback()?.talkClick()
             dismiss()
         }
 
         binding.mainDrawerWatchlistContainer.setOnClickListener {
             BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerWatchlistContainer)
+            BreadcrumbLogEvent().logClick(requireActivity(), binding.mainDrawerWatchlistContainer)
             callback()?.watchlistClick()
             dismiss()
         }
 
         binding.mainDrawerSettingsContainer.setOnClickListener {
             BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerSettingsContainer)
+            BreadcrumbLogEvent().logClick(requireActivity(), binding.mainDrawerSettingsContainer)
             callback()?.settingsClick()
             dismiss()
         }
 
         binding.mainDrawerContribsContainer.setOnClickListener {
             BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerContribsContainer)
+            BreadcrumbLogEvent().logClick(requireActivity(), binding.mainDrawerContribsContainer)
             callback()?.contribsClick()
             dismiss()
         }
 
         binding.mainDrawerDonateContainer.setOnClickListener {
             BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerDonateContainer)
+            BreadcrumbLogEvent().logClick(requireActivity(), binding.mainDrawerDonateContainer)
             visitInExternalBrowser(requireContext(),
                     Uri.parse(getString(R.string.donate_url,
                             BuildConfig.VERSION_NAME, WikipediaApp.instance.languageState.systemLanguageCode)))

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
@@ -58,6 +58,7 @@ class NotificationPollBroadcastReceiver : BroadcastReceiver() {
             }
             ACTION_CANCEL == intent.action -> {
                 NotificationInteractionEvent.processIntent(intent)
+                org.wikipedia.analytics.metricsplatform.NotificationInteractionEvent.processIntent(intent)
             }
             ACTION_DIRECT_REPLY == intent.action -> {
                 val remoteInput = RemoteInput.getResultsFromIntent(intent)
@@ -144,11 +145,13 @@ class NotificationPollBroadcastReceiver : BroadcastReceiver() {
             if (notificationsToDisplay.size > 2) {
                 // Record that there is an incoming notification to track/compare further actions on it.
                 NotificationInteractionEvent.logIncoming(notificationsToDisplay[0], TYPE_MULTIPLE)
+                org.wikipedia.analytics.metricsplatform.NotificationInteractionEvent.logIncoming(notificationsToDisplay[0], TYPE_MULTIPLE)
                 NotificationPresenter.showMultipleUnread(context, notificationsToDisplay.size)
             } else {
                 for (n in notificationsToDisplay) {
                     // Record that there is an incoming notification to track/compare further actions on it.
                     NotificationInteractionEvent.logIncoming(n, null)
+                    org.wikipedia.analytics.metricsplatform.NotificationInteractionEvent.logIncoming(n, null)
                     NotificationPresenter.showNotification(context, n,
                         dbWikiNameMap.getOrElse(n.wiki) { n.wiki },
                         dbWikiSiteMap.getValue(n.wiki).languageCode)

--- a/app/src/main/java/org/wikipedia/notifications/NotificationViewModel.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationViewModel.kt
@@ -170,6 +170,7 @@ class NotificationViewModel : ViewModel() {
             notificationsPerWiki.getOrPut(wiki) { mutableListOf() }.add(notification)
             if (!markUnread) {
                 NotificationInteractionEvent.logMarkRead(notification, selectionKey)
+                org.wikipedia.analytics.metricsplatform.NotificationInteractionEvent.logMarkRead(notification, selectionKey)
             }
         }
 

--- a/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.kt
@@ -10,6 +10,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.wikipedia.R
 import org.wikipedia.analytics.BreadcrumbsContextHelper
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.ResourceUtil
 
@@ -21,6 +22,7 @@ open class ExtendedBottomSheetDialogFragment : BottomSheetDialogFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         BreadCrumbLogEvent.logScreenShown(requireContext(), this)
+        BreadcrumbLogEvent().logScreenShown(requireContext(), this)
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/app/src/main/java/org/wikipedia/page/LinkMovementMethodExt.kt
+++ b/app/src/main/java/org/wikipedia/page/LinkMovementMethodExt.kt
@@ -9,6 +9,7 @@ import android.widget.TextView
 import androidx.core.text.getSpans
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.util.UriUtil
 import org.wikipedia.util.log.L
@@ -63,6 +64,7 @@ class LinkMovementMethodExt : LinkMovementMethod {
                 val url = UriUtil.decodeURL(links[0].url)
 
                 BreadCrumbLogEvent.logClick(widget.context, widget)
+                BreadcrumbLogEvent().logClick(widget.context, widget)
 
                 handler?.run {
                     onUrlClick(url)

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -24,6 +24,7 @@ import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.ArticleLinkPreviewInteractionEvent
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.analytics.metricsplatform.ArticleLinkPreviewInteraction
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.ActivityPageBinding
@@ -714,6 +715,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
                     isTooltipShowing = false
                 }
                 BreadCrumbLogEvent.logTooltipShown(this@PageActivity, binding.pageToolbarButtonShowOverflowMenu)
+                BreadcrumbLogEvent().logTooltipShown(this@PageActivity, binding.pageToolbarButtonShowOverflowMenu)
                 showAlignBottom(binding.pageToolbarButtonShowOverflowMenu)
                 setCurrentTooltip(this)
                 isTooltipShowing = true

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -318,6 +318,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
             return
         }
         app.appSessionEvent.backPressed()
+        app.sessionEvent.backPressed()
         if (pageFragment.onBackPressed()) {
             return
         }
@@ -588,6 +589,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Ca
                 else -> pageFragment.openFromExistingTab(pageTitle, entry)
             }
             app.appSessionEvent.pageViewed(entry)
+            app.sessionEvent.pageViewed(entry)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -359,6 +359,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
             // update our session, since it's possible for the user to remain on the page for
             // a long time, and we wouldn't want the session to time out.
             app.appSessionEvent.touchSession()
+            app.sessionEvent.touchSession()
         }
         webView.addOnContentHeightChangedListener(scrollTriggerListener)
         webView.webViewClient = object : OkHttpWebViewClient() {

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -236,6 +236,7 @@ class PageFragmentLoadState(private var model: PageViewModel,
             }
             if (title.description.isNullOrEmpty()) {
                 app.appSessionEvent.noDescription()
+                app.sessionEvent.noDescription()
             }
             if (!title.isMainPage) {
                 title.displayText = page?.displayTitle.orEmpty()

--- a/app/src/main/java/org/wikipedia/page/customize/CustomizeToolbarFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/customize/CustomizeToolbarFragment.kt
@@ -27,11 +27,13 @@ class CustomizeToolbarFragment : Fragment() {
     private lateinit var itemTouchHelper: ItemTouchHelper
     private lateinit var adapter: RecyclerItemAdapter
     private lateinit var customizeToolbarEvent: CustomizeToolbarEvent
+    private lateinit var customizeToolbarEventMetricsPlatform : org.wikipedia.analytics.metricsplatform.CustomizeToolbarEvent
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View {
         super.onCreateView(inflater, container, savedInstanceState)
         customizeToolbarEvent = CustomizeToolbarEvent()
+        customizeToolbarEventMetricsPlatform = org.wikipedia.analytics.metricsplatform.CustomizeToolbarEvent()
         _binding = FragmentCustomizeToolbarBinding.inflate(LayoutInflater.from(context), container, false)
         return binding.root
     }
@@ -39,11 +41,13 @@ class CustomizeToolbarFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         customizeToolbarEvent.resume()
+        customizeToolbarEventMetricsPlatform.timer.resume()
     }
 
     override fun onPause() {
         super.onPause()
         customizeToolbarEvent.pause()
+        customizeToolbarEventMetricsPlatform.timer.pause()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -53,6 +57,7 @@ class CustomizeToolbarFragment : Fragment() {
 
     override fun onDestroyView() {
         customizeToolbarEvent.logCustomization(Prefs.customizeToolbarOrder.toMutableList(), Prefs.customizeToolbarMenuOrder.toMutableList())
+        customizeToolbarEventMetricsPlatform.logCustomization(Prefs.customizeToolbarOrder.toMutableList(), Prefs.customizeToolbarMenuOrder.toMutableList())
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListActivity.kt
@@ -65,6 +65,7 @@ class EditHistoryListActivity : BaseActivity() {
     private var actionMode: ActionMode? = null
     private val searchActionModeCallback = SearchCallback()
     private var editHistoryInteractionEvent: EditHistoryInteractionEvent? = null
+    private var editHistoryInteractionEventMetricsPlatform: org.wikipedia.analytics.metricsplatform.EditHistoryInteractionEvent? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -86,6 +87,7 @@ class EditHistoryListActivity : BaseActivity() {
             viewModel.toggleCompareState()
             updateCompareState()
             editHistoryInteractionEvent?.logCompare1()
+            editHistoryInteractionEventMetricsPlatform?.logCompare1()
         }
 
         binding.compareConfirmButton.setOnClickListener {
@@ -95,6 +97,7 @@ class EditHistoryListActivity : BaseActivity() {
                         viewModel.selectedRevisionTo!!.revId))
             }
             editHistoryInteractionEvent?.logCompare2()
+            editHistoryInteractionEventMetricsPlatform?.logCompare2()
         }
 
         binding.editHistoryRefreshContainer.setOnRefreshListener {
@@ -148,6 +151,8 @@ class EditHistoryListActivity : BaseActivity() {
                 if (editHistoryInteractionEvent == null) {
                     editHistoryInteractionEvent = EditHistoryInteractionEvent(viewModel.pageTitle.wikiSite.dbName(), viewModel.pageId)
                     editHistoryInteractionEvent?.logShowHistory()
+                    editHistoryInteractionEventMetricsPlatform = org.wikipedia.analytics.metricsplatform.EditHistoryInteractionEvent(viewModel)
+                    editHistoryInteractionEventMetricsPlatform?.logShowHistory()
                 }
             }
             editHistoryStatsAdapter.notifyItemChanged(0)
@@ -213,10 +218,12 @@ class EditHistoryListActivity : BaseActivity() {
     private fun startSearchActionMode() {
         actionMode = startSupportActionMode(searchActionModeCallback)
         editHistoryInteractionEvent?.logSearchClick()
+        editHistoryInteractionEventMetricsPlatform?.logSearchClick()
     }
 
     fun showFilterOverflowMenu() {
         editHistoryInteractionEvent?.logFilterClick()
+        editHistoryInteractionEventMetricsPlatform?.logFilterClick()
         val editCountsValue = viewModel.editHistoryStatsData.value
         if (editCountsValue is Resource.Success) {
             val anchorView = if (actionMode != null && searchActionModeCallback.searchAndFilterActionProvider != null)
@@ -224,6 +231,7 @@ class EditHistoryListActivity : BaseActivity() {
                     editHistorySearchBarAdapter.viewHolder!!.binding.filterByButton else binding.root
             EditHistoryFilterOverflowView(this@EditHistoryListActivity).show(anchorView, editCountsValue.data) {
                 editHistoryInteractionEvent?.logFilterSelection(Prefs.editHistoryFilterType.ifEmpty { EditCount.EDIT_TYPE_ALL })
+                editHistoryInteractionEventMetricsPlatform?.logFilterSelection(Prefs.editHistoryFilterType.ifEmpty { EditCount.EDIT_TYPE_ALL })
                 setupAdapters()
                 editHistoryListAdapter.reload()
                 editHistorySearchBarAdapter.notifyItemChanged(0)
@@ -441,6 +449,7 @@ class EditHistoryListActivity : BaseActivity() {
                 viewModel.toggleCompareState()
                 updateCompareState()
                 editHistoryInteractionEvent?.logCompare1()
+                editHistoryInteractionEventMetricsPlatform?.logCompare1()
             }
             toggleSelectState()
         }

--- a/app/src/main/java/org/wikipedia/readinglist/LongPressMenu.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/LongPressMenu.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.readinglist.database.ReadingList
@@ -116,6 +117,7 @@ class LongPressMenu(private val anchorView: View, private val existsInAnyList: B
     private inner class PageSaveMenuClickListener : PopupMenu.OnMenuItemClickListener {
         override fun onMenuItemClick(item: MenuItem): Boolean {
             BreadCrumbLogEvent.logClick(anchorView.context, item)
+            BreadcrumbLogEvent().logClick(anchorView.context, item)
             return when (item.itemId) {
                 R.id.menu_long_press_open_page -> {
                     entry?.let { callback?.onOpenLink(it) }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListItemView.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListItemView.kt
@@ -11,6 +11,7 @@ import androidx.core.widget.TextViewCompat
 import org.wikipedia.R
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.databinding.ItemReadingListBinding
 import org.wikipedia.readinglist.database.ReadingList
 import org.wikipedia.util.*
@@ -205,6 +206,7 @@ class ReadingListItemView : ConstraintLayout {
     private inner class OverflowMenuClickListener constructor(private val list: ReadingList?) : PopupMenu.OnMenuItemClickListener {
         override fun onMenuItemClick(item: MenuItem): Boolean {
             BreadCrumbLogEvent.logClick(context, item)
+            BreadcrumbLogEvent().logClick(context, item)
             when (item.itemId) {
                 R.id.menu_reading_list_rename -> {
                     list?.let { callback?.onRename(it) }

--- a/app/src/main/java/org/wikipedia/recurring/DailyEventTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/DailyEventTask.kt
@@ -5,7 +5,7 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.DailyStatsEvent
 import org.wikipedia.analytics.eventplatform.EventPlatformClient
-import java.util.*
+import java.util.Date
 import java.util.concurrent.TimeUnit
 
 class DailyEventTask(context: Context) : RecurringTask() {
@@ -17,6 +17,7 @@ class DailyEventTask(context: Context) : RecurringTask() {
 
     override fun run(lastRun: Date) {
         DailyStatsEvent.log(WikipediaApp.instance)
+        org.wikipedia.analytics.metricsplatform.DailyStatsEvent().log(WikipediaApp.instance)
         EventPlatformClient.refreshStreamConfigs()
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.kt
+++ b/app/src/main/java/org/wikipedia/settings/DeveloperSettingsPreferenceLoader.kt
@@ -152,6 +152,7 @@ internal class DeveloperSettingsPreferenceLoader(fragment: PreferenceFragmentCom
         }
         findPreference(R.string.preference_key_send_event_platform_test_event).onPreferenceClickListener = Preference.OnPreferenceClickListener {
             UserContributionEvent.logOpen()
+            org.wikipedia.analytics.metricsplatform.UserContributionEvent.logOpen()
             true
         }
     }

--- a/app/src/main/java/org/wikipedia/settings/PreferenceMultiLine.kt
+++ b/app/src/main/java/org/wikipedia/settings/PreferenceMultiLine.kt
@@ -12,6 +12,7 @@ import androidx.preference.Preference.OnPreferenceClickListener
 import androidx.preference.PreferenceViewHolder
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.util.DimenUtil
 
 @Suppress("unused")
@@ -50,6 +51,7 @@ class PreferenceMultiLine : Preference {
     @SuppressLint("RestrictedApi")
     override fun performClick() {
         BreadCrumbLogEvent.logSettingsSelection(context, if (!key.isNullOrEmpty()) key else title.toString())
+        BreadcrumbLogEvent().logSettingsSelection(context, if (!key.isNullOrEmpty()) key else title.toString())
         super.performClick()
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/SwitchPreferenceMultiLine.kt
+++ b/app/src/main/java/org/wikipedia/settings/SwitchPreferenceMultiLine.kt
@@ -8,6 +8,7 @@ import androidx.preference.PreferenceViewHolder
 import androidx.preference.SwitchPreferenceCompat
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.util.DimenUtil
 
 open class SwitchPreferenceMultiLine : SwitchPreferenceCompat {
@@ -31,6 +32,7 @@ open class SwitchPreferenceMultiLine : SwitchPreferenceCompat {
     override fun callChangeListener(newValue: Any?): Boolean {
         val ret = super.callChangeListener(newValue)
         BreadCrumbLogEvent.logSettingsSelection(context, key, newValue)
+        BreadcrumbLogEvent().logSettingsSelection(context, key, newValue)
         return ret
     }
 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -24,6 +24,7 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.analytics.eventplatform.UserContributionEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.FragmentSuggestedEditsTasksBinding
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.*
@@ -63,6 +64,7 @@ class SuggestedEditsTasksFragment : Fragment() {
             .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editQualityStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editQualityStatsView.getDescriptionView())
         Prefs.showOneTimeSequentialUserStatsTooltip = false
         BreadCrumbLogEvent.logTooltipShown(requireActivity(), binding.contributionsStatsView)
+        BreadcrumbLogEvent().logTooltipShown(requireActivity(), binding.contributionsStatsView)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.kt
+++ b/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.kt
@@ -47,6 +47,7 @@ class ThemeChooserDialog : ExtendedBottomSheetDialogFragment() {
 
     private var app = WikipediaApp.instance
     private lateinit var appearanceSettingInteractionEvent: AppearanceSettingInteractionEvent
+    private lateinit var appearanceSettingInteractionEventMetricsPlatform: org.wikipedia.analytics.metricsplatform.AppearanceSettingInteractionEvent
     private lateinit var invokeSource: InvokeSource
     private val disposables = CompositeDisposable()
     private var updatingFont = false
@@ -92,6 +93,7 @@ class ThemeChooserDialog : ExtendedBottomSheetDialogFragment() {
                     }
                 }
                 appearanceSettingInteractionEvent.logFontSizeChange(currentMultiplier.toFloat(), Prefs.textSizeMultiplier.toFloat())
+                appearanceSettingInteractionEventMetricsPlatform.logFontSizeChange(currentMultiplier.toFloat(), Prefs.textSizeMultiplier.toFloat())
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) {}
@@ -129,6 +131,7 @@ class ThemeChooserDialog : ExtendedBottomSheetDialogFragment() {
         super.onCreate(savedInstanceState)
         invokeSource = requireArguments().getSerializable(Constants.INTENT_EXTRA_INVOKE_SOURCE) as InvokeSource
         appearanceSettingInteractionEvent = AppearanceSettingInteractionEvent(invokeSource)
+        appearanceSettingInteractionEventMetricsPlatform = org.wikipedia.analytics.metricsplatform.AppearanceSettingInteractionEvent(invokeSource)
     }
 
     override fun onDestroyView() {
@@ -186,6 +189,7 @@ class ThemeChooserDialog : ExtendedBottomSheetDialogFragment() {
     private fun onToggleReadingFocusMode(enabled: Boolean) {
         Prefs.readingFocusModeEnabled = enabled
         appearanceSettingInteractionEvent.logReadingFocusMode(enabled)
+        appearanceSettingInteractionEventMetricsPlatform.logReadingFocusMode(enabled)
         callback()?.onToggleReadingFocusMode()
     }
 
@@ -274,6 +278,7 @@ class ThemeChooserDialog : ExtendedBottomSheetDialogFragment() {
         override fun onClick(v: View) {
             if (app.currentTheme !== theme) {
                 appearanceSettingInteractionEvent.logThemeChange(app.currentTheme, theme)
+                appearanceSettingInteractionEventMetricsPlatform.logThemeChange(app.currentTheme, theme)
                 app.currentTheme = theme
             }
         }
@@ -284,6 +289,7 @@ class ThemeChooserDialog : ExtendedBottomSheetDialogFragment() {
             if (v.tag != null) {
                 val newFontFamily = v.tag as String
                 appearanceSettingInteractionEvent.logFontThemeChange(Prefs.fontFamily, newFontFamily)
+                appearanceSettingInteractionEventMetricsPlatform.logFontThemeChange(Prefs.fontFamily, newFontFamily)
                 app.setFontFamily(newFontFamily)
             }
         }
@@ -321,6 +327,7 @@ class ThemeChooserDialog : ExtendedBottomSheetDialogFragment() {
                 }
             }
             appearanceSettingInteractionEvent.logFontSizeChange(currentMultiplier.toFloat(), Prefs.textSizeMultiplier.toFloat())
+            appearanceSettingInteractionEventMetricsPlatform.logFontSizeChange(currentMultiplier.toFloat(), Prefs.textSizeMultiplier.toFloat())
         }
     }
 

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -19,6 +19,7 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.databinding.ViewPlainTextTooltipBinding
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.main.MainActivity
@@ -157,6 +158,7 @@ object FeedbackUtil {
             (activity as BaseActivity).setCurrentTooltip(balloon)
         }
         BreadCrumbLogEvent.logTooltipShown(activity, anchor)
+        BreadcrumbLogEvent().logTooltipShown(activity, anchor)
         return balloon
     }
 

--- a/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
@@ -118,6 +118,7 @@ class NotificationActionsOverflowView(context: Context) : FrameLayout(context) {
         val notification = container.notification
         if (url.isNotEmpty() && notification != null) {
             NotificationInteractionEvent.logAction(notification, linkIndex, link)
+            org.wikipedia.analytics.metricsplatform.NotificationInteractionEvent.logAction(notification, linkIndex, link)
             linkHandler.wikiSite = WikiSite(url)
             linkHandler.onUrlClick(url, null, "")
         }

--- a/app/src/main/java/org/wikipedia/views/ReadingListsOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/ReadingListsOverflowView.kt
@@ -9,6 +9,7 @@ import android.widget.PopupWindow
 import androidx.core.widget.PopupWindowCompat
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.metricsplatform.BreadcrumbLogEvent
 import org.wikipedia.databinding.ViewReadingListsOverflowBinding
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DateUtil
@@ -30,26 +31,31 @@ class ReadingListsOverflowView(context: Context) : FrameLayout(context) {
     init {
         binding.readingListsOverflowSortBy.setOnClickListener {
             BreadCrumbLogEvent.logClick(context, it)
+            BreadcrumbLogEvent().logClick(context, it)
             dismissPopupWindowHost()
             callback?.sortByClick()
         }
         binding.readingListsOverflowCreateNewList.setOnClickListener {
             BreadCrumbLogEvent.logClick(context, it)
+            BreadcrumbLogEvent().logClick(context, it)
             dismissPopupWindowHost()
             callback?.createNewListClick()
         }
         binding.readingListsOverflowImportList.setOnClickListener {
             BreadCrumbLogEvent.logClick(context, it)
+            BreadcrumbLogEvent().logClick(context, it)
             dismissPopupWindowHost()
             callback?.importNewList()
         }
         binding.readingListsOverflowSelect.setOnClickListener {
             BreadCrumbLogEvent.logClick(context, it)
+            BreadcrumbLogEvent().logClick(context, it)
             dismissPopupWindowHost()
             callback?.selectListClick()
         }
         binding.readingListsOverflowRefresh.setOnClickListener {
             BreadCrumbLogEvent.logClick(context, it)
+            BreadcrumbLogEvent().logClick(context, it)
             dismissPopupWindowHost()
             callback?.refreshClick()
         }


### PR DESCRIPTION
After verifying data coming thru in a recent pre-prod beta release, this PR proposes to submit events for the remaining Android instruments (currently submitted via Modern Event Platform).

The following instruments are included for logging events via Metrics Platform:
- AppearanceSettingInteractionEvent
- AppSessionEvent
- BreadcrumbLogEvent
- CreateAccountEvent
- CustomizeToolbarEvent
- DailyStatsEvent
- EditHistoryInteractionEvent
- InstallReferrerEvent
- NotificationInteractionEvent
- UserContributionEvent

Some of the new MP classes aim to consolidate some of the above instruments. If it is preferred to keep naming conventions 1:1, I can adjust accordingly.

Note: these changes are purely additive - no changes should occur with current event logging.

Bug: T330355