### PR TITLE
Fix potential crash when finding text in editor.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.kt
+++ b/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.kt
@@ -72,11 +72,15 @@ class FindInEditorActionProvider(private val scrollView: View,
 
     private fun scrollToCurrentResult() {
         setMatchesResults(currentResultIndex, resultPositions.size)
-        val textPosition = resultPositions.getOrElse(currentResultIndex) { return }
-        textView.setSelection(textPosition, textPosition + searchQuery.orEmpty().length)
+        var highlightLength = searchQuery.orEmpty().length
+        val textPosition = resultPositions.getOrElse(currentResultIndex) {
+            highlightLength = 0
+            0
+        }
+        textView.setSelection(textPosition, textPosition + highlightLength)
         val r = Rect()
         textView.getFocusedRect(r)
         scrollView.scrollTo(0, r.top - DimenUtil.roundedDpToPx(32f))
-        syntaxHighlighter.setSearchQueryInfo(resultPositions, searchQuery.orEmpty().length, currentResultIndex)
+        syntaxHighlighter.setSearchQueryInfo(resultPositions, highlightLength, currentResultIndex)
     }
 }

--- a/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.kt
+++ b/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.kt
@@ -63,8 +63,8 @@ class FindInEditorActionProvider(private val scrollView: View,
         currentResultIndex = 0
         resultPositions.clear()
 
-        searchQuery?.let {
-            resultPositions += it.toRegex(StringUtil.SEARCH_REGEX_OPTIONS).findAll(textView.text)
+        searchQuery?.let { query ->
+            resultPositions += query.toRegex(StringUtil.SEARCH_REGEX_OPTIONS).findAll(textView.text)
                 .map { it.range.first }
         }
         scrollToCurrentResult()
@@ -72,7 +72,7 @@ class FindInEditorActionProvider(private val scrollView: View,
 
     private fun scrollToCurrentResult() {
         setMatchesResults(currentResultIndex, resultPositions.size)
-        val textPosition = resultPositions.getOrElse(currentResultIndex) { 0 }
+        val textPosition = resultPositions.getOrElse(currentResultIndex) { return }
         textView.setSelection(textPosition, textPosition + searchQuery.orEmpty().length)
         val r = Rect()
         textView.getFocusedRect(r)


### PR DESCRIPTION
This is a very minor and rare crash, but it can happen as follows:
* In the wikitext editor window, make sure there is very little text, e.g. 4 characters total.
* Tap the "Find in article" button, and try searching for a string with more characters, e.g. 5 characters.