### PR TITLE
Correctly insert edit summary when rolling back.

### DIFF
--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -243,8 +243,12 @@ class ArticleEditDetailsViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             rollbackResponse.postValue(Resource.Error(throwable))
         }) {
+
+            val rollbackSummaryMsg = ServiceFactory.get(title.wikiSite).getMessages("revertpage", null)
+                .query?.allmessages?.firstOrNull { it.name == "revertpage" }?.content
+
             val rollbackToken = ServiceFactory.get(title.wikiSite).getToken("rollback").query!!.rollbackToken()!!
-            val summary = if (fromRecentEdits) DescriptionEditFragment.SUGGESTED_EDITS_PATROLLER_TASKS_ROLLBACK else if (fromWatchList) WatchlistFragment.WATCHLIST_ROLLBACK_COMMENT
+            val summary = "$rollbackSummaryMsg, " + if (fromRecentEdits) DescriptionEditFragment.SUGGESTED_EDITS_PATROLLER_TASKS_ROLLBACK else if (fromWatchList) WatchlistFragment.WATCHLIST_ROLLBACK_COMMENT
             else ArticleEditDetailsFragment.DIFF_ROLLBACK_COMMENT
             val rollbackPostResponse = ServiceFactory.get(title.wikiSite).postRollback(title.prefixedText, summary, user, rollbackToken)
             rollbackResponse.postValue(Resource.Success(rollbackPostResponse))


### PR DESCRIPTION
When we started adding our "hashtag"-style comments into the edit summary, we forgot that the Rollback action _automatically generates_ a summary (if the provided summary is blank). So when we provide just the hashtag summary, it overrides and erases the default summary, leading to an edit summary that is not descriptive enough.
This updates our logic to manually fetch the standard summary message, then append our hashtag to it, and then submit the combined message as the edit summary, which will result in a much improved and informative summary when rolling back.

https://phabricator.wikimedia.org/T359006