### PR TITLE
Remove duplicated open-in-new drawable and use proper tint method

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsSurvey.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsSurvey.kt
@@ -3,10 +3,12 @@ package org.wikipedia.suggestededits
 import android.app.Activity
 import android.net.Uri
 import android.widget.TextView
+import androidx.core.widget.TextViewCompat
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.UriUtil
 
 object SuggestedEditsSurvey {
@@ -18,8 +20,9 @@ object SuggestedEditsSurvey {
             val snackbar = FeedbackUtil.makeSnackbar(activity,
                 activity.getString(R.string.suggested_edits_snackbar_survey_text), FeedbackUtil.LENGTH_MEDIUM)
             val actionView = snackbar.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_action)
-            actionView.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, R.drawable.ic_open_in_new_accent_24, 0)
+            actionView.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, R.drawable.ic_open_in_new_black_24px, 0)
             actionView.compoundDrawablePadding = activity.resources.getDimensionPixelOffset(R.dimen.margin)
+            TextViewCompat.setCompoundDrawableTintList(actionView, ResourceUtil.getThemedColorStateList(activity, R.attr.progressive_color))
             snackbar.setAction(activity.getString(R.string.suggested_edits_snackbar_survey_action_text)) { openSurveyInBrowser() }
             snackbar.show()
             Prefs.showSuggestedEditsSurvey = false

--- a/app/src/main/res/drawable/ic_open_in_new_accent_24.xml
+++ b/app/src/main/res/drawable/ic_open_in_new_accent_24.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24.0"
-    android:viewportHeight="24.0">
-    <path
-        android:fillColor="?attr/progressive_color"
-        android:pathData="M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z" />
-</vector>


### PR DESCRIPTION
This is the one with `?attr/progressive_color` in the XML, and it can be replaced with a regular drawable and apply the tint programmatically.