### PR TITLE
Fix: update view items visibility for Patroller Tasks only

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -114,6 +114,8 @@ class TalkReplyActivity : BaseActivity(), LinkPreviewDialog.Callback, UserMentio
                 requestManageTalkTemplate.launch(TalkTemplatesActivity.newIntent(this))
             }
             FeedbackUtil.setButtonLongPressToast(binding.talkTemplateButton)
+        } else {
+            binding.talkTemplateContainer.isVisible = false
         }
 
         linkHandler = TalkLinkHandler(this)

--- a/app/src/main/res/layout/activity_talk_reply.xml
+++ b/app/src/main/res/layout/activity_talk_reply.xml
@@ -25,7 +25,8 @@
                 android:id="@+id/talkTemplateContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:visibility="gone">
 
                 <TextView
                     style="@style/P.MaterialListTitle"


### PR DESCRIPTION
We need to hide the ores buttons, the warn button, and disable the feedback dialog if is not accessing from Patroller Tasks.

This PR also fixes some issues in the `TalkReplyActivity` where the warn template container is visible by default.  