### PR TITLE
Fix: dismiss the LinkPreviewDialog when changing device's orientation

### DIFF
--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -508,6 +508,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
         binding.mapView.onResume()
         updateSearchCardViews()
         updateToggleViews(lastCheckedId == R.id.mapViewButton)
+        ExclusiveBottomSheetPresenter.dismiss(childFragmentManager)
     }
 
     override fun onStop() {


### PR DESCRIPTION
Steps to reproduce:
1. Go to Places.
2. Click on the marker and see the `LinkPreviewDialog`
3. Change the device's orientation.
4. The content in the `LinkPreviewDialog` becomes empty