### PR TITLE
Remove unused string resources causing warnings.

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1297,7 +1297,6 @@
   <string name="revision_diff_from">من:</string>
   <string name="revision_diff_to">إلى:</string>
   <string name="revision_diff_line_num">السطر %d</string>
-  <string name="revision_diff_line_nums">الأسطر %d–%d</string>
   <string name="revision_diff_line_added">سطر مُضاف</string>
   <string name="revision_diff_line_removed">سطر مُزال</string>
   <string name="revision_diff_paragraph_added">فقرة مُضافة</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -1287,7 +1287,6 @@
   <string name="revision_diff_from">Od:</string>
   <string name="revision_diff_to">Do:</string>
   <string name="revision_diff_line_num">Linija %d</string>
-  <string name="revision_diff_line_nums">Linije %d–%d</string>
   <string name="revision_diff_lines_from_to">Linije %1$d–%2$d</string>
   <string name="revision_diff_line_added">Linija dodata</string>
   <string name="revision_diff_line_removed">Linija uklonjena</string>

--- a/app/src/main/res/values-b+tt+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+tt+Cyrl/strings.xml
@@ -1313,7 +1313,6 @@
   <string name="revision_diff_from">Кемнән:</string>
   <string name="revision_diff_to">Кемгә:</string>
   <string name="revision_diff_line_num">%d номерлы юл</string>
-  <string name="revision_diff_line_nums">%d–%d юллары</string>
   <string name="revision_diff_lines_from_to">%1$d–%2$d юллары</string>
   <string name="revision_diff_line_added">Юл өстәлгән</string>
   <string name="revision_diff_line_removed">Юл бетерелгән</string>

--- a/app/src/main/res/values-ba/strings.xml
+++ b/app/src/main/res/values-ba/strings.xml
@@ -1317,7 +1317,6 @@
   <string name="revision_diff_from">Кемдән:</string>
   <string name="revision_diff_to">Кемгә:</string>
   <string name="revision_diff_line_num">Юл %d</string>
-  <string name="revision_diff_line_nums">%d–%d юлдар</string>
   <string name="revision_diff_lines_from_to">%1$d–%2$d юлдар</string>
   <string name="revision_diff_line_added">Юл өҫтәлгән</string>
   <string name="revision_diff_line_removed">Юл юйылған</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -1410,7 +1410,6 @@
   <string name="revision_diff_from">Ад:</string>
   <string name="revision_diff_to">Да:</string>
   <string name="revision_diff_line_num">Радок %d</string>
-  <string name="revision_diff_line_nums">Радкі %d–%d</string>
   <string name="revision_diff_lines_from_to">Радкі %1$d–%2$d</string>
   <string name="revision_diff_line_added">Радок дададзены</string>
   <string name="revision_diff_line_removed">Радок выдалены</string>

--- a/app/src/main/res/values-bew/strings.xml
+++ b/app/src/main/res/values-bew/strings.xml
@@ -1306,7 +1306,6 @@
   <string name="revision_diff_from">Deri:</string>
   <string name="revision_diff_to">Ke:</string>
   <string name="revision_diff_line_num">Baris %d</string>
-  <string name="revision_diff_line_nums">Baris %d–%d</string>
   <string name="revision_diff_lines_from_to">Baris %1$d–%2$d</string>
   <string name="revision_diff_line_added">Baris ditambahin</string>
   <string name="revision_diff_line_removed">Baris dibuang</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1186,7 +1186,6 @@
   <string name="revision_diff_from">От:</string>
   <string name="revision_diff_to">До:</string>
   <string name="revision_diff_line_num">Ред %d</string>
-  <string name="revision_diff_line_nums">Редове %d–%d</string>
   <string name="revision_diff_lines_from_to">Редове %1$d–%2$d</string>
   <string name="revision_diff_line_added">Добавен е ред</string>
   <string name="revision_diff_line_removed">Премахнат е ред</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -1154,7 +1154,6 @@
   <string name="revision_diff_from">Digant:</string>
   <string name="revision_diff_to">Da:</string>
   <string name="revision_diff_line_num">Linenn %d</string>
