### PR TITLE
Simplify the logic of adding/moving article to reading list

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/news/NewsFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsFragment.kt
@@ -21,13 +21,16 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.feed.model.Card
 import org.wikipedia.feed.view.ListCardItemView
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.PageActivity
-import org.wikipedia.readinglist.AddToReadingListDialog
-import org.wikipedia.readinglist.MoveToReadingListDialog
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.richtext.RichTextUtil
-import org.wikipedia.util.*
+import org.wikipedia.util.DeviceUtil
+import org.wikipedia.util.DimenUtil
+import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.GradientUtil
+import org.wikipedia.util.L10nUtil
+import org.wikipedia.util.ResourceUtil
+import org.wikipedia.util.TabUtil
 import org.wikipedia.views.DefaultRecyclerAdapter
 import org.wikipedia.views.DefaultViewHolder
 import org.wikipedia.views.DrawableItemDecoration
@@ -118,15 +121,11 @@ class NewsFragment : Fragment() {
         }
 
         override fun onAddPageToList(entry: HistoryEntry, addToDefault: Boolean) {
-            if (addToDefault) {
-                ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), entry.title, InvokeSource.NEWS_ACTIVITY) { readingListId -> onMovePageToList(readingListId, entry) }
-            } else {
-                ExclusiveBottomSheetPresenter.show(childFragmentManager, AddToReadingListDialog.newInstance(entry.title, InvokeSource.NEWS_ACTIVITY))
-            }
+            ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), entry.title, addToDefault, InvokeSource.NEWS_ACTIVITY)
         }
 
         override fun onMovePageToList(sourceReadingListId: Long, entry: HistoryEntry) {
-            ExclusiveBottomSheetPresenter.show(childFragmentManager, MoveToReadingListDialog.newInstance(sourceReadingListId, entry.title, InvokeSource.NEWS_ACTIVITY))
+            ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, listOf(entry.title), InvokeSource.NEWS_ACTIVITY)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/feed/news/NewsFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsFragment.kt
@@ -125,7 +125,7 @@ class NewsFragment : Fragment() {
         }
 
         override fun onMovePageToList(sourceReadingListId: Long, entry: HistoryEntry) {
-            ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, listOf(entry.title), InvokeSource.NEWS_ACTIVITY)
+            ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, entry.title, InvokeSource.NEWS_ACTIVITY)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.kt
@@ -142,7 +142,7 @@ class OnThisDayCardView(context: Context) : DefaultFeedCardView<OnThisDayCard>(c
 
                             override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
                                 page?.let {
-                                    ReadingListBehaviorsUtil.moveToList(context as AppCompatActivity, page.listId, listOf(entry.title), InvokeSource.ON_THIS_DAY_CARD_BODY)
+                                    ReadingListBehaviorsUtil.moveToList(context as AppCompatActivity, page.listId, entry.title, InvokeSource.ON_THIS_DAY_CARD_BODY)
                                 }
                             }
                         }).show(entry)

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayCardView.kt
@@ -14,10 +14,7 @@ import org.wikipedia.feed.view.CardFooterView
 import org.wikipedia.feed.view.DefaultFeedCardView
 import org.wikipedia.feed.view.FeedAdapter
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.page.ExclusiveBottomSheetPresenter
-import org.wikipedia.readinglist.AddToReadingListDialog
 import org.wikipedia.readinglist.LongPressMenu
-import org.wikipedia.readinglist.MoveToReadingListDialog
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.readinglist.database.ReadingListPage
 import org.wikipedia.util.DateUtil
