### PR TITLE
Add padding to bottom of TalkReply input fields.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -445,11 +445,10 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
     }
 
     private fun getWikitextBody(): String {
-        var body = binding.replyInputView.editText.text.toString().trim()
-        body = body.replace(getString(R.string.username_wikitext), getString(R.string.wikiText_replace_url, viewModel.pageTitle.prefixedText, "@" + StringUtil.removeNamespace(viewModel.pageTitle.prefixedText)))
-        body = body.replace(getString(R.string.sender_username_wikitext), AccountUtil.userName.orEmpty())
-        body = body.replace(getString(R.string.diff_link_wikitext), viewModel.pageTitle.getWebApiUrl("diff=${viewModel.toRevisionId}&oldid=${viewModel.fromRevisionId}&variant=${viewModel.pageTitle.wikiSite.languageCode}"))
-        return body
+        return binding.replyInputView.editText.text.toString().trim()
+            .replace(getString(R.string.username_wikitext), getString(R.string.wikiText_replace_url, viewModel.pageTitle.prefixedText, "@" + StringUtil.removeNamespace(viewModel.pageTitle.prefixedText)))
+            .replace(getString(R.string.sender_username_wikitext), AccountUtil.userName.orEmpty())
+            .replace(getString(R.string.diff_link_wikitext), viewModel.pageTitle.getWebApiUrl("diff=${viewModel.toRevisionId}&oldid=${viewModel.fromRevisionId}&variant=${viewModel.pageTitle.wikiSite.languageCode}"))
     }
 
     private fun onSaveSuccess(newRevision: Long) {

--- a/app/src/main/res/layout/activity_talk_reply.xml
+++ b/app/src/main/res/layout/activity_talk_reply.xml
@@ -14,7 +14,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:paddingBottom="64dp">
 
             <org.wikipedia.talk.TalkThreadItemView
                 android:id="@+id/threadItemView"


### PR DESCRIPTION
When the message to which you're replying is very long, the input field becomes obscured by the wikitext button bar.

![image](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/9cd29528-91bd-4dc7-a47f-8429d3fc5609)
