### PR TITLE
Fix expected behavior upon publishing Talk message from saved messages.

### DIFF
--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.PopupMenu
@@ -38,6 +39,7 @@ import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.databinding.FragmentArticleEditDetailsBinding
 import org.wikipedia.dataclient.mwapi.MwQueryPage.Revision
 import org.wikipedia.dataclient.okhttp.HttpStatusException
+import org.wikipedia.extensions.parcelableExtra
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.Namespace
@@ -48,6 +50,7 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.staticdata.UserAliasData
 import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.suggestededits.SuggestedEditsCardsFragment
+import org.wikipedia.talk.TalkReplyActivity
 import org.wikipedia.talk.TalkTopicsActivity
 import org.wikipedia.talk.UserTalkPopupHelper
 import org.wikipedia.talk.template.TalkTemplatesActivity
@@ -83,9 +86,23 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
             binding.overlayRevisionDetailsView.isVisible = -verticalOffset > bounds.top
         }
 
-    private fun sendPatrollerExperienceEvent(action: String, activeInterface: String, actionData: String = "") {
-        if (viewModel.fromRecentEdits) {
-            PatrollerExperienceEvent.logAction(action, activeInterface, actionData)
+    private val requestTalk = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == TalkReplyActivity.RESULT_EDIT_SUCCESS || result.resultCode == TalkReplyActivity.RESULT_SAVE_TEMPLATE) {
+            val pageTitle = result.data?.parcelableExtra<PageTitle>(Constants.ARG_TITLE) ?: viewModel.pageTitle
+            val message = if (result.resultCode == TalkReplyActivity.RESULT_EDIT_SUCCESS) {
+                PatrollerExperienceEvent.logAction("publish_message_toast", "pt_warning_messages")
+                R.string.talk_warn_submitted
+            } else {
+                PatrollerExperienceEvent.logAction("publish_message_saved_toast", "pt_warning_messages")
+                R.string.talk_warn_submitted_and_saved
+            }
+            FeedbackUtil.makeSnackbar(requireActivity(), getString(message))
+                .setAction(R.string.patroller_tasks_patrol_edit_snackbar_view) {
+                    if (isAdded) {
+                        PatrollerExperienceEvent.logAction("publish_message_view_click", "pt_warning_messages")
+                        startActivity(TalkTopicsActivity.newIntent(requireContext(), pageTitle, InvokeSource.DIFF_ACTIVITY))
+                    }
+                }.show()
         }
     }
 
@@ -337,7 +354,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
             sendPatrollerExperienceEvent("warn_init", "pt_toolbar")
             viewModel.revisionTo?.let { revision ->
                 val pageTitle = PageTitle(UserTalkAliasData.valueFor(viewModel.pageTitle.wikiSite.languageCode), revision.user, viewModel.pageTitle.wikiSite)
-                requireActivity().startActivity(TalkTemplatesActivity.newIntent(requireContext(), pageTitle, fromRevisionId = viewModel.revisionFromId, toRevisionId = viewModel.revisionToId))
+                requestTalk.launch(TalkTemplatesActivity.newIntent(requireContext(), pageTitle, fromRevisionId = viewModel.revisionFromId, toRevisionId = viewModel.revisionToId))
             }
         }
 
@@ -687,6 +704,12 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
     private fun copyLink(uri: String?) {
         ClipboardUtil.setPlainText(requireContext(), text = uri)
         FeedbackUtil.showMessage(this, R.string.address_copied)
+    }
+
+    private fun sendPatrollerExperienceEvent(action: String, activeInterface: String, actionData: String = "") {
+        if (viewModel.fromRecentEdits) {
+            PatrollerExperienceEvent.logAction(action, activeInterface, actionData)
+        }
     }
 
     private fun callback(): Callback? {

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -513,7 +513,7 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
                     sendPatrollerExperienceEvent("publish_exit_cancel", "pt_warning_messages")
                 }
                 .show()