@@ -140,44 +137,12 @@ class OnThisDayCardView(context: Context) : DefaultFeedCardView<OnThisDayCard>(c
                             }
 
                             override fun onAddRequest(entry: HistoryEntry, addToDefault: Boolean) {
-                                if (addToDefault) {
-                                    ReadingListBehaviorsUtil.addToDefaultList(
-                                        context as AppCompatActivity, entry.title,
-                                        InvokeSource.ON_THIS_DAY_CARD_BODY
-                                    ) { readingListId ->
-                                        ExclusiveBottomSheetPresenter.show(
-                                            (context as AppCompatActivity).supportFragmentManager,
-                                            MoveToReadingListDialog.newInstance(
-                                                readingListId,
-                                                entry.title,
-                                                InvokeSource.ON_THIS_DAY_CARD_BODY
-                                            )
-                                        )
-                                    }
-                                } else {
-                                    ExclusiveBottomSheetPresenter.show(
-                                        (context as AppCompatActivity).supportFragmentManager,
-                                        AddToReadingListDialog.newInstance(
-                                            entry.title,
-                                            InvokeSource.ON_THIS_DAY_CARD_BODY
-                                        )
-                                    )
-                                }
+                                ReadingListBehaviorsUtil.addToDefaultList(context as AppCompatActivity, entry.title, addToDefault, InvokeSource.ON_THIS_DAY_CARD_BODY)
                             }
 
-                            override fun onMoveRequest(
-                                page: ReadingListPage?,
-                                entry: HistoryEntry
-                            ) {
+                            override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
                                 page?.let {
-                                    ExclusiveBottomSheetPresenter.show(
-                                        (context as AppCompatActivity).supportFragmentManager,
-                                        MoveToReadingListDialog.newInstance(
-                                            it.listId,
-                                            entry.title,
-                                            InvokeSource.ON_THIS_DAY_CARD_BODY
-                                        )
-                                    )
+                                    ReadingListBehaviorsUtil.moveToList(context as AppCompatActivity, page.listId, listOf(entry.title), InvokeSource.ON_THIS_DAY_CARD_BODY)
                                 }
                             }
                         }).show(entry)

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.kt
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.kt
@@ -105,7 +105,7 @@ class OnThisDayPagesViewHolder(
 
             override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
                 page?.let {
-                    ReadingListBehaviorsUtil.moveToList(activity, it.listId, listOf(entry.title), InvokeSource.ON_THIS_DAY_ACTIVITY)
+                    ReadingListBehaviorsUtil.moveToList(activity, it.listId, entry.title, InvokeSource.ON_THIS_DAY_ACTIVITY)
                 }
             }
         }).show(entry)

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.kt
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayPagesViewHolder.kt
@@ -14,14 +14,16 @@ import org.wikipedia.R
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.PageActivity
-import org.wikipedia.readinglist.AddToReadingListDialog
 import org.wikipedia.readinglist.LongPressMenu
-import org.wikipedia.readinglist.MoveToReadingListDialog
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.readinglist.database.ReadingListPage
-import org.wikipedia.util.*
+import org.wikipedia.util.DeviceUtil
+import org.wikipedia.util.DimenUtil
+import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.StringUtil
+import org.wikipedia.util.TabUtil
+import org.wikipedia.util.TransitionUtil
 import org.wikipedia.views.FaceAndColorDetectImageView
 
 class OnThisDayPagesViewHolder(
@@ -98,39 +100,13 @@ class OnThisDayPagesViewHolder(
             }
 
             override fun onAddRequest(entry: HistoryEntry, addToDefault: Boolean) {
-                if (addToDefault) {
-                    ReadingListBehaviorsUtil.addToDefaultList(
-                        activity, entry.title, InvokeSource.NEWS_ACTIVITY
-                    ) { readingListId ->
-                        ExclusiveBottomSheetPresenter.show(
-                            fragmentManager,
-                            MoveToReadingListDialog.newInstance(
-                                readingListId,
-                                entry.title,
-                                InvokeSource.ON_THIS_DAY_ACTIVITY
-                            )
-                        )
-                    }
-                } else {
-                    ExclusiveBottomSheetPresenter.show(
-                        fragmentManager,
-                        AddToReadingListDialog.newInstance(
-                            entry.title,
-                            InvokeSource.ON_THIS_DAY_ACTIVITY
-                        )
-                    )
-                }
+                ReadingListBehaviorsUtil.addToDefaultList(activity, entry.title, addToDefault, InvokeSource.ON_THIS_DAY_ACTIVITY)
             }
 
             override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
-                ExclusiveBottomSheetPresenter.show(
-                    fragmentManager,
-                    MoveToReadingListDialog.newInstance(
-                        page!!.listId,
-                        entry.title,
-                        InvokeSource.ON_THIS_DAY_ACTIVITY
-                    )
-                )
+                page?.let {
+                    ReadingListBehaviorsUtil.moveToList(activity, it.listId, listOf(entry.title), InvokeSource.ON_THIS_DAY_ACTIVITY)
+                }
             }
         }).show(entry)
         return true

