### PR TITLE
Refactor EditPreviewFragment to be usable from other activities.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -75,7 +75,7 @@ import org.wikipedia.views.ViewUtil
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
-class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, LinkPreviewDialog.LoadPageCallback {
+class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPreviewFragment.Callback, LinkPreviewDialog.LoadPageCallback {
     private lateinit var binding: ActivityEditSectionBinding
     private lateinit var textWatcher: TextWatcher
     private lateinit var captchaHandler: CaptchaHandler
@@ -464,6 +464,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, LinkPre
             else -> {
                 // we must be showing the editing window, so show the Preview.
                 DeviceUtil.hideSoftKeyboard(this)
+                binding.editSectionContainer.isVisible = false
                 editPreviewFragment.showPreview(pageTitle, binding.editSectionText.text.toString())
                 EditAttemptStepEvent.logSaveIntent(pageTitle)
                 supportActionBar?.title = getString(R.string.edit_preview)
@@ -601,7 +602,8 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, LinkPre
             editSummaryFragment.hide()
         }
         if (editPreviewFragment.isActive) {
-            editPreviewFragment.hide(binding.editSectionContainer)
+            editPreviewFragment.hide()
+            binding.editSectionContainer.isVisible = true
         }
     }
 
@@ -705,8 +707,12 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, LinkPre
         binding.editSectionText.highlightText(highlightText)
     }
 
-    fun showProgressBar(enable: Boolean) {
-        binding.viewProgressBar.isVisible = enable
+    override fun getParentPageTitle(): PageTitle {
+        return pageTitle
+    }
+
+    override fun showProgressBar(visible: Boolean) {
+        binding.viewProgressBar.isVisible = visible
         invalidateOptionsMenu()
     }
 
@@ -738,7 +744,8 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, LinkPre
                 recommendationSourceProjects = addImageSourceProjects.orEmpty(), acceptanceState = "accepted",
                 captionAdd = !intent.getStringExtra(InsertMediaActivity.RESULT_IMAGE_CAPTION).isNullOrEmpty(),
                 altTextAdd = !intent.getStringExtra(InsertMediaActivity.RESULT_IMAGE_ALT).isNullOrEmpty()), pageTitle.wikiSite.languageCode)
-            editPreviewFragment.hide(binding.editSectionContainer)
+            editPreviewFragment.hide()
+            binding.editSectionContainer.isVisible = true
             supportActionBar?.title = null
 
             // If we came from the Image Recommendations workflow, bring back the Add Image activity.


### PR DESCRIPTION
This is a light refactor of the edit preview fragment which decouples it from the general editing workflow, and makes it usable from other activities where a preview will be necessary, such as TalkReplyActivity.
(No changes to existing behavior.)