### PR TITLE
Parse GeoHack URLs and launch PlacesActivity with it.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/LinkHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.page
 
+import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import kotlinx.serialization.json.JsonObject
@@ -7,6 +8,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.wikipedia.bridge.CommunicationBridge.JSEventListener
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.page.LinkMovementMethodExt.UrlHandlerWithText
+import org.wikipedia.places.PlacesActivity
+import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
 import org.wikipedia.util.log.L
 
@@ -99,6 +102,12 @@ abstract class LinkHandler(protected val context: Context) : JSEventListener, Ur
     }
 
     open fun onExternalLinkClicked(uri: Uri) {
+        if (uri.authority.orEmpty().contains("geohack") && context is Activity) {
+            StringUtil.geoHackToLocation(uri.getQueryParameter("params"))?.let {
+                context.startActivity(PlacesActivity.newIntent(context, null, it))
+                return
+            }
+        }
         UriUtil.handleExternalLink(context, uri)
     }
 

--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
 import android.icu.text.CompactDecimalFormat
+import android.location.Location
 import android.os.Build
 import android.text.Spanned
 import android.text.style.BackgroundColorSpan
@@ -240,5 +241,30 @@ object StringUtil {
 
     fun capitalize(str: String?): String? {
         return str?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+    }
+
+    fun geoHackToLocation(params: String?): Location? {
+        if (!params.isNullOrBlank()) {
+            val regex = """((\d+)_)((\d+)_)?((\d+)_)?(([NS])_)((\d+)_)?((\d+)_)?((\d+)_)?([EW])""".toRegex()
+            val match = regex.find(params)
+            if (match != null) {
+                val latDeg = match.groupValues[2].ifEmpty { "0" }
+                val latMin = match.groupValues[4].ifEmpty { "0" }
+                val latSec = match.groupValues[6].ifEmpty { "0" }
+                val latDir = match.groupValues[8].ifEmpty { "0" }
+                val lonDeg = match.groupValues[10].ifEmpty { "0" }
+                val lonMin = match.groupValues[12].ifEmpty { "0" }
+                val lonSec = match.groupValues[14].ifEmpty { "0" }
+                val lonDir = match.groupValues[15].ifEmpty { "0" }
+                val lat = latDeg.toDouble() + latMin.toDouble() / 60 + latSec.toDouble() / 3600
+                val lon = lonDeg.toDouble() + lonMin.toDouble() / 60 + lonSec.toDouble() / 3600
+
+                return Location("").apply {
+                    latitude = if (latDir == "S") -lat else lat
+                    longitude = if (lonDir == "W") -lon else lon
+                }
+            }
+        }
+        return null
     }
 }

--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -245,7 +245,7 @@ object StringUtil {
 
     fun geoHackToLocation(params: String?): Location? {
         if (!params.isNullOrBlank()) {
-            val regex = """((\d+)_)((\d+)_)?((\d+)_)?(([NS])_)((\d+)_)?((\d+)_)?((\d+)_)?([EW])""".toRegex()
+            val regex = """(([\d.]+)_)(([\d.]+)_)?(([\d.]+)_)?(([NS])_)(([\d.]+)_)?(([\d.]+)_)?(([\d.]+)_)?([EW])""".toRegex()
             val match = regex.find(params)
             if (match != null) {
                 val latDeg = match.groupValues[2].ifEmpty { "0" }

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.util
 
-import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -114,12 +113,6 @@ object UriUtil {
     }
 
     fun handleExternalLink(context: Context, uri: Uri) {
-        if (uri.authority.orEmpty().contains("geohack") && context is Activity) {
-            StringUtil.geoHackToLocation(uri.getQueryParameter("params"))?.let {
-                GeoUtil.sendGeoIntent(context, it, uri.getQueryParameter("pagename") ?: "")
-                return
-            }
-        }
         visitInExternalBrowser(context, uri)
     }
 

--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.util
 
+import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -113,6 +114,12 @@ object UriUtil {
     }
 
     fun handleExternalLink(context: Context, uri: Uri) {
+        if (uri.authority.orEmpty().contains("geohack") && context is Activity) {
+            StringUtil.geoHackToLocation(uri.getQueryParameter("params"))?.let {
+                GeoUtil.sendGeoIntent(context, it, uri.getQueryParameter("pagename") ?: "")
+                return
+            }
+        }
         visitInExternalBrowser(context, uri)
     }
 

--- a/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
+++ b/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.util
 
+import android.location.Location
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test
@@ -110,5 +111,17 @@ class StringUtilTest {
     @Test
     fun testSanitizeAbuseFilterCode() {
         MatcherAssert.assertThat(StringUtil.sanitizeAbuseFilterCode("⧼abusefilter-warning-selfpublished⧽"), Matchers.`is`("abusefilter-warning-selfpublished"))
+    }
+
+    @Test
+    fun testGeoHackToLocation() {
+        MatcherAssert.assertThat(StringUtil.geoHackToLocation("test"), Matchers.nullValue())
+        val location1 = StringUtil.geoHackToLocation("42_N_71_12_13_W")!!
+        val location2 = Location("").apply {
+            latitude = 42.0
+            longitude = 71.0 + 12.0 / 60 + 13.0 / 3600
+        }
+        MatcherAssert.assertThat(location1.latitude, Matchers.equalTo(location2.latitude))
+        MatcherAssert.assertThat(-location1.longitude, Matchers.equalTo(location2.longitude))
     }
 }


### PR DESCRIPTION
Whenever a user clicks on a "coordinates" link in an article, which is generally formatted as a GeoHack URL, we can now route it as an `Intent` with a proper Location, and open our PlacesActivity centered on that location.

![image](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/7eba223f-5dab-45be-81fb-23fb5dc8e9ff)

https://phabricator.wikimedia.org/T136579