### PR TITLE
Remove unused methods and optimize code in TalkTemplates

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesFragment.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesFragment.kt
@@ -521,7 +521,7 @@ class TalkTemplatesFragment : Fragment() {
         }
     }
 
-    private inner class RearrangeableItemTouchHelperCallback constructor(private val adapter: RecyclerAdapter) : ItemTouchHelper.Callback() {
+    private inner class RearrangeableItemTouchHelperCallback(private val adapter: RecyclerAdapter) : ItemTouchHelper.Callback() {
         override fun isLongPressDragEnabled(): Boolean {
             return false
         }

--- a/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesItemView.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesItemView.kt
@@ -17,7 +17,7 @@ import org.wikipedia.talk.db.TalkTemplate
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.ResourceUtil
 
-class TalkTemplatesItemView constructor(context: Context, attrs: AttributeSet? = null) : LinearLayout(context, attrs) {
+class TalkTemplatesItemView(context: Context, attrs: AttributeSet? = null) : LinearLayout(context, attrs) {
 
     interface Callback {
         fun onClick(position: Int)
@@ -45,15 +45,16 @@ class TalkTemplatesItemView constructor(context: Context, attrs: AttributeSet? =
     }
 
     fun setContents(talkTemplate: TalkTemplate, position: Int, isSaveMessagesTab: Boolean = false) {
-        binding.listItemTitle.isVisible = !(isSaveMessagesTab && position == 0)
+        val nonTemplateMessage = isSaveMessagesTab && position == 0
+        binding.listItemTitle.isVisible = !nonTemplateMessage
         binding.listItemTitle.text = talkTemplate.subject
         binding.listItemDescription.text = talkTemplate.message
-        binding.listItemDescription.setTypeface(Typeface.SANS_SERIF, if (position == 0 && isSaveMessagesTab) Typeface.ITALIC else Typeface.NORMAL)
-        binding.listItemDescription.isSingleLine = !(position == 0 && isSaveMessagesTab)
+        binding.listItemDescription.setTypeface(Typeface.SANS_SERIF, if (nonTemplateMessage) Typeface.ITALIC else Typeface.NORMAL)
+        binding.listItemDescription.isSingleLine = !(nonTemplateMessage)
         binding.listItem.setBackgroundResource(ResourceUtil.getThemedAttributeId(context,
-            if (position == 0 && isSaveMessagesTab) R.attr.background_color else android.R.attr.selectableItemBackground))
+            if (nonTemplateMessage) R.attr.background_color else android.R.attr.selectableItemBackground))
         binding.listItemDescription.ellipsize =
-            if (position == 0 && isSaveMessagesTab) null else TextUtils.TruncateAt.END
+            if (nonTemplateMessage) null else TextUtils.TruncateAt.END
 
         binding.listItem.setOnClickListener {
             callback?.onClick(position)

--- a/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesRepository.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesRepository.kt
@@ -3,7 +3,7 @@ package org.wikipedia.talk.template
 import org.wikipedia.talk.db.TalkTemplate
 import org.wikipedia.talk.db.TalkTemplateDao
 
-class TalkTemplatesRepository constructor(private val talkTemplateDao: TalkTemplateDao) {
+class TalkTemplatesRepository(private val talkTemplateDao: TalkTemplateDao) {
 
     suspend fun getAllTemplates() = talkTemplateDao.getAllTemplates()
 
@@ -25,8 +25,5 @@ class TalkTemplatesRepository constructor(private val talkTemplateDao: TalkTempl
 
     suspend fun deleteTemplates(talkTemplates: List<TalkTemplate>) {
         talkTemplateDao.deleteTemplates(talkTemplates.map { it.id })
-    }
-    suspend fun getTemplateById(id: Int): TalkTemplate? {
-        return talkTemplateDao.getTemplateById(id)
     }
 }

--- a/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesTextInputDialog.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesTextInputDialog.kt
@@ -8,13 +8,11 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doOnTextChanged
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wikipedia.R
-import org.wikipedia.analytics.eventplatform.PatrollerExperienceEvent
 import org.wikipedia.databinding.DialogTalkTemplatesTextInputBinding
-import org.wikipedia.talk.TalkReplyActivity
 
-class TalkTemplatesTextInputDialog constructor(private val activity: Activity,
-                                               positiveButtonText: Int = R.string.text_input_dialog_ok_button_text,
-                                               negativeButtonText: Int = R.string.text_input_dialog_cancel_button_text) : MaterialAlertDialogBuilder(activity, R.style.AlertDialogTheme_Input) {
+class TalkTemplatesTextInputDialog(private val activity: Activity,
+                                   positiveButtonText: Int = R.string.text_input_dialog_ok_button_text,
+                                   negativeButtonText: Int = R.string.text_input_dialog_cancel_button_text) : MaterialAlertDialogBuilder(activity, R.style.AlertDialogTheme_Input) {
     interface Callback {
         fun onSuccess(subjectText: String)
         fun onCancel()
@@ -67,12 +65,6 @@ class TalkTemplatesTextInputDialog constructor(private val activity: Activity,
 
     fun setPositiveButtonEnabled(enabled: Boolean) {
         dialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = enabled
-    }
-
-    private fun sendPatrollerExperienceEvent(action: String) {
-        PatrollerExperienceEvent.logAction(
-            action, if (activity is TalkReplyActivity) "pt_warning_messages" else "pt_templates"
-        )
     }
 
     fun getView(): ViewGroup {

--- a/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesViewModel.kt
@@ -1,7 +1,5 @@
 package org.wikipedia.talk.template
 
-import android.content.Context
-import android.content.res.Configuration
 import android.os.Bundle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -14,15 +12,14 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.R
-import org.wikipedia.WikipediaApp
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.extensions.parcelable
 import org.wikipedia.page.PageTitle
 import org.wikipedia.talk.TalkReplyActivity
 import org.wikipedia.talk.TalkReplyActivity.Companion.EXTRA_TEMPLATE_MANAGEMENT
 import org.wikipedia.talk.db.TalkTemplate
+import org.wikipedia.util.L10nUtil
 import java.util.Collections
-import java.util.Locale
 
 class TalkTemplatesViewModel(bundle: Bundle) : ViewModel() {
 
@@ -65,21 +62,12 @@ class TalkTemplatesViewModel(bundle: Bundle) : ViewModel() {
 
     private fun loadSavedTemplates() {
         val langCode = pageTitle.wikiSite.languageCode
-        val context = WikipediaApp.instance.applicationContext
         for (i in savedMessagesSubjectList.indices) {
-            val talkTemplate = TalkTemplate(0, 0, -1, savedMessagesTitleList[i],
-                if (i == 0) "" else getLocaleStringResource(Locale(langCode), savedMessagesSubjectList[i], context),
-                getLocaleStringResource(Locale(langCode), savedMessagesBodyList[i], context))
+            val subjectString = if (i == 0) "" else L10nUtil.getStringForArticleLanguage(langCode, savedMessagesSubjectList[i])
+            val bodyString = L10nUtil.getStringForArticleLanguage(langCode, savedMessagesBodyList[i])
+            val talkTemplate = TalkTemplate(0, 0, -1, savedMessagesTitleList[i], subjectString, bodyString)
             savedTemplatesList.add(talkTemplate)
         }
-    }
-
-    private fun getLocaleStringResource(requestedLocale: Locale, resourceId: Int, context: Context): String {
-        val result: String
-        val config = Configuration(context.resources.configuration)
-        config.setLocale(requestedLocale)
-        result = context.createConfigurationContext(config).getText(resourceId).toString()
-        return result
     }
 
     fun swapList(oldPosition: Int, newPosition: Int) {


### PR DESCRIPTION
Remove some unused methods, and use `L10nUtil.getStringForArticleLanguage()` instead of creating a new one.