### PR TITLE
Revisit TODOs and remove/update them

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationRepository.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationRepository.kt
@@ -33,7 +33,6 @@ class NotificationRepository constructor(private val notificationDao: Notificati
         var newContinueStr: String? = null
         val response = ServiceFactory.get(WikipediaApp.instance.wikiSite).getAllNotifications(wikiList, filter, continueStr)
         response.query?.notifications?.let {
-            // TODO: maybe add a logic to avoid adding same data into database.
             insertNotifications(it.list.orEmpty())
             newContinueStr = it.continueStr
         }

--- a/app/src/main/java/org/wikipedia/views/AutoFitRecyclerView.kt
+++ b/app/src/main/java/org/wikipedia/views/AutoFitRecyclerView.kt
@@ -40,7 +40,7 @@ open class AutoFitRecyclerView constructor(context: Context, attrs: AttributeSet
 
     override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
         // https://issuetracker.google.com/issues/37034096
-        // TODO: check again in Sep 2021
+        // TODO: check again in August 2024
         try {
             super.onLayout(changed, l, t, r, b)
         } catch (e: Exception) {


### PR DESCRIPTION
1. Remove the TODO in `NotificationRepository` since we use `@Insert(onConflict = OnConflictStrategy.REPLACE)` in `NotificationDao`

2. The issue in `AutoFitRecyclerView` is still there, we will check it next year. 