### PR TITLE
Fix: handle Patroller Tasks input field error message in the dialog correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesTextInputDialog.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesTextInputDialog.kt
@@ -163,8 +163,7 @@ class TalkTemplatesTextInputDialog constructor(context: Context,
     }
 
     fun setError(text: CharSequence?) {
-        binding.titleInput.error = text
-        binding.titleInputContainer.isErrorEnabled = !text.isNullOrEmpty()
+        binding.titleInputContainer.error = text
     }
 
     fun setPositiveButtonEnabled(enabled: Boolean) {

--- a/app/src/main/java/org/wikipedia/views/TextInputDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/TextInputDialog.kt
@@ -73,7 +73,6 @@ class TextInputDialog constructor(context: Context) : MaterialAlertDialogBuilder
 
     fun setError(text: CharSequence?) {
         binding.textInputContainer.error = text
-        binding.textInputContainer.isErrorEnabled = !text.isNullOrEmpty()
     }
 
     fun setPositiveButtonEnabled(enabled: Boolean) {


### PR DESCRIPTION
Change from `binding.titleInput` to `binding.titleInputContainer` to avoid view jumps when losing target.