-  <string name="revision_diff_line_nums">Linennoù %d-%d</string>
   <string name="revision_diff_lines_from_to">Linennoù %1$d–%2$d</string>
   <string name="revision_diff_line_added">Linenn ouzhpennet</string>
   <string name="revision_undo_summary_hint">Diverradur (diret)</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1337,7 +1337,6 @@
   <string name="revision_diff_from">De:</string>
   <string name="revision_diff_to">Per a:</string>
   <string name="revision_diff_line_num">Línia %d</string>
-  <string name="revision_diff_line_nums">Línies %d–%d</string>
   <string name="revision_diff_lines_from_to">Línies %1$d–%2$d</string>
   <string name="revision_diff_line_added">Línia afegida</string>
   <string name="revision_diff_line_removed">Línia eliminada</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -1166,7 +1166,6 @@
   <string name="revision_diff_from">لە:</string>
   <string name="revision_diff_to">بۆ:</string>
   <string name="revision_diff_line_num">دێڕی %d</string>
-  <string name="revision_diff_line_nums">دێڕی %d-%d</string>
   <string name="revision_diff_lines_from_to">دێڕەکانی %1$d–%2$d</string>
   <string name="revision_diff_line_added">دێڕ زیاد کرا</string>
   <string name="revision_diff_line_removed">دێڕ سڕدرایەوە</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1250,7 +1250,6 @@
   <string name="revision_diff_from">Od:</string>
   <string name="revision_diff_to">Do:</string>
   <string name="revision_diff_line_num">Řádek %d</string>
-  <string name="revision_diff_line_nums">Řádky %d-%d</string>
   <string name="revision_diff_lines_from_to">Řádky %1$d-%2$d</string>
   <string name="revision_compare_button">Porovnat</string>
   <string name="watchlist_page_add_to_watchlist_snackbar">Stránka „%1$s“ a její diskusní stránka byly přidány do sledovaných stránek %2$s.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1303,7 +1303,6 @@
   <string name="revision_diff_from">Fra:</string>
   <string name="revision_diff_to">Til:</string>
   <string name="revision_diff_line_num">Linje %d</string>
-  <string name="revision_diff_line_nums">Linjerne %d–%d</string>
   <string name="revision_diff_lines_from_to">Linjerne %1$d–%2$d</string>
   <string name="revision_diff_line_added">Linje tilføjet</string>
   <string name="revision_diff_line_removed">Linje fjernet</string>

--- a/app/src/main/res/values-dag/strings.xml
+++ b/app/src/main/res/values-dag/strings.xml
@@ -1301,7 +1301,6 @@
   <string name="revision_diff_from">Dingbaai:</string>
   <string name="revision_diff_to">hali ni:</string>
   <string name="revision_diff_line_num">Kuliga %d</string>
-  <string name="revision_diff_line_nums">Kulisi %d–%d</string>
   <string name="revision_diff_lines_from_to">Kulisi %1$d–%2$d</string>
   <string name="revision_diff_line_added">Kuligi pahiya</string>
   <string name="revision_diff_line_removed">Kuligi yihiya</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1343,7 +1343,6 @@
   <string name="revision_diff_from">Von:</string>
   <string name="revision_diff_to">Nach:</string>
   <string name="revision_diff_line_num">Zeile %d</string>
-  <string name="revision_diff_line_nums">Zeilen %d–%d</string>
   <string name="revision_diff_lines_from_to">Zeilen %1$d–%2$d</string>
   <string name="revision_diff_line_added">Zeile hinzugefügt</string>
   <string name="revision_diff_line_removed">Zeile entfernt</string>

--- a/app/src/main/res/values-dga/strings.xml
+++ b/app/src/main/res/values-dga/strings.xml
@@ -1267,7 +1267,6 @@
   <string name="revision_diff_from">A yi:</string>
   <string name="revision_diff_to">ko:</string>
   <string name="revision_diff_line_num">Soɔmaa %d</string>
-  <string name="revision_diff_line_nums">Soɔmie %d-%d</string>
   <string name="revision_diff_lines_from_to">Soɔmie %1$d-%2$d</string>
   <string name="revision_diff_line_added">Soɔmaa paale la</string>
   <string name="revision_diff_line_removed">Soɔmaa ire la</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -981,7 +981,6 @@
   <string name="revision_diff_from">Από:</string>
   <string name="revision_diff_to">Προς:</string>
   <string name="revision_diff_line_num">Γραμμή %d</string>
