### PR TITLE
Use the newer version of build tools for the Github sign-android-release action

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,6 +31,9 @@ jobs:
         alias: ${{ secrets.KEY_STORE_ALIAS }}
         keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
         keyPassword: ${{ secrets.KEY_PASSWORD }}
+      env:
+        # override default build-tools version (29.0.3) -- optional
+        BUILD_TOOLS_VERSION: "34.0.0"
     - name: Create hash
       run: git rev-parse HEAD > app/build/outputs/apk/alpha/release/rev-hash.txt
     - name: Rename APK to universal

--- a/.github/workflows/android_branch.yml
+++ b/.github/workflows/android_branch.yml
@@ -30,6 +30,9 @@ jobs:
         alias: ${{ secrets.KEY_STORE_ALIAS }}
         keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
         keyPassword: ${{ secrets.KEY_PASSWORD }}
+      env:
+        # override default build-tools version (29.0.3) -- optional
+        BUILD_TOOLS_VERSION: "34.0.0"
     - uses: actions/upload-artifact@v3
       name: Upload APK artifact
       with:


### PR DESCRIPTION
The current Github action is failed. Update to the latest build tool fixes the issue.
https://github.com/wikimedia/apps-android-wikipedia/actions/runs/7468471414/job/20323975669

```
Error: Couldnt find the Android build tools @ /usr/local/lib/android/sdk/build-tools/29.0.3
Error: Unable to locate executable file: /usr/local/lib/android/sdk/build-tools/29.0.3/zipalign. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```