### PR TITLE
Places: A bit more general cleanup.

### DIFF
--- a/app/src/main/res/layout/fragment_places.xml
+++ b/app/src/main/res/layout/fragment_places.xml
@@ -93,7 +93,6 @@
             android:layout_height="wrap_content"
             android:layout_marginVertical="8dp"
             android:layout_gravity="center_horizontal"
-            android:visibility="gone"
             app:selectionRequired="true"
             app:singleSelection="true">
 


### PR DESCRIPTION
* Move "lastLocation" variables into the ViewModel, and rename them to be more clear: `lastViewportLocation` and `lastKnownUserLocation`.
* Move the LiveData observation call inside the MapView initialization callback. With these changes, we no longer need to re-query the API when rotating the screen.
* Remove unnecessary `post` call to make `viewButtonsGroup` visible.
* Make a function to `clearAnnotationCache()` properly. When changing languages, the annotation cache list was emptied, but the Bitmaps in each annotation were not added back to the pool. This can lead to memory leaks.