-  <string name="revision_diff_line_nums">Γραμμές %d–%d</string>
   <string name="revision_diff_paragraph_added">Προστέθηκε παράγραφος</string>
   <string name="watchlist_page_add_to_watchlist_snackbar_period_for_one_week">για 1 εβδομάδα</string>
   <string name="watchlist_page_add_to_watchlist_snackbar_period_for_one_month">για 1 μήνα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1254,7 +1254,6 @@
   <string name="revision_diff_from">De:</string>
   <string name="revision_diff_to">Para:</string>
   <string name="revision_diff_line_num">Línea %d</string>
-  <string name="revision_diff_line_nums">Líneas %d–%d</string>
   <string name="revision_diff_line_added">Línea añadida</string>
   <string name="revision_diff_line_removed">Línea eliminada</string>
   <string name="revision_diff_paragraph_added">Párrafo añadido</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1308,7 +1308,6 @@
   <string name="revision_diff_from">از:</string>
   <string name="revision_diff_to">به:</string>
   <string name="revision_diff_line_num">خط %d</string>
-  <string name="revision_diff_line_nums">خطوط %d-%d</string>
   <string name="revision_diff_lines_from_to">خطوط %1$d–%2$d</string>
   <string name="revision_diff_line_added">خط اضافه شد</string>
   <string name="revision_diff_line_removed">سطر حذف شد</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1335,7 +1335,6 @@
   <string name="revision_diff_from">Versiosta:</string>
   <string name="revision_diff_to">Versioon:</string>
   <string name="revision_diff_line_num">Rivi %d</string>
-  <string name="revision_diff_line_nums">Rivit %d–%d</string>
   <string name="revision_diff_lines_from_to">Rivit %1$d–%2$d</string>
   <string name="revision_diff_line_added">Rivi lisätty</string>
   <string name="revision_diff_line_removed">Rivi poistettu</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1374,7 +1374,6 @@
   <string name="revision_diff_from">Depuis :</string>
   <string name="revision_diff_to">Jusqu’à :</string>
   <string name="revision_diff_line_num">Ligne %d</string>
-  <string name="revision_diff_line_nums">Lignes %d – %d</string>
   <string name="revision_diff_lines_from_to">Lignes %1$d–%2$d</string>
   <string name="revision_diff_line_added">Ligne ajoutée</string>
   <string name="revision_diff_line_removed">Ligne supprimée</string>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -1312,7 +1312,6 @@
   <string name="revision_diff_from">Daga:</string>
   <string name="revision_diff_to">Zuwa:</string>
   <string name="revision_diff_line_num">Layi %d</string>
-  <string name="revision_diff_line_nums">Lines %d-%d</string>
   <string name="revision_diff_lines_from_to">Lines %1$d-%2$d</string>
   <string name="revision_diff_line_added">Layin da aka kara</string>
   <string name="revision_diff_line_removed">An cire layin</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1315,7 +1315,6 @@
   <string name="revision_diff_from">प्रेषक:</string>
   <string name="revision_diff_to">प्राप्तकर्ता:</string>
   <string name="revision_diff_line_num">लाइन %d</string>
-  <string name="revision_diff_line_nums">लाइन्स %d–%d</string>
   <string name="revision_diff_lines_from_to">पंक्तियाँ %1$d–%2$d</string>
   <string name="revision_diff_line_added">लाइन जोड़ी गई</string>
   <string name="revision_diff_line_removed">लाइन हटाई गई</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1330,7 +1330,6 @@
   <string name="revision_diff_from">Ettől:</string>
   <string name="revision_diff_to">Eddig:</string>
   <string name="revision_diff_line_num">%d. sor</string>
-  <string name="revision_diff_line_nums">%d–%d. sor</string>
   <string name="revision_diff_lines_from_to">%1$d–%2$d. sor</string>
   <string name="revision_diff_line_added">Sor hozzáadva</string>
   <string name="revision_diff_line_removed">Sor eltávolítva</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -1313,7 +1313,6 @@
   <string name="revision_diff_from">De:</string>
   <string name="revision_diff_to">A:</string>
   <string name="revision_diff_line_num">Linea %d</string>
