### PR TITLE
IR data: Change of stream name

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/ImageRecommendationsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/ImageRecommendationsEvent.kt
@@ -19,7 +19,7 @@ class ImageRecommendationsEvent(
 ) : MobileAppsEvent(STREAM_NAME) {
 
     companion object {
-        private const val STREAM_NAME = "android.android_image_recommendation_event"
+        private const val STREAM_NAME = "android.image_recommendation_event"
         val reasons = listOf("notrelevant", "noinfo", "offensive", "lowquality", "unfamiliar", "other")
         private val timer = ActiveTimer()
 


### PR DESCRIPTION
We had to change the stream name to keep it consistent with other streams and for it to be alphabetically listed properly.
**Phab:** https://phabricator.wikimedia.org/T346179