### PR TITLE
Fix width calculation of tooltop "Got it" button.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -3,6 +3,7 @@ package org.wikipedia.util
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.graphics.Rect
 import android.net.Uri
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -179,7 +180,16 @@ object FeedbackUtil {
         val binding = ViewPlainTextTooltipBinding.inflate(LayoutInflater.from(context))
         binding.textView.text = text
         binding.buttonView.isVisible = showDismissButton
-        binding.buttonView.setText(dismissButtonText)
+
+        // Explicitly measure the width of the button text and set the button width, with some padding.
+        // The Balloon library seems to present our custom layout in a way that causes the automatic
+        // sizing of the button to be incorrect.
+        val dismissText = context.getString(dismissButtonText)
+        val bounds = Rect()
+        binding.buttonView.paint.getTextBounds(dismissText, 0, dismissText.length, bounds)
+        binding.buttonView.layoutParams = binding.buttonView.layoutParams.apply {
+            width = bounds.width() + DimenUtil.roundedDpToPx(40f)
+        }
 
         if (countTotal > 0) {
             binding.countView.isVisible = true

--- a/app/src/main/res/layout/view_plain_text_tooltip.xml
+++ b/app/src/main/res/layout/view_plain_text_tooltip.xml
@@ -25,7 +25,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/App.Button.Secondary"
-            android:minWidth="88dp"
             android:text="@string/onboarding_got_it"/>
 
         <TextView


### PR DESCRIPTION
The Balloon library has an issue where it incorrectly inflates our custom View where the "Got it" button gets an incorrect width.
We were fixing this by giving it a `minWidth`, and optimizing the minWidth for English, but this is not a complete solution and causes weird overflow behavior like this:
![Screenshot_20240131_132702 - Copy](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/9a494515-930b-4452-a224-e7c4a98dd62a)

This will now explicitly measure the width of the text that the button is supposed to be, and update its layoutParams explicitly.
![Screenshot_20240131_132445](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/ae2fcedb-cc6b-48ae-a404-c42728e88bb5)