-        } else if (viewModel.isFromDiff && messagePreviewFragment.isActive) {
+        } else if (messagePreviewFragment.isActive) {
             showProgressBar(true)
             binding.talkScrollContainer.isVisible = true
             messagePreviewFragment.hide()

--- a/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesFragment.kt
+++ b/app/src/main/java/org/wikipedia/talk/template/TalkTemplatesFragment.kt
@@ -2,6 +2,7 @@ package org.wikipedia.talk.template
 
 import android.annotation.SuppressLint
 import android.app.Activity.RESULT_OK
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -81,32 +82,15 @@ class TalkTemplatesFragment : Fragment() {
 
     private val requestNewTemplate = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         binding.talkTemplatesTabLayout.getTabAt(0)?.select()
-
         if (result.resultCode == RESULT_OK || result.resultCode == RESULT_BACK_FROM_TOPIC) {
             viewModel.loadTalkTemplates()
             PatrollerExperienceEvent.logAction("save_message_toast", "pt_templates")
             if (result.resultCode != RESULT_BACK_FROM_TOPIC) {
                 FeedbackUtil.showMessage(this, R.string.talk_templates_new_message_saved)
             }
-        }
-        if (result.resultCode == TalkReplyActivity.RESULT_EDIT_SUCCESS || result.resultCode == TalkReplyActivity.RESULT_SAVE_TEMPLATE) {
-            val pageTitle = viewModel.pageTitle
-            val message = if (result.resultCode == TalkReplyActivity.RESULT_EDIT_SUCCESS) {
-                PatrollerExperienceEvent.logAction("publish_message_toast", "pt_warning_messages")
-                R.string.talk_warn_submitted
-            } else {
-                PatrollerExperienceEvent.logAction("publish_message_saved_toast", "pt_warning_messages")
-                R.string.talk_warn_submitted_and_saved
-            }
-            updateAndNotifyAdapter()
-            val snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(message))
-            snackbar.setAction(R.string.patroller_tasks_patrol_edit_snackbar_view) {
-                if (isAdded) {
-                    PatrollerExperienceEvent.logAction("publish_message_view_click", "pt_warning_messages")
-                    startActivity(TalkTopicsActivity.newIntent(requireContext(), pageTitle, Constants.InvokeSource.DIFF_ACTIVITY))
-                }
-            }
-            snackbar.show()
+        } else if (result.resultCode == TalkReplyActivity.RESULT_EDIT_SUCCESS || result.resultCode == TalkReplyActivity.RESULT_SAVE_TEMPLATE) {
+            requireActivity().setResult(result.resultCode, Intent().putExtra(Constants.ARG_TITLE, viewModel.pageTitle))
+            requireActivity().finish()
         }
     }
 
@@ -118,25 +102,9 @@ class TalkTemplatesFragment : Fragment() {
             if (result.resultCode != RESULT_BACK_FROM_TOPIC) {
                 FeedbackUtil.showMessage(this, R.string.talk_templates_edit_message_updated)
             }
-        }
-        if (result.resultCode == TalkReplyActivity.RESULT_EDIT_SUCCESS || result.resultCode == TalkReplyActivity.RESULT_SAVE_TEMPLATE) {
-            val pageTitle = viewModel.pageTitle
-            val message = if (result.resultCode == TalkReplyActivity.RESULT_EDIT_SUCCESS) {
-                PatrollerExperienceEvent.logAction("publish_message_toast", "pt_warning_messages")
-                R.string.talk_warn_submitted
-            } else {
-                PatrollerExperienceEvent.logAction("publish_message_saved_toast", "pt_warning_messages")
-                R.string.talk_warn_submitted_and_saved
-            }
-            updateAndNotifyAdapter()
-            val snackbar = FeedbackUtil.makeSnackbar(requireActivity(), getString(message))
-            snackbar.setAction(R.string.patroller_tasks_patrol_edit_snackbar_view) {
-                if (isAdded) {
-                    PatrollerExperienceEvent.logAction("publish_message_view_click", "pt_warning_messages")
-                    startActivity(TalkTopicsActivity.newIntent(requireContext(), pageTitle, Constants.InvokeSource.DIFF_ACTIVITY))
-                }
-            }
-            snackbar.show()
+        } else if (result.resultCode == TalkReplyActivity.RESULT_EDIT_SUCCESS || result.resultCode == TalkReplyActivity.RESULT_SAVE_TEMPLATE) {
+            requireActivity().setResult(result.resultCode, Intent().putExtra(Constants.ARG_TITLE, viewModel.pageTitle))
+            requireActivity().finish()
         }
     }
 


### PR DESCRIPTION
* When publishing a Talk message successfully based on a saved message, the user shouldn't land back on the Saved Messages activity, but rather back on the _previous_ activity from which Saved Messages was invoked.
* When previewing a Talk message and pressing Back, it should always go back to editing the message. (it was doing this only in the case of arriving from the Diff screen)

This addresses all of the following:
https://phabricator.wikimedia.org/T358898#9671612
https://phabricator.wikimedia.org/T355141#9671572
https://phabricator.wikimedia.org/T356774#9671554
