### PR TITLE
Fix: add toolbar view to the SE cards landscape layout

### DIFF
--- a/app/src/main/res/layout-land/fragment_suggested_edits_cards.xml
+++ b/app/src/main/res/layout-land/fragment_suggested_edits_cards.xml
@@ -1,152 +1,164 @@
-<androidx.coordinatorlayout.widget.CoordinatorLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/addTitleDescriptionsLayout"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="?attr/actionBarSize"
+        style="@style/ToolbarStyle.Small" />
 
-        <LinearLayout
-            android:id="@+id/wikiLanguageDropdownContainer"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginTop="1px"
-            android:elevation="4dp"
-            android:gravity="center_vertical"
-            app:layout_constraintTop_toTopOf="parent"
-            android:visibility="gone"
-            tools:visibility="visible">
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1">
-
-                <Spinner
-                    android:id="@+id/wikiFromLanguageSpinner"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:backgroundTint="?attr/progressive_color"/>
-            </LinearLayout>
-
-
-            <ImageView
-                android:id="@+id/arrow"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_gravity="center"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@null"
-                android:paddingStart="4dp"
-                android:paddingTop="8dp"
-                android:paddingEnd="4dp"
-                android:paddingBottom="8dp"
-                android:scaleType="center"
-                app:srcCompat="@drawable/ic_baseline_arrow_right_alt_24px"
-                app:tint="?attr/secondary_color" />
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="end">
-
-                <Spinner
-                    android:id="@+id/wikiToLanguageSpinner"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:backgroundTint="?attr/progressive_color"/>
-
-            </LinearLayout>
-
-        </LinearLayout>
-
-        <androidx.coordinatorlayout.widget.CoordinatorLayout
-            android:id="@+id/suggestedEditsCardsCoordinator"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintVertical_weight="1"
-            app:layout_constraintHorizontal_weight="1"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/bottomButtonContainer"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/wikiLanguageDropdownContainer">
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/cardsViewPager"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-        </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/bottomButtonContainer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingStart="8dp"
-            android:paddingEnd="16dp"
-            android:clipToPadding="false"
-            android:layout_gravity="center_vertical"
-            app:layout_constraintVertical_weight="1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/wikiLanguageDropdownContainer"
-            app:layout_constraintBottom_toBottomOf="parent">
+            android:id="@+id/addTitleDescriptionsLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-            <ImageView
-                android:id="@+id/backButton"
-                android:layout_width="48dp"
+            <LinearLayout
+                android:id="@+id/wikiLanguageDropdownContainer"
+                android:layout_width="match_parent"
                 android:layout_height="48dp"
-                android:layout_marginBottom="8dp"
-                android:padding="12dp"
-                android:focusable="true"
-                android:clickable="true"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@null"
-                android:scaleX="-1"
-                app:tint="?attr/progressive_color"
-                app:srcCompat="@drawable/ic_chevron_forward_white_24dp"
-                app:layout_constraintBottom_toTopOf="@+id/addContributionButton"
+                android:layout_marginTop="1px"
+                android:elevation="4dp"
+                android:gravity="center_vertical"
+                app:layout_constraintTop_toTopOf="parent"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1">
+
+                    <Spinner
+                        android:id="@+id/wikiFromLanguageSpinner"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:backgroundTint="?attr/progressive_color"/>
+                </LinearLayout>
+
+
+                <ImageView
+                    android:id="@+id/arrow"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="@null"
+                    android:paddingStart="4dp"
+                    android:paddingTop="8dp"
+                    android:paddingEnd="4dp"
+                    android:paddingBottom="8dp"
+                    android:scaleType="center"
+                    app:srcCompat="@drawable/ic_baseline_arrow_right_alt_24px"
+                    app:tint="?attr/secondary_color" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:gravity="end">
+
+                    <Spinner
+                        android:id="@+id/wikiToLanguageSpinner"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:backgroundTint="?attr/progressive_color"/>
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <androidx.coordinatorlayout.widget.CoordinatorLayout
+                android:id="@+id/suggestedEditsCardsCoordinator"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintVertical_weight="1"
+                app:layout_constraintHorizontal_weight="1"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/addContributionButton"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                android:insetTop="0dp"
-                android:insetBottom="0dp"
-                android:text="@null"
-                android:tag="landscape"
-                app:iconPadding="0dp"
-                app:iconGravity="textStart"
-                app:icon="@drawable/ic_add_gray_white_24dp"
+                app:layout_constraintEnd_toStartOf="@id/bottomButtonContainer"
                 app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/wikiLanguageDropdownContainer">
+                <androidx.viewpager2.widget.ViewPager2
+                    android:id="@+id/cardsViewPager"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" />
+            </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/bottomButtonContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="8dp"
+                android:paddingEnd="16dp"
+                android:clipToPadding="false"
+                android:layout_gravity="center_vertical"
+                app:layout_constraintVertical_weight="1"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintTop_toBottomOf="@id/wikiLanguageDropdownContainer"
+                app:layout_constraintBottom_toBottomOf="parent">
 
