### PR TITLE
Use correct color attributes in compass icon.

### DIFF
--- a/app/src/main/res/drawable/ic_compass_with_bg.xml
+++ b/app/src/main/res/drawable/ic_compass_with_bg.xml
@@ -5,21 +5,21 @@
     android:viewportHeight="36">
   <path
       android:pathData="M18.53,0L18.53,0A18,18 0,0 1,36.53 18L36.53,18A18,18 0,0 1,18.53 36L18.53,36A18,18 0,0 1,0.53 18L0.53,18A18,18 0,0 1,18.53 0z"
-      android:fillColor="#fff"/>
+      android:fillColor="?attr/background_color"/>
   <path
       android:pathData="m13.273,18 l4.727,-13v11.316c-0.453,0 -0.847,0.167 -1.182,0.502 -0.335,0.335 -0.502,0.729 -0.502,1.182z"
       android:strokeAlpha="0.9"
-      android:fillColor="#b32424"
+      android:fillColor="?attr/destructive_color"
       android:fillAlpha="0.9"/>
   <path
       android:pathData="m18,5 l4.727,13h-3.043c0,-0.453 -0.167,-0.847 -0.502,-1.182 -0.335,-0.335 -0.729,-0.502 -1.182,-0.502z"
-      android:fillColor="#b32424"/>
+      android:fillColor="?attr/destructive_color"/>
   <path
       android:pathData="m18,31 l-4.727,-13h3.043c0,0.453 0.167,0.847 0.502,1.182 0.335,0.335 0.729,0.502 1.182,0.502z"
-      android:fillColor="#a2a9b1"/>
+      android:fillColor="?attr/inactive_color"/>
   <path
       android:pathData="m22.727,18 l-4.727,13v-11.316c0.453,0 0.847,-0.167 1.182,-0.502 0.335,-0.335 0.502,-0.729 0.502,-1.182z"
       android:strokeAlpha="0.9"
-      android:fillColor="#a2a9b1"
+      android:fillColor="?attr/inactive_color"
       android:fillAlpha="0.9"/>
 </vector>


### PR DESCRIPTION
The compass icon was hard-coded for Light mode. This updates it to be responsive to the current theme.