### PR TITLE
Update fromLegacyString method

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.kt
@@ -70,7 +70,9 @@ open class PageSummary(
     }
 
     fun getPageTitle(wiki: WikiSite): PageTitle {
-        return PageTitle(apiTitle, wiki, thumbnailUrl, description, displayTitle, extract)
+        return PageTitle(apiTitle, wiki, thumbnailUrl, description, displayTitle, extract).apply {
+            namespace = ns.name
+        }
     }
 
     override fun toString(): String {

--- a/app/src/main/java/org/wikipedia/page/Namespace.kt
+++ b/app/src/main/java/org/wikipedia/page/Namespace.kt
@@ -4,8 +4,11 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.extensions.getByCode
 import org.wikipedia.language.AppLanguageLookUpTable
 import org.wikipedia.model.EnumCode
-import org.wikipedia.staticdata.*
-import java.util.*
+import org.wikipedia.staticdata.FileAliasData
+import org.wikipedia.staticdata.SpecialAliasData
+import org.wikipedia.staticdata.TalkAliasData
+import org.wikipedia.staticdata.UserAliasData
+import org.wikipedia.staticdata.UserTalkAliasData
 
 /** An enumeration describing the different possible namespace codes. Do not attempt to use this
  * class to preserve URL path information such as Talk: or User: or localization.
@@ -190,7 +193,7 @@ enum class Namespace(private val code: Int) : EnumCode {
             return if (UserTalkAliasData.valueFor(wiki.languageCode).equals(name, true) ||
                     UserTalkAliasData.valueFor(AppLanguageLookUpTable.FALLBACK_LANGUAGE_CODE).equals(name, true)) {
                 USER_TALK
-            } else MAIN
+            } else entries.firstOrNull { it.name.equals(name, true) } ?: MAIN
         }
 
         @JvmStatic

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -485,7 +485,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         model.title?.run {
             historyEntry.referrer = uri
         }
-        if (title.namespace() !== Namespace.MAIN || !Prefs.isLinkPreviewEnabled) {
+        if (!Prefs.isLinkPreviewEnabled) {
             loadPage(title, historyEntry)
         } else {
             callback()?.onPageShowLinkPreview(historyEntry)

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewContents.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewContents.kt
@@ -7,7 +7,6 @@ import org.wikipedia.util.L10nUtil
 
 class LinkPreviewContents(pageSummary: PageSummary, wiki: WikiSite) {
     val title = pageSummary.getPageTitle(wiki)
-    val ns = pageSummary.namespace
     val isDisambiguation = pageSummary.type == PageSummary.TYPE_DISAMBIGUATION
     val extract = if (isDisambiguation)
         "<p>" + L10nUtil.getStringForArticleLanguage(title, R.string.link_preview_disambiguation_description) + "</p>" + pageSummary.extractHtml

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -398,7 +398,7 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
             )
         )
         val dir = if (L10nUtil.isLangRTL(viewModel.pageTitle.wikiSite.languageCode)) "rtl" else "ltr"
-        val editVisibility = contents.extract.isNullOrBlank() && contents.ns?.id == Namespace.MAIN.code()
+        val editVisibility = contents.extract.isNullOrBlank() && viewModel.pageTitle.namespace() == Namespace.MAIN
         binding.linkPreviewEditButton.isVisible = editVisibility
         binding.linkPreviewThumbnailGallery.isVisible = !editVisibility
         val extract = if (editVisibility) "<i>" + getString(R.string.link_preview_stub_placeholder_text) + "</i>" else contents.extract

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
@@ -16,7 +16,6 @@ import org.wikipedia.database.AppDatabase
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.extensions.parcelable
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.log.L
 import org.wikipedia.watchlist.WatchlistExpiry
@@ -51,10 +50,7 @@ class LinkPreviewViewModel(bundle: Bundle) : ViewModel() {
             val summary = response.body()!!
             // Rebuild our PageTitle, since it may have been redirected or normalized.
             val oldFragment = pageTitle.fragment
-            pageTitle = PageTitle(
-                    summary.apiTitle, pageTitle.wikiSite, summary.thumbnailUrl,
-                    summary.description, summary.displayTitle
-            )
+            pageTitle = summary.getPageTitle(pageTitle.wikiSite)
 
             // check if our URL was redirected, which might include a URL fragment that leads
             // to a specific section in the target article.


### PR DESCRIPTION
- Update the `Namespace.fromLegacyString()` and try to find the closest namespace from the entries.
- Update `PageSummary.getPageTitle()` for a proper namespace
- Use `PageSumary.getPageTitle()` for `LinkPreviewViewModel.kt`

Pending discussion:
- Performance issue when searching namespace in `entries`?
- Should we show the `LinkPreviewDialog` for pages in all namespaces?