### PR TITLE
Remove "All" option from Latest revision group and fix reset button in Watchlist filter

### DIFF
--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFilterActivity.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFilterActivity.kt
@@ -43,7 +43,9 @@ class WatchlistFilterActivity : BaseActivity() {
     }
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-        val shouldShowResetButton = Prefs.watchlistExcludedWikiCodes.isNotEmpty() || !Prefs.watchlistIncludedTypeCodes.containsAll(WatchlistFilterTypes.DEFAULT_FILTER_TYPE_SET.map { it.id })
+        val defaultTypeSet = WatchlistFilterTypes.DEFAULT_FILTER_TYPE_SET.map { it.id }
+        val shouldShowResetButton = Prefs.watchlistExcludedWikiCodes.isNotEmpty() ||
+                !(Prefs.watchlistIncludedTypeCodes.containsAll(defaultTypeSet) && Prefs.watchlistIncludedTypeCodes.subtract(defaultTypeSet.toSet()).isEmpty())
         menu.findItem(R.id.menu_filter_reset).isVisible = shouldShowResetButton
         return super.onPrepareOptionsMenu(menu)
     }

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFilterTypes.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFilterTypes.kt
@@ -38,8 +38,6 @@ enum class WatchlistFilterTypes constructor(val id: String,
         R.string.watchlist_filter_watchlist_activity_unseen, "unread"),
     SEEN_CHANGES("seenChanges",
         R.string.watchlist_filter_watchlist_activity_seen, "!unread"),
-    ALL_REVISIONS("allRevisions",
-        R.string.watchlist_filter_all_text, ""),
     LATEST_REVISION("latestRevision",
         R.string.watchlist_filter_latest_revisions_latest_revision, ""),
     NOT_LATEST_REVISION("notLatestRevision",
@@ -92,13 +90,13 @@ enum class WatchlistFilterTypes constructor(val id: String,
         val MINOR_EDITS_GROUP = listOf(ALL_EDITS, MINOR_EDITS, NON_MINOR_EDITS)
         val BOT_EDITS_GROUP = listOf(ALL_EDITORS, BOT, HUMAN)
         val UNSEEN_CHANGES_GROUP = listOf(ALL_CHANGES, UNSEEN_CHANGES, SEEN_CHANGES)
-        val LATEST_REVISIONS_GROUP = listOf(ALL_REVISIONS, LATEST_REVISION, NOT_LATEST_REVISION)
+        val LATEST_REVISIONS_GROUP = listOf(LATEST_REVISION, NOT_LATEST_REVISION)
         val USER_STATUS_GROUP = listOf(ALL_USERS, UNREGISTERED, REGISTERED)
 
         // Multiple choice
         val DEFAULT_FILTER_TYPE_OF_CHANGES = setOf(PAGE_EDITS, PAGE_CREATIONS, LOGGED_ACTIONS)
         // Single choice
-        val DEFAULT_FILTER_OTHERS = setOf(ALL_EDITS, ALL_CHANGES, ALL_REVISIONS, ALL_EDITORS, ALL_USERS)
+        val DEFAULT_FILTER_OTHERS = setOf(ALL_EDITS, ALL_CHANGES, LATEST_REVISION, ALL_EDITORS, ALL_USERS)
         val DEFAULT_FILTER_TYPE_SET = DEFAULT_FILTER_OTHERS + DEFAULT_FILTER_TYPE_OF_CHANGES
 
         private val MAP = EnumCodeMap(WatchlistFilterTypes::class.java)


### PR DESCRIPTION
https://phabricator.wikimedia.org/T345869

This keeps the original logic of handling the filter value, in case we need to add something more in the future.

This PR also fixes the Reset button logic in the `WatchlistFilterActivity`.