### PR TITLE
Fix possible crash when tapping on map markers with location permissions disabled.

### DIFF
--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -417,8 +417,9 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
         PlacesEvent.logImpression("detail_view")
         val entry = HistoryEntry(pageTitle, HistoryEntry.SOURCE_PLACES)
         updateSearchText(pageTitle.displayText)
+
         ExclusiveBottomSheetPresenter.show(childFragmentManager,
-            LinkPreviewDialog.newInstance(entry, location, lastKnownLocation = mapboxMap?.locationComponent?.lastKnownLocation))
+            LinkPreviewDialog.newInstance(entry, location, getLastKnownUserLocation()))
     }
 
     private fun resetMagnifiedSymbol() {
@@ -628,6 +629,11 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
                 ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
     }
 
+    private fun getLastKnownUserLocation(): Location? {
+        return if (mapboxMap?.locationComponent?.isLocationComponentActivated == true)
+            mapboxMap?.locationComponent?.lastKnownLocation else null
+    }
+
     @SuppressLint("MissingPermission")
     private fun startLocationTracking() {
         mapboxMap?.let {
@@ -642,7 +648,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
         if (haveLocationPermissions()) {
             binding.viewButtonsGroup.check(R.id.mapViewButton)
             mapboxMap?.let {
-                viewModel.lastKnownLocation = it.locationComponent.lastKnownLocation
+                viewModel.lastKnownLocation = getLastKnownUserLocation()
                 var currentLatLngLoc: LatLng? = null
                 viewModel.lastKnownLocation?.let { loc -> currentLatLngLoc = LatLng(loc.latitude, loc.longitude) }
                 val location = preferredLocation?.let { loc -> LatLng(loc.latitude, loc.longitude) }


### PR DESCRIPTION
This (minor) crash occurs when a user declines the Location permission, then goes on to tap on map markers to see a link preview.