### PR TITLE
Fix incorrect Close icon in MGAD problem report dialog.

### DIFF
--- a/app/src/main/res/layout/dialog_description_suggestion_report.xml
+++ b/app/src/main/res/layout/dialog_description_suggestion_report.xml
@@ -108,7 +108,7 @@
             android:gravity="start"
             android:hint="@string/edit_summary_tag_other"
             android:textAlignment="viewStart"
-            app:endIconDrawable="@drawable/chip_close_button_dark"
+            app:endIconDrawable="@drawable/ic_close_black_24dp"
             app:endIconMode="custom"
             app:endIconTint="?attr/placeholder_color"
             app:errorTextAppearance="@style/TextInputLayoutErrorTextAppearance">

--- a/app/src/main/res/menu/menu_suggested_edits.xml
+++ b/app/src/main/res/menu/menu_suggested_edits.xml
@@ -7,6 +7,6 @@
         android:id="@+id/menu_help"
         android:title="@string/suggested_edits_menu_info"
         android:icon="@drawable/ic_info_outline_black_24dp"
-        app:tint="?attr/progressive_color"
+        app:iconTint="?attr/progressive_color"
         app:showAsAction="ifRoom" />
 </menu>


### PR DESCRIPTION
In the popup dialog for reporting a problem with machine-generated descriptions (a really obscure place!) we're using a `drawable` icon that is actually coming from a library (the `chrome-like-tab-switcher` library) and it's not even a vector drawable, but a PNG.
Let's use a standard "close" drawable here, and untangle this dependency.

This also fixes an incorrect `tint` attribute in the menu when looking at suggested article descriptions.