### PR TITLE
Re-introduce minimum movement constraint for querying map updates.

### DIFF
--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -82,6 +82,7 @@ import org.wikipedia.util.StringUtil
 import org.wikipedia.util.TabUtil
 import org.wikipedia.util.log.L
 import org.wikipedia.views.ViewUtil
+import kotlin.math.abs
 
 class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap.OnMapClickListener {
 
@@ -96,8 +97,10 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
     private var symbolManager: SymbolManager? = null
 
     private val annotationCache = ArrayDeque<PlacesFragmentViewModel.NearbyPage>()
-    private var lastLocationUpdated: Location? = null
+    private var lastLocation: Location? = null
+    private var lastLocationQueried: Location? = null
     private var lastZoom = 15.0
+    private var lastZoomQueried = 0.0
 
     private lateinit var markerBitmapBase: Bitmap
     private lateinit var markerPaintSrc: Paint
@@ -146,9 +149,9 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
             if (languageChanged) {
                 annotationCache.clear()
                 symbolManager?.deleteAll()
-                  viewModel.fetchNearbyPages(lastLocationUpdated?.latitude ?: 0.0,
-                      lastLocationUpdated?.longitude ?: 0.0, searchRadius, ITEMS_PER_REQUEST)
-                  goToLocation(1000, lastLocationUpdated, lastZoom)
+                  viewModel.fetchNearbyPages(lastLocation?.latitude ?: 0.0,
+                      lastLocation?.longitude ?: 0.0, searchRadius, ITEMS_PER_REQUEST)
+                  goToLocation(1000, lastLocation, lastZoom)
               }
           }
     }
@@ -218,7 +221,6 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
         }
 
         binding.searchLangContainer.setOnClickListener {
-            lastZoom = mapboxMap?.cameraPosition?.zoom ?: 15.0
             filterLauncher.launch(PlacesFilterActivity.newIntent(requireActivity()))
         }
 
@@ -282,7 +284,9 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
                 map.uiSettings.setAttributionMargins(defMargin, 0, defMargin, navBarMargin + DimenUtil.roundedDpToPx(36f))
 
                 map.addOnCameraIdleListener {
-                    onUpdateCameraPosition(mapboxMap?.cameraPosition?.target)
+                    mapboxMap?.cameraPosition?.target?.let {
+                        onUpdateCameraPosition(it)
+                    }
                 }
 
                 map.addOnMapClickListener(this)
@@ -457,22 +461,29 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
         super.onDestroyView()
     }
 
-    private fun onUpdateCameraPosition(latLng: LatLng?) {
-        if (latLng == null) {
-            return
-        }
-
-        lastLocationUpdated = Location("").also {
+    private fun onUpdateCameraPosition(latLng: LatLng) {
+        lastLocation = Location("").also {
             it.latitude = latLng.latitude
             it.longitude = latLng.longitude
         }
+        lastZoom = mapboxMap?.cameraPosition?.zoom ?: 15.0
 
-        LatLng(latLng.latitude, latLng.longitude)
-
-        if ((mapboxMap?.cameraPosition?.zoom ?: 0.0) < 3.0) {
+        if (lastZoom < 3.0) {
             // Don't fetch pages if the map is zoomed out too far.
             return
         }
+
+        // Fetch new pages within the current viewport, but only if the map has moved a significant distance.
+        val latEpsilon = (mapboxMap?.projection?.visibleRegion?.latLngBounds?.latitudeSpan ?: 0.0) * 0.2
+        val lngEpsilon = (mapboxMap?.projection?.visibleRegion?.latLngBounds?.longitudeSpan ?: 0.0) * 0.2
+        if (lastLocationQueried != null &&
+            abs(latLng.latitude - (lastLocationQueried?.latitude ?: 0.0)) < latEpsilon &&
+            abs(latLng.longitude - (lastLocationQueried?.longitude ?: 0.0)) < lngEpsilon &&
+            abs(lastZoom - lastZoomQueried) < 0.5) {
+            return
+        }
+        lastLocationQueried = lastLocation
+        lastZoomQueried = lastZoom
 
         L.d(">>> requesting update: " + latLng.latitude + ", " + latLng.longitude + ", " + mapboxMap?.cameraPosition?.zoom)
         viewModel.fetchNearbyPages(latLng.latitude, latLng.longitude, searchRadius, ITEMS_PER_REQUEST)


### PR DESCRIPTION
We really don't need to re-query the API if the user moves the map by 1 pixel  ¯\\_(ツ)\_/¯