-  <string name="revision_diff_line_nums">Lineas %d–%d</string>
   <string name="revision_diff_lines_from_to">Lineas %1$d–%2$d</string>
   <string name="revision_diff_line_added">Linea addite</string>
   <string name="revision_diff_line_removed">Linea removite</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1304,7 +1304,6 @@
   <string name="revision_diff_from">Dari:</string>
   <string name="revision_diff_to">Ke:</string>
   <string name="revision_diff_line_num">Baris %d</string>
-  <string name="revision_diff_line_nums">Baris %d–%d</string>
   <string name="revision_diff_lines_from_to">Baris %1$d–%2$d</string>
   <string name="revision_diff_line_added">Baris ditambahkan</string>
   <string name="revision_diff_line_removed">Baris dihapus</string>

--- a/app/src/main/res/values-inh/strings.xml
+++ b/app/src/main/res/values-inh/strings.xml
@@ -1277,7 +1277,6 @@
   <string name="revision_diff_from">Укх ханагара:</string>
   <string name="revision_diff_to">Цу ханага:</string>
   <string name="revision_diff_line_num">МугӀ %d</string>
-  <string name="revision_diff_line_nums">МугӀараш %d–%d</string>
   <string name="revision_diff_line_added">МугӀ тӀатехаб</string>
   <string name="revision_diff_line_removed">МугӀ дӀабаьккхаб</string>
   <string name="revision_diff_paragraph_added">ЦӀе мугӀ тӀатехаб</string>

--- a/app/src/main/res/values-io/strings.xml
+++ b/app/src/main/res/values-io/strings.xml
@@ -1136,7 +1136,6 @@
   <string name="revision_diff_from">De:</string>
   <string name="revision_diff_to">A(d):</string>
   <string name="revision_diff_line_num">Lineo %d</string>
-  <string name="revision_diff_line_nums">Linei %d–%d</string>
   <string name="revision_diff_line_added">Lineo adjuntita</string>
   <string name="revision_diff_line_removed">Lineo efacita</string>
   <string name="revision_diff_paragraph_added">Paragrafo adjuntita</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -1298,7 +1298,6 @@
   <string name="revision_diff_from">Frá:</string>
   <string name="revision_diff_to">Til:</string>
   <string name="revision_diff_line_num">Lína %d</string>
-  <string name="revision_diff_line_nums">Línur %d–%d</string>
   <string name="revision_diff_lines_from_to">Línur %1$d–%2$d</string>
   <string name="revision_diff_line_added">Línu bætt við</string>
   <string name="revision_diff_line_removed">Lína fjarlægð</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1321,7 +1321,6 @@
   <string name="revision_diff_from">Da:</string>
   <string name="revision_diff_to">A:</string>
   <string name="revision_diff_line_num">Riga %d</string>
-  <string name="revision_diff_line_nums">Righe %d–%d</string>
   <string name="revision_diff_lines_from_to">Righe %1$d–%2$d</string>
   <string name="revision_diff_line_added">Riga aggiunta</string>
   <string name="revision_diff_line_removed">Riga rimossa</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1418,7 +1418,6 @@
   <string name="revision_diff_from">מאת:</string>
   <string name="revision_diff_to">אל:</string>
   <string name="revision_diff_line_num">שורה %d</string>
-  <string name="revision_diff_line_nums">שורות %d–%d</string>
   <string name="revision_diff_lines_from_to">שורות %1$d–%2$d</string>
   <string name="revision_diff_line_added">שורה שנוספה</string>
   <string name="revision_diff_line_removed">שורה שהוסרה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1355,7 +1355,6 @@
   <string name="revision_diff_from">古い版：</string>
   <string name="revision_diff_to">新しい版：</string>
   <string name="revision_diff_line_num">%d行目</string>
-  <string name="revision_diff_line_nums">%d–%d行目</string>
   <string name="revision_diff_lines_from_to">%1$d–%2$d行目</string>
   <string name="revision_diff_line_added">行を追加</string>
   <string name="revision_diff_line_removed">行を除去</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -378,7 +378,6 @@
   <string name="revision_diff_from">ពី៖</string>
   <string name="revision_diff_to">ទៅជា៖</string>
   <string name="revision_diff_line_num">បន្ទាត់ទី %d</string>
