### PR TITLE
Optimize date format cache.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/DateUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.kt
@@ -110,17 +110,18 @@ object DateUtil {
     }
 
     private fun getDateStringWithSkeletonPattern(date: Date, pattern: String): String {
-        return getCachedDateFormat(DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault(), false).format(date)
+        return getCachedDateFormat(pattern, Locale.getDefault(), utc = false, skeleton = true)
+            .format(date)
     }
 
     private fun getDateStringWithSkeletonPattern(temporalAccessor: TemporalAccessor, pattern: String): String {
-        return getCachedDateTimeFormatter(DateFormat.getBestDateTimePattern(Locale.getDefault(), pattern), Locale.getDefault(), false)
+        return getCachedDateTimeFormatter(pattern, Locale.getDefault(), utc = false, skeleton = true)
             .format(temporalAccessor)
     }
 
-    private fun getCachedDateFormat(pattern: String, locale: Locale, utc: Boolean): SimpleDateFormat {
+    private fun getCachedDateFormat(pattern: String, locale: Locale, utc: Boolean, skeleton: Boolean = false): SimpleDateFormat {
         return DATE_FORMATS.getOrPut(pattern) {
-            val df = SimpleDateFormat(pattern, locale)
+            val df = SimpleDateFormat(if (skeleton) DateFormat.getBestDateTimePattern(locale, pattern) else pattern, locale)
             if (utc) {
                 df.timeZone = TimeZone.getTimeZone("UTC")
             }
@@ -128,9 +129,9 @@ object DateUtil {
         }
     }
 
-    private fun getCachedDateTimeFormatter(pattern: String, locale: Locale, utc: Boolean): DateTimeFormatter {
+    private fun getCachedDateTimeFormatter(pattern: String, locale: Locale, utc: Boolean, skeleton: Boolean = false): DateTimeFormatter {
         return DATE_TIME_FORMATTERS.getOrPut(pattern) {
-            val dtf = DateTimeFormatter.ofPattern(pattern, locale)
+            val dtf = DateTimeFormatter.ofPattern(if (skeleton) DateFormat.getBestDateTimePattern(locale, pattern) else pattern, locale)
             return if (utc) dtf.withZone(ZoneOffset.UTC) else dtf
         }
     }


### PR DESCRIPTION
In our DateUtil class we use a static cache for caching date formatting objects, which are expensive. However, the `DateFormat.getBestDateTimePattern()` function is also expensive, and should not be called every time a date is rendered. It can be easily rolled into the same format cache.

This will provide a slight speedup of rendering date fields, particularly in long lists of items that contain dates.
