### PR TITLE
Increase maximum zoom level in the map.

### DIFF
--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -250,11 +250,6 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        // Style JSON taken from:
-        // https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Kartographer/+/663867 (mvt-style.json)
-        // https://tegola-wikimedia.s3.amazonaws.com/wikimedia-tilejson.json (for some reason)
-
         binding.mapView.onCreate(savedInstanceState)
 
         binding.mapView.getMapAsync { map ->
@@ -264,8 +259,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
 
                 style.addImage(MARKER_DRAWABLE, markerBitmapBase)
 
-                // TODO: Currently the style seems to break when zooming beyond 16.0. See if we can fix this.
-                map.setMaxZoomPreference(15.999)
+                map.setMaxZoomPreference(20.0)
 
                 map.uiSettings.isLogoEnabled = false
                 val defMargin = DimenUtil.roundedDpToPx(16f)


### PR DESCRIPTION
We were artificially constraining the maximum zoom level at <16, because for some reason it wasn't working properly earlier.
But now all zoom levels are working correctly, so let's increase the maximum to 20, which is the same maximum as Google Maps.