### PR TITLE
Fix possible crash due to Receiver on API 34.

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -1,10 +1,8 @@
 package org.wikipedia.gallery
 
 import android.app.Activity
-import android.app.DownloadManager
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -207,14 +207,12 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.Callback, GalleryItemF
 
     public override fun onResume() {
         super.onResume()
-        registerReceiver(downloadReceiver, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
-        downloadReceiver.callback = downloadReceiverCallback
+        downloadReceiver.register(this, downloadReceiverCallback)
     }
 
     public override fun onPause() {
         super.onPause()
-        downloadReceiver.callback = null
-        unregisterReceiver(downloadReceiver)
+        downloadReceiver.unregister(this)
     }
 
     override fun onDownload(item: GalleryItemFragment) {

--- a/app/src/main/java/org/wikipedia/gallery/MediaDownloadReceiver.kt
+++ b/app/src/main/java/org/wikipedia/gallery/MediaDownloadReceiver.kt
@@ -1,11 +1,14 @@
 package org.wikipedia.gallery
 
+import android.annotation.SuppressLint
 import android.app.DownloadManager
 import android.content.BroadcastReceiver
 import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.net.Uri
+import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import androidx.core.content.contentValuesOf
@@ -23,7 +26,22 @@ class MediaDownloadReceiver : BroadcastReceiver() {
         fun onSuccess()
     }
 
-    var callback: Callback? = null
+    private var callback: Callback? = null
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    fun register(context: Context, callback: Callback) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(this, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE), Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            context.registerReceiver(this, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
+        }
+        this.callback = callback
+    }
+
+    fun unregister(context: Context) {
+        context.unregisterReceiver(this)
+        callback = null
+    }
 
     fun download(context: Context, featuredImage: FeaturedImage) {
         val filename = FileUtil.sanitizeFileName(featuredImage.title)

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -3,10 +3,8 @@ package org.wikipedia.main
 import android.Manifest
 import android.app.Activity
 import android.app.ActivityOptions
-import android.app.DownloadManager
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.os.Build

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -154,15 +154,12 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
 
     override fun onPause() {
         super.onPause()
-        downloadReceiver.callback = null
-        requireContext().unregisterReceiver(downloadReceiver)
+        downloadReceiver.unregister(requireContext())
     }
 
     override fun onResume() {
         super.onResume()
-        requireContext().registerReceiver(downloadReceiver,
-                IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
-        downloadReceiver.callback = downloadReceiverCallback
+        downloadReceiver.register(requireContext(), downloadReceiverCallback)
         // reset the last-page-viewed timer
         Prefs.pageLastShown = 0
         maybeShowWatchlistTooltip()


### PR DESCRIPTION
Android 34 (beta) will now crash if we try to register a Receiver without specifying a `RECEIVER_NOT_EXPORTED` or `RECEIVER_EXPORTED` flag.