### PR TITLE
Make tab closing animation snappier.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
@@ -12,6 +12,7 @@ import androidx.core.view.drawToBitmap
 import androidx.core.view.isVisible
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.mrapp.android.tabswitcher.Animation
+import de.mrapp.android.tabswitcher.SwipeAnimation
 import de.mrapp.android.tabswitcher.TabSwitcher
 import de.mrapp.android.tabswitcher.TabSwitcherDecorator
 import de.mrapp.android.tabswitcher.TabSwitcherListener
@@ -111,6 +112,15 @@ class TabActivity : BaseActivity() {
         binding.tabSwitcher.logLevel = LogLevel.OFF
         binding.tabSwitcher.addListener(tabListener)
         binding.tabSwitcher.showSwitcher()
+
+        binding.tabSwitcher.addCloseTabListener { tabSwitcher, tab ->
+            tabSwitcher.removeTab(tab, SwipeAnimation.Builder()
+                .setDuration(0)
+                .setRelocateAnimationDuration(100)
+                .setInterpolator(null).create())
+            false
+        }
+
         launchedFromPageActivity = intent.hasExtra(LAUNCHED_FROM_PAGE_ACTIVITY)
         setStatusBarColor(ResourceUtil.getThemedColor(this, android.R.attr.colorBackground))
         setNavigationBarColor(ResourceUtil.getThemedColor(this, android.R.attr.colorBackground))


### PR DESCRIPTION
When closing a single tab in the TabActivity, the animation that swipes the tab away (and then the animation that relocates the remaining tabs) is unnecessarily slow, and impedes the user if they want to close additional tabs right away.
This animation can be sped up, for a snappier UX.

https://phabricator.wikimedia.org/T358162