### PR TITLE
Further improve/fix Search interface.

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -154,9 +154,7 @@ class SearchResultsFragment : Fragment() {
 
     private inner class SearchResultsDiffCallback : DiffUtil.ItemCallback<SearchResult>() {
         override fun areItemsTheSame(oldItem: SearchResult, newItem: SearchResult): Boolean {
-            return oldItem.pageTitle.prefixedText == newItem.pageTitle.prefixedText &&
-                    oldItem.pageTitle.namespace == newItem.pageTitle.namespace &&
-                    oldItem.pageTitle.description == newItem.pageTitle.description
+            return false
         }
 
         override fun areContentsTheSame(oldItem: SearchResult, newItem: SearchResult): Boolean {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
@@ -117,7 +117,7 @@ class SearchResultsViewModel : ViewModel() {
                     }
                 }
 
-                return LoadResult.Page(resultList.distinctBy { it.pageTitle.prefixedText }, null, continuation)
+                return LoadResult.Page(resultList.distinctBy { it.pageTitle.prefixedText }, params.key, continuation)
             } catch (e: Exception) {
                 LoadResult.Error(e)
             }


### PR DESCRIPTION
The previous Search fixes were correct, but there was one other issue: the `PagingDataAdapter` that was used by the RecyclerView wasn't scrolling back to the top when the search term was updated. This caused updated search results to get populated above the current scroll position, resulting in a bit of confusion.

This fixes the scroll behavior by leveraging `SearchResultsDiffCallback`, or rather un-leveraging it, since we know that all search results are unique (done at the level of the PagingSource).