### PR TITLE
Generalize composing feedback email.

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
@@ -1,8 +1,6 @@
 package org.wikipedia.settings
 
 import android.app.Activity
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.view.View
@@ -15,7 +13,6 @@ import org.wikipedia.activity.BaseActivity
 import org.wikipedia.databinding.ActivityAboutBinding
 import org.wikipedia.richtext.setHtml
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.log.L
 
 class AboutActivity : BaseActivity() {
 
@@ -35,14 +32,7 @@ class AboutActivity : BaseActivity() {
         makeEverythingClickable(binding.aboutContainer)
 
         binding.sendFeedbackText.setOnClickListener {
-            val intent = Intent()
-                    .setAction(Intent.ACTION_SENDTO)
-                    .setData(Uri.parse("mailto:android-support@wikimedia.org?subject=Android App ${BuildConfig.VERSION_NAME} Feedback"))
-            try {
-                startActivity(intent)
-            } catch (e: Exception) {
-                L.e(e)
-            }
+            FeedbackUtil.composeFeedbackEmail(this, "Android App ${BuildConfig.VERSION_NAME} Feedback")
         }
     }
 

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -2,6 +2,7 @@ package org.wikipedia.util
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -29,6 +30,7 @@ import org.wikipedia.random.RandomActivity
 import org.wikipedia.readinglist.ReadingListActivity
 import org.wikipedia.suggestededits.SuggestionsActivity
 import org.wikipedia.talk.TalkTopicsActivity
+import org.wikipedia.util.log.L
 
 object FeedbackUtil {
     private const val LENGTH_SHORT = 3000
@@ -104,6 +106,17 @@ object FeedbackUtil {
     fun showAndroidAppEditingFAQ(context: Context,
                                  @StringRes urlStr: Int = R.string.android_app_edit_help_url) {
         UriUtil.visitInExternalBrowser(context, Uri.parse(context.getString(urlStr)))
+    }
+
+    fun composeFeedbackEmail(context: Context, subject: String, body: String = "") {
+        val intent = Intent()
+            .setAction(Intent.ACTION_SENDTO)
+            .setData(Uri.parse("mailto:${context.getString(R.string.support_email)}?subject=${Uri.encode(subject)}&body=${Uri.encode(body)}"))
+        try {
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            L.e(e)
+        }
     }
 
     fun setButtonLongPressToast(vararg views: View) {

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1099,8 +1099,11 @@
   <string name="image_recommendation_tooltip_3">Tooltip message during the onboarding sequence for the image recommendations feature.</string>
   <string name="image_recommendation_tooltip_next">Button label for going to the next tooltip in the onboarding sequence.</string>
   <string name="image_recommendation_tooltip_warning">Tooltip that warns the user to examine the article thoroughly before acting on the recommendation.</string>
+  <string name="suggested_edits_report_feature">Menu item for reporting a general issue with the feature.</string>
+  <string name="suggested_edits_report_feature_subject">Subject heading for message when reporting a problem with the feature.</string>
   <string name="edit_summary_added_image">Edit summary when an image was added.</string>
   <string name="edit_summary_added_caption">Edit summary when an image caption was added.</string>
+  <string name="edit_summary_added_image_and_caption">Edit summary when an image and its caption were added.</string>
   <string name="edit_published_view">Button label for viewing an edit after it is published.</string>
   <string name="file_page_activity_title">Title shown at the top of the activity for the file page.</string>
   <string name="file_page_add_image_caption_button">Button label to add image caption for the file.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1120,8 +1120,11 @@
     <string name="image_recommendation_tooltip_3">Decide if the image helps readers understand this topic better</string>
     <string name="image_recommendation_tooltip_next">Next</string>
     <string name="image_recommendation_tooltip_warning">Please review the article to understand its topic and inspect the image</string>
+    <string name="suggested_edits_report_feature">Problem with feature</string>
+    <string name="suggested_edits_report_feature_subject">Problem with Suggested Edits</string>
     <string name="edit_summary_added_image">Added image</string>
     <string name="edit_summary_added_caption">Added caption</string>
+    <string name="edit_summary_added_image_and_caption">Added image and caption</string>
     <string name="edit_published_view">View</string>
     <!-- /Suggested edits -->
 

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -4,6 +4,7 @@
     <string name="channel" />
 
     <!-- URLs -->
+    <string name="support_email">android-support@wikimedia.org</string>
     <string name="donate_url">https://donate.wikimedia.org/?utm_medium=WikipediaApp&amp;utm_campaign=Android&amp;utm_source=%1$s&amp;uselang=%2$s</string>
     <string name="suggested_edits_survey_url">@null</string>
     <string name="talk_pages_survey_url">https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/Android/Communication/UsertestingOctober2021</string>


### PR DESCRIPTION
This factors out a special function for composing an email (i.e. sending an Intent that contains email information), currently used only from AboutActivity for sending feedback, but will be used in the upcoming Image Recommendation and Patroller Tasks features.

This also includes a few new strings for use in Image Recommendations, which should be merged now, so that they'll be synced to TWN and get translated sooner.