### PR TITLE
Update logic for Places survey.

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -19,12 +19,10 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.navtab.NavTab
 import org.wikipedia.onboarding.InitialOnboardingActivity
 import org.wikipedia.page.PageActivity
-import org.wikipedia.places.PlacesFragment
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ResourceUtil
-import org.wikipedia.views.SurveyDialog
 
 class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callback {
 
@@ -63,18 +61,8 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
     }
 
     override fun onResume() {
-        maybeShowPlacesSurvey()
         super.onResume()
         invalidateOptionsMenu()
-    }
-
-    private fun maybeShowPlacesSurvey() {
-        binding.root.postDelayed({
-            if (!isDestroyed && Prefs.shouldShowOneTimePlacesSurvey == PlacesFragment.SURVEY_SHOW) {
-                Prefs.shouldShowOneTimePlacesSurvey = PlacesFragment.SURVEY_DO_NOT_SHOW
-                SurveyDialog.showFeedbackOptionsDialog(this, Constants.InvokeSource.PLACES)
-            }
-        }, 1000)
     }
 
     override fun createFragment(): MainFragment {

--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -61,6 +61,7 @@ import com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeWidth
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.textFont
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.textIgnorePlacement
+import kotlinx.coroutines.launch
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -92,6 +93,7 @@ import org.wikipedia.util.StringUtil
 import org.wikipedia.util.TabUtil
 import org.wikipedia.util.log.L
 import org.wikipedia.views.DrawableItemDecoration
+import org.wikipedia.views.SurveyDialog
 import org.wikipedia.views.ViewUtil
 import java.util.Locale
 import kotlin.math.abs
@@ -393,6 +395,8 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
                 FeedbackUtil.showError(requireActivity(), it.throwable)
             }
         }
+
+        maybeShowSurvey()
     }
 
     private fun updateToggleViews(isMapVisible: Boolean) {
@@ -544,9 +548,6 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
 
         clearAnnotationCache()
         markerBitmapBase.recycle()
-        if (Prefs.shouldShowOneTimePlacesSurvey == SURVEY_NOT_INITIALIZED) {
-            Prefs.shouldShowOneTimePlacesSurvey = SURVEY_SHOW
-        }
         super.onDestroyView()
     }
 
@@ -752,6 +753,15 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
         return false
     }
 
+    private fun maybeShowSurvey() {
+        binding.root.postDelayed({
+            if (isAdded && Prefs.shouldShowOneTimePlacesSurvey == 1) {
+                Prefs.shouldShowOneTimePlacesSurvey++
+                SurveyDialog.showFeedbackOptionsDialog(requireActivity(), Constants.InvokeSource.PLACES)
+            }
+        }, 1000)
+    }
+
     private inner class RecyclerViewAdapter(val nearbyPages: List<PlacesFragmentViewModel.NearbyPage>) : RecyclerView.Adapter<RecyclerViewItemHolder>() {
         override fun getItemCount(): Int {
             return nearbyPages.size
@@ -831,8 +841,6 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
         const val CLUSTER_CIRCLE_LAYER_ID = "mapbox-android-cluster-circle0"
         const val ZOOM_IN_ANIMATION_DURATION = 1000
         const val SURVEY_NOT_INITIALIZED = -1
-        const val SURVEY_SHOW = 0
-        const val SURVEY_DO_NOT_SHOW = 1
 
         val CLUSTER_FONT_STACK = arrayOf("Open Sans Semibold")
         val MARKER_FONT_STACK = arrayOf("Open Sans Regular")

--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -61,7 +61,6 @@ import com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeWidth
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.textFont
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.textIgnorePlacement
-import kotlinx.coroutines.launch
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp

--- a/app/src/main/java/org/wikipedia/places/PlacesFragmentViewModel.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragmentViewModel.kt
@@ -28,6 +28,10 @@ class PlacesFragmentViewModel(bundle: Bundle) : ViewModel() {
     var lastKnownLocation: Location? = null
     val nearbyPagesLiveData = MutableLiveData<Resource<List<NearbyPage>>>()
 
+    init {
+        Prefs.shouldShowOneTimePlacesSurvey++
+    }
+
     fun fetchNearbyPages(latitude: Double, longitude: Double, radius: Int, maxResults: Int) {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             nearbyPagesLiveData.postValue(Resource.Error(throwable))

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -466,7 +466,7 @@
         <org.wikipedia.settings.IntPreference
             style="@style/IntPreference"
             android:key="@string/preference_key_places_show_one_time_survey"
-            android:title="Survey status for places feature \n(-1=not initiated, 0=show the survey, 1=survey shown)" />
+            android:title="Survey status for places feature \n(-1=not initiated, 1=show survey, >1=do not show survey)" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
After some preliminary findings, we want to update the logic of when the survey is shown:
Instead of showing after the user _exits_ the Places screen, we want to show the survey the _second time that the user enters_ the Places screen.

https://phabricator.wikimedia.org/T355140#9521475

Incrementing the `Prefs` counter for showing the survey is now moved into the ViewModel, so that rotating the screen doesn't count as "entering" the activity.