### PR TITLE
Fix showing Link Preview stub edit pencil only for Main namespace.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewContents.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewContents.kt
@@ -5,8 +5,9 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.util.L10nUtil
 
-class LinkPreviewContents constructor(pageSummary: PageSummary, wiki: WikiSite) {
+class LinkPreviewContents(pageSummary: PageSummary, wiki: WikiSite) {
     val title = pageSummary.getPageTitle(wiki)
+    val ns = pageSummary.namespace
     val isDisambiguation = pageSummary.type == PageSummary.TYPE_DISAMBIGUATION
     val extract = if (isDisambiguation)
         "<p>" + L10nUtil.getStringForArticleLanguage(title, R.string.link_preview_disambiguation_description) + "</p>" + pageSummary.extractHtml

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -398,7 +398,7 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
             )
         )
         val dir = if (L10nUtil.isLangRTL(viewModel.pageTitle.wikiSite.languageCode)) "rtl" else "ltr"
-        val editVisibility = contents.extract.isNullOrBlank() && viewModel.pageTitle.namespace() == Namespace.MAIN
+        val editVisibility = contents.extract.isNullOrBlank() && contents.ns?.id == Namespace.MAIN.code()
         binding.linkPreviewEditButton.isVisible = editVisibility
         binding.linkPreviewThumbnailGallery.isVisible = !editVisibility
         val extract = if (editVisibility) "<i>" + getString(R.string.link_preview_stub_placeholder_text) + "</i>" else contents.extract


### PR DESCRIPTION
The way we were checking the Namespace of the PageTitle is incorrect, and in fact we should probably check other places in the code where we might do similar checks.
This changes the logic to use the `namespace` directly from the PageSummary response, which is the source of truth.

https://phabricator.wikimedia.org/T362815