### PR TITLE
Change in edit comment tag naming order for IR

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
@@ -373,8 +373,8 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
     companion object {
         const val ARG_LANG = "lang"
         const val MIN_TIME_WARNING_MILLIS = 5000
-        const val IMAGE_REC_EDIT_COMMENT_TOP = "#suggestededit-image-add-top"
-        const val IMAGE_REC_EDIT_COMMENT_INFOBOX = "#suggestededit-image-add-infobox"
+        const val IMAGE_REC_EDIT_COMMENT_TOP = "#suggestededit-add-image-top"
+        const val IMAGE_REC_EDIT_COMMENT_INFOBOX = "#suggestededit-add-image-infobox"
 
         fun newInstance(): SuggestedEditsItemFragment {
             return SuggestedEditsImageRecsFragment()


### PR DESCRIPTION
There is a request in the instrumentation doc to change the naming order to keep consistent with the rest: https://docs.google.com/presentation/d/10Twu9rnHy4XFzBjxRKDQPMKDVPDJDd9hBQXYwN7nilU/edit#slide=id.g1e4cd7273df_0_29