### PR TITLE
Fix: The Featured Article widget cannot show the content properly

### DIFF
--- a/app/src/main/java/org/wikipedia/widgets/WidgetFeaturedPageWorker.kt
+++ b/app/src/main/java/org/wikipedia/widgets/WidgetFeaturedPageWorker.kt
@@ -43,7 +43,7 @@ class WidgetFeaturedPageWorker(
             val pageTitle = summary.getPageTitle(app.wikiSite)
             pageTitle.displayText = summary.displayTitle
 
-            WidgetProviderFeaturedPage.forceUpdateWidget(applicationContext, pageTitle, false)
+            WidgetProviderFeaturedPage.forceUpdateWidget(applicationContext, pageTitle)
 
             Result.success()
         } catch (e: Exception) {

--- a/app/src/main/java/org/wikipedia/widgets/WidgetProviderFeaturedPage.kt
+++ b/app/src/main/java/org/wikipedia/widgets/WidgetProviderFeaturedPage.kt
@@ -95,7 +95,7 @@ class WidgetProviderFeaturedPage : AppWidgetProvider() {
     companion object {
         private var lastServerUpdateMillis = 0L
 
-        fun forceUpdateWidget(context: Context, pageTitle: PageTitle? = null, sendIntent: Boolean = true) {
+        fun forceUpdateWidget(context: Context, pageTitle: PageTitle? = null) {
             val appWidgetManager = AppWidgetManager.getInstance(context.applicationContext)
             val ids = appWidgetManager.getAppWidgetIds(ComponentName(context.applicationContext, WidgetProviderFeaturedPage::class.java))
             ids.forEach { id ->
@@ -105,7 +105,7 @@ class WidgetProviderFeaturedPage : AppWidgetProvider() {
                 options.putParcelable(Constants.ARG_TITLE, bundle)
                 appWidgetManager.updateAppWidgetOptions(id, options)
             }
-            if (ids.isNotEmpty() && sendIntent) {
+            if (ids.isNotEmpty()) {
                 context.sendBroadcast(Intent(context, WidgetProviderFeaturedPage::class.java)
                     .setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
                     .putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids))


### PR DESCRIPTION
By tracking the logs, it looks like we still need to run `sendBroadcast` in order to run into the `onUpdate()` properly, otherwise the loop will end at the first `enqueue()` 

<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/dcc52a53-cb08-4f47-b4fb-a4e16fb608ea" width="450" />

Bug: T362585