### PR TITLE
Use list.partition to make sure the top-matched items show on the to of TemplateData search.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/templates/TemplatesSearchViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/templates/TemplatesSearchViewModel.kt
@@ -49,12 +49,15 @@ class TemplatesSearchViewModel(bundle: Bundle) : ViewModel() {
                     val recentUsedTemplates = Prefs.recentUsedTemplates.filter { it.wikiSite == wikiSite }
                     return LoadResult.Page(recentUsedTemplates, null, null)
                 }
-                val query = Namespace.TEMPLATE.name + ":" + searchQuery + "*"
+                val query = Namespace.TEMPLATE.name + ":" + searchQuery
                 val response = ServiceFactory.get(wikiSite)
-                    .fullTextSearchTemplates(query, params.loadSize, params.key)
+                    .fullTextSearchTemplates("$query*", params.loadSize, params.key)
 
                 return response.query?.pages?.let { list ->
-                    val results = list.sortedBy { it.index }.map {
+                    val partition = list.partition { it.title.equals(query, true) }.apply {
+                        second.sortedBy { it.index }
+                    }
+                    val results = partition.toList().flatten().map {
                         val pageTitle = PageTitle(wikiSite = wikiSite, _text = it.title, description = it.description)
                         pageTitle.displayText = it.displayTitle(wikiSite.languageCode)
                         pageTitle


### PR DESCRIPTION
When searching `Template: Help me`, the top-matched item is not on the top of the list. We can use `partition` to find it out.