--- a/app/src/main/java/org/wikipedia/feed/topread/TopReadFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/topread/TopReadFragment.kt
@@ -98,7 +98,7 @@ class TopReadFragment : Fragment() {
         }
 
         override fun onMovePageToList(sourceReadingListId: Long, entry: HistoryEntry) {
-            ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, listOf(entry.title), InvokeSource.MOST_READ_ACTIVITY)
+            ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, entry.title, InvokeSource.MOST_READ_ACTIVITY)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/feed/topread/TopReadFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/topread/TopReadFragment.kt
@@ -18,10 +18,7 @@ import org.wikipedia.databinding.FragmentMostReadBinding
 import org.wikipedia.feed.model.Card
 import org.wikipedia.feed.view.ListCardItemView
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.PageActivity
-import org.wikipedia.readinglist.AddToReadingListDialog
-import org.wikipedia.readinglist.MoveToReadingListDialog
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
@@ -97,18 +94,11 @@ class TopReadFragment : Fragment() {
         }
 
         override fun onAddPageToList(entry: HistoryEntry, addToDefault: Boolean) {
-            if (addToDefault) {
-                ReadingListBehaviorsUtil.addToDefaultList(requireActivity(),
-                    entry.title, InvokeSource.MOST_READ_ACTIVITY) { readingListId -> onMovePageToList(readingListId, entry) }
-            } else {
-                ExclusiveBottomSheetPresenter.show(childFragmentManager,
-                    AddToReadingListDialog.newInstance(entry.title, InvokeSource.MOST_READ_ACTIVITY))
-            }
+            ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), entry.title, addToDefault, InvokeSource.MOST_READ_ACTIVITY)
         }
 
         override fun onMovePageToList(sourceReadingListId: Long, entry: HistoryEntry) {
-            ExclusiveBottomSheetPresenter.show(childFragmentManager,
-                MoveToReadingListDialog.newInstance(sourceReadingListId, entry.title, InvokeSource.MOST_READ_ACTIVITY))
+            ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, listOf(entry.title), InvokeSource.MOST_READ_ACTIVITY)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -11,7 +11,12 @@ import android.os.Build
 import android.os.Bundle
 import android.speech.RecognizerIntent
 import android.util.Pair
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -57,8 +62,6 @@ import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
 import org.wikipedia.page.tabs.TabActivity
 import org.wikipedia.random.RandomActivity
-import org.wikipedia.readinglist.AddToReadingListDialog
-import org.wikipedia.readinglist.MoveToReadingListDialog
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.readinglist.ReadingListsFragment
 import org.wikipedia.search.SearchActivity
@@ -71,7 +74,10 @@ import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.suggestededits.SuggestedEditsTasksFragment
 import org.wikipedia.talk.TalkTopicsActivity
 import org.wikipedia.usercontrib.UserContribListActivity
-import org.wikipedia.util.*
+import org.wikipedia.util.DimenUtil
+import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.ShareUtil
+import org.wikipedia.util.TabUtil
 import org.wikipedia.views.NotificationButtonView
 import org.wikipedia.views.TabCountsView
 import org.wikipedia.watchlist.WatchlistActivity
