### PR TITLE
Refactor and remove race condition from AppInteractionEvent instantiation.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/AppInteractionEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/AppInteractionEvent.kt
@@ -1,10 +1,14 @@
 package org.wikipedia.analytics.eventplatform
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Suppress("unused")
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 @SerialName("/analytics/mobile_apps/app_interaction/1.0.0")
 class AppInteractionEvent(
     private val action: String,
@@ -12,9 +16,6 @@ class AppInteractionEvent(
     private val action_data: String,
     private val primary_language: String,
     private val wiki_id: String,
-    private var platform: String,
-) : MobileAppsEvent(STREAM_NAME) {
-    companion object {
-        var STREAM_NAME = "app_donor_experience"
-    }
-}
+    @Transient private val streamName: String = "",
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS) private val platform: String = "android",
+) : MobileAppsEvent(streamName)

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/DonorExperienceEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/DonorExperienceEvent.kt
@@ -5,8 +5,6 @@ import org.wikipedia.WikipediaApp
 class DonorExperienceEvent {
 
     companion object {
-        private const val STREAM_NAME = "app_donor_experience"
-
         fun logImpression(activeInterface: String, campaignId: String? = null, wikiId: String = "") {
             submitDonorExperienceEvent("impression", activeInterface, getActionDataString(campaignId), wikiId)
         }
@@ -35,7 +33,6 @@ class DonorExperienceEvent {
             actionData: String,
             wikiId: String
         ) {
-            AppInteractionEvent.STREAM_NAME = STREAM_NAME
             EventPlatformClient.submit(
                 AppInteractionEvent(
                     action,
@@ -43,7 +40,7 @@ class DonorExperienceEvent {
                     actionData,
                     WikipediaApp.instance.languageState.appLanguageCode,
                     wikiId,
-                    "android"
+                    "app_donor_experience"
                 )
             )
         }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -9,6 +9,7 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.okhttp.HttpStatusException
+import org.wikipedia.json.JsonUtil
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.util.log.L
@@ -62,6 +63,9 @@ object EventPlatformClient {
      */
     @Synchronized
     fun submit(event: Event) {
+
+        L.d(">>>> submitting: " + JsonUtil.encodeToString(event))
+
         if (!SamplingController.isInSample(event)) {
             return
         }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -9,7 +9,6 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.okhttp.HttpStatusException
-import org.wikipedia.json.JsonUtil
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.util.log.L
@@ -63,9 +62,6 @@ object EventPlatformClient {
      */
     @Synchronized
     fun submit(event: Event) {
-
-        L.d(">>>> submitting: " + JsonUtil.encodeToString(event))
-
         if (!SamplingController.isInSample(event)) {
             return
         }

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/PatrollerExperienceEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/PatrollerExperienceEvent.kt
@@ -6,8 +6,6 @@ import org.wikipedia.settings.Prefs
 class PatrollerExperienceEvent {
 
     companion object {
-        private const val STREAM_NAME = "app_patroller_experience"
-
         fun logImpression(activeInterface: String) {
             submitPatrollerActivityEvent("impression", activeInterface)
         }
@@ -44,7 +42,6 @@ class PatrollerExperienceEvent {
         }
 
         private fun submitPatrollerActivityEvent(action: String, activeInterface: String, actionData: String = "") {
-            AppInteractionEvent.STREAM_NAME = STREAM_NAME
             EventPlatformClient.submit(
                 AppInteractionEvent(
                     action,
@@ -52,7 +49,7 @@ class PatrollerExperienceEvent {
                     actionData,
                     WikipediaApp.instance.languageState.appLanguageCode,
                     Prefs.recentEditsWikiCode,
-                    "android"
+                    "app_patroller_experience"
                 )
             )
         }


### PR DESCRIPTION
It's not necessary to have a static `STREAM_NAME` that needs to be set before an `AppInteractionEvent` is instantiated, and in fact this creates a race condition.
We can simply pass the stream name directly as a constructor parameter, and mark it as Transient for serialization.

The resulting serialized objects are exactly the same.