### PR TITLE
Minor fix

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
@@ -84,8 +84,7 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
                 .show()
             ImageRecommendationsEvent.logAction("editsummary_success_confirm", "editsummary_dialog",
                 getActionStringForAnalytics(acceptanceState = "accepted", revisionId = revId, addTimeSpent = true), viewModel.langCode)
-            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
-            EditAttemptStepEvent.logSaveSuccess(title)
+            EditAttemptStepEvent.logSaveSuccess(viewModel.pageTitle)
             viewModel.acceptRecommendation(null, revId)
             callback().nextPage(this)
         }
@@ -132,8 +131,7 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
         binding.acceptButton.setOnClickListener {
             ImageRecommendationsEvent.logAction("suggestion_accept", "recommendedimagetoolbar",
                 getActionStringForAnalytics(acceptanceState = "accepted"), viewModel.langCode)
-            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
-            EditAttemptStepEvent.logInit(title)
+            EditAttemptStepEvent.logInit(viewModel.pageTitle)
             doPublish()
         }
 
@@ -170,8 +168,7 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
         binding.readMoreButton.setOnClickListener {
             ImageRecommendationsEvent.logAction("read_more", "recommendedimagetoolbar",
                 getActionStringForAnalytics(), viewModel.langCode)
-            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
-            startActivity(PageActivity.newIntentForNewTab(requireActivity(), HistoryEntry(title, HistoryEntry.SOURCE_SUGGESTED_EDITS), title))
+            startActivity(PageActivity.newIntentForNewTab(requireActivity(), HistoryEntry(viewModel.pageTitle, HistoryEntry.SOURCE_SUGGESTED_EDITS), viewModel.pageTitle))
         }
 
         ImageZoomHelper.setViewZoomable(binding.imageView)

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewModelScope
 import androidx.palette.graphics.Palette
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import kotlinx.coroutines.launch
@@ -430,12 +431,17 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
 
     private fun getActionStringForAnalytics(acceptanceState: String? = null, rejectionReasons: String? = null,
                                             revisionId: Long? = null, addTimeSpent: Boolean = false): String {
-        val recommendedImage = viewModel.recommendation.images[0]
-        return ImageRecommendationsEvent.getActionDataString(filename = recommendedImage.image,
-            recommendationSource = recommendedImage.source,
-            recommendationSourceProjects = recommendedImage.projects.toString(),
-            acceptanceState = acceptanceState, rejectionReasons = rejectionReasons,
-            revisionId = revisionId, addTimeSpent = addTimeSpent)
+
+        return if (viewModel.isRecommendationInitialized) {
+            val recommendedImage = viewModel.recommendation.images[0]
+            ImageRecommendationsEvent.getActionDataString(
+                filename = recommendedImage.image,
+                recommendationSource = recommendedImage.source,
+                recommendationSourceProjects = recommendedImage.projects.toString(),
+                acceptanceState = acceptanceState, rejectionReasons = rejectionReasons,
+                revisionId = revisionId, addTimeSpent = addTimeSpent
+            )
+        } else ""
     }
 
     override fun onBackPressed(): Boolean {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
@@ -32,6 +32,7 @@ import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
+import org.wikipedia.analytics.eventplatform.EditAttemptStepEvent
 import org.wikipedia.analytics.eventplatform.ImageRecommendationsEvent
 import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.FragmentSuggestedEditsImageRecsItemBinding
@@ -83,6 +84,8 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
                 .show()
             ImageRecommendationsEvent.logAction("editsummary_success_confirm", "editsummary_dialog",
                 getActionStringForAnalytics(acceptanceState = "accepted", revisionId = revId, addTimeSpent = true), viewModel.langCode)
+            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
+            EditAttemptStepEvent.logSaveSuccess(title)
             viewModel.acceptRecommendation(null, revId)
             callback().nextPage(this)
         }
@@ -129,6 +132,8 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
         binding.acceptButton.setOnClickListener {
             ImageRecommendationsEvent.logAction("suggestion_accept", "recommendedimagetoolbar",
                 getActionStringForAnalytics(acceptanceState = "accepted"), viewModel.langCode)
+            val title = PageTitle(viewModel.recommendation.titleText, WikiSite.forLanguageCode(viewModel.langCode))
+            EditAttemptStepEvent.logInit(title)
             doPublish()
         }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragmentViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragmentViewModel.kt
@@ -41,6 +41,7 @@ class SuggestedEditsImageRecsFragmentViewModel(bundle: Bundle) : ViewModel() {
     lateinit var summary: PageSummary
     lateinit var recommendedImageTitle: PageTitle
     var attemptInsertInfobox = false
+    val isRecommendationInitialized get() = ::recommendation.isInitialized
 
     val langCode = bundle.getString(SuggestedEditsImageRecsFragment.ARG_LANG)!!
     private val _uiState = MutableStateFlow(UiState())


### PR DESCRIPTION
On edge case, when a user sees the fullscreen onboarding for IR, if they backpress, app crashes because the image hasnt been set up yet. Adding this check will prevent the crash.