@@ -342,16 +348,11 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     }
 
     override fun onFeedAddPageToList(entry: HistoryEntry, addToDefault: Boolean) {
-        if (addToDefault) {
-            ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), entry.title, InvokeSource.FEED) { readingListId -> onFeedMovePageToList(readingListId, entry) }
-        } else {
-            ExclusiveBottomSheetPresenter.show(childFragmentManager, AddToReadingListDialog.newInstance(entry.title, InvokeSource.FEED))
-        }
+        ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), entry.title, addToDefault, InvokeSource.FEED)
     }
 
     override fun onFeedMovePageToList(sourceReadingListId: Long, entry: HistoryEntry) {
-        ExclusiveBottomSheetPresenter.show(childFragmentManager,
-                MoveToReadingListDialog.newInstance(sourceReadingListId, entry.title, InvokeSource.FEED))
+        ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, listOf(entry.title), InvokeSource.FEED)
     }
 
     override fun onFeedNewsItemSelected(card: NewsCard, view: NewsItemView) {

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -352,7 +352,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     }
 
     override fun onFeedMovePageToList(sourceReadingListId: Long, entry: HistoryEntry) {
-        ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, listOf(entry.title), InvokeSource.FEED)
+        ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, entry.title, InvokeSource.FEED)
     }
 
     override fun onFeedNewsItemSelected(card: NewsCard, view: NewsItemView) {

--- a/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.kt
+++ b/app/src/main/java/org/wikipedia/page/ExclusiveBottomSheetPresenter.kt
@@ -1,37 +1,10 @@
 package org.wikipedia.page
 
-import android.content.DialogInterface
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
-import org.wikipedia.Constants.InvokeSource
-import org.wikipedia.readinglist.AddToReadingListDialog
-import org.wikipedia.readinglist.MoveToReadingListDialog
 
 object ExclusiveBottomSheetPresenter {
     const val BOTTOM_SHEET_FRAGMENT_TAG = "bottom_sheet_fragment"
-
-    fun showAddToListDialog(fm: FragmentManager,
-                            title: PageTitle,
-                            source: InvokeSource) {
-        show(fm, AddToReadingListDialog.newInstance(title, source))
-    }
-
-    fun showAddToListDialog(fm: FragmentManager,
-                            title: PageTitle,
-                            source: InvokeSource,
-                            listener: DialogInterface.OnDismissListener?) {
-        show(fm, AddToReadingListDialog.newInstance(title, source, listener))
-    }
-
-    fun showMoveToListDialog(fm: FragmentManager,
-                             sourceReadingListId: Long,
-                             title: PageTitle,
-                             source: InvokeSource,
-                             showDefaultList: Boolean,
-                             listener: DialogInterface.OnDismissListener?) {
-        show(fm, MoveToReadingListDialog.newInstance(sourceReadingListId, listOf(title), source, showDefaultList, listener))
-    }
-
     fun show(manager: FragmentManager, dialog: DialogFragment) {
         if (manager.isStateSaved || manager.isDestroyed) {
             return

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -2,7 +2,6 @@ package org.wikipedia.page
 
 import android.app.SearchManager
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
@@ -79,7 +78,7 @@ import org.wikipedia.views.ViewUtil
 import org.wikipedia.watchlist.WatchlistExpiry
 import java.util.Locale
 
-class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.LoadPageCallback, LinkPreviewDialog.AddToListCallback, FrameLayoutNavMenuTriggerer.Callback {
+class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.LoadPageCallback, FrameLayoutNavMenuTriggerer.Callback {
 
     enum class TabPosition {
         CURRENT_TAB, CURRENT_TAB_SQUASH, NEW_TAB_BACKGROUND, NEW_TAB_FOREGROUND, EXISTING_TAB
@@ -93,7 +92,6 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
     private var wasTransitionShown = false
     private val currentActionModes = mutableSetOf<ActionMode>()
     private val disposables = CompositeDisposable()
-    private val listDialogDismissListener = DialogInterface.OnDismissListener { pageFragment.updateBookmarkAndMenuOptionsFromDao() }
     private val isCabOpen get() = currentActionModes.isNotEmpty()
     private var exclusiveTooltipRunnable: Runnable? = null
     private var isTooltipShowing = false
@@ -403,14 +401,6 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
         DeviceUtil.hideSoftKeyboard(this)
     }
 
-    override fun onPageAddToReadingList(title: PageTitle, source: InvokeSource) {
-        showAddToListDialog(title, source)
-    }
-
-    override fun onPageMoveToReadingList(sourceReadingListId: Long, title: PageTitle, source: InvokeSource, showDefaultList: Boolean) {
-        showMoveToListDialog(sourceReadingListId, title, source, showDefaultList)
-    }
-
     override fun onPageWatchlistExpirySelect(expiry: WatchlistExpiry) {
         pageFragment.updateWatchlistExpiry(expiry)
     }
@@ -467,10 +457,6 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
 
     override fun onLinkPreviewLoadPage(title: PageTitle, entry: HistoryEntry, inNewTab: Boolean) {
         loadPage(title, entry, if (inNewTab) TabPosition.NEW_TAB_BACKGROUND else TabPosition.CURRENT_TAB)
-    }
-
-    override fun onLinkPreviewAddToList(title: PageTitle) {
-        showAddToListDialog(title, InvokeSource.LINK_PREVIEW_MENU)
     }
 
     private fun handleIntent(intent: Intent) {
@@ -648,15 +634,6 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
 
     private fun hideLinkPreview() {
         ExclusiveBottomSheetPresenter.dismiss(supportFragmentManager)
-    }
-
-    private fun showAddToListDialog(title: PageTitle, source: InvokeSource) {
-        ExclusiveBottomSheetPresenter.showAddToListDialog(supportFragmentManager, title, source, listDialogDismissListener)
-    }
-
-    private fun showMoveToListDialog(sourceReadingListId: Long, title: PageTitle, source: InvokeSource, showDefaultList: Boolean) {
-        ExclusiveBottomSheetPresenter.showMoveToListDialog(supportFragmentManager, sourceReadingListId,
-            title, source, showDefaultList, listDialogDismissListener)
     }
 
     private fun removeTransitionAnimState() {

--- a/app/src/main/java/org/wikipedia/page/PageContainerLongPressHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/PageContainerLongPressHandler.kt
@@ -1,8 +1,9 @@
 package org.wikipedia.page
 
-import org.wikipedia.Constants
+import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.LongPressHandler.WebViewMenuCallback
 import org.wikipedia.history.HistoryEntry
+import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.readinglist.database.ReadingListPage
 
 class PageContainerLongPressHandler(private val fragment: PageFragment) : WebViewMenuCallback {
@@ -16,12 +17,12 @@ class PageContainerLongPressHandler(private val fragment: PageFragment) : WebVie
     }
 
     override fun onAddRequest(entry: HistoryEntry, addToDefault: Boolean) {
-        fragment.addToReadingList(entry.title, Constants.InvokeSource.CONTEXT_MENU, addToDefault)
+        ReadingListBehaviorsUtil.addToDefaultList(fragment.requireActivity(), entry.title, addToDefault, InvokeSource.CONTEXT_MENU)
     }
 
     override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
         page?.run {
-            fragment.moveToReadingList(listId, entry.title, Constants.InvokeSource.CONTEXT_MENU, true)
+            ReadingListBehaviorsUtil.moveToList(fragment.requireActivity(), this.listId, listOf(entry.title), InvokeSource.CONTEXT_MENU)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageContainerLongPressHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/PageContainerLongPressHandler.kt
@@ -22,7 +22,7 @@ class PageContainerLongPressHandler(private val fragment: PageFragment) : WebVie
 
     override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
         page?.run {
-            ReadingListBehaviorsUtil.moveToList(fragment.requireActivity(), this.listId, listOf(entry.title), InvokeSource.CONTEXT_MENU)
+            ReadingListBehaviorsUtil.moveToList(fragment.requireActivity(), this.listId, entry.title, InvokeSource.CONTEXT_MENU)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -1354,7 +1354,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
                     override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
                         page?.let { readingListPage ->
                             title?.run {
-                                ReadingListBehaviorsUtil.moveToList(requireActivity(), readingListPage.listId, listOf(this), InvokeSource.BOOKMARK_BUTTON)
+                                ReadingListBehaviorsUtil.moveToList(requireActivity(), readingListPage.listId, this, InvokeSource.BOOKMARK_BUTTON)
                             }
                         }
                     }

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -223,6 +223,7 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
 
     private fun doAddToList() {
         ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), viewModel.pageTitle, true, Constants.InvokeSource.LINK_PREVIEW_MENU)
+        dialog?.dismiss()
     }
 
     private fun showPreview(contents: LinkPreviewContents) {

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -27,11 +27,11 @@ import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.gallery.GalleryActivity
 import org.wikipedia.gallery.GalleryThumbnailScrollView.GalleryViewListener
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
+import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.util.ClipboardUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.GeoUtil
@@ -47,15 +47,10 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
         fun onLinkPreviewLoadPage(title: PageTitle, entry: HistoryEntry, inNewTab: Boolean)
     }
 
-    interface AddToListCallback {
-        fun onLinkPreviewAddToList(title: PageTitle)
-    }
-
     private var _binding: DialogLinkPreviewBinding? = null
     private val binding get() = _binding!!
 
     private val loadPageCallback get() = getCallback(this, LoadPageCallback::class.java)
-    private val addToListCallback get() = getCallback(this, AddToListCallback::class.java)
 
     private var articleLinkPreviewInteractionEvent: ArticleLinkPreviewInteractionEvent? = null
     private var linkPreviewInteraction: ArticleLinkPreviewInteraction? = null
@@ -227,14 +222,7 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
     }
 
     private fun doAddToList() {
-        addToListCallback.let {
-            if (it != null) {
-                it.onLinkPreviewAddToList(viewModel.pageTitle)
-            } else {
-                ExclusiveBottomSheetPresenter.showAddToListDialog(requireActivity().supportFragmentManager,
-                    viewModel.pageTitle, Constants.InvokeSource.LINK_PREVIEW_MENU)
-            }
-        }
+        ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), viewModel.pageTitle, true, Constants.InvokeSource.LINK_PREVIEW_MENU)
     }
 
     private fun showPreview(contents: LinkPreviewContents) {

--- a/app/src/main/java/org/wikipedia/random/RandomFragment.kt
+++ b/app/src/main/java/org/wikipedia/random/RandomFragment.kt
@@ -146,7 +146,7 @@ class RandomFragment : Fragment() {
 
                 override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
                     page?.let {
-                        ReadingListBehaviorsUtil.moveToList(requireActivity(), page.listId, listOf(title), InvokeSource.RANDOM_ACTIVITY, true) {
+                        ReadingListBehaviorsUtil.moveToList(requireActivity(), page.listId, listOf(title), InvokeSource.RANDOM_ACTIVITY) {
                             updateSaveShareButton()
                         }
                     }

--- a/app/src/main/java/org/wikipedia/random/RandomFragment.kt
+++ b/app/src/main/java/org/wikipedia/random/RandomFragment.kt
@@ -25,15 +25,10 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.events.ArticleSavedOrDeletedEvent
 import org.wikipedia.extensions.parcelable
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
-import org.wikipedia.readinglist.AddToReadingListDialog
 import org.wikipedia.readinglist.LongPressMenu
-import org.wikipedia.readinglist.MoveToReadingListDialog
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil
-import org.wikipedia.readinglist.ReadingListBehaviorsUtil.AddToDefaultListCallback
-import org.wikipedia.readinglist.ReadingListBehaviorsUtil.addToDefaultList
 import org.wikipedia.readinglist.database.ReadingListPage
 import org.wikipedia.util.AnimationUtil.PagerTransformer
 import org.wikipedia.util.DimenUtil
@@ -144,15 +139,23 @@ class RandomFragment : Fragment() {
                 }
 
                 override fun onAddRequest(entry: HistoryEntry, addToDefault: Boolean) {
-                    onAddPageToList(title, addToDefault)
+                    ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), title, addToDefault, InvokeSource.RANDOM_ACTIVITY) {
+                        updateSaveShareButton(title)
+                    }
                 }
 
                 override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
-                    onMovePageToList(page!!.listId, title)
+                    page?.let {
+                        ReadingListBehaviorsUtil.moveToList(requireActivity(), page.listId, listOf(title), InvokeSource.RANDOM_ACTIVITY, true) {
+                            updateSaveShareButton()
+                        }
+                    }
                 }
             }).show(HistoryEntry(title, HistoryEntry.SOURCE_RANDOM))
         } else {
-            onAddPageToList(title, true)
+            ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), title, true, InvokeSource.RANDOM_ACTIVITY) {
+                updateSaveShareButton(title)
+            }
         }
     }
 
@@ -172,37 +175,6 @@ class RandomFragment : Fragment() {
             intent,
             if (DimenUtil.isLandscape(requireContext()) || sharedElements.isEmpty()) null else options.toBundle()
         )
-    }
-
-    fun onAddPageToList(title: PageTitle, addToDefault: Boolean) {
-        if (addToDefault) {
-            addToDefaultList(requireActivity(), title, InvokeSource.RANDOM_ACTIVITY,
-                AddToDefaultListCallback { readingListId ->
-                    onMovePageToList(
-                        readingListId,
-                        title
-                    )
-                },
-                ReadingListBehaviorsUtil.Callback { updateSaveShareButton(title) }
-            )
-        } else {
-            ExclusiveBottomSheetPresenter.show(childFragmentManager,
-                AddToReadingListDialog.newInstance(title, InvokeSource.RANDOM_ACTIVITY) {
-                    updateSaveShareButton(title)
-                })
-        }
-    }
-
-    fun onMovePageToList(sourceReadingListId: Long, title: PageTitle) {
-        ExclusiveBottomSheetPresenter.show(childFragmentManager,
-            MoveToReadingListDialog.newInstance(
-                sourceReadingListId,
-                listOf(title),
-                InvokeSource.RANDOM_ACTIVITY,
-                true
-            ) {
-                updateSaveShareButton(title)
-            })
     }
 
     private fun updateBackButton(pagerPosition: Int) {

--- a/app/src/main/java/org/wikipedia/random/RandomFragment.kt
+++ b/app/src/main/java/org/wikipedia/random/RandomFragment.kt
@@ -146,7 +146,7 @@ class RandomFragment : Fragment() {
 
                 override fun onMoveRequest(page: ReadingListPage?, entry: HistoryEntry) {
                     page?.let {
-                        ReadingListBehaviorsUtil.moveToList(requireActivity(), page.listId, listOf(title), InvokeSource.RANDOM_ACTIVITY) {
+                        ReadingListBehaviorsUtil.moveToList(requireActivity(), page.listId, title, InvokeSource.RANDOM_ACTIVITY) {
                             updateSaveShareButton()
                         }
                     }

--- a/app/src/main/java/org/wikipedia/readinglist/MoveToReadingListDialog.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/MoveToReadingListDialog.kt
@@ -66,6 +66,14 @@ class MoveToReadingListDialog : AddToReadingListDialog() {
         }
 
         fun newInstance(sourceReadingListId: Long,
+                        title: PageTitle,
+                        source: InvokeSource,
+                        showDefaultList: Boolean = true,
+                        listener: DialogInterface.OnDismissListener? = null): MoveToReadingListDialog {
+            return newInstance(sourceReadingListId, listOf(title), source, showDefaultList, listener)
+        }
+
+        fun newInstance(sourceReadingListId: Long,
                         titles: List<PageTitle>,
                         source: InvokeSource,
                         showDefaultList: Boolean = true,

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -311,6 +311,8 @@ object ReadingListBehaviorsUtil {
                             .setAction(R.string.reading_list_add_to_list_button) {
                                 moveToList(activity, defaultList.id, finalPageTitle, invokeSource, false, listener)
                             }.show()
+                    } else {
+                        FeedbackUtil.showMessage(activity, activity.getString(R.string.reading_list_article_already_exists_message, defaultList.title, title.displayText))
                     }
                 }
             }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -294,10 +294,9 @@ object ReadingListBehaviorsUtil {
     }
 
     fun addToDefaultList(activity: Activity, title: PageTitle, addToDefault: Boolean, invokeSource: InvokeSource, listener: DialogInterface.OnDismissListener? = null) {
-        activity as AppCompatActivity
         if (addToDefault) {
             // If the title is a redirect, resolve it before saving to the reading list.
-            activity.lifecycleScope.launch(CoroutineExceptionHandler { _, t -> L.e(t) }) {
+            (activity as AppCompatActivity).lifecycleScope.launch(CoroutineExceptionHandler { _, t -> L.e(t) }) {
                 var finalPageTitle = title
                 try {
                     ServiceFactory.get(title.wikiSite).getInfoByPageIdsOrTitles(null, title.prefixedText)
@@ -310,22 +309,21 @@ object ReadingListBehaviorsUtil {
                     if (addedTitles.isNotEmpty()) {
                         FeedbackUtil.makeSnackbar(activity, activity.getString(R.string.reading_list_article_added_to_default_list, StringUtil.fromHtml(finalPageTitle.displayText)))
                             .setAction(R.string.reading_list_add_to_list_button) {
-                                moveToList(activity, defaultList.id, listOf(finalPageTitle), invokeSource, false, listener)
+                                moveToList(activity, defaultList.id, finalPageTitle, invokeSource, false, listener)
                             }.show()
                     }
                 }
             }
         } else {
-            ExclusiveBottomSheetPresenter.show(activity.supportFragmentManager,
+            ExclusiveBottomSheetPresenter.show((activity as AppCompatActivity).supportFragmentManager,
                 AddToReadingListDialog.newInstance(title, invokeSource, listener))
         }
     }
 
-    fun moveToList(activity: Activity, sourceReadingListId: Long, titles: List<PageTitle>, source: InvokeSource,
+    fun moveToList(activity: Activity, sourceReadingListId: Long, title: PageTitle, source: InvokeSource,
                    showDefaultList: Boolean = true, listener: DialogInterface.OnDismissListener? = null) {
-        activity as AppCompatActivity
-        ExclusiveBottomSheetPresenter.show(activity.supportFragmentManager,
-            MoveToReadingListDialog.newInstance(sourceReadingListId, titles, source, showDefaultList, listener))
+        ExclusiveBottomSheetPresenter.show((activity as AppCompatActivity).supportFragmentManager,
+            MoveToReadingListDialog.newInstance(sourceReadingListId, title, source, showDefaultList, listener))
     }
 
     private fun toggleOffline(activity: Activity, page: ReadingListPage, forcedSave: Boolean) {

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -217,7 +217,7 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
     }
 
     override fun onSearchMovePageToList(sourceReadingListId: Long, entry: HistoryEntry) {
-        ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, listOf(entry.title), InvokeSource.SEARCH)
+        ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, entry.title, InvokeSource.SEARCH)
     }
 
     override fun onSearchProgressBar(enabled: Boolean) {

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -25,11 +25,8 @@ import org.wikipedia.databinding.FragmentSearchBinding
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.language.LanguageUtil
-import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
-import org.wikipedia.readinglist.AddToReadingListDialog
-import org.wikipedia.readinglist.MoveToReadingListDialog
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.search.db.RecentSearch
 import org.wikipedia.settings.Prefs
@@ -40,7 +37,7 @@ import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.views.LanguageScrollView
 import org.wikipedia.views.ViewUtil
-import java.util.*
+import java.util.Locale
 
 class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearchesFragment.Callback, LanguageScrollView.Callback {
     private var _binding: FragmentSearchBinding? = null
@@ -216,19 +213,11 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
     }
 
     override fun onSearchAddPageToList(entry: HistoryEntry, addToDefault: Boolean) {
-        if (addToDefault) {
-            ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), entry.title, InvokeSource.FEED) { readingListId ->
-                onSearchMovePageToList(readingListId, entry)
-            }
-        } else {
-            ExclusiveBottomSheetPresenter.show(childFragmentManager,
-                    AddToReadingListDialog.newInstance(entry.title, InvokeSource.FEED))
-        }
+        ReadingListBehaviorsUtil.addToDefaultList(requireActivity(), entry.title, addToDefault, InvokeSource.SEARCH)
     }
 
     override fun onSearchMovePageToList(sourceReadingListId: Long, entry: HistoryEntry) {
-        ExclusiveBottomSheetPresenter.show(childFragmentManager,
-                MoveToReadingListDialog.newInstance(sourceReadingListId, entry.title, InvokeSource.FEED))
+        ReadingListBehaviorsUtil.moveToList(requireActivity(), sourceReadingListId, listOf(entry.title), InvokeSource.SEARCH)
     }
 
     override fun onSearchProgressBar(enabled: Boolean) {


### PR DESCRIPTION
This PR simplified the logic of adding/moving an article to the list, which now can use either `ReadingListBehaviorsUtil.addToDefaultList` or `ReadingListBehaviorsUtil.moveToList` with an optional dialog dismiss listener.

This PR also fixed the issue that some views have incorrect invoke sources implemented.