### PR TITLE
IR data: EditattemptStep events

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
@@ -84,8 +84,7 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
                 .show()
             ImageRecommendationsEvent.logAction("editsummary_success_confirm", "editsummary_dialog",
                 getActionStringForAnalytics(acceptanceState = "accepted", revisionId = revId, addTimeSpent = true), viewModel.langCode)
-            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
-            EditAttemptStepEvent.logSaveSuccess(title)
+            EditAttemptStepEvent.logSaveSuccess(viewModel.pageTitle)
             viewModel.acceptRecommendation(null, revId)
             callback().nextPage(this)
         }
@@ -132,8 +131,7 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
         binding.acceptButton.setOnClickListener {
             ImageRecommendationsEvent.logAction("suggestion_accept", "recommendedimagetoolbar",
                 getActionStringForAnalytics(acceptanceState = "accepted"), viewModel.langCode)
-            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
-            EditAttemptStepEvent.logInit(title)
+            EditAttemptStepEvent.logInit(viewModel.pageTitle)
             doPublish()
         }
 
@@ -170,8 +168,7 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
         binding.readMoreButton.setOnClickListener {
             ImageRecommendationsEvent.logAction("read_more", "recommendedimagetoolbar",
                 getActionStringForAnalytics(), viewModel.langCode)
-            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
-            startActivity(PageActivity.newIntentForNewTab(requireActivity(), HistoryEntry(title, HistoryEntry.SOURCE_SUGGESTED_EDITS), title))
+            startActivity(PageActivity.newIntentForNewTab(requireActivity(), HistoryEntry(viewModel.pageTitle, HistoryEntry.SOURCE_SUGGESTED_EDITS), viewModel.pageTitle))
         }
 
         ImageZoomHelper.setViewZoomable(binding.imageView)

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
@@ -32,6 +32,7 @@ import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
+import org.wikipedia.analytics.eventplatform.EditAttemptStepEvent
 import org.wikipedia.analytics.eventplatform.ImageRecommendationsEvent
 import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.FragmentSuggestedEditsImageRecsItemBinding
@@ -83,6 +84,8 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
                 .show()
             ImageRecommendationsEvent.logAction("editsummary_success_confirm", "editsummary_dialog",
                 getActionStringForAnalytics(acceptanceState = "accepted", revisionId = revId, addTimeSpent = true), viewModel.langCode)
+            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
+            EditAttemptStepEvent.logSaveSuccess(title)
             viewModel.acceptRecommendation(null, revId)
             callback().nextPage(this)
         }
@@ -129,6 +132,8 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
         binding.acceptButton.setOnClickListener {
             ImageRecommendationsEvent.logAction("suggestion_accept", "recommendedimagetoolbar",
                 getActionStringForAnalytics(acceptanceState = "accepted"), viewModel.langCode)
+            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
+            EditAttemptStepEvent.logInit(title)
             doPublish()
         }
 


### PR DESCRIPTION
Couple more data wirings for image recs data. Simultaneously sending data to the legacy EditAttemptStep table as well.
Doc: https://docs.google.com/presentation/d/10Twu9rnHy4XFzBjxRKDQPMKDVPDJDd9hBQXYwN7nilU/edit#slide=id.g1e4cd7273df_0_29