### PR TITLE
Respect isImageDownloadedEnabled setting in Places

### DIFF
--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -651,7 +651,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
 
     private fun queueImageForAnnotation(page: PlacesFragmentViewModel.NearbyPage) {
         val url = page.pageTitle.thumbUrl
-        if (url.isNullOrEmpty()) {
+        if (!Prefs.isImageDownloadEnabled || url.isNullOrEmpty()) {
             return
         }
 


### PR DESCRIPTION
The thumbnails will still be applied to the markers even if the `isImageDownloadedEnabled` is off.