### PR TITLE
Fix Gallery playback of Ogg and other audio files.

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
@@ -184,7 +184,7 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
             }
             .subscribe({ response ->
                 mediaPage = response.query?.firstPage()
-                if (FileUtil.isVideo(mediaListItem.type)) {
+                if (FileUtil.isVideo(mediaPage?.imageInfo()?.mime.orEmpty())) {
                     loadVideo()
                 } else {
                     loadImage(ImageUrlUtil.getUrlForPreferredSize(mediaInfo!!.thumbUrl,
@@ -197,7 +197,7 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
     }
 
     private fun getMediaInfoDisposable(title: String, lang: String): Observable<MwQueryResponse> {
-        return if (FileUtil.isVideo(mediaListItem.type)) {
+        return if (mediaListItem.isVideo) {
             ServiceFactory.get(if (mediaListItem.isInCommons) Constants.commonsWikiSite
             else pageTitle!!.wikiSite).getVideoInfo(title, lang)
         } else {
@@ -209,13 +209,12 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
     private val videoThumbnailClickListener: View.OnClickListener = object : View.OnClickListener {
         private var loading = false
         override fun onClick(v: View) {
-            val derivative = mediaInfo?.getBestDerivativeForSize(Constants.PREFERRED_GALLERY_IMAGE_SIZE)
-            if (loading || derivative == null) {
+            if (loading) {
                 return
             }
-            val bestDerivative = derivative.src
+            val bestUrl = mediaInfo?.getBestDerivativeForSize(Constants.PREFERRED_GALLERY_IMAGE_SIZE)?.src ?: mediaInfo?.originalUrl ?: return
             loading = true
-            L.d("Loading video from url: $bestDerivative")
+            L.d("Loading video from url: $bestUrl")
             binding.videoView.visibility = View.VISIBLE
             mediaController = MediaController(requireActivity())
             if (!DeviceUtil.isNavigationBarShowing) {
@@ -244,7 +243,7 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
                 loading = false
                 true
             }
-            binding.videoView.setVideoURI(Uri.parse(bestDerivative))
+            binding.videoView.setVideoURI(Uri.parse(bestUrl))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/gallery/MediaListItem.kt
+++ b/app/src/main/java/org/wikipedia/gallery/MediaListItem.kt
@@ -19,6 +19,8 @@ class MediaListItem constructor(val title: String = "",
 
     val isInCommons get() = srcSets.firstOrNull()?.src?.contains(Service.URL_FRAGMENT_FROM_COMMONS) == true
 
+    val isVideo get() = type == "video"
+
     fun getImageUrl(deviceScale: Float): String {
         var imageUrl = srcSets[0].src
         var lastScale = 1.0f


### PR DESCRIPTION
This fixes playback of audio files in our Gallery. At some point, it looks like we started assuming that a Gallery item must be either an image or a video, with no regard for pure audio. This untangles that assumption and restores the functionality to play audio files.

https://phabricator.wikimedia.org/T362329
