### PR TITLE
Avoid accidental link clicks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -185,7 +185,7 @@ dependencies {
 
     implementation "com.google.android.material:material:1.9.0"
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation "androidx.core:core-ktx:1.10.1"
+    implementation "androidx.core:core-ktx:1.12.0"
     implementation "androidx.browser:browser:1.5.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "androidx.fragment:fragment-ktx:1.6.1"

--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.kt
@@ -2,10 +2,10 @@ package org.wikipedia.feed.announcement
 
 import android.content.Context
 import android.net.Uri
-import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
+import androidx.core.text.method.LinkMovementMethodCompat
 import androidx.core.view.updateLayoutParams
 import org.wikipedia.R
 import org.wikipedia.databinding.ViewCardAnnouncementBinding
@@ -24,8 +24,8 @@ class AnnouncementCardView(context: Context) : DefaultFeedCardView<AnnouncementC
     var localCallback: Callback? = null
 
     init {
-        binding.viewAnnouncementText.movementMethod = LinkMovementMethod.getInstance()
-        binding.viewAnnouncementFooterText.movementMethod = LinkMovementMethod.getInstance()
+        binding.viewAnnouncementText.movementMethod = LinkMovementMethodCompat.getInstance()
+        binding.viewAnnouncementFooterText.movementMethod = LinkMovementMethodCompat.getInstance()
         binding.viewAnnouncementActionPositive.setOnClickListener { onPositiveActionClick() }
         binding.viewAnnouncementDialogActionPositive.setOnClickListener { onPositiveActionClick() }
         binding.viewAnnouncementActionNegative.setOnClickListener { onNegativeActionClick() }

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
@@ -111,10 +111,10 @@ class NotificationPollBroadcastReceiver : BroadcastReceiver() {
         private fun getAlarmPendingIntent(context: Context): PendingIntent {
             val intent = Intent(context, NotificationPollBroadcastReceiver::class.java)
             intent.action = ACTION_POLL
-            return PendingIntentCompat.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT, false)
+            return PendingIntentCompat.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT, false)!!
         }
 
-        fun getCancelNotificationPendingIntent(context: Context, id: Long, type: String?): PendingIntent {
+        fun getCancelNotificationPendingIntent(context: Context, id: Long, type: String?): PendingIntent? {
             val intent = Intent(context, NotificationPollBroadcastReceiver::class.java)
                     .setAction(ACTION_CANCEL)
                     .putExtra(Constants.INTENT_EXTRA_NOTIFICATION_ID, id)

--- a/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
@@ -2,11 +2,10 @@ package org.wikipedia.settings
 
 import android.app.Activity
 import android.os.Bundle
-import android.text.method.LinkMovementMethod
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
-import androidx.core.view.forEach
+import androidx.core.text.method.LinkMovementMethodCompat
+import androidx.core.view.descendants
 import org.wikipedia.BuildConfig
 import org.wikipedia.R
 import org.wikipedia.activity.BaseActivity
@@ -29,20 +28,11 @@ class AboutActivity : BaseActivity() {
         binding.activityAboutLibraries.setHtml(getString(R.string.libraries_list))
         binding.aboutVersionText.text = BuildConfig.VERSION_NAME
         binding.aboutLogoImage.setOnClickListener(AboutLogoClickListener())
-        makeEverythingClickable(binding.aboutContainer)
-
+        binding.aboutContainer.descendants.filterIsInstance<TextView>().forEach {
+            it.movementMethod = LinkMovementMethodCompat.getInstance()
+        }
         binding.sendFeedbackText.setOnClickListener {
             FeedbackUtil.composeFeedbackEmail(this, "Android App ${BuildConfig.VERSION_NAME} Feedback")
-        }
-    }
-
-    private fun makeEverythingClickable(vg: ViewGroup) {
-        vg.forEach {
-            if (it is ViewGroup) {
-                makeEverythingClickable(it)
-            } else if (it is TextView) {
-                it.movementMethod = LinkMovementMethod.getInstance()
-            }
         }
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -4,7 +4,6 @@ import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Bundle
-import android.text.method.LinkMovementMethod
 import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.View
@@ -12,6 +11,7 @@ import android.view.View.*
 import android.view.ViewGroup
 import android.widget.CompoundButton
 import android.widget.Toast
+import androidx.core.text.method.LinkMovementMethodCompat
 import androidx.core.view.children
 import androidx.core.widget.ImageViewCompat
 import com.google.android.material.chip.Chip
@@ -86,7 +86,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
 
         binding.tagsLicenseText.text = StringUtil.fromHtml(getString(R.string.suggested_edits_cc0_notice,
                 getString(R.string.terms_of_use_url), getString(R.string.cc_0_url)))
-        binding.tagsLicenseText.movementMethod = LinkMovementMethod.getInstance()
+        binding.tagsLicenseText.movementMethod = LinkMovementMethodCompat.getInstance()
 
         binding.imageView.setOnClickListener {
             if (Prefs.showImageZoomTooltip) {

--- a/app/src/main/java/org/wikipedia/views/NotificationWithProgressBar.kt
+++ b/app/src/main/java/org/wikipedia/views/NotificationWithProgressBar.kt
@@ -105,7 +105,7 @@ class NotificationWithProgressBar {
     private fun pendingIntentBuilder(context: Context,
                                      targetClass: Class<*>,
                                      intentExtra: String,
-                                     requestCode: Int): PendingIntent {
+                                     requestCode: Int): PendingIntent? {
         val resultIntent = Intent(context, targetClass)
         resultIntent.putExtra(intentExtra, true)
         resultIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)


### PR DESCRIPTION
Fix an issue on all current versions of Android where it is possible to activate links even when touching outside their line bounds. The issue is fixed on Android V.

**Before change**

https://github.com/wikimedia/apps-android-wikipedia/assets/31027858/2f684ec8-dabe-4983-b984-c6116364dc4a

**After change**

https://github.com/wikimedia/apps-android-wikipedia/assets/31027858/b0761582-1a82-43ea-85bd-102815b2821e