-  <string name="revision_diff_line_nums">បន្ទាត់ទី %d–%d</string>
   <string name="revision_diff_line_added">បន្ទាត់​ដែល​បាន​បន្ថែម</string>
   <string name="revision_diff_line_removed">បន្ទាត់​ដែល​បានលុប</string>
   <string name="revision_diff_paragraph_added">កថាខណ្ឌ​ដែល​បាន​បន្ថែម</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1297,7 +1297,6 @@
   <string name="revision_diff_from">이전 판:</string>
   <string name="revision_diff_to">다음 판:</string>
   <string name="revision_diff_line_num">줄 %d</string>
-  <string name="revision_diff_line_nums">줄 %d-%d</string>
   <string name="revision_diff_lines_from_to">줄 %1$d–%2$d</string>
   <string name="revision_diff_line_added">줄 추가됨</string>
   <string name="revision_diff_line_removed">줄 제거됨</string>

--- a/app/src/main/res/values-ks/strings.xml
+++ b/app/src/main/res/values-ks/strings.xml
@@ -729,7 +729,6 @@
   <string name="revision_diff_from">پؠٹھ:</string>
   <string name="revision_diff_to">تام:</string>
   <string name="revision_diff_line_num">سٕتٕر %d</string>
-  <string name="revision_diff_line_nums">سٕتٕرٕ %d-%d</string>
   <string name="revision_diff_lines_from_to">سٕترٕ %1$d-%2$d</string>
   <string name="revision_diff_line_added">سٕتٕر کٕرٕکھ درٕج</string>
   <string name="revision_diff_line_removed">سٕتٕر مِٹٲوٕکھ</string>

--- a/app/src/main/res/values-kus/strings.xml
+++ b/app/src/main/res/values-kus/strings.xml
@@ -1015,7 +1015,6 @@
   <string name="revision_diff_from">Di yinɛ:</string>
   <string name="revision_diff_to">Ken:</string>
   <string name="revision_diff_line_num">Lai %d</string>
-  <string name="revision_diff_line_nums">Lai %d–%d</string>
   <string name="revision_diff_lines_from_to">Lainam %1$d–%2$d</string>
   <string name="revision_diff_line_added">Lai paasya</string>
   <string name="revision_diff_line_removed">Lai yisya</string>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -1051,7 +1051,6 @@
   <string name="revision_diff_from">Vum:</string>
   <string name="revision_diff_to">Fir:</string>
   <string name="revision_diff_line_num">Zeil %d</string>
-  <string name="revision_diff_line_nums">Zeile(n) %d-%d</string>
   <string name="revision_diff_lines_from_to">Zeile(n) %1$d–%2$d</string>
   <string name="revision_diff_line_added">Zeil derbäigesat</string>
   <string name="revision_diff_line_removed">Zeil ewechgeholl</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1125,7 +1125,6 @@
   <string name="revision_diff_from">Nuo:</string>
   <string name="revision_diff_to">Kam:</string>
   <string name="revision_diff_line_num">%d eilutė</string>
-  <string name="revision_diff_line_nums">Eilutės %d–%d</string>
   <string name="revision_diff_lines_from_to">Eilutės %1$d–%2$d</string>
   <string name="revision_diff_line_added">Eilutė pridėta</string>
   <string name="revision_diff_line_removed">Eilutė pašalinta</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -1322,7 +1322,6 @@
   <string name="revision_diff_from">Од:</string>
   <string name="revision_diff_to">До:</string>
   <string name="revision_diff_line_num">Ред %d</string>
-  <string name="revision_diff_line_nums">Редови %d – %d</string>
   <string name="revision_diff_lines_from_to">Редови %1$d–%2$d</string>
   <string name="revision_diff_line_added">Додаден ред</string>
   <string name="revision_diff_line_removed">Отстранет ред</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1334,7 +1334,6 @@
   <string name="revision_diff_from">Fra:</string>
   <string name="revision_diff_to">Til:</string>
   <string name="revision_diff_line_num">Linje %d</string>
