### PR TITLE
Show notification Read/Unread menu item in notification's language.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
@@ -75,7 +75,8 @@ class NotificationActionsOverflowView(context: Context) : FrameLayout(context) {
                     val pageTitle = PageTitle.titleForUri(uri, WikiSite(uri))
                     if (pageTitle.isUserPage) {
                         binding.overflowViewSecondaryTalk.visibility = View.VISIBLE
-                        binding.overflowViewSecondaryTalk.text = context.getString(R.string.notifications_menu_user_talk_page, secondary.first().label)
+                        binding.overflowViewSecondaryTalk.text = String.format(L10nUtil.getStringForArticleLanguage(StringUtil.dbNameToLangCode(container.notification.wiki),
+                            R.string.notifications_menu_user_talk_page), secondary.first().label)
                         binding.overflowViewSecondaryTalk.setOnClickListener {
                             if (UriUtil.isAppSupportedLink(uri)) {
                                 context.startActivity(TalkTopicsActivity.newIntent(context, pageTitle, Constants.InvokeSource.NOTIFICATION))

--- a/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
@@ -29,6 +29,7 @@ import org.wikipedia.notifications.NotificationListItemContainer
 import org.wikipedia.notifications.db.Notification
 import org.wikipedia.page.PageTitle
 import org.wikipedia.talk.TalkTopicsActivity
+import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
@@ -93,7 +94,8 @@ class NotificationActionsOverflowView(context: Context) : FrameLayout(context) {
         }
 
         container.notification?.isUnread?.let {
-            binding.overflowMarkAsRead.setText(if (it) R.string.notifications_menu_mark_as_read else R.string.notifications_menu_mark_as_unread)
+            binding.overflowMarkAsRead.text = L10nUtil.getStringForArticleLanguage(StringUtil.dbNameToLangCode(container.notification.wiki),
+                if (it) R.string.notifications_menu_mark_as_read else R.string.notifications_menu_mark_as_unread)
             binding.overflowMarkAsRead.setCompoundDrawablesRelativeWithIntrinsicBounds(if (it) R.drawable.ic_outline_markunread_24 else R.drawable.ic_outline_drafts_24, 0, 0, 0)
         }
 


### PR DESCRIPTION
@amire80 correctly points out that the menu options in the popup menu for each Notification item should be in the language of the notification, which most of them are (because they come from the API structure itself) except the "Mark read" item, which comes from the app's local resources. We can easily match this option to be in the same language as the rest of the options.

https://phabricator.wikimedia.org/T359600
