### PR TITLE
Fix fetching Wikidata edit counts.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -383,6 +383,7 @@ interface Service {
     suspend fun getUserContributions(
         @Query("ucuser") username: String,
         @Query("uclimit") maxCount: Int,
+        @Query("ucnamespace") ns: Int?,
         @Query("uccontinue") uccontinue: String?
     ): MwQueryResponse
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragmentViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragmentViewModel.kt
@@ -58,10 +58,10 @@ class SuggestedEditsTasksFragmentViewModel : ViewModel() {
             latestEditStreak = 0
             revertSeverity = 0
 
-            val homeSiteCall = async { ServiceFactory.get(WikipediaApp.instance.wikiSite).getUserContributions(AccountUtil.userName!!, 10, null) }
+            val homeSiteCall = async { ServiceFactory.get(WikipediaApp.instance.wikiSite).getUserContributions(AccountUtil.userName!!, 10, null, null) }
             // val homeSiteParamCall = async { ServiceFactory.get(WikipediaApp.instance.wikiSite).getParamInfo("query+growthtasks") }
-            val commonsCall = async { ServiceFactory.get(Constants.commonsWikiSite).getUserContributions(AccountUtil.userName!!, 10, null) }
-            val wikidataCall = async { ServiceFactory.get(Constants.wikidataWikiSite).getUserContributions(AccountUtil.userName!!, 10, null) }
+            val commonsCall = async { ServiceFactory.get(Constants.commonsWikiSite).getUserContributions(AccountUtil.userName!!, 10, null, null) }
+            val wikidataCall = async { ServiceFactory.get(Constants.wikidataWikiSite).getUserContributions(AccountUtil.userName!!, 10, 0, null) }
             val editCountsCall = async { UserContribStats.verifyEditCountsAndPauseState() }
 
             val homeSiteResponse = homeSiteCall.await()


### PR DESCRIPTION
The edit counts that we get from Wikidata should be only for the Main namespace. If a user makes edits in the non-main namespace, our logic to fetch pageviews breaks, and we show an error.

https://phabricator.wikimedia.org/T358845