### PR TITLE
Fix: incorrect behavior after changing device orientation in Patrol edit

### DIFF
--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -339,9 +339,6 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     }
 
     override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        if (menu.isNotEmpty()) {
-            return
-        }
         inflater.inflate(R.menu.menu_edit_details, menu)
     }
 

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -20,7 +20,6 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.os.bundleOf
 import androidx.core.view.MenuProvider
-import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
 import androidx.core.widget.ImageViewCompat
 import androidx.core.widget.NestedScrollView

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -20,6 +20,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.os.bundleOf
 import androidx.core.view.MenuProvider
+import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
 import androidx.core.widget.ImageViewCompat
 import androidx.core.widget.NestedScrollView
@@ -338,6 +339,9 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, L
     }
 
     override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
+        if (menu.isNotEmpty()) {
+            return
+        }
         inflater.inflate(R.menu.menu_edit_details, menu)
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsVandalismPatrolFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsVandalismPatrolFragment.kt
@@ -21,7 +21,7 @@ class SuggestedEditsVandalismPatrolFragment : SuggestedEditsItemFragment(), Arti
         val targetWikiLangCode = Prefs.recentEditsWikiCode
 
         childFragmentManager.beginTransaction()
-            .add(binding.suggestedEditsItemRootView.id, ArticleEditDetailsFragment
+            .replace(binding.suggestedEditsItemRootView.id, ArticleEditDetailsFragment
                 .newInstance(PageTitle("", WikiSite.forLanguageCode(targetWikiLangCode)), -1, -1, -1, fromRecentEdits = true))
             .commit()
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsVandalismPatrolFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsVandalismPatrolFragment.kt
@@ -20,11 +20,12 @@ class SuggestedEditsVandalismPatrolFragment : SuggestedEditsItemFragment(), Arti
 
         val targetWikiLangCode = Prefs.recentEditsWikiCode
 
-        childFragmentManager.beginTransaction()
-            .replace(binding.suggestedEditsItemRootView.id, ArticleEditDetailsFragment
-                .newInstance(PageTitle("", WikiSite.forLanguageCode(targetWikiLangCode)), -1, -1, -1, fromRecentEdits = true))
-            .commit()
-
+        if (savedInstanceState == null) {
+            childFragmentManager.beginTransaction()
+                .add(binding.suggestedEditsItemRootView.id, ArticleEditDetailsFragment
+                    .newInstance(PageTitle("", WikiSite.forLanguageCode(targetWikiLangCode)), -1, -1, -1, fromRecentEdits = true))
+                .commit()
+        }
         return binding.root
     }
 


### PR DESCRIPTION
Otherwise, the fragment will be added every time when you change the device's orientation. 