### PR TITLE
Update Metrics Platform version, MetricsEvent, ArticleEvent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     String roomVersion = "2.6.1"
     String espressoVersion = '3.5.1'
     String serialization_version = '1.6.2'
-    String metricsVersion = '2.0'
+    String metricsVersion = '2.1'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/ArticleEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/ArticleEvent.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.analytics.metricsplatform
 
 import org.wikimedia.metrics_platform.context.PageData
+import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.page.PageFragment
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
@@ -22,6 +23,7 @@ class ArticleFindInPageInteraction(private val fragment: PageFragment) : TimedMe
 
     fun logDone() {
         submitEvent(
+            "android.product_metrics.find_in_page_interaction",
             "/analytics/mobile_apps/product_metrics/android_find_in_page_interaction/1.0.0",
             "find_in_page_interaction",
             mapOf(
@@ -142,6 +144,7 @@ class ArticleToolbarInteraction(private val fragment: PageFragment) : TimedMetri
     private fun submitEvent(action: String) {
 
         submitEvent(
+            "android.product_metrics.article_toolbar_interaction",
             "article_toolbar_interaction",
             getInteractionData(
                 "article_toolbar_interaction",
@@ -183,6 +186,7 @@ class ArticleTocInteraction(private val fragment: PageFragment, private val numS
             return
         }
         submitEvent(
+            "android.product_metrics.article_toc_interaction",
             "/analytics/mobile_apps/product_metrics/android_article_toc_interaction/1.0.0",
             "article_toc_interaction",
             mapOf(
@@ -211,6 +215,11 @@ class ArticleLinkPreviewInteraction : TimedMetricsEvent {
         pageData = getPageData(pageTitle, pageId)
     }
 
+    constructor(pageTitle: PageTitle, summary: PageSummary, source: Int) {
+        this.source = source
+        pageData = getPageData(pageTitle, summary)
+    }
+
     fun logLinkClick() {
         submitEvent("linkclick")
     }
@@ -225,6 +234,7 @@ class ArticleLinkPreviewInteraction : TimedMetricsEvent {
 
     private fun submitEvent(action: String) {
         submitEvent(
+            "android.product_metrics.article_link_preview_interaction",
             "article_link_preview_interaction",
             getInteractionData(
                 "article_link_preview_interaction",

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
@@ -7,6 +7,7 @@ import org.wikimedia.metrics_platform.context.PerformerData
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.EventPlatformClient
 import org.wikipedia.auth.AccountUtil
+import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageFragment
 import org.wikipedia.page.PageTitle
@@ -18,17 +19,20 @@ open class MetricsEvent {
     /**
      * Submit an event to the Metrics Platform using a base interaction schema
      *
+     * @param streamName the name of the stream
      * @param eventName the name of the event
      * @param interactionData a data object that conforms to core interactions
      * @param pageData dynamic page data that should be added to the ClientData object
      */
     protected fun submitEvent(
+        streamName: String,
         eventName: String,
         interactionData: InteractionData?,
         pageData: PageData? = null
     ) {
         if (ReleaseUtil.isPreProdRelease && Prefs.isEventLoggingEnabled) {
             MetricsPlatform.client.submitInteraction(
+                streamName,
                 EVENT_NAME_BASE + eventName,
                 getClientData(pageData),
                 interactionData)
@@ -38,6 +42,7 @@ open class MetricsEvent {
     /**
      * Submit an event to the Metrics Platform using a custom schema
      *
+     * @param streamName the name of the stream
      * @param schemaId the custom schema ID
      * @param eventName the name of the event
      * @param customData the custom data key-value pairs that are top-level properties
@@ -45,6 +50,7 @@ open class MetricsEvent {
      * @param pageData dynamic page data that should be added to the ClientData object
      */
     protected fun submitEvent(
+        streamName: String,
         schemaId: String,
         eventName: String,
         customData: Map<String, Any>,
@@ -53,6 +59,7 @@ open class MetricsEvent {
     ) {
         if (ReleaseUtil.isPreProdRelease && Prefs.isEventLoggingEnabled) {
             MetricsPlatform.client.submitInteraction(
+                streamName,
                 schemaId,
                 EVENT_NAME_BASE + eventName,
                 getClientData(pageData),
@@ -62,7 +69,7 @@ open class MetricsEvent {
         }
     }
 
-    protected fun getClientData(pageData: PageData?): ClientData {
+    private fun getClientData(pageData: PageData?): ClientData {
         return ClientData(
             MetricsPlatform.agentData,
             pageData,
@@ -94,6 +101,19 @@ open class MetricsEvent {
             Namespace.of(pageTitle.namespace().code()).toString(),
             revisionId,
             null,
+            pageTitle.wikiSite.languageCode
+        )
+    }
+
+    protected fun getPageData(pageTitle: PageTitle?, pageSummary: PageSummary?): PageData? {
+        if (pageTitle == null) return null
+        return PageData(
+            pageSummary?.pageId,
+            pageTitle.prefixedText,
+            pageTitle.namespace().code(),
+            Namespace.of(pageTitle.namespace().code()).toString(),
+            pageSummary?.revision,
+            pageSummary?.wikiBaseItem,
             pageTitle.wikiSite.languageCode
         )
     }

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -197,7 +197,7 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
 
         linkPreviewInteraction = ArticleLinkPreviewInteraction(
             viewModel.pageTitle,
-            summary.pageId,
+            summary,
             viewModel.historyEntry.source
         )
         linkPreviewInteraction?.logLinkClick()


### PR DESCRIPTION
- Bump Metrics Platform library version to 2.1
- Update `MetricsEvent` submit methods to require stream name
- Update `ArticleEvent` methods to pass in required stream name
- Overload `getPageData` method to accept `PageSummary` (to populate `page_wikidata_qid`)
- Overload constructor for `ArticleLinkPreviewInteraction`

Bug: [T355360](https://phabricator.wikimedia.org/T355360)