### PR TITLE
Rename the APK file name for Samsung app store

### DIFF
--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -147,6 +147,7 @@ def copy_apk(flavor, version_name):
     output_file = '%s/wikipedia-%s.apk' % (folder_path, version_name)
     sh.cp(get_output_apk_file_name(flavor), output_file)
     print(' apk: %s' % output_file)
+    return output_file
 
 def copy_bundle(flavor, version_name):
     folder_path = 'releases'
@@ -230,13 +231,19 @@ def main():
         make_release(flavors, custom_channel)
         version_name = get_version_name_from_apk(get_output_apk_file_name(flavors[0]))
         print('Copying APK...')
-        copy_apk(flavors[0], version_name)
+        output_file = copy_apk(flavors[0], version_name)
 
         if args.bundle:
             print('Building bundle: ' + str(flavors))
             make_bundle(flavors, custom_channel)
             print('Copying bundle...')
             copy_bundle(flavors[0], version_name)
+
+        """
+        Remove the '.' to match the Samsung app store APK naming style.
+        """
+        if custom_channel == 'samsung':
+            os.rename(output_file, output_file.replace('.apk', '').replace('.', '-') + '.apk')
 
         print('Please test the APK. After that, run w/ --push flag, and release the tested APK.')
         print('A useful command for collecting the release notes:')


### PR DESCRIPTION
We usually manually rename/remove the `.` from the Samsung APK before uploading it to the app store. This PR helps us to skip that process.