### PR TITLE
Enable support for per-app language selection in Android 13+.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,10 @@ android {
         buildConfig true
     }
 
+    androidResources {
+        generateLocaleConfig = true
+    }
+
     sourceSets {
 
         prod { java.srcDirs += 'src/extra/java' }

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US


### PR DESCRIPTION
Android 13 and higher now supports per-app language selection in the System settings. Apps can opt into this functionality with just a few lines of configuration, which auto-generates everything else that's necessary.

https://developer.android.com/guide/topics/resources/app-languages
https://phabricator.wikimedia.org/T359701