### PR TITLE
Chore: update deps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,7 +176,7 @@ dependencies {
     String retrofitVersion = '2.11.0'
     String glideVersion = '4.16.0'
     String mockitoVersion = '5.2.0'
-    String leakCanaryVersion = '2.13'
+    String leakCanaryVersion = '2.14'
     String kotlinCoroutinesVersion = '1.8.0'
     String firebaseMessagingVersion = '23.4.1'
     String mlKitVersion = '17.0.5'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.google.devtools.ksp' version '1.9.23-1.0.19' apply false
+    id 'com.google.devtools.ksp' version '1.9.23-1.0.20' apply false
 }
 
 allprojects {


### PR DESCRIPTION
## changes

### com.google.devtools.ksp
- Replace IdKey's impl with identityHashCode
- Cache enclosed descriptors by name
- Add excludedSources to the KSP extension object
- NoClassDefFoundError for LZ4Factory when trying KSP2
- Calling KSType.replace() with original arguments results
- Static fields in base class appear in derived classes
- support sealed inheritors lookup.
- support type alias for getSymbolsWithAnnotation
- support more types for reference elements

### leakcanary
- Removed accidental usage of SettableFuture, a WorkManager internal class, which will be removed in a future release of WorkManager. After updating WorkManager to that future release, all versions of LeakCanary from 2.8 to 2.13 will crash on leak analysis. To avoid a nasty surprise in the near future, update to LeakCanary 2.14.
- Add proguard mapping support for LeakCanary release.
- Heap dump & leak lists not preserving list position when navigating.
- Automatic fix of AOSP PermissionControllerManager leak (issuetracker.google.com/issues/318415056).
- Ignore UiModeManager AOSP leak.
- Fixed rare crash on RenderHeapDumpScreen.