-  <string name="revision_diff_line_nums">Linje %d–%d</string>
   <string name="revision_diff_lines_from_to">Linjer %1$d–%2$d</string>
   <string name="revision_diff_line_added">Linje lagt til</string>
   <string name="revision_diff_line_removed">Linje fjernet</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1353,7 +1353,6 @@
   <string name="revision_diff_from">Van:</string>
   <string name="revision_diff_to">Naar:</string>
   <string name="revision_diff_line_num">Regel %d</string>
-  <string name="revision_diff_line_nums">Regels %d–%d</string>
   <string name="revision_diff_lines_from_to">Regels %1$d–%2$d</string>
   <string name="revision_diff_line_added">Regel toegevoegd</string>
   <string name="revision_diff_line_removed">Regel verwijderd</string>

--- a/app/src/main/res/values-nqo/strings.xml
+++ b/app/src/main/res/values-nqo/strings.xml
@@ -1114,7 +1114,6 @@
   <string name="revision_diff_from">ߞߵߊ߬ ߘߊߡߌ߬ߣߊ߬:</string>
   <string name="revision_diff_to">ߞߊ߬ ߥߴߊ߬ ߛߌ߰:</string>
   <string name="revision_diff_line_num">ߛߌ߬ߕߊߙߌ %d</string>
-  <string name="revision_diff_line_nums">ߛߌ߬ߕߊߙߌ %d–%d</string>
   <string name="revision_diff_lines_from_to">ߛߌ߬ߕߊߙߌ %1$d-%2$d</string>
   <string name="revision_diff_line_added">ߛߌ߬ߕߊߙߌ ߓߘߊ߫ ߝߙߊ߬</string>
   <string name="revision_diff_line_removed">ߛߌ߬ߕߊߙߌ ߓߘߊ߫ ߖߏ߰ߛߌ߫</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1240,7 +1240,6 @@
   <string name="revision_diff_from">Od:</string>
   <string name="revision_diff_to">Do:</string>
   <string name="revision_diff_line_num">Wiersz %d</string>
-  <string name="revision_diff_line_nums">Wiersze %d-%d</string>
   <string name="revision_diff_line_added">Dodany wiersz</string>
   <string name="revision_diff_line_removed">Wiersz usunięty</string>
   <string name="revision_diff_paragraph_added">Dodany akapit</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1319,7 +1319,6 @@
   <string name="revision_diff_from">De:</string>
   <string name="revision_diff_to">Para:</string>
   <string name="revision_diff_line_num">Linha %d</string>
-  <string name="revision_diff_line_nums">Linhas %d–%d</string>
   <string name="revision_diff_lines_from_to">Linhas %1$d–%2$d</string>
   <string name="revision_diff_line_added">Linha acrescentada</string>
   <string name="revision_diff_line_removed">Linha removida</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1340,7 +1340,6 @@
   <string name="revision_diff_from">De:</string>
   <string name="revision_diff_to">Para:</string>
   <string name="revision_diff_line_num">Linha %d</string>
-  <string name="revision_diff_line_nums">Linhas %d–%d</string>
   <string name="revision_diff_lines_from_to">Linhas %1$d–%2$d</string>
   <string name="revision_diff_line_added">Linha acrescentada</string>
   <string name="revision_diff_line_removed">Linha removida</string>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1349,7 +1349,6 @@
   <string name="revision_diff_from">Label for older revision to be compared.</string>
   <string name="revision_diff_to">Label for newer revision to be compared.</string>
   <string name="revision_diff_line_num">Label for line number seen in a diff between revisions. The %d symbol is replaced with the line number.</string>
-  <string name="revision_diff_line_nums">Label for range of line numbers seen in a diff between revisions. The first %d symbol is the starting line number, and the second %d symbol is the ending line number.</string>
   <string name="revision_diff_lines_from_to">Label for range of line numbers seen in a diff between revisions. The %1$d symbol is the starting line number, and the %2$d symbol is the ending line number.</string>
   <string name="revision_diff_line_added">Label shown in a diff when a line was added.</string>
   <string name="revision_diff_line_removed">Label shown in a diff when a line was removed.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1241,7 +1241,6 @@
   <string name="revision_diff_from">De la:</string>
   <string name="revision_diff_to">La:</string>
   <string name="revision_diff_line_num">Linia %d</string>
