### PR TITLE
Clarify "All wikis" and "All types" notifications messages

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -776,8 +776,8 @@
     <string name="notifications_menu_uncheck_all">Uncheck all items</string>
     <string name="notifications_wiki_filter_header">Wiki filter</string>
     <string name="notifications_type_filter_header">Type filter</string>
-    <string name="notifications_all_wikis_text">All \"wiki\"</string>
-    <string name="notifications_all_types_text">All \"type\"</string>
+    <string name="notifications_all_wikis_text">All wikis</string>
+    <string name="notifications_all_types_text">All types</string>
     <string name="notifications_menu_user_talk_page">%s\'s talk page</string>
     <string name="notifications_offline_disable_message">The function is not available while offline.</string>
     <!-- /Notifications -->


### PR DESCRIPTION
Those two messages were:
* All "wiki"
* All "type"

This was quite weird to read even in English, and hard to translate, too. The quotation marks are unnecessary, and the nouns should be plural, because it's a selection out of multiple things.