### PR TITLE
Untangle another component from ChromeTabSwitcher library.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -10,10 +10,12 @@ import android.view.LayoutInflater
 import android.view.inputmethod.EditorInfo
 import android.widget.LinearLayout
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.BlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.ImageViewCompat
 import androidx.core.widget.addTextChangedListener
-import de.mrapp.android.view.drawable.CircularProgressDrawable
+import androidx.swiperefreshlayout.widget.CircularProgressDrawable
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.MachineGeneratedArticleDescriptionsAnalyticsHelper
@@ -417,7 +419,11 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
     fun showSuggestedDescriptionsLoadingProgress() {
         binding.suggestedDescButton.isVisible = true
         binding.suggestedDescButton.isEnabled = false
-        binding.suggestedDescButton.chipIcon = CircularProgressDrawable(ResourceUtil.getThemedColor(context, R.attr.primary_color), 1).also { it.start() }
+        val drawable = CircularProgressDrawable(context)
+        drawable.strokeWidth = DimenUtil.dpToPx(1.5f)
+        drawable.colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(ResourceUtil.getThemedColor(context, R.attr.primary_color), BlendModeCompat.SRC_IN)
+        binding.suggestedDescButton.chipIcon = drawable
+        drawable.start()
     }
 
      fun updateSuggestedDescriptionsButtonVisibility() {

--- a/app/src/main/res/layout/view_description_edit.xml
+++ b/app/src/main/res/layout/view_description_edit.xml
@@ -177,6 +177,7 @@
                                     android:visibility="gone"
                                     app:chipIcon="@drawable/ic_robot_24"
                                     app:chipIconSize="20dp"
+                                    app:chipIconTint="?attr/primary_color"
                                     tools:visibility="visible" />
 
                                 <org.wikipedia.views.PlainPasteEditText


### PR DESCRIPTION
Sorry, there's one other place where we were accidentally using a component from within the `chrome-like-tab-switcher` library, which is the CircularProgressDrawable component, which actually already exists in the base AndroidX library.

(This is for the purpose of fully untangling ourselves from this library, for any potential upcoming work on rebuilding our Tabs screen.)