### PR TITLE
Remove PreProdRelease condition from the MetricsEvent class

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
@@ -11,7 +11,6 @@ import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageFragment
 import org.wikipedia.page.PageTitle
-import org.wikipedia.util.ReleaseUtil
 
 open class MetricsEvent {
 
@@ -54,16 +53,14 @@ open class MetricsEvent {
         interactionData: InteractionData?,
         pageData: PageData? = null
     ) {
-        if (ReleaseUtil.isPreProdRelease) {
-            MetricsPlatform.client.submitInteraction(
-                streamName,
-                schemaId,
-                EVENT_NAME_BASE + eventName,
-                getClientData(pageData),
-                interactionData,
-                customData
-            )
-        }
+        MetricsPlatform.client.submitInteraction(
+            streamName,
+            schemaId,
+            EVENT_NAME_BASE + eventName,
+            getClientData(pageData),
+            interactionData,
+            customData
+        )
     }
 
     private fun getClientData(pageData: PageData?): ClientData {

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/MetricsEvent.kt
@@ -29,13 +29,11 @@ open class MetricsEvent {
         interactionData: InteractionData?,
         pageData: PageData? = null
     ) {
-        if (ReleaseUtil.isPreProdRelease) {
-            MetricsPlatform.client.submitInteraction(
-                streamName,
-                EVENT_NAME_BASE + eventName,
-                getClientData(pageData),
-                interactionData)
-        }
+        MetricsPlatform.client.submitInteraction(
+            streamName,
+            EVENT_NAME_BASE + eventName,
+            getClientData(pageData),
+            interactionData)
     }
 
     /**


### PR DESCRIPTION
Per discussion from the Slack channel, it is time to include it in the production.