### PR TITLE
Fix: use TextView in the description edit success page

### DIFF
--- a/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
+++ b/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.core.widget.ImageViewCompat
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import org.wikipedia.BuildConfig
-import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
@@ -16,7 +15,6 @@ import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.analytics.eventplatform.DonorExperienceEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.ViewMainDrawerBinding
-import org.wikipedia.descriptions.DescriptionEditSuccessActivity
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil.getThemedColorStateList

--- a/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
+++ b/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
@@ -1,24 +1,21 @@
 package org.wikipedia.navtab
 
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.widget.ImageViewCompat
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import org.wikipedia.BuildConfig
+import org.wikipedia.Constants
 import org.wikipedia.R
-import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
-import org.wikipedia.analytics.eventplatform.DonorExperienceEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.ViewMainDrawerBinding
+import org.wikipedia.descriptions.DescriptionEditSuccessActivity
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil.getThemedColorStateList
-import org.wikipedia.util.UriUtil.visitInExternalBrowser
 
 class MenuNavTabDialog : ExtendedBottomSheetDialogFragment() {
     interface Callback {
@@ -71,12 +68,14 @@ class MenuNavTabDialog : ExtendedBottomSheetDialogFragment() {
         }
 
         binding.mainDrawerDonateContainer.setOnClickListener {
-            DonorExperienceEvent.logAction("donate_start_click", "more_menu")
-            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerDonateContainer)
-            visitInExternalBrowser(requireContext(),
-                    Uri.parse(getString(R.string.donate_url,
-                            BuildConfig.VERSION_NAME, WikipediaApp.instance.languageState.systemLanguageCode)))
-            dismiss()
+            requireActivity().startActivity(DescriptionEditSuccessActivity.newIntent(requireContext(), Constants.InvokeSource.SUGGESTED_EDITS_RECENT_EDITS))
+//
+//            DonorExperienceEvent.logAction("donate_start_click", "more_menu")
+//            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerDonateContainer)
+//            visitInExternalBrowser(requireContext(),
+//                    Uri.parse(getString(R.string.donate_url,
+//                            BuildConfig.VERSION_NAME, WikipediaApp.instance.languageState.systemLanguageCode)))
+//            dismiss()
         }
 
         updateState()

--- a/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
+++ b/app/src/main/java/org/wikipedia/navtab/MenuNavTabDialog.kt
@@ -1,21 +1,26 @@
 package org.wikipedia.navtab
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.widget.ImageViewCompat
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import org.wikipedia.BuildConfig
 import org.wikipedia.Constants
 import org.wikipedia.R
+import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.eventplatform.DonorExperienceEvent
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.databinding.ViewMainDrawerBinding
 import org.wikipedia.descriptions.DescriptionEditSuccessActivity
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil.getThemedColorStateList
+import org.wikipedia.util.UriUtil.visitInExternalBrowser
 
 class MenuNavTabDialog : ExtendedBottomSheetDialogFragment() {
     interface Callback {
@@ -68,14 +73,12 @@ class MenuNavTabDialog : ExtendedBottomSheetDialogFragment() {
         }
 
         binding.mainDrawerDonateContainer.setOnClickListener {
-            requireActivity().startActivity(DescriptionEditSuccessActivity.newIntent(requireContext(), Constants.InvokeSource.SUGGESTED_EDITS_RECENT_EDITS))
-//
-//            DonorExperienceEvent.logAction("donate_start_click", "more_menu")
-//            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerDonateContainer)
-//            visitInExternalBrowser(requireContext(),
-//                    Uri.parse(getString(R.string.donate_url,
-//                            BuildConfig.VERSION_NAME, WikipediaApp.instance.languageState.systemLanguageCode)))
-//            dismiss()
+            DonorExperienceEvent.logAction("donate_start_click", "more_menu")
+            BreadCrumbLogEvent.logClick(requireActivity(), binding.mainDrawerDonateContainer)
+            visitInExternalBrowser(requireContext(),
+                    Uri.parse(getString(R.string.donate_url,
+                            BuildConfig.VERSION_NAME, WikipediaApp.instance.languageState.systemLanguageCode)))
+            dismiss()
         }
 
         updateState()

--- a/app/src/main/res/layout/view_description_edit_success.xml
+++ b/app/src/main/res/layout/view_description_edit_success.xml
@@ -30,7 +30,7 @@
                 android:contentDescription="@null"
                 app:srcCompat="@drawable/ic_illustration_description_success" />
 
-            <org.wikipedia.views.AppTextView
+            <TextView
                 style="@style/TextViewCentered"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -40,7 +40,7 @@
                 android:textColor="@android:color/white"
                 android:textSize="30sp" />
 
-            <org.wikipedia.views.AppTextView
+            <TextView
                 style="@style/TextViewCentered"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -71,7 +71,7 @@
             android:orientation="vertical"
             android:padding="16dp">
 
-            <org.wikipedia.views.AppTextView
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"


### PR DESCRIPTION
Somehow the texts on the screen show up after the first description edit were missing. Replace with a regular `TextView` since they are plain text.

Before:
<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/fcec92e0-be2e-43e6-97b1-8c9050b62c71" width="400">

After:
<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/90949115-8d1e-408f-9b2f-15c48faf7b60" width="400">
