### PR TITLE
Update material-components-android to 1.11.0 and update styles

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version"
 
-    implementation "com.google.android.material:material:1.10.0"
+    implementation "com.google.android.material:material:1.11.0"
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation "androidx.core:core-ktx:1.12.0"
     implementation "androidx.browser:browser:1.7.0"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,7 +41,7 @@
         <item name="popupMenuStyle">@style/PopupMenuStyle</item>
 
         <item name="collapsingToolbarLayoutStyle">@style/CollapsingToolbarStyle</item>
-``
+
         <item name="talk_page_empty_state_drawable">@drawable/talk_page_empty_state_illustration_light</item>
 
         <item name="colorPrimary">?attr/progressive_color</item>
@@ -547,7 +547,6 @@
 
     <style name="App.BottomSheetStyle" parent="Widget.Material3.BottomSheet.Modal">
         <item name="behavior_peekHeight">@dimen/bottomSheetPeekHeight</item>
-        <item name="android:background">?attr/paper_color</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,7 +41,7 @@
         <item name="popupMenuStyle">@style/PopupMenuStyle</item>
 
         <item name="collapsingToolbarLayoutStyle">@style/CollapsingToolbarStyle</item>
-
+``
         <item name="talk_page_empty_state_drawable">@drawable/talk_page_empty_state_illustration_light</item>
 
         <item name="colorPrimary">?attr/progressive_color</item>
@@ -49,6 +49,11 @@
         <item name="colorError">?attr/destructive_color</item>
 
         <item name="colorSurface">?attr/paper_color</item>
+        <item name="colorSurfaceContainerLowest">?attr/paper_color</item>
+        <item name="colorSurfaceContainerLow">?attr/paper_color</item>
+        <item name="colorSurfaceContainer">?attr/paper_color</item>
+        <item name="colorSurfaceContainerHigh">?attr/paper_color</item>
+        <item name="colorSurfaceContainerHighest">?attr/paper_color</item>
         <item name="colorOnSurface">?attr/primary_color</item>
 
         <item name="colorTertiaryContainer">?attr/paper_color</item>
@@ -542,6 +547,7 @@
 
     <style name="App.BottomSheetStyle" parent="Widget.Material3.BottomSheet.Modal">
         <item name="behavior_peekHeight">@dimen/bottomSheetPeekHeight</item>
+        <item name="android:background">?attr/paper_color</item>
     </style>
 
 </resources>


### PR DESCRIPTION
https://github.com/material-components/material-components-android/releases/tag/1.11.0

https://github.com/material-components/material-components-android/commit/2114a11378fd801b32cd7431bb8a2c94de4f462c
Add `paper_color` to the related `colorSurfaceContainer` styles.
