### PR TITLE
Reset selected language if the previous selected language was deleted

### DIFF
--- a/app/src/main/java/org/wikipedia/usercontrib/UserContribFilterActivity.kt
+++ b/app/src/main/java/org/wikipedia/usercontrib/UserContribFilterActivity.kt
@@ -27,6 +27,9 @@ class UserContribFilterActivity : BaseActivity() {
     private lateinit var binding: ActivityUserContribWikiSelectBinding
 
     private val langUpdateLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        if (!WikipediaApp.instance.languageState.appLanguageCodes.contains(Prefs.userContribFilterLangCode)) {
+            Prefs.userContribFilterLangCode = WikipediaApp.instance.appOrSystemLanguageCode
+        }
         binding.recyclerView.adapter = ItemAdapter(this)
     }
 


### PR DESCRIPTION
Steps to reproduce:
1. Go to More.
2. Click on Contributions.
3. Click on Filter contributions.
4. See the selected wiki language, and click on update app languages.
5. Remove the selected wiki language from the list.
6. Go back to the filter contributions page.