### PR TITLE
Update ktlint to 0.5.0.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,15 @@
 # Customizations for ktlint
 [*.{kt,kts}]
-disabled_rules=indent,parameter-list-wrapping,no-wildcard-imports
+ktlint_standard_indent = disabled
+ktlint_standard_argument-list-wrapping = disabled
+ktlint_standard_parameter-list-wrapping = disabled
+ktlint_standard_wrapping = disabled
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_multiline-if-else = disabled
+ktlint_standard_spacing-between-declarations-with-annotations = disabled
+ktlint_standard_annotation = disabled
+ktlint_standard_spacing-between-declarations-with-comments = disabled
+ktlint_standard_no-empty-first-line-in-method-block = disabled
+

--- a/app/src/androidTest/java/org/wikipedia/TestUtil.kt
+++ b/app/src/androidTest/java/org/wikipedia/TestUtil.kt
@@ -80,7 +80,7 @@ object TestUtil {
 
         device.executeShellCommand("su 0 settings put global airplane_mode_on " + if (enabled) "1" else "0")
         device.executeShellCommand("su 0 am broadcast -a android.intent.action.AIRPLANE_MODE")
-        */
+         */
         /*
         Extremely hacky:
 
@@ -90,7 +90,7 @@ object TestUtil {
         Thread.sleep(2000)
         device.pressBack()
         Thread.sleep(delaySecAfter * 1000)
-        */
+         */
 
         // Slightly less hacky:
         device.executeShellCommand("am start -a android.settings.AIRPLANE_MODE_SETTINGS")

--- a/app/src/androidTest/java/org/wikipedia/main/LoggedInTests.kt
+++ b/app/src/androidTest/java/org/wikipedia/main/LoggedInTests.kt
@@ -7,8 +7,8 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.`is`
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/org/wikipedia/main/SmokeTests.kt
+++ b/app/src/androidTest/java/org/wikipedia/main/SmokeTests.kt
@@ -22,8 +22,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/DestinationEventService.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/DestinationEventService.kt
@@ -13,5 +13,5 @@ import org.wikipedia.BuildConfig
 enum class DestinationEventService(val id: String, val baseUri: String) {
 
     ANALYTICS("eventgate-analytics-external", BuildConfig.EVENTGATE_ANALYTICS_EXTERNAL_BASE_URI),
-    LOGGING("eventgate-logging-external", BuildConfig.EVENTGATE_LOGGING_EXTERNAL_BASE_URI);
+    LOGGING("eventgate-logging-external", BuildConfig.EVENTGATE_LOGGING_EXTERNAL_BASE_URI)
 }

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
@@ -22,7 +22,7 @@ abstract class OkHttpWebViewClient : WebViewClient() {
     /*
         Note: Any data transformations performed here are only for the benefit of WebViews.
         They should not be made into general Interceptors.
-    */
+     */
 
     abstract val model: PageViewModel
     abstract val linkHandler: LinkHandler

--- a/app/src/main/java/org/wikipedia/history/HistoryEntry.kt
+++ b/app/src/main/java/org/wikipedia/history/HistoryEntry.kt
@@ -19,8 +19,8 @@ import java.util.*
 @Parcelize
 @TypeParceler<Date, DateParceler>()
 @Entity
-// TODO: change these properties back to val when HistoryEntry is no longer serializable. (i.e. when we update Tabs to be in the database instead of Prefs)
 class HistoryEntry(
+    // TODO: change these properties back to val when HistoryEntry is no longer serializable. (i.e. when we update Tabs to be in the database instead of Prefs)
     var authority: String = "",
     var lang: String = "",
     var apiTitle: String = "",

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsShareHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsShareHelper.kt
@@ -79,7 +79,7 @@ object ReadingListsShareHelper {
         pageIdMap.keys.forEach { key -> projectUrlMap[key] = pageIdMap[key]!!.values.map { JsonPrimitive(it) } }
 
         // TODO: for now we're not transmitting the free-form Name and Description of a reading list.
-        val exportedReadingLists = ExportedReadingLists(projectUrlMap /*, readingList.title, readingList.description */)
+        val exportedReadingLists = ExportedReadingLists(projectUrlMap) // , readingList.title, readingList.description)
         return Base64.encodeToString(JsonUtil.encodeToString(exportedReadingLists)!!.toByteArray(), Base64.NO_WRAP)
     }
 

--- a/gradle/src/ktlint.gradle
+++ b/gradle/src/ktlint.gradle
@@ -3,7 +3,7 @@ configurations {
 }
 
 dependencies {
-    ktlint "com.pinterest:ktlint:0.40.0"
+    ktlint 'com.pinterest:ktlint:0.50.0'
     // additional 3rd party ruleset(s) can be specified here
     // just add them to the classpath (e.g. ktlint 'groupId:artifactId:version') and
     // ktlint will pick them up
@@ -13,7 +13,7 @@ task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
     mainClass.set("com.pinterest.ktlint.Main")
-    args "--verbose", "src/**/*.kt"
+    args "src/**/*.kt"
     // to generate report in checkstyle format prepend following args:
     // "--reporter=plain", "--reporter=checkstyle,output=${buildDir}/ktlint.xml"
     // to add a baseline to check against prepend following args:


### PR DESCRIPTION
This upgrades to the latest version of ktlint (we've been behind for a few versions):
https://github.com/pinterest/ktlint/releases/tag/0.50.0

The latest version has totally changed and expanded their collection of standard rules, so we need to update our `.editorconfig` file to match the rules that we were disabling before.
This also makes a few tweaks that play with the newest ktlint rules.