### PR TITLE
Fix foreground color of MapView while loading.

### DIFF
--- a/app/src/main/res/layout/fragment_places.xml
+++ b/app/src/main/res/layout/fragment_places.xml
@@ -9,7 +9,8 @@
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        app:maplibre_foregroundLoadColor="?attr/paper_color"/>
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
In dark mode, when loading the Places screen, I was seeing a flash of white background before the map starts loading.
This is because we must explicitly set the foreground loading color attribute in the MapView.