### PR TITLE
Fix playback of videos in Gallery.

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
@@ -209,10 +209,11 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
     private val videoThumbnailClickListener: View.OnClickListener = object : View.OnClickListener {
         private var loading = false
         override fun onClick(v: View) {
-            if (loading || mediaInfo?.bestDerivative == null) {
+            val derivative = mediaInfo?.getBestDerivativeForSize(Constants.PREFERRED_GALLERY_IMAGE_SIZE)
+            if (loading || derivative == null) {
                 return
             }
-            val bestDerivative = mediaInfo!!.bestDerivative!!.src
+            val bestDerivative = derivative.src
             loading = true
             L.d("Loading video from url: $bestDerivative")
             binding.videoView.visibility = View.VISIBLE

--- a/app/src/main/java/org/wikipedia/gallery/ImageInfo.kt
+++ b/app/src/main/java/org/wikipedia/gallery/ImageInfo.kt
@@ -46,10 +46,11 @@ class ImageInfo {
     val width = 0
     val height = 0
 
+    @Suppress("KotlinConstantConditions")
     fun getBestDerivativeForSize(widthDp: Int): Derivative? {
         var derivative: Derivative? = null
         derivatives.forEach {
-            if (it.width > 0 && it.width < widthDp) {
+            if (it.width in 1..<widthDp) {
                 if (derivative == null || it.width > derivative!!.width) {
                     derivative = it
                 }

--- a/app/src/main/java/org/wikipedia/gallery/ImageInfo.kt
+++ b/app/src/main/java/org/wikipedia/gallery/ImageInfo.kt
@@ -46,16 +46,25 @@ class ImageInfo {
     val width = 0
     val height = 0
 
-    val bestDerivative get() = derivatives.lastOrNull()
+    fun getBestDerivativeForSize(widthDp: Int): Derivative? {
+        var derivative: Derivative? = null
+        derivatives.forEach {
+            if (it.width > 0 && it.width < widthDp) {
+                if (derivative == null || it.width > derivative!!.width) {
+                    derivative = it
+                }
+            }
+        }
+        return derivative
+    }
 
-    // TODO: make this smarter.
     @Serializable
     class Derivative {
         val src = ""
         private val type: String? = null
         private val title: String? = null
         private val shorttitle: String? = null
-        private val width = 0
+        val width = 0
         private val height = 0
         private val bandwidth: Long = 0
     }

--- a/app/src/main/java/org/wikipedia/gallery/MediaDownloadReceiver.kt
+++ b/app/src/main/java/org/wikipedia/gallery/MediaDownloadReceiver.kt
@@ -14,6 +14,7 @@ import android.provider.MediaStore
 import androidx.core.content.contentValuesOf
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
+import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.feed.image.FeaturedImage
@@ -53,9 +54,10 @@ class MediaDownloadReceiver : BroadcastReceiver() {
         val saveFilename = FileUtil.sanitizeFileName(trimFileNamespace(imageTitle.displayText))
         var fileUrl = mediaInfo.originalUrl
         val targetDirectoryType: String
-        if (FileUtil.isVideo(mediaInfo.mime) && mediaInfo.bestDerivative != null) {
+        val derivative = mediaInfo.getBestDerivativeForSize(Constants.PREFERRED_GALLERY_IMAGE_SIZE)
+        if (FileUtil.isVideo(mediaInfo.mime) && derivative != null) {
             targetDirectoryType = Environment.DIRECTORY_MOVIES
-            fileUrl = mediaInfo.bestDerivative!!.src
+            fileUrl = derivative.src
         } else if (FileUtil.isAudio(mediaInfo.mime)) {
             targetDirectoryType = Environment.DIRECTORY_MUSIC
         } else if (FileUtil.isImage(mediaInfo.mime)) {


### PR DESCRIPTION
Video playback is currently broken.
This is because our logic for selecting the best possible derivative for playback was not smart enough, and was blindly selecting the "last" derivative.
The list of derivatives can change, and indeed it has changed to include an unplayable derivative as the "last" one.
This improves the logic of selecting the proper derivative.

https://phabricator.wikimedia.org/T352315
