### PR TITLE
Fix: use null-safe for LinkPreviewDialog action menu options

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/LongPressMenu.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/LongPressMenu.kt
@@ -88,7 +88,7 @@ class LongPressMenu(
                     saveItem.isVisible = it.isEmpty()
                     saveItem.isEnabled = it.isEmpty()
                 }
-                menu.menu.findItem(R.id.menu_long_press_get_directions).isVisible = location != null
+                menu.menu.findItem(R.id.menu_long_press_get_directions)?.isVisible = location != null
                 menu.show()
             }
         }


### PR DESCRIPTION
Steps to reproduce:
1. Go to Places
2. Save an article from the map.
3. Click on the saved article, and click on "Saved" to see the popup menu.