### PR TITLE
Fix: crash when tapping on the "Warn" button in the Patroller Tasks

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesFragment.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesFragment.kt
@@ -186,7 +186,6 @@ class TalkTemplatesFragment : Fragment() {
 
             override fun onTabReselected(tab: TabLayout.Tab) {}
         })
-        setUpTouchListeners()
 
         binding.talkTemplatesEmptyStateTextView.text = StringUtil.fromHtml(getString(R.string.talk_templates_empty_message))
 
@@ -234,6 +233,7 @@ class TalkTemplatesFragment : Fragment() {
         binding.talkTemplatesRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         binding.talkTemplatesRecyclerView.addItemDecoration(DrawableItemDecoration(requireContext(), R.attr.list_divider, drawStart = true, drawEnd = false))
         updateAndNotifyAdapter()
+        setUpTouchListeners()
     }
 
     private fun onLoading() {


### PR DESCRIPTION
The app crashes when following the steps below:
1. Go to `Edit patrol`
2. Select any edits
3. Click on "Warn"

It shows `kotlin.UninitializedPropertyAccessException: lateinit property adapter has not been initialized`.