### PR TITLE
Don't use MaterialDialogBuilder for announcement dialogs.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/AnnouncementDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/AnnouncementDialog.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import android.widget.ScrollView
 import androidx.appcompat.app.AlertDialog
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.Constants
 import org.wikipedia.feed.announcement.Announcement
 import org.wikipedia.feed.announcement.AnnouncementCard

--- a/app/src/main/java/org/wikipedia/page/AnnouncementDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/AnnouncementDialog.kt
@@ -20,7 +20,7 @@ import org.wikipedia.util.UriUtil
 class AnnouncementDialog internal constructor(
     context: Context,
     val announcement: Announcement
-) : MaterialAlertDialogBuilder(context), AnnouncementCardView.Callback {
+) : AlertDialog.Builder(context), AnnouncementCardView.Callback {
 
     private var dialog: AlertDialog? = null
 


### PR DESCRIPTION
When using the MaterialDialog style with announcement dialogs, it makes them unnecessarily tiny, and also gives incorrect rounded corners.
For now, let's no longer use MaterialDialogBuilder for announcements, and use the standard AlertDialog.

![image](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/8e64f31e-278a-420a-98e4-9f63a1c4f536) | ![image](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/5e062cf0-63ea-4c61-8236-5f87d47f94fd)
