### PR TITLE
Support SteadyView (screen stabilizer) library

### DIFF
--- a/SteadyFixedDrawerLayout.java
+++ b/SteadyFixedDrawerLayout.java
@@ -1,0 +1,41 @@
+package org.wikipedia.views;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.util.AttributeSet;
+
+import androidx.annotation.Nullable;
+import androidx.drawerlayout.widget.FixedDrawerLayout;
+import lib.sublimis.steadyview.ISteadyView;
+
+public class SteadyFixedDrawerLayout extends FixedDrawerLayout implements ISteadyView
+{
+   public SteadyFixedDrawerLayout(final Context context)
+   {
+      super(context);
+
+      ISteadyView.super.initSteadyView();
+   }
+
+   public SteadyFixedDrawerLayout(final Context context, final AttributeSet attrs)
+   {
+      super(context, attrs);
+
+      ISteadyView.super.initSteadyView();
+   }
+
+   public SteadyFixedDrawerLayout(final Context context, final AttributeSet attrs, final int defStyle)
+   {
+      super(context, attrs, defStyle);
+
+      ISteadyView.super.initSteadyView();
+   }
+
+   @Override
+   public boolean performAccessibilityAction(final int action, @Nullable final Bundle arguments)
+   {
+      final boolean status = ISteadyView.super.performSteadyViewAction(action, arguments);
+
+      return super.performAccessibilityAction(action, arguments) || status;
+   }
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -266,6 +266,9 @@ dependencies {
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestImplementation "androidx.room:room-testing:$roomVersion"
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
+
+    implementation 'com.github.Sublimis:SteadyView:1.3.1'
+    implementation 'com.github.Sublimis:SteadyViews:1.3.1'
 }
 
 private setSigningConfigKey(config, Properties props) {

--- a/app/src/main/java/org/wikipedia/views/SteadyFixedDrawerLayout.java
+++ b/app/src/main/java/org/wikipedia/views/SteadyFixedDrawerLayout.java
@@ -1,0 +1,41 @@
+package org.wikipedia.views;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.util.AttributeSet;
+
+import androidx.annotation.Nullable;
+import androidx.drawerlayout.widget.FixedDrawerLayout;
+import lib.sublimis.steadyview.ISteadyView;
+
+public class SteadyFixedDrawerLayout extends FixedDrawerLayout implements ISteadyView
+{
+   public SteadyFixedDrawerLayout(final Context context)
+   {
+      super(context);
+
+      ISteadyView.super.initSteadyView();
+   }
+
+   public SteadyFixedDrawerLayout(final Context context, final AttributeSet attrs)
+   {
+      super(context, attrs);
+
+      ISteadyView.super.initSteadyView();
+   }
+
+   public SteadyFixedDrawerLayout(final Context context, final AttributeSet attrs, final int defStyle)
+   {
+      super(context, attrs, defStyle);
+
+      ISteadyView.super.initSteadyView();
+   }
+
+   @Override
+   public boolean performAccessibilityAction(final int action, @Nullable final Bundle arguments)
+   {
+      final boolean status = ISteadyView.super.performSteadyViewAction(action, arguments);
+
+      return super.performAccessibilityAction(action, arguments) || status;
+   }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<lib.sublimis.steadyviews.SteadyLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -28,4 +28,4 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />
-</LinearLayout>
+</lib.sublimis.steadyviews.SteadyLinearLayout>

--- a/app/src/main/res/layout/activity_page.xml
+++ b/app/src/main/res/layout/activity_page.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.FixedDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<org.wikipedia.views.SteadyFixedDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/navigation_drawer"
@@ -147,4 +147,4 @@
 
     </FrameLayout>
 
-</androidx.drawerlayout.widget.FixedDrawerLayout>
+</org.wikipedia.views.SteadyFixedDrawerLayout>


### PR DESCRIPTION
With a few simple changes this pull request aims at supporting the [SteadyScreen](https://github.com/Sublimis/SteadyScreen) screen stabilization service (by utilizing the [SteadyView library](https://github.com/Sublimis/SteadyView)).

It makes on-screen reading easier by softening small movements of mobile screens.