### PR TITLE
Set input field hint properly in TextInputDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/views/TextInputDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/TextInputDialog.kt
@@ -64,7 +64,7 @@ class TextInputDialog constructor(context: Context) : MaterialAlertDialogBuilder
     }
 
     fun setHint(@StringRes id: Int) {
-        binding.textInput.hint = context.resources.getString(id)
+        binding.textInputContainer.hint = context.resources.getString(id)
     }
 
     fun setSecondaryHint(@StringRes id: Int) {


### PR DESCRIPTION
Before: no label (title) on the input field
<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/b57dcd38-80c5-44c8-a24f-248efc708f78" width="400">

After:
<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/73ad9a26-cbe5-47d1-9569-e0d000ac6278" width="400">
