### PR TITLE
Improve performance of Link Preview when used in Places.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -40,9 +41,12 @@ class LinkPreviewViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             _uiState.value = LinkPreviewViewState.Error(throwable)
         }) {
-            val response = ServiceFactory.getRest(pageTitle.wikiSite)
-                .getSummaryResponseSuspend(pageTitle.prefixedText, null, null, null, null, null)
+            val summaryCall = async { ServiceFactory.getRest(pageTitle.wikiSite)
+                .getSummaryResponseSuspend(pageTitle.prefixedText, null, null, null, null, null) }
 
+            val watchedCall = async { if (fromPlaces) ServiceFactory.get(pageTitle.wikiSite).getWatchedStatus(pageTitle.prefixedText) else null }
+
+            val response = summaryCall.await()
             val summary = response.body()!!
             // Rebuild our PageTitle, since it may have been redirected or normalized.
             val oldFragment = pageTitle.fragment
@@ -60,7 +64,7 @@ class LinkPreviewViewModel(bundle: Bundle) : ViewModel() {
             }
 
             if (fromPlaces) {
-                val watchStatus = ServiceFactory.get(pageTitle.wikiSite).getWatchedStatus(pageTitle.prefixedText).query?.firstPage()
+                val watchStatus = watchedCall.await()?.query?.firstPage()
                 isWatched = watchStatus?.watched ?: false
 
                 val readingList = AppDatabase.instance.readingListPageDao().findPageInAnyList(pageTitle)

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wikipedia.analytics.eventplatform.WatchlistAnalyticsHelper
+import org.wikipedia.auth.AccountUtil
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.extensions.parcelable
@@ -44,7 +45,7 @@ class LinkPreviewViewModel(bundle: Bundle) : ViewModel() {
             val summaryCall = async { ServiceFactory.getRest(pageTitle.wikiSite)
                 .getSummaryResponseSuspend(pageTitle.prefixedText, null, null, null, null, null) }
 
-            val watchedCall = async { if (fromPlaces) ServiceFactory.get(pageTitle.wikiSite).getWatchedStatus(pageTitle.prefixedText) else null }
+            val watchedCall = async { if (fromPlaces && AccountUtil.isLoggedIn) ServiceFactory.get(pageTitle.wikiSite).getWatchedStatus(pageTitle.prefixedText) else null }
 
             val response = summaryCall.await()
             val summary = response.body()!!
@@ -64,9 +65,7 @@ class LinkPreviewViewModel(bundle: Bundle) : ViewModel() {
             }
 
             if (fromPlaces) {
-                val watchStatus = watchedCall.await()?.query?.firstPage()
-                isWatched = watchStatus?.watched ?: false
-
+                isWatched = watchedCall.await()?.query?.firstPage()?.watched ?: false
                 val readingList = AppDatabase.instance.readingListPageDao().findPageInAnyList(pageTitle)
                 isInReadingList = readingList != null
             }


### PR DESCRIPTION
When we integrated Places into the LinkPreviewDialog, we introduced an API call to see if the article is currently in the user's watchlist. However, this call is being made serially, while it could easily be made in _parallel_ with other calls.