### PR TITLE
Use Coroutine on Feed related classes

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/RestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.kt
@@ -12,11 +12,23 @@ import org.wikipedia.feed.configure.FeedAvailability
 import org.wikipedia.feed.onthisday.OnThisDay
 import org.wikipedia.gallery.MediaList
 import org.wikipedia.readinglist.sync.SyncedReadingLists
-import org.wikipedia.readinglist.sync.SyncedReadingLists.*
+import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteIdResponse
+import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteIdResponseBatch
+import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingList
+import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingListEntry
+import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingListEntryBatch
 import org.wikipedia.suggestededits.provider.SuggestedEditItem
 import retrofit2.Call
 import retrofit2.Response
-import retrofit2.http.*
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface RestService {
 
@@ -105,14 +117,6 @@ interface RestService {
     @get:GET("feed/announcements")
     @get:Headers("Accept: " + ACCEPT_HEADER_PREFIX + "announcements/0.1.0\"")
     val announcements: Observable<AnnouncementList>
-
-    @Headers("Accept: " + ACCEPT_HEADER_PREFIX + "aggregated-feed/0.5.0\"")
-    @GET("feed/featured/{year}/{month}/{day}")
-    fun getAggregatedFeed(
-        @Path("year") year: String?,
-        @Path("month") month: String?,
-        @Path("day") day: String?
-    ): Observable<AggregatedFeedContent>
 
     @Headers("Accept: " + ACCEPT_HEADER_PREFIX + "aggregated-feed/0.5.0\"")
     @GET("feed/featured/{year}/{month}/{day}")

--- a/app/src/main/java/org/wikipedia/feed/FeedCoordinator.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedCoordinator.kt
@@ -1,9 +1,11 @@
 package org.wikipedia.feed
 
 import android.content.Context
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
-import io.reactivex.rxjava3.core.Completable
-import io.reactivex.rxjava3.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wikipedia.WikipediaApp
 import org.wikipedia.feed.aggregated.AggregatedFeedContentClient
 import org.wikipedia.feed.announcement.AnnouncementClient
@@ -40,12 +42,12 @@ class FeedCoordinator internal constructor(context: Context) : FeedCoordinatorBa
 
     companion object {
         fun postCardsToCallback(cb: FeedClient.Callback, cards: List<Card>) {
-            Completable.fromAction {
-                val delayMillis = 150L
-                Thread.sleep(delayMillis)
-            }.subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { cb.success(cards) }
+            CoroutineScope(Dispatchers.Default).launch {
+                delay(150L)
+                withContext(Dispatchers.Main) {
+                    cb.success(cards)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This is for the upcoming Chinese language variants fixes.

- Remove the usage of `Observable<AggregatedFeedContent>`.
- Remove RxJava usage from `AggregatedFeedContentClient` and `FeedCoordinator`.
