### PR TITLE
Possibly fix TransactionTooLarge crashes.

### DIFF
--- a/app/src/main/java/org/wikipedia/random/RandomFragment.kt
+++ b/app/src/main/java/org/wikipedia/random/RandomFragment.kt
@@ -241,6 +241,11 @@ class RandomFragment : Fragment() {
             prevPosition = position
 
             updateSaveShareButton()
+
+            val storedOffScreenPagesCount = binding.randomItemPager.offscreenPageLimit * 2 + 1
+            if (position >= storedOffScreenPagesCount) {
+                (binding.randomItemPager.adapter as RandomItemAdapter).removeFragmentAt(position - storedOffScreenPagesCount)
+            }
         }
     }
 


### PR DESCRIPTION
I found a spot that could potentially lead to the obscure `TransactionTooLarge` exceptions that we see occasionally in the crash logs. If the user goes to the Randomizer activity, and flips through very many (hundreds) of RandomFragments, the ViewPager adapter actually keeps a reference to all those fragments, and when the activity is stopped, it tries to save the state of all those fragments.

We therefore need to _explicitly remove_ fragments that are sufficiently far into the history of the ViewPager. We actually already do this in the SuggestedEdits view pager, but not in the Randomizer.