### PR TITLE
Fix warning from gradle build variable.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 
     sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true


### PR DESCRIPTION
Having the `buildconfig=true` variable in `gradle.properties` is deprecated.