### PR TITLE
Remove hydrated Summary response from Reading List structure.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
@@ -433,10 +433,6 @@ class ReadingListSyncAdapter : JobIntentService() {
             }
         }
         localPage.remoteId = remotePage.id
-        if (remotePage.summary != null) {
-            localPage.description = remotePage.summary.description
-            localPage.thumbUrl = remotePage.summary.thumbnailUrl
-        }
         if (updateOnly) {
             L.d("Updating local page " + localPage.apiTitle)
             AppDatabase.instance.readingListPageDao().updateReadingListPage(localPage)

--- a/app/src/main/java/org/wikipedia/readinglist/sync/SyncedReadingLists.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/SyncedReadingLists.kt
@@ -2,7 +2,6 @@ package org.wikipedia.readinglist.sync
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.wikipedia.dataclient.page.PageSummary
 import java.text.Normalizer
 import java.time.Instant
 import java.util.*
@@ -34,7 +33,6 @@ data class SyncedReadingLists(val lists: List<RemoteReadingList>? = null,
         private val title: String,
         val created: String = Instant.now().toString(),
         val updated: String = Instant.now().toString(),
-        val summary: PageSummary? = null,
         @SerialName("deleted") val isDeleted: Boolean = false
     ) {
         fun project(): String = Normalizer.normalize(project, Normalizer.Form.NFC)


### PR DESCRIPTION
It's no longer being sent by the server anyway, and the app works perfectly fine without it.

https://phabricator.wikimedia.org/T346739