### PR TITLE
Fix AgentData property, bump Metrics Platform library version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     String roomVersion = "2.6.1"
     String espressoVersion = '3.5.1'
     String serialization_version = '1.6.2'
-    String metricsVersion = '2.1'
+    String metricsVersion = '2.2'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
@@ -15,7 +15,7 @@ object MetricsPlatform {
         BuildConfig.FLAVOR + BuildConfig.BUILD_TYPE,
         WikipediaApp.instance.appInstallID,
         WikipediaApp.instance.currentTheme.toString(),
-        WikipediaApp.instance.versionCode.toString(),
+        WikipediaApp.instance.versionCode,
         "android",
         "app",
         WikipediaApp.instance.languageState.systemLanguageCode,


### PR DESCRIPTION
- Make `app_version` integer
- Bump MP lib to 2.2

Bug: [T356938](https://phabricator.wikimedia.org/T356938)