### PR TITLE
Fix: use lastKnownLocation instead of the last map location for distance

### DIFF
--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -761,7 +761,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
         init {
             itemView.setOnClickListener(this)
             itemView.setOnLongClickListener(this)
-            currentLocation = lastLocation ?: Prefs.placesLastLocationAndZoomLevel?.first
+            currentLocation = mapboxMap?.locationComponent?.lastKnownLocation
             DeviceUtil.setContextClickAsLongClick(itemView)
         }
 


### PR DESCRIPTION
We should use the `lastKnownLocation` from the `locationComponent` instead of the last "map" location.