### PR TITLE
Revert "Update material-components-android library version to 1.11.0"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version"
 
-    implementation "com.google.android.material:material:1.11.0"
+    implementation "com.google.android.material:material:1.10.0"
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation "androidx.core:core-ktx:1.12.0"
     implementation "androidx.browser:browser:1.7.0"


### PR DESCRIPTION
Reverts wikimedia/apps-android-wikipedia#4352

This introduced some major visual regressions, giving certain components a pink hue:

![Screenshot_20240103_113053](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/568d3353-c22a-414d-a362-f439ab81febc) | ![Screenshot_20240103_112900](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/a3d43561-a92d-4d82-b3e6-6a6f24faf9ef)

When reintroducing this new version of the Material library, please also fix the corresponding styles.