-            <ImageView
-                android:id="@+id/nextButton"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:padding="12dp"
-                android:layout_marginTop="8dp"
-                android:focusable="true"
-                android:clickable="true"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@null"
-                app:tint="?attr/progressive_color"
-                app:srcCompat="@drawable/ic_chevron_forward_white_24dp"
-                app:layout_constraintTop_toBottomOf="@id/addContributionButton"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"/>
+                <ImageView
+                    android:id="@+id/backButton"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_marginBottom="8dp"
+                    android:padding="12dp"
+                    android:focusable="true"
+                    android:clickable="true"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="@null"
+                    android:scaleX="-1"
+                    app:tint="?attr/progressive_color"
+                    app:srcCompat="@drawable/ic_chevron_forward_white_24dp"
+                    app:layout_constraintBottom_toTopOf="@+id/addContributionButton"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
 
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/addContributionButton"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="8dp"
+                    android:insetTop="0dp"
+                    android:insetBottom="0dp"
+                    android:text="@null"
+                    android:tag="landscape"
+                    app:iconPadding="0dp"
+                    app:iconGravity="textStart"
+                    app:icon="@drawable/ic_add_gray_white_24dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"/>
+
+                <ImageView
+                    android:id="@+id/nextButton"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:padding="12dp"
+                    android:layout_marginTop="8dp"
+                    android:focusable="true"
+                    android:clickable="true"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="@null"
+                    app:tint="?attr/progressive_color"
+                    app:srcCompat="@drawable/ic_chevron_forward_white_24dp"
+                    app:layout_constraintTop_toBottomOf="@id/addContributionButton"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_suggested_edits_cards.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_cards.xml
@@ -11,134 +11,134 @@
         android:layout_height="?attr/actionBarSize"
         style="@style/ToolbarStyle.Small" />
 
-<androidx.constraintlayout.widget.ConstraintLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_marginTop="?attr/actionBarSize">
-
-    <LinearLayout
-        android:id="@+id/wikiLanguageDropdownContainer"
-        android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:layout_marginTop="1px"
-        android:elevation="4dp"
-        android:gravity="center_vertical"
-        android:visibility="gone"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible">
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1">
-
-            <Spinner
-                android:id="@+id/wikiFromLanguageSpinner"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:backgroundTint="?attr/progressive_color" />
-        </LinearLayout>
-
-
-        <ImageView
-            android:id="@+id/arrow"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_gravity="center"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@null"
-            android:paddingStart="4dp"
-            android:paddingTop="8dp"
-            android:paddingEnd="4dp"
-            android:paddingBottom="8dp"
-            android:scaleType="center"
-            app:srcCompat="@drawable/ic_baseline_arrow_right_alt_24px"
-            app:tint="?attr/secondary_color" />
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="end">
-
-            <Spinner
-                android:id="@+id/wikiToLanguageSpinner"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:backgroundTint="?attr/progressive_color" />
-
-        </LinearLayout>
-
-    </LinearLayout>
-
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/suggestedEditsCardsCoordinator"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@id/bottomButtonContainer"
-        app:layout_constraintTop_toBottomOf="@id/wikiLanguageDropdownContainer">
-        <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/cardsViewPager"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/bottomButtonContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:paddingTop="10dp"
-        android:paddingBottom="24dp"
-        app:layout_constraintBottom_toBottomOf="parent">
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize">
 
-        <ImageView
-            android:id="@+id/backButton"
-            android:layout_width="48dp"
+        <LinearLayout
+            android:id="@+id/wikiLanguageDropdownContainer"
+            android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:clickable="true"
-            android:contentDescription="@null"
-            android:focusable="true"
-            android:padding="12dp"
-            android:scaleX="-1"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="1px"
+            android:elevation="4dp"
+            android:gravity="center_vertical"
+            android:visibility="gone"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_chevron_forward_white_24dp"
-            app:tint="?attr/progressive_color" />
+            tools:visibility="visible">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/addContributionButton"
-            android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1">
+
+                <Spinner
+                    android:id="@+id/wikiFromLanguageSpinner"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:backgroundTint="?attr/progressive_color" />
+            </LinearLayout>
+
+
+            <ImageView
+                android:id="@+id/arrow"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@null"
+                android:paddingStart="4dp"
+                android:paddingTop="8dp"
+                android:paddingEnd="4dp"
+                android:paddingBottom="8dp"
+                android:scaleType="center"
+                app:srcCompat="@drawable/ic_baseline_arrow_right_alt_24px"
+                app:tint="?attr/secondary_color" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="end">
+
+                <Spinner
+                    android:id="@+id/wikiToLanguageSpinner"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:backgroundTint="?attr/progressive_color" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/suggestedEditsCardsCoordinator"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/bottomButtonContainer"
+            app:layout_constraintTop_toBottomOf="@id/wikiLanguageDropdownContainer">
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/cardsViewPager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/bottomButtonContainer"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/suggested_edits_add_description_button"
-            android:tag="portrait"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:icon="@drawable/ic_add_gray_white_24dp"/>
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:paddingTop="10dp"
+            android:paddingBottom="24dp"
+            app:layout_constraintBottom_toBottomOf="parent">
 
-        <ImageView
-            android:id="@+id/nextButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:clickable="true"
-            android:contentDescription="@string/view_next_random_article"
-            android:focusable="true"
-            android:padding="12dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_chevron_forward_white_24dp"
-            app:tint="?attr/progressive_color" />
+            <ImageView
+                android:id="@+id/backButton"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@null"
+                android:focusable="true"
+                android:padding="12dp"
+                android:scaleX="-1"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_chevron_forward_white_24dp"
+                app:tint="?attr/progressive_color" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/addContributionButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/suggested_edits_add_description_button"
+                android:tag="portrait"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:icon="@drawable/ic_add_gray_white_24dp"/>
+
+            <ImageView
+                android:id="@+id/nextButton"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/view_next_random_article"
+                android:focusable="true"
+                android:padding="12dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_chevron_forward_white_24dp"
+                app:tint="?attr/progressive_color" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
 
 </FrameLayout>


### PR DESCRIPTION
In #4129, we added `MaterialToolbar` for `fragment_suggested_edits_cards`, but forgot to update the one in `land` folder. 