-  <string name="revision_diff_line_nums">Linii %d–%d</string>
   <string name="revision_diff_line_added">Linie adăugată</string>
   <string name="revision_diff_line_removed">Linia a fost scoasă</string>
   <string name="revision_diff_paragraph_added">Paragraf adăugat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1408,7 +1408,6 @@
   <string name="revision_diff_from">От:</string>
   <string name="revision_diff_to">Поучат.:</string>
   <string name="revision_diff_line_num">Строка %d</string>
-  <string name="revision_diff_line_nums">Строки с %d-й по %d-ю</string>
   <string name="revision_diff_lines_from_to">Строки %1$d–%2$d</string>
   <string name="revision_diff_line_added">Строка добавлена</string>
   <string name="revision_diff_line_removed">Строка удалена</string>

--- a/app/src/main/res/values-sd/strings.xml
+++ b/app/src/main/res/values-sd/strings.xml
@@ -1148,7 +1148,6 @@
   <string name="revision_diff_from">کان:</string>
   <string name="revision_diff_to">تائين:</string>
   <string name="revision_diff_line_num">سِٽ %d</string>
-  <string name="revision_diff_line_nums">سِٽون %d–%d</string>
   <string name="revision_diff_lines_from_to">سٽون %1$d–%2$d</string>
   <string name="revision_diff_line_added">وڌل سِٽ</string>
   <string name="revision_diff_line_removed">ڪڍيل سِٽ</string>

--- a/app/src/main/res/values-sdc/strings.xml
+++ b/app/src/main/res/values-sdc/strings.xml
@@ -293,7 +293,6 @@
   <string name="revision_diff_from">Dà:</string>
   <string name="revision_diff_to">A:</string>
   <string name="revision_diff_line_num">Riga %d</string>
-  <string name="revision_diff_line_nums">Righi %d–%d</string>
   <string name="revision_diff_line_added">Riga aggiùnta</string>
   <string name="revision_diff_line_removed">riga rimossa</string>
   <string name="revision_undo_title">Sei sigura/u ki vói annullà kistha mudìfigga?</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1219,7 +1219,6 @@
   <string name="revision_diff_from">Od:</string>
   <string name="revision_diff_to">Do:</string>
   <string name="revision_diff_line_num">Riadok %d</string>
-  <string name="revision_diff_line_nums">Riadky %d-%d</string>
   <string name="revision_diff_line_added">Riadok pridaný</string>
   <string name="revision_diff_line_removed">Riadok odstránený</string>
   <string name="revision_diff_paragraph_added">Odsek pridaný</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1407,7 +1407,6 @@
   <string name="revision_diff_from">Iz:</string>
   <string name="revision_diff_to">V:</string>
   <string name="revision_diff_line_num">Vrstica %d</string>
-  <string name="revision_diff_line_nums">Vrstice %d–%d</string>
   <string name="revision_diff_lines_from_to">Vrstice %1$d–%2$d</string>
   <string name="revision_diff_line_added">Vrstica dodana</string>
   <string name="revision_diff_line_removed">Vrstica odstranjena</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1308,7 +1308,6 @@
   <string name="revision_diff_from">Од:</string>
   <string name="revision_diff_to">До:</string>
   <string name="revision_diff_line_num">Линија %d</string>
-  <string name="revision_diff_line_nums">Линије %d–%d</string>
   <string name="revision_diff_lines_from_to">Линије %1$d–%2$d</string>
   <string name="revision_diff_line_added">Линија додата</string>
   <string name="revision_diff_line_removed">Линија уклоњена</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1332,7 +1332,6 @@
   <string name="revision_diff_from">Från:</string>
   <string name="revision_diff_to">Till:</string>
   <string name="revision_diff_line_num">Rad %d</string>
-  <string name="revision_diff_line_nums">Rader %d–%d</string>
   <string name="revision_diff_lines_from_to">Rader %1$d–%2$d</string>
   <string name="revision_diff_line_added">Raden lades till</string>
   <string name="revision_diff_line_removed">Raden togs bort</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -1093,7 +1093,6 @@
   <string name="revision_diff_from">నుండి:</string>
   <string name="revision_diff_to">వరకు:</string>
   <string name="revision_diff_line_num">పంక్తి %d</string>
