### PR TITLE
Fix: Patroller Tasks user experience update

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsRecentEditsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsRecentEditsViewModel.kt
@@ -20,6 +20,7 @@ import org.wikipedia.dataclient.mwapi.UserInfo
 import org.wikipedia.settings.Prefs
 import org.wikipedia.suggestededits.provider.EditingSuggestionsProvider
 import org.wikipedia.util.DateUtil
+import org.wikipedia.util.log.L
 import retrofit2.HttpException
 import java.io.IOException
 import java.time.Duration
@@ -231,10 +232,12 @@ class SuggestedEditsRecentEditsViewModel : ViewModel() {
                             val requiredMinLength = requiredLength.first().toLong()
                             val requiredMaxLength = requiredLength.last().toLong()
 
-                            qualifiedUser = if (requiredMaxEdits == -1 && requiredMaxLength == -1L) {
+                            qualifiedUser = if (requiredMaxEdits == -1 && requiredMaxLength == -1L) { // Experienced user
                                 editsCount >= requiredMinEdits && diffDays >= requiredMinLength
-                            } else {
+                            } else if (requiredMinEdits == 0 && requiredMinLength == 0L) { // New comers
                                 editsCount in requiredMinEdits..requiredMaxEdits && diffDays in requiredMinLength..requiredMaxLength
+                            } else { // Learners
+                                true
                             }
                             if (qualifiedUser) {
                                 return@filter qualifiedUser

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsRecentEditsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsRecentEditsViewModel.kt
@@ -20,7 +20,6 @@ import org.wikipedia.dataclient.mwapi.UserInfo
 import org.wikipedia.settings.Prefs
 import org.wikipedia.suggestededits.provider.EditingSuggestionsProvider
 import org.wikipedia.util.DateUtil
-import org.wikipedia.util.log.L
 import retrofit2.HttpException
 import java.io.IOException
 import java.time.Duration
@@ -232,7 +231,7 @@ class SuggestedEditsRecentEditsViewModel : ViewModel() {
                             val requiredMinLength = requiredLength.first().toLong()
                             val requiredMaxLength = requiredLength.last().toLong()
 
-                            qualifiedUser = if (requiredMaxEdits == -1 && requiredMaxLength == -1L) { // Experienced user
+                            qualifiedUser = if (requiredMaxEdits == -1 && requiredMaxLength == -1L) { // Experienced users
                                 editsCount >= requiredMinEdits && diffDays >= requiredMinLength
                             } else if (requiredMinEdits == 0 && requiredMinLength == 0L) { // New comers
                                 editsCount in requiredMinEdits..requiredMaxEdits && diffDays in requiredMinLength..requiredMaxLength


### PR DESCRIPTION
This PR corrects the logic of the user experience filter where the "Learners" filter should be between Experienced users and newcomers. 