### PR TITLE
Make regex for Phab bot more powerful.

### DIFF
--- a/.github/workflows/android_phab.yml
+++ b/.github/workflows/android_phab.yml
@@ -17,8 +17,8 @@ jobs:
         echo -e "${PR_BODY}" | grep -oEi "(^Bug:\s*T[0-9]+)|(^([*]*phabricator[*]*:[*]*\s*)?https:\/\/phabricator\.wikimedia\.org\/T[0-9]+)" | grep -oEi "T[0-9]+" | while IFS= read -r line; do
           echo "Processing: $line"
           curl https://phabricator.wikimedia.org/api/maniphest.edit \
-          -d api.token=${{ secrets.PHAB_BOT_API_KEY }} \
-          -d transactions[0][type]=comment \
-          -d transactions[0][value]="${message}" \
-          -d objectIdentifier=${line}
+              -d api.token=${{ secrets.PHAB_BOT_API_KEY }} \
+              -d transactions[0][type]=comment \
+              -d transactions[0][value]="${message}" \
+              -d objectIdentifier=${line}
         done


### PR DESCRIPTION
This makes the regex that integrates with the Phab bot even more powerful, now supporting different types of task callouts:

* Supports the old-style Gerrit callout: `Bug: T...`
* Supports simply pasting a Phab link on its own line: `https://phabricator.wikimedia.org/T12345`
* Supports the new-style convention: `Phabricator: https://phabricator.wikimedia.org/T12345`
* Supports the convention in the iOS repository: `**Phabricator**: https://phabricator.wikimedia.org/T12345`
