### PR TITLE
Log invokeSource in breadcrumbs "show" events.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
@@ -58,7 +58,7 @@ class BreadCrumbLogEvent(
         fun logScreenShown(context: Context, fragment: Fragment? = null) {
             val invokeSource = (fragment?.activity?.intent ?: (context as? Activity)?.intent)?.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as? Constants.InvokeSource
             EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context, fragment),
-                "show" + (invokeSource?.let { ".from." + it.value } ?: "")))
+                "show" + invokeSource?.let { ".from." + it.value }.orEmpty()))
         }
 
         fun logBackPress(context: Context) {

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/BreadCrumbLogEvent.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.analytics.eventplatform
 
+import android.app.Activity
 import android.content.Context
 import android.view.MenuItem
 import android.view.View
@@ -8,6 +9,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.wikipedia.Constants
 import org.wikipedia.WikipediaApp
 import org.wikipedia.settings.SettingsActivity
 import org.wikipedia.util.log.L
@@ -54,7 +56,9 @@ class BreadCrumbLogEvent(
         }
 
         fun logScreenShown(context: Context, fragment: Fragment? = null) {
-            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context, fragment), "show"))
+            val invokeSource = (fragment?.activity?.intent ?: (context as? Activity)?.intent)?.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as? Constants.InvokeSource
+            EventPlatformClient.submit(BreadCrumbLogEvent(BreadCrumbViewUtil.getReadableScreenName(context, fragment),
+                "show" + (invokeSource?.let { ".from." + it.value } ?: "")))
         }
 
         fun logBackPress(context: Context) {


### PR DESCRIPTION
This automatically detects if a screen that's being shown contains an `InvokeSource` in its intent, and logs it as part of the event in a structured way, making breadcrumbs a bit more powerful.
This will automatically enable us to measure incoming clicks from widgets, without extra schemas.