-  <string name="revision_diff_line_nums">పంక్తులు %d–%d</string>
   <string name="revision_diff_line_added">పంక్తిని చేర్చారు</string>
   <string name="revision_diff_line_removed">పంక్తిని తీసేసారు</string>
   <string name="revision_diff_paragraph_added">పేరాగ్రాఫును చేర్చారు</string>

--- a/app/src/main/res/values-tly/strings.xml
+++ b/app/src/main/res/values-tly/strings.xml
@@ -899,7 +899,6 @@
   <string name="revision_diff_from">Ce:</string>
   <string name="revision_diff_to">Bə:</string>
   <string name="revision_diff_line_num">Sətyr %d</string>
-  <string name="revision_diff_line_nums">Sətyron ce %d-ku tosə %d-nə</string>
   <string name="revision_diff_lines_from_to">Sətyron %1$d–%2$d</string>
   <string name="revision_diff_line_added">Sətyr əlovə kardə byə</string>
   <string name="revision_diff_line_removed">Sətyr molə byə</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1360,7 +1360,6 @@
   <string name="revision_diff_from">Gönderen:</string>
   <string name="revision_diff_to">Alıcı:</string>
   <string name="revision_diff_line_num">Satır %d</string>
-  <string name="revision_diff_line_nums">Satırlar %d-%d</string>
   <string name="revision_diff_lines_from_to">%1$d–%2$d satırları</string>
   <string name="revision_diff_line_added">Satır eklendi</string>
   <string name="revision_diff_line_removed">Satır kaldırıldı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1419,7 +1419,6 @@
   <string name="revision_diff_from">Від:</string>
   <string name="revision_diff_to">До:</string>
   <string name="revision_diff_line_num">Рядок %d</string>
-  <string name="revision_diff_line_nums">Рядки %d—%d</string>
   <string name="revision_diff_lines_from_to">Рядки %1$d–%2$d</string>
   <string name="revision_diff_line_added">Рядок додано</string>
   <string name="revision_diff_line_removed">Рядок вилучено</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -1319,7 +1319,6 @@
   <string name="revision_diff_from">Bundan:</string>
   <string name="revision_diff_to">Bunga:</string>
   <string name="revision_diff_line_num">%d-qator</string>
-  <string name="revision_diff_line_nums">%d-%d qatorlar</string>
   <string name="revision_diff_lines_from_to">%1$d–%2$d qatorlar</string>
   <string name="revision_diff_line_added">Qator qoʻshildi</string>
   <string name="revision_diff_line_removed">Qator oʻchirildi</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1347,7 +1347,6 @@
   <string name="revision_diff_from">從：</string>
   <string name="revision_diff_to">至：</string>
   <string name="revision_diff_line_num">第%d行</string>
-  <string name="revision_diff_line_nums">第%d到%d行</string>
   <string name="revision_diff_lines_from_to">第%1$d到%2$d行</string>
   <string name="revision_diff_line_added">已新增行數</string>
   <string name="revision_diff_line_removed">已移除行數</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1372,7 +1372,6 @@
   <string name="revision_diff_from">从：</string>
   <string name="revision_diff_to">至：</string>
   <string name="revision_diff_line_num">第%d行</string>
-  <string name="revision_diff_line_nums">第%d到第%d行</string>
   <string name="revision_diff_lines_from_to">第%1$d–%2$d行</string>
   <string name="revision_diff_line_added">已添加行</string>
   <string name="revision_diff_line_removed">已移除行</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1403,7 +1403,6 @@
     <string name="revision_diff_from">From:</string>
     <string name="revision_diff_to">To:</string>
     <string name="revision_diff_line_num">Line %d</string>
-    <string name="revision_diff_line_nums">Lines %d–%d</string>
     <string name="revision_diff_lines_from_to">Lines %1$d–%2$d</string>
     <string name="revision_diff_line_added">Line added</string>
     <string name="revision_diff_line_removed">Line removed</string>


### PR DESCRIPTION
This string was causing a bunch of warnings because of incorrect format parameters. (and it's unused!)