### PR TITLE
Remove redundant attribute from custom CardView.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/WikiCardView.kt
+++ b/app/src/main/java/org/wikipedia/views/WikiCardView.kt
@@ -15,24 +15,21 @@ open class WikiCardView(context: Context, attrs: AttributeSet? = null) : Materia
 
     init {
         if (!isInEditMode) {
-            val (hasBorder, cardRadius, elevation) = context
+            val (hasBorder, elevation) = context
                 .obtainStyledAttributes(attrs, R.styleable.WikiCardView)
                 .use {
-                    Triple(
+                    Pair(
                         it.getBoolean(R.styleable.WikiCardView_hasBorder, true),
-                        it.getDimension(R.styleable.WikiCardView_radius,
-                            context.resources.getDimension(R.dimen.wiki_card_radius)),
                         it.getDimension(R.styleable.WikiCardView_elevation,
                             DimenUtil.dpToPx(if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) 8f else 2f))
                     )
                 }
 
-            setup(cardRadius, elevation, hasBorder)
+            setup(elevation, hasBorder)
         }
     }
 
-    private fun setup(cardRadius: Float, elevation: Float, hasBorder: Boolean) {
-        radius = cardRadius
+    private fun setup(elevation: Float, hasBorder: Boolean) {
         if (hasBorder) {
             setDefaultBorder()
         }

--- a/app/src/main/res/layout/activity_insert_media.xml
+++ b/app/src/main/res/layout/activity_insert_media.xml
@@ -99,7 +99,7 @@
             android:focusable="true"
             android:transitionName="@string/transition_search_bar"
             app:elevation="0dp"
-            app:radius="22dp">
+            app:cardCornerRadius="22dp">
 
             <ImageView
                 android:layout_width="48dp"

--- a/app/src/main/res/layout/dialog_campaign.xml
+++ b/app/src/main/res/layout/dialog_campaign.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     app:strokeColor="@color/red700"
     app:strokeWidth="2dp"
-    app:radius="0dp"
+    app:cardCornerRadius="0dp"
     app:hasBorder="false">
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_places.xml
+++ b/app/src/main/res/layout/fragment_places.xml
@@ -26,7 +26,7 @@
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
             app:elevation="0dp"
-            app:radius="22dp">
+            app:cardCornerRadius="22dp">
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/view_edit_history_search_bar.xml
+++ b/app/src/main/res/layout/view_edit_history_search_bar.xml
@@ -8,7 +8,7 @@
     android:focusable="true"
     android:transitionName="@string/transition_search_bar"
     app:elevation="0dp"
-    app:radius="22dp">
+    app:cardCornerRadius="22dp">
 
     <ImageView
         android:layout_width="48dp"

--- a/app/src/main/res/layout/view_notification_search_bar.xml
+++ b/app/src/main/res/layout/view_notification_search_bar.xml
@@ -8,7 +8,7 @@
     android:focusable="true"
     android:transitionName="@string/transition_search_bar"
     app:elevation="0dp"
-    app:radius="22dp">
+    app:cardCornerRadius="22dp">
 
     <ImageView
         android:layout_width="48dp"

--- a/app/src/main/res/layout/view_search_bar.xml
+++ b/app/src/main/res/layout/view_search_bar.xml
@@ -10,7 +10,7 @@
     android:focusable="true"
     android:transitionName="@string/transition_search_bar"
     app:elevation="0dp"
-    app:radius="22dp">
+    app:cardCornerRadius="22dp">
 
     <ImageView
         android:layout_width="48dp"

--- a/app/src/main/res/layout/view_suggested_edits_recent_edits_search_bar.xml
+++ b/app/src/main/res/layout/view_suggested_edits_recent_edits_search_bar.xml
@@ -10,7 +10,7 @@
     android:focusable="true"
     android:transitionName="@string/transition_search_bar"
     app:elevation="0dp"
-    app:radius="22dp">
+    app:cardCornerRadius="22dp">
 
     <ImageView
         android:layout_width="48dp"

--- a/app/src/main/res/layout/view_talk_topics_header.xml
+++ b/app/src/main/res/layout/view_talk_topics_header.xml
@@ -32,7 +32,7 @@
         android:focusable="true"
         android:transitionName="@string/transition_search_bar"
         app:elevation="0dp"
-        app:radius="22dp">
+        app:cardCornerRadius="22dp">
 
         <ImageView
             android:layout_width="48dp"

--- a/app/src/main/res/layout/view_watchlist_search_bar.xml
+++ b/app/src/main/res/layout/view_watchlist_search_bar.xml
@@ -10,7 +10,7 @@
     android:focusable="true"
     android:transitionName="@string/transition_search_bar"
     app:elevation="0dp"
-    app:radius="22dp">
+    app:cardCornerRadius="22dp">
 
     <ImageView
         android:layout_width="48dp"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -94,7 +94,6 @@
     <declare-styleable name="WikiCardView">
         <attr name="hasBorder" format="boolean" />
         <attr name="elevation" format="dimension" />
-        <attr name="radius" format="dimension" />
     </declare-styleable>
 
     <declare-styleable name="LangCodeView">


### PR DESCRIPTION
We have a `radius` attribute which is a duplicate of the standard `cardCornerRadius`.