### PR TITLE
Places: reset the search bar text and icon after dismissing the link preview dialog

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -57,10 +57,15 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
         fun onLinkPreviewLoadPage(title: PageTitle, entry: HistoryEntry, inNewTab: Boolean)
     }
 
+    interface DismissCallback {
+        fun onLinkPreviewDismiss()
+    }
+
     private var _binding: DialogLinkPreviewBinding? = null
     private val binding get() = _binding!!
 
     private val loadPageCallback get() = getCallback(this, LoadPageCallback::class.java)
+    private val dismissCallback get() = getCallback(this, DismissCallback::class.java)
 
     private var articleLinkPreviewInteractionEvent: ArticleLinkPreviewInteractionEvent? = null
     private var linkPreviewInteraction: ArticleLinkPreviewInteraction? = null
@@ -276,6 +281,7 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
 
     override fun onDismiss(dialogInterface: DialogInterface) {
         super.onDismiss(dialogInterface)
+        dismissCallback?.onLinkPreviewDismiss()
         if (!navigateSuccess) {
             articleLinkPreviewInteractionEvent?.logCancel()
             linkPreviewInteraction?.logCancel()
@@ -288,6 +294,10 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
 
     override fun onDismiss() {
         dismiss()
+    }
+
+    fun setOnCancelListener(listener: DialogInterface.OnCancelListener) {
+        dialog?.setOnCancelListener(listener)
     }
 
     private fun showWatchlistSnackbar(activity: AppCompatActivity, pageTitle: PageTitle) {
@@ -460,15 +470,13 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
         const val ARG_ENTRY = "entry"
         const val ARG_LOCATION = "location"
         const val ARG_LAST_KNOWN_LOCATION = "lastKnownLocation"
-        const val ARG_FROM_PLACES = "fromPlaces"
 
-        fun newInstance(entry: HistoryEntry, location: Location? = null, lastKnownLocation: Location? = null, fromPlaces: Boolean = false): LinkPreviewDialog {
+        fun newInstance(entry: HistoryEntry, location: Location? = null, lastKnownLocation: Location? = null): LinkPreviewDialog {
             return LinkPreviewDialog().apply {
                 arguments = bundleOf(
                     ARG_ENTRY to entry,
                     ARG_LOCATION to location,
-                    ARG_LAST_KNOWN_LOCATION to lastKnownLocation,
-                    ARG_FROM_PLACES to fromPlaces
+                    ARG_LAST_KNOWN_LOCATION to lastKnownLocation
                 )
             }
         }

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
@@ -25,7 +25,7 @@ class LinkPreviewViewModel(bundle: Bundle) : ViewModel() {
     val historyEntry = bundle.parcelable<HistoryEntry>(LinkPreviewDialog.ARG_ENTRY)!!
     var pageTitle = historyEntry.title
     var location = bundle.parcelable<Location>(LinkPreviewDialog.ARG_LOCATION)
-    val fromPlaces = bundle.getBoolean(LinkPreviewDialog.ARG_FROM_PLACES, false)
+    val fromPlaces = historyEntry.source == HistoryEntry.SOURCE_PLACES
     val lastKnownLocation = bundle.parcelable<Location>(LinkPreviewDialog.ARG_LAST_KNOWN_LOCATION)
     var isInReadingList = false
 

--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -84,7 +84,7 @@ import org.wikipedia.util.log.L
 import org.wikipedia.views.ViewUtil
 import kotlin.math.abs
 
-class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap.OnMapClickListener {
+class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPreviewDialog.DismissCallback, MapboxMap.OnMapClickListener {
 
     private var _binding: FragmentPlacesBinding? = null
     private val binding get() = _binding!!
@@ -329,7 +329,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
     private fun showLinkPreview(pageTitle: PageTitle, location: Location) {
         val entry = HistoryEntry(pageTitle, HistoryEntry.SOURCE_PLACES)
         ExclusiveBottomSheetPresenter.show(childFragmentManager,
-            LinkPreviewDialog.newInstance(entry, location, lastKnownLocation = mapboxMap?.locationComponent?.lastKnownLocation, true))
+            LinkPreviewDialog.newInstance(entry, location,lastKnownLocation = mapboxMap?.locationComponent?.lastKnownLocation))
     }
 
     private fun resetMagnifiedSymbol() {
@@ -612,6 +612,10 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, MapboxMap
         } else {
             startActivity(PageActivity.newIntentForCurrentTab(requireActivity(), entry, entry.title, false))
         }
+    }
+
+    override fun onLinkPreviewDismiss() {
+        updateSearchText()
     }
 
     override fun onMapClick(point: LatLng): Boolean {

--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -329,7 +329,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
     private fun showLinkPreview(pageTitle: PageTitle, location: Location) {
         val entry = HistoryEntry(pageTitle, HistoryEntry.SOURCE_PLACES)
         ExclusiveBottomSheetPresenter.show(childFragmentManager,
-            LinkPreviewDialog.newInstance(entry, location,lastKnownLocation = mapboxMap?.locationComponent?.lastKnownLocation))
+            LinkPreviewDialog.newInstance(entry, location, lastKnownLocation = mapboxMap?.locationComponent?.lastKnownLocation))
     }
 
     private fun resetMagnifiedSymbol() {

--- a/app/src/main/res/layout/fragment_places.xml
+++ b/app/src/main/res/layout/fragment_places.xml
@@ -59,6 +59,7 @@
                 android:background="?attr/selectableItemBackground"
                 android:backgroundTint="?attr/primary_color"
                 android:contentDescription="@null"
+                android:visibility="gone"
                 app:srcCompat="@drawable/ic_close_black_24dp"
                 app:tint="?attr/primary_color" />
 


### PR DESCRIPTION
This PR also fixes:
1. Use `historyEntry.source == HistoryEntry.SOURCE_PLACES` instead of sending `fromPlaces` boolean.
2. Do not show the "x" icon by default on the search bar.