### PR TITLE
Update Kotlin gradle plugin version to 1.9.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.20'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/releases/tag/v1.9.22

You will see the following message when trying to run `./gradlew ktlint`
> ksp-1.9.22-1.0.16 is too new for kotlin-1.9.20. Please upgrade kotlin-gradle-plugin to 1.9.22.