### PR TITLE
Fix: Opt-in default value to `false`

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -62,7 +62,7 @@
     <PreferenceCategory android:title="@string/preferences_privacy_settings_heading">
         <org.wikipedia.settings.SwitchPreferenceMultiLine
             android:key="@string/preference_key_eventlogging_opt_in"
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:title="@string/preference_title_eventlogging_opt_in"
             android:summary="@string/preference_summary_eventlogging_opt_in" />
     </PreferenceCategory>


### PR DESCRIPTION
Visiting the settings page when the preference is not set explicitly is ending up setting this value to `true`. Since we want to keep them not signed for collection by default, let us turn this to `false`