### PR TITLE
Add a few more non-language redirect domains.

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.kt
+++ b/app/src/main/java/org/wikipedia/Constants.kt
@@ -50,7 +50,7 @@ object Constants {
     const val WIKI_CODE_WIKIDATA = "wikidata"
     const val WIKIDATA_DB_NAME = "wikidatawiki"
 
-    val NON_LANGUAGE_SUBDOMAINS = listOf("donate", "thankyou", "quote")
+    val NON_LANGUAGE_SUBDOMAINS = listOf("donate", "thankyou", "quote", "textbook", "sources", "species", "commons", "meta")
 
     val commonsWikiSite = WikiSite(Service.COMMONS_URL)
     val wikidataWikiSite = WikiSite(Service.WIKIDATA_URL)


### PR DESCRIPTION
This adds a few more subdomains of `wikipedia.org` which redirect to `wikimedia.org` and others, which the app isn't meant to handle, so we will automatically bounce these out to the default browser.
These types of redirects are becoming slightly more common in Google search results (because wikipedia.org has such good reputation), so we can expect some more false-positives to be caught by the app.