### PR TITLE
Integrate with Phabricator message bot.

### DIFF
--- a/.github/workflows/android_phab.yml
+++ b/.github/workflows/android_phab.yml
@@ -1,0 +1,24 @@
+name: Post to Phabricator
+
+on:
+  pull_request:
+    types: [opened, closed]
+
+jobs:
+  post_to_phab:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Post to Phabricator when pull request is opened or closed
+      if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'closed') }}
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        message="${{ github.actor }} ${{ github.event.action }} ${{ github.event.pull_request._links.html.href }}"
+        echo -e "${PR_BODY}" | grep -oEi "^Bug:\s*T[0-9]*" | grep -oEi "T[0-9]*" | while IFS= read -r line; do
+          echo "Processing: $line"
+          curl https://phabricator.wikimedia.org/api/maniphest.edit \
+              -d api.token=${{ secrets.PHAB_BOT_API_KEY }} \
+              -d transactions[0][type]=comment \
+              -d transactions[0][value]="${message}" \
+              -d objectIdentifier=${line}
+        done


### PR DESCRIPTION
This integrates with our Phab bot which should automatically post messages on the corresponding task.
From now on, we can use the old-style GerritBot convention of mentioning the task at the bottom of the pull request description (by saying `Bug: T...` on its own line), and it will be posted automatically to the corresponding task.

(supports multiple tasks!)
(case insensitive!)
(optional whitespace between "Bug" and T number!)

Bug: T360680