### PR TITLE
One more follow-up to template flow.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -49,7 +49,6 @@ import org.wikipedia.edit.insertmedia.InsertMediaViewModel
 import org.wikipedia.edit.preview.EditPreviewFragment
 import org.wikipedia.edit.richtext.SyntaxHighlighter
 import org.wikipedia.edit.summaries.EditSummaryFragment
-import org.wikipedia.edit.templates.TemplatesSearchActivity
 import org.wikipedia.extensions.parcelableExtra
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.login.LoginActivity
@@ -155,15 +154,6 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
         }
     }
 
-    private val requestInsertTemplate = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        if (it.resultCode == TemplatesSearchActivity.RESULT_INSERT_TEMPLATE_SUCCESS) {
-            it.data?.let { data ->
-                val newWikiText = data.getStringExtra(TemplatesSearchActivity.RESULT_WIKI_TEXT)
-                binding.editSectionText.inputConnection?.commitText(newWikiText, 1)
-            }
-        }
-    }
-
     private val editTokenThenSave: Unit
         get() {
             cancelCalls()
@@ -240,7 +230,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
 
         SyntaxHighlightViewAdapter(this, pageTitle, binding.root, binding.editSectionText,
             binding.editKeyboardOverlay, binding.editKeyboardOverlayFormatting, binding.editKeyboardOverlayHeadings,
-            Constants.InvokeSource.EDIT_ACTIVITY, requestInsertMedia, requestInsertTemplate)
+            Constants.InvokeSource.EDIT_ACTIVITY, requestInsertMedia)
 
         binding.editSectionText.setOnClickListener { finishActionMode() }
         onEditingPrefsChanged()

--- a/app/src/main/java/org/wikipedia/edit/SyntaxHighlightViewAdapter.kt
+++ b/app/src/main/java/org/wikipedia/edit/SyntaxHighlightViewAdapter.kt
@@ -28,7 +28,6 @@ class SyntaxHighlightViewAdapter(
     private val wikiTextKeyboardHeadingsView: WikiTextKeyboardHeadingsView,
     private val invokeSource: Constants.InvokeSource,
     private val requestInsertMedia: ActivityResultLauncher<Intent>,
-    private val requestInsertTemplate: ActivityResultLauncher<Intent>,
     showUserMention: Boolean = false
 ) : WikiTextKeyboardView.Callback {
 
@@ -59,6 +58,15 @@ class SyntaxHighlightViewAdapter(
         if (it.resultCode == SearchActivity.RESULT_LINK_SUCCESS) {
             it.data?.parcelableExtra<PageTitle>(SearchActivity.EXTRA_RETURN_LINK_TITLE)?.let { title ->
                 wikiTextKeyboardView.insertLink(title, pageTitle.wikiSite.languageCode)
+            }
+        }
+    }
+
+    private val requestInsertTemplate = activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        if (it.resultCode == TemplatesSearchActivity.RESULT_INSERT_TEMPLATE_SUCCESS) {
+            it.data?.let { data ->
+                val newWikiText = data.getStringExtra(TemplatesSearchActivity.RESULT_WIKI_TEXT)
+                editText.inputConnection?.commitText(newWikiText, 1)
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -28,7 +28,6 @@ import org.wikipedia.edit.SyntaxHighlightViewAdapter
 import org.wikipedia.edit.insertmedia.InsertMediaActivity
 import org.wikipedia.edit.insertmedia.InsertMediaViewModel
 import org.wikipedia.edit.preview.EditPreviewFragment
-import org.wikipedia.edit.templates.TemplatesSearchActivity
 import org.wikipedia.extensions.parcelableExtra
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.login.LoginActivity
@@ -108,15 +107,6 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
         }
     }
 
-    private val requestInsertTemplate = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        if (it.resultCode == TemplatesSearchActivity.RESULT_INSERT_TEMPLATE_SUCCESS) {
-            it.data?.let { data ->
-                val newWikiText = data.getStringExtra(TemplatesSearchActivity.RESULT_WIKI_TEXT)
-                binding.replyInputView.editText.inputConnection?.commitText(newWikiText, 1)
-            }
-        }
-    }
-
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityTalkReplyBinding.inflate(layoutInflater)
@@ -190,7 +180,7 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
 
         SyntaxHighlightViewAdapter(this, viewModel.pageTitle, binding.root, binding.replyInputView.editText,
             binding.editKeyboardOverlay, binding.editKeyboardOverlayFormatting, binding.editKeyboardOverlayHeadings,
-            Constants.InvokeSource.TALK_REPLY_ACTIVITY, requestInsertMedia, requestInsertTemplate, true)
+            Constants.InvokeSource.TALK_REPLY_ACTIVITY, requestInsertMedia, true)
 
         messagePreviewFragment = supportFragmentManager.findFragmentById(R.id.message_preview_fragment) as EditPreviewFragment
 

--- a/app/src/main/java/org/wikipedia/talk/template/AddTemplateActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/AddTemplateActivity.kt
@@ -64,10 +64,6 @@ class AddTemplateActivity : BaseActivity(), UserMentionInputView.Listener {
         }
     }
 
-    private val requestInsertTemplate = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        // TODO: implement this
-    }
-
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityAddTemplateBinding.inflate(layoutInflater)
@@ -93,7 +89,7 @@ class AddTemplateActivity : BaseActivity(), UserMentionInputView.Listener {
 
         SyntaxHighlightViewAdapter(this, PageTitle("Main Page", wikiSite), binding.root, binding.addTemplateInputView.editText,
             binding.editKeyboardOverlay, binding.editKeyboardOverlayFormatting, binding.editKeyboardOverlayHeadings,
-            Constants.InvokeSource.ADD_TEMPLATE_ACTIVITY, requestInsertMedia, requestInsertTemplate, true)
+            Constants.InvokeSource.ADD_TEMPLATE_ACTIVITY, requestInsertMedia, true)
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {


### PR DESCRIPTION
This makes the template insertion logic completely self-contained inside `SyntaxHighlightViewAdapter`, so that we don't need to put the logic in every Activity that uses it.

https://phabricator.wikimedia.org/T355141