### PR TITLE
Fix showing link previews in EditSectionActivity.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -823,7 +823,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, LinkPre
 
     override fun onLinkPreviewAddToList(title: PageTitle) {
         ExclusiveBottomSheetPresenter.show(supportFragmentManager,
-            AddToReadingListDialog.newInstance(title, Constants.InvokeSource.TALK_REPLY_ACTIVITY))
+            AddToReadingListDialog.newInstance(title, Constants.InvokeSource.EDIT_ACTIVITY))
     }
 
     override fun onLinkPreviewShareLink(title: PageTitle) {


### PR DESCRIPTION
I just noticed that when previewing a link in EditSectionActivity (using the wikitext keyboard button), the link preview doesn't appear at all.
It looks like this was never actually wired up (probably my fault).

This wires up the link preview dialog logic properly, _and also_ makes sure to show the exit-confirmation dialog if you tap through a link preview and exit the editing flow.