### PR TITLE
Update Featured article widget and show article title in the correct variant

### DIFF
--- a/app/src/main/java/org/wikipedia/widgets/WidgetFeaturedPageWorker.kt
+++ b/app/src/main/java/org/wikipedia/widgets/WidgetFeaturedPageWorker.kt
@@ -29,7 +29,12 @@ class WidgetFeaturedPageWorker(
 
             // TODO: don't use PageSummary.
             val summary = if (result.tfa != null) {
-                result.tfa
+                val hasParentLanguageCode = !WikipediaApp.instance.languageState.getDefaultLanguageCode(WikipediaApp.instance.wikiSite.languageCode).isNullOrEmpty()
+                if (hasParentLanguageCode) {
+                    ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getPageSummary(null, result.tfa.apiTitle)
+                } else {
+                    result.tfa
+                }
             } else {
                 val response = ServiceFactory.get(mainPageTitle.wikiSite).parseTextForMainPage(mainPageTitle.prefixedText)
                 ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getPageSummary(null, findFeaturedArticleTitle(response.text))

--- a/app/src/main/res/layout/widget_featured_page.xml
+++ b/app/src/main/res/layout/widget_featured_page.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/widget_container"
@@ -14,7 +14,7 @@
     <ImageView
         android:layout_width="32dp"
         android:layout_height="32dp"
-        android:layout_marginStart="16dp"
+        android:layout_marginHorizontal="16dp"
         android:layout_gravity="center_vertical"
         android:contentDescription="@null"
         android:src="@drawable/ic_wikipedia_w"
@@ -22,11 +22,11 @@
         tools:ignore="UseAppTint" />
 
     <LinearLayout
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="64dp"
-        android:layout_marginEnd="72dp"
         android:layout_gravity="center"
+        android:layout_weight="1"
+        android:layout_marginEnd="12dp"
         android:background="@drawable/widget_shape_inner"
         android:gravity="center_vertical"
         android:orientation="vertical">
@@ -63,4 +63,4 @@
         android:layout_gravity="center_vertical|end"
         android:contentDescription="@null" />
 
-</FrameLayout>
+</LinearLayout>


### PR DESCRIPTION
This PR fixes two things:
1. The text layout should match the width if the article does not contain an image.
2. The article title shows an incorrect language variant because the `PageSummary` from the feed endpoint is incorrect. 

<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/afef369f-f83b-4f4b-bc71-cfa0557a5d7c" width="480" />
<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/996ef174-823f-4f0a-b8ef-51ed0b7b0fcd" width="480" />
