### PR TITLE
Simplify string operations

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -71,7 +71,7 @@ object JavaScriptActionHandler {
     }
 
     fun scrollToAnchor(anchorLink: String): String {
-        val anchor = if (anchorLink.contains("#")) anchorLink.substring(anchorLink.indexOf("#") + 1) else anchorLink
+        val anchor = anchorLink.substringAfter('#')
         return "var el = document.getElementById('$anchor');" +
                 "window.scrollTo(0, el.offsetTop - (screen.height / 2));" +
                 "setTimeout(function(){ el.style.backgroundColor='#fc3';" +

--- a/app/src/main/java/org/wikipedia/edit/WikiTextKeyboardView.kt
+++ b/app/src/main/java/org/wikipedia/edit/WikiTextKeyboardView.kt
@@ -90,34 +90,27 @@ class WikiTextKeyboardView constructor(context: Context, attrs: AttributeSet?) :
         binding.wikitextButtonPreviewLink.setOnClickListener {
             editText?.inputConnection?.let { inputConnection ->
                 var title: String? = null
-                val selection = inputConnection.getSelectedText(0)
-                if (!selection.isNullOrEmpty() && !selection.toString().contains("[[")) {
-                    title = trimPunctuation(selection.toString())
+                val selection = inputConnection.getSelectedText(0)?.toString()
+                if (!selection.isNullOrEmpty() && "[[" !in selection) {
+                    title = selection.trim('.', ',', ';', '?', '!')
                 } else {
-                    val before: String
-                    val after: String
-                    if (selection != null && selection.length > 1) {
-                        val selectionStr = selection.toString()
-                        before = selectionStr.substring(0, selectionStr.length / 2)
-                        after = selectionStr.substring(selectionStr.length / 2)
+                    val (before, after) = if (selection != null && selection.length > 1) {
+                        selection.substring(0, selection.length / 2) to
+                                selection.substring(selection.length / 2)
                     } else {
                         val peekLength = 64
-                        before = inputConnection.getTextBeforeCursor(peekLength, 0).toString()
-                        after = inputConnection.getTextAfterCursor(peekLength, 0).toString()
+                        inputConnection.getTextBeforeCursor(peekLength, 0)?.toString() to
+                                inputConnection.getTextAfterCursor(peekLength, 0)?.toString()
                     }
 
-                    if (before.isNotEmpty() && after.isNotEmpty()) {
-                        var str = before + after
-                        val i1 = lastIndexOf(before, "[[")
-                        val i2 = after.indexOf("]]") + before.length
-                        if (i1 >= 0 && i2 > 0 && i2 > i1) {
-                            str = str.substring(i1 + 2, i2).trim()
-                            if (str.isNotEmpty()) {
-                                if (str.contains("|")) {
-                                    str = str.split("\\|".toRegex()).toTypedArray()[0]
-                                }
-                                title = str
-                            }
+                    if (!before.isNullOrEmpty() && !after.isNullOrEmpty()) {
+                        val str = before + after
+                        val i1 = before.lastIndexOf("[[")
+                        if (i1 >= 0) {
+                            title = str.substring(i1 + 2).substringBefore("]]")
+                                .trim()
+                                .splitToSequence('|')
+                                .firstOrNull()?.ifEmpty { null }
                         }
                     }
                 }
@@ -173,7 +166,6 @@ class WikiTextKeyboardView constructor(context: Context, attrs: AttributeSet?) :
     }
 
     companion object {
-
         fun toggleSyntaxAroundCurrentSelection(editText: EditText?, ic: InputConnection, prefix: String, suffix: String) {
             editText?.let {
                 if (it.selectionStart == it.selectionEnd) {
@@ -200,33 +192,6 @@ class WikiTextKeyboardView constructor(context: Context, attrs: AttributeSet?) :
                     ic.setSelection(it.selectionStart - selection.length, it.selectionEnd)
                 }
             }
-        }
-
-        @Suppress("SameParameterValue")
-        fun lastIndexOf(str: String, subStr: String): Int {
-            var index = -1
-            var a = 0
-            while (a < str.length) {
-                val i = str.indexOf(subStr, a)
-                if (i >= 0) {
-                    index = i
-                    a = i + 1
-                } else {
-                    break
-                }
-            }
-            return index
-        }
-
-        fun trimPunctuation(str: String): String {
-            var newStr = str
-            while (newStr.startsWith(".") || newStr.startsWith(",") || newStr.startsWith(";") || newStr.startsWith("?") || newStr.startsWith("!")) {
-                newStr = newStr.substring(1)
-            }
-            while (newStr.endsWith(".") || newStr.endsWith(",") || newStr.endsWith(";") || newStr.endsWith("?") || newStr.endsWith("!")) {
-                newStr = newStr.substring(0, newStr.length - 1)
-            }
-            return newStr
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/gallery/MediaDownloadReceiver.kt
+++ b/app/src/main/java/org/wikipedia/gallery/MediaDownloadReceiver.kt
@@ -140,7 +140,7 @@ class MediaDownloadReceiver : BroadcastReceiver() {
         private const val FILE_NAMESPACE = "File:"
 
         private fun trimFileNamespace(filename: String): String {
-            return if (filename.startsWith(FILE_NAMESPACE)) filename.substring(FILE_NAMESPACE.length) else filename
+            return filename.substringAfter(FILE_NAMESPACE)
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
@@ -2,7 +2,11 @@ package org.wikipedia.language
 
 import android.content.Context
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.view.ActionMode
@@ -20,7 +24,6 @@ import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 import org.wikipedia.views.ViewAnimations
-import java.util.*
 
 class LangLinksActivity : BaseActivity() {
     private lateinit var binding: ActivityLanglinksBinding
@@ -203,13 +206,11 @@ class LangLinksActivity : BaseActivity() {
         fun setFilterText(filterText: String) {
             isSearching = true
             languageEntries.clear()
-            val filter = filterText.lowercase(Locale.getDefault())
             for (entry in originalLanguageEntries) {
                 val languageCode = entry.wikiSite.languageCode
                 val canonicalName = app.languageState.getAppLanguageCanonicalName(languageCode).orEmpty()
                 val localizedName = app.languageState.getAppLanguageLocalizedName(languageCode).orEmpty()
-                if (canonicalName.lowercase(Locale.getDefault()).contains(filter) ||
-                        localizedName.lowercase(Locale.getDefault()).contains(filter)) {
+                if (canonicalName.contains(filterText, true) || localizedName.contains(filterText, true)) {
                     languageEntries.add(entry)
                 }
             }

--- a/app/src/main/java/org/wikipedia/language/LanguagesListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguagesListViewModel.kt
@@ -13,7 +13,6 @@ import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.mwapi.SiteMatrix
 import org.wikipedia.util.Resource
 import org.wikipedia.util.log.L
-import java.util.*
 
 class LanguagesListViewModel : ViewModel() {
 
@@ -42,7 +41,7 @@ class LanguagesListViewModel : ViewModel() {
 
     fun getListBySearchTerm(context: Context, searchTerm: String?): List<LanguageListItem> {
         val results = mutableListOf<LanguageListItem>()
-        val filter = StringUtils.stripAccents(searchTerm.orEmpty()).lowercase(Locale.getDefault())
+        val filter = StringUtils.stripAccents(searchTerm.orEmpty())
 
         addFilteredLanguageListItems(filter, suggestedLanguageCodes,
                 context.getString(R.string.languages_list_suggested_text), results)
@@ -59,9 +58,9 @@ class LanguagesListViewModel : ViewModel() {
         for (code in codes) {
             val localizedName = StringUtils.stripAccents(WikipediaApp.instance.languageState.getAppLanguageLocalizedName(code).orEmpty())
             val canonicalName = StringUtils.stripAccents(getCanonicalName(code).orEmpty())
-            if (filter.isEmpty() || code.contains(filter) ||
-                    localizedName.lowercase(Locale.getDefault()).contains(filter) ||
-                    canonicalName.lowercase(Locale.getDefault()).contains(filter)) {
+            if (filter.isEmpty() || code.contains(filter, true) ||
+                    localizedName.contains(filter, true) ||
+                    canonicalName.contains(filter, true)) {
                 if (first) {
                     results.add(LanguageListItem(headerText, true))
                     first = false

--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -67,22 +67,15 @@ object StringUtil {
     }
 
     fun dbNameToLangCode(wikiDbName: String): String {
-        return (if (wikiDbName.endsWith("wiki")) wikiDbName.substring(0, wikiDbName.length - "wiki".length) else wikiDbName)
-                .replace("_", "-")
+        return wikiDbName.substringBefore("wiki").replace("_", "-")
     }
 
     fun removeSectionAnchor(text: String?): String {
-        text.orEmpty().let {
-            return if (it.contains("#")) it.substring(0, it.indexOf("#")) else it
-        }
+        return text.orEmpty().substringBefore('#')
     }
 
     fun removeNamespace(text: String): String {
-        return if (text.length > text.indexOf(":")) {
-            text.substring(text.indexOf(":") + 1)
-        } else {
-            text
-        }
+        return text.substringAfter(':')
     }
 
     fun removeHTMLTags(text: String?): String {

--- a/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.kt
+++ b/app/src/main/java/org/wikipedia/views/FaceAndColorDetectImageView.kt
@@ -19,7 +19,6 @@ import com.bumptech.glide.request.target.Target
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.CenterCropWithFaceTransformation
 import org.wikipedia.util.WhiteBackgroundTransformation
-import java.util.*
 
 class FaceAndColorDetectImageView : AppCompatImageView {
 
@@ -34,8 +33,8 @@ class FaceAndColorDetectImageView : AppCompatImageView {
 
     private fun shouldDetectFace(uri: Uri): Boolean {
         // TODO: not perfect; should ideally detect based on MIME type.
-        val path = uri.path.orEmpty().lowercase(Locale.ROOT)
-        return path.endsWith(".jpg") || path.endsWith(".jpeg")
+        val path = uri.path.orEmpty()
+        return path.endsWith(".jpg", true) || path.endsWith(".jpeg", true)
     }
 
     fun loadImage(uri: Uri?, roundedCorners: Boolean = false, cropped: Boolean = true, emptyPlaceholder: Boolean = false, listener: OnImageLoadListener? = null) {

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
@@ -140,7 +140,7 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
     }
 
     private fun getTermFromWikiLink(url: String): String {
-        return removeLinkFragment(url.substring(url.lastIndexOf("/") + 1))
+        return removeLinkFragment(url.substringAfterLast('/'))
     }
 
     private fun removeLinkFragment(url: String): String {

--- a/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
+++ b/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
@@ -75,9 +75,21 @@ class StringUtilTest {
     }
 
     @Test
+    fun testDbNameToLangCode() {
+        MatcherAssert.assertThat(StringUtil.dbNameToLangCode("en"), Matchers.`is`("en"))
+        MatcherAssert.assertThat(StringUtil.dbNameToLangCode("enwiki"), Matchers.`is`("en"))
+    }
+
+    @Test
     fun testRemoveSectionAnchor() {
         MatcherAssert.assertThat(StringUtil.removeSectionAnchor("#te_st"), Matchers.`is`(""))
         MatcherAssert.assertThat(StringUtil.removeSectionAnchor("sec#te_st"), Matchers.`is`("sec"))
+    }
+
+    @Test
+    fun testRemoveNamespace() {
+        MatcherAssert.assertThat(StringUtil.removeNamespace("RSP"), Matchers.`is`("RSP"))
+        MatcherAssert.assertThat(StringUtil.removeNamespace("WP:RSP"), Matchers.`is`("RSP"))
     }
 
     @Test


### PR DESCRIPTION
* Use Kotlin's string extensions to simplify some string operations.
* Set the `ignoreCase` parameter for methods such as `contains` and `endsWith`.