### PR TITLE
Fix: update snackbar messages and make the Undo button enabled by default

### DIFF
--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -550,7 +550,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     }
 
     private fun showUndoSnackbar() {
-        val snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(R.string.revision_undo_success))
+        val snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(R.string.patroller_tasks_patrol_edit_undo_success))
         snackbar.addCallback(object : Snackbar.Callback() {
             override fun onDismissed(transientBottomBar: Snackbar, @DismissEvent event: Int) {
                 if (!isAdded) {
@@ -576,7 +576,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     }
 
     private fun showRollbackSnackbar() {
-        val snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(R.string.revision_rollback_success))
+        val snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(R.string.patroller_tasks_patrol_edit_rollback_success))
         snackbar.addCallback(object : Snackbar.Callback() {
             override fun onDismissed(transientBottomBar: Snackbar, @DismissEvent event: Int) {
                 if (!isAdded) {

--- a/app/src/main/java/org/wikipedia/diff/UndoEditDialog.kt
+++ b/app/src/main/java/org/wikipedia/diff/UndoEditDialog.kt
@@ -46,7 +46,6 @@ class UndoEditDialog constructor(
 
         dialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.setTextColor(ResourceUtil.getThemedColor(context, R.attr.destructive_color))
 
-        setPositiveButtonEnabled(false)
         return dialog!!
     }
 


### PR DESCRIPTION
1. Update the snackbar messages.
2. Make the Undo dialog "Undo" button enabled by default.