### PR TITLE
Metrics Platform minor updates, bump version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     String roomVersion = "2.6.1"
     String espressoVersion = '3.5.1'
     String serialization_version = '1.6.2'
-    String metricsVersion = '2.2'
+    String metricsVersion = '2.3'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/ArticleEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/ArticleEvent.kt
@@ -24,7 +24,7 @@ class ArticleFindInPageInteraction(private val fragment: PageFragment) : TimedMe
     fun logDone() {
         submitEvent(
             "android.product_metrics.find_in_page_interaction",
-            "/analytics/mobile_apps/product_metrics/android_find_in_page_interaction/1.0.0",
+            "/analytics/mobile_apps/product_metrics/android_find_in_page_interaction/1.1.0",
             "find_in_page_interaction",
             mapOf(
                 "find_text" to findText,
@@ -147,8 +147,8 @@ class ArticleToolbarInteraction(private val fragment: PageFragment) : TimedMetri
             "android.product_metrics.article_toolbar_interaction",
             "article_toolbar_interaction",
             getInteractionData(
-                "article_toolbar_interaction",
                 action,
+                null,
                 null,
                 "time_spent_ms.${timer.elapsedMillis}"
             ),
@@ -187,7 +187,7 @@ class ArticleTocInteraction(private val fragment: PageFragment, private val numS
         }
         submitEvent(
             "android.product_metrics.article_toc_interaction",
-            "/analytics/mobile_apps/product_metrics/android_article_toc_interaction/1.0.0",
+            "/analytics/mobile_apps/product_metrics/android_article_toc_interaction/1.1.0",
             "article_toc_interaction",
             mapOf(
                 "num_opens" to numOpens,
@@ -237,8 +237,8 @@ class ArticleLinkPreviewInteraction : TimedMetricsEvent {
             "android.product_metrics.article_link_preview_interaction",
             "article_link_preview_interaction",
             getInteractionData(
-                "article_link_preview_interaction",
                 action,
+                null,
                 source.toString(),
                 "time_spent_ms.${timer.elapsedMillis}",
             ),

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsPlatform.kt
@@ -16,6 +16,7 @@ object MetricsPlatform {
         WikipediaApp.instance.appInstallID,
         WikipediaApp.instance.currentTheme.toString(),
         WikipediaApp.instance.versionCode,
+        "WikipediaApp/" + BuildConfig.VERSION_NAME,
         "android",
         "app",
         WikipediaApp.instance.languageState.systemLanguageCode,


### PR DESCRIPTION
- Update references to updated custom schema versions
- Include `app_version_name` in `AgentData` object
- Update parameters for 2 article instruments
- Bump MP version to 2.3 to fix session_id

Bug: [T357371](https://phabricator.wikimedia.org/T357371)
Bug: [T357181](https://phabricator.wikimedia.org/T357181)

Depends-On: https://gerrit.wikimedia.org/r/c/schemas/event/secondary/+/1003810