### PR TITLE
Correctly handle nested list tags in Html.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -374,6 +374,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
     }
 
     private fun updateOnError(t: Throwable) {
+        binding.talkProgressBar.isVisible = false
         binding.talkRecyclerView.adapter?.notifyDataSetChanged()
 
         // In the case of 404, it just means that the talk page hasn't been created yet.
@@ -389,6 +390,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
     }
 
     private fun updateOnEmpty() {
+        binding.talkProgressBar.isVisible = false
         binding.talkRefreshView.isRefreshing = false
         binding.talkEmptyContainer.isVisible = true
         binding.talkConditionContainer.isVisible = true


### PR DESCRIPTION
Previously we were incorrectly handling nested ordered lists (lists within lists).
We were also making incorrect assumptions about the structure of lists, i.e. assuming that list items are separated by a newline `\n`, which is not always the case.
(as seen in https://en.wikipedia.org/wiki/User_talk:QTE-Test3-WMF)

This fixes the logic to handle any kind of ordered list correctly, and with no assumptions of structure.