### PR TITLE
Fix: use localizeDate for the watchlist day header

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -50,6 +50,8 @@ import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
 import org.wikipedia.views.DefaultRecyclerAdapter
 import org.wikipedia.views.DefaultViewHolder
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class SuggestedEditsTasksFragment : Fragment() {
     private var _binding: FragmentSuggestedEditsTasksBinding? = null
@@ -286,7 +288,8 @@ class SuggestedEditsTasksFragment : Fragment() {
             return true
         } else if (pauseEndDate != null) {
             clearContents()
-            binding.disabledStatesView.setPaused(getString(R.string.suggested_edits_paused_message, DateUtil.getShortDateString(pauseEndDate), AccountUtil.userName))
+            val localDateTime = LocalDateTime.ofInstant(pauseEndDate.toInstant(), ZoneId.systemDefault()).toLocalDate()
+            binding.disabledStatesView.setPaused(getString(R.string.suggested_edits_paused_message, DateUtil.getShortDateString(localDateTime), AccountUtil.userName))
             binding.disabledStatesView.visibility = VISIBLE
             UserContributionEvent.logPaused()
             return true

--- a/app/src/main/java/org/wikipedia/views/EditHistoryStatsView.kt
+++ b/app/src/main/java/org/wikipedia/views/EditHistoryStatsView.kt
@@ -16,7 +16,7 @@ import org.wikipedia.util.DateUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.StringUtil
-import java.util.*
+import java.time.LocalDateTime
 
 class EditHistoryStatsView constructor(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
 
@@ -35,10 +35,9 @@ class EditHistoryStatsView constructor(context: Context, attrs: AttributeSet? = 
             val timestamp = stats.revision.timeStamp
             if (timestamp.isNotBlank()) {
                 val createdYear = DateUtil.getYearOnlyDateString(DateUtil.iso8601DateParse(timestamp))
-                val calendar = Calendar.getInstance()
-                val today = DateUtil.getShortDateString(calendar.time)
-                calendar.add(Calendar.YEAR, -1)
-                val lastYear = DateUtil.getShortDateString(calendar.time)
+                val localDateTime = LocalDateTime.now()
+                val today = DateUtil.getShortDateString(localDateTime.toLocalDate())
+                val lastYear = DateUtil.getShortDateString(localDateTime.minusYears(1).toLocalDate())
                 binding.editCountsView.text = context.resources.getQuantityString(R.plurals.page_edit_history_article_edits_since_year,
                     stats.allEdits.count, stats.allEdits.count, createdYear)
                 binding.statsGraphView.setData(stats.metrics.map { it.edits.toFloat() })

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFragment.kt
@@ -49,6 +49,8 @@ import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.views.NotificationButtonView
 import org.wikipedia.views.SearchAndFilterActionProvider
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.Date
 
 class WatchlistFragment : Fragment(), WatchlistItemView.Callback, MenuProvider {
@@ -211,7 +213,8 @@ class WatchlistFragment : Fragment(), WatchlistItemView.Callback, MenuProvider {
     internal inner class WatchlistDateViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         fun bindItem(date: Date) {
             val textView = itemView.findViewById<TextView>(R.id.dateText)
-            textView.text = DateUtil.getShortDateString(date)
+            val localDateTime = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()).toLocalDate()
+            textView.text = DateUtil.getShortDateString(localDateTime)
         }
     }
 


### PR DESCRIPTION
We have two `getShortDateString()` methods: one applies the UTC timezone, and the other one applies the default locale.

This PR changes the watchlist header item to use the one with `localDate` method for consistency.

Follow-up question: the `getShortDateString()` method with `UTC` timezone is only used by the feed card short date, should we use the local date instead of the UTC timezone?

Bug: T360873