### PR TITLE
Ensure that search bar hint is single-line.

### DIFF
--- a/app/src/main/res/layout/activity_page.xml
+++ b/app/src/main/res/layout/activity_page.xml
@@ -50,6 +50,8 @@
                         android:drawablePadding="8dp"
                         android:paddingStart="12dp"
                         android:layout_marginEnd="4dp"
+                        android:maxLines="1"
+                        android:ellipsize="end"
                         app:drawableTint="?attr/placeholder_color"
                         app:drawableStartCompat="@drawable/ic_search_white_24dp"/>
 


### PR DESCRIPTION
The hint in the Search bar must be a single line with ellipsis; otherwise it overflows and looks weird:

![image](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/36d95026-6e28-40a4-9bf9-9aaca688128a)
