### PR TITLE
Further fix video playback!

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/ImageInfo.kt
+++ b/app/src/main/java/org/wikipedia/gallery/ImageInfo.kt
@@ -51,7 +51,7 @@ class ImageInfo {
         var derivative: Derivative? = null
         derivatives.forEach {
             if (it.width in 1..<widthDp) {
-                if (derivative == null || it.width > derivative!!.width) {
+                if ((derivative == null || it.width > derivative!!.width) && !it.type.contains("ogg") && !it.type.contains("ogv")) {
                     derivative = it
                 }
             }
@@ -62,7 +62,7 @@ class ImageInfo {
     @Serializable
     class Derivative {
         val src = ""
-        private val type: String? = null
+        val type = ""
         private val title: String? = null
         private val shorttitle: String? = null
         val width = 0


### PR DESCRIPTION
There are still some videos that are not playable. This is because some of the `derivative` candidates are encoded as OGG/OGV video, which is not supported by most versions of Android.
This will ensure that ogg derivatives are excluded when selecting the best derivative.