### PR TITLE
Show IP blocked message in Suggested Edits correctly

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -368,6 +368,10 @@ class SuggestedEditsTasksFragment : Fragment() {
             displayedTasks.add(addImageCaptionsTask)
             displayedTasks.add(addImageTagsTask)
         }
+
+        if (displayedTasks.isEmpty() && !viewModel.blockMessageWikipedia.isNullOrEmpty()) {
+            setIPBlockedStatus()
+        }
     }
 
     private inner class TaskViewCallback : SuggestedEditsTaskView.Callback {


### PR DESCRIPTION
We did not show the IP-blocked message correctly for a long time, and it will show an empty screen with only the user contribution card in the "Edits".

I have a VPN enabled and it looks like the IP from the VPN has been blocked.

Demo: https://youtube.com/shorts/pdNHG2bIWIQ