### PR TITLE
Further improve concurrency in EventPlatformClient.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -114,7 +114,7 @@ object EventPlatformClient {
             WikipediaApp.instance.mainThreadHandler.removeCallbacksAndMessages(TOKEN)
             if (ENABLED) {
                 val eventsByStream: Map<String, List<Event>>
-                synchronized (QUEUE) {
+                synchronized(QUEUE) {
                     eventsByStream = QUEUE.groupBy { it.stream }
                     QUEUE.clear()
                 }
@@ -129,7 +129,7 @@ object EventPlatformClient {
          */
         fun schedule(event: Event) {
             if (ENABLED || QUEUE.size <= MAX_QUEUE_SIZE) {
-                synchronized (QUEUE) {
+                synchronized(QUEUE) {
                     QUEUE.add(event)
                 }
             }


### PR DESCRIPTION
The previous improvement to concurrency actually helped expose a slightly larger issue:
The `@Synchronized` annotations were placing a lock on the entire `EventPlatformClient` object, which is too much, and can potentially cause an ANR, since some of the synchronized functions could hold on to the lock for too long.

This updates STREAM_CONFIGS to be a built-in `ConcurrentHashMap`, and then the queueing/dequeueing of actual events is synchronized on the `QUEUE` object itself, making it correctly granular.