### PR TITLE
Foundations for Google Pay integration.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -175,7 +175,7 @@ dependencies {
     String retrofitVersion = '2.11.0'
     String glideVersion = '4.16.0'
     String mockitoVersion = '5.2.0'
-    String leakCanaryVersion = '2.13'
+    String leakCanaryVersion = '2.14'
     String kotlinCoroutinesVersion = '1.8.0'
     String firebaseMessagingVersion = '23.4.1'
     String mlKitVersion = '17.0.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,11 +71,10 @@ android {
 
     sourceSets {
 
-        prod { java.srcDirs += 'src/extra/java' }
-        beta { java.srcDirs += 'src/extra/java' }
-        alpha { java.srcDirs += 'src/extra/java' }
-        dev { java.srcDirs += 'src/extra/java' }
-        custom { java.srcDirs += 'src/extra/java' }
+        [ prod, beta, alpha, dev, custom ].forEach {
+            it.java.srcDirs += 'src/extra/java'
+            it.res.srcDirs += 'src/extra/res'
+        }
 
         androidTest {
             assets.srcDirs += files("$projectDir/schemas".toString())
@@ -176,10 +175,11 @@ dependencies {
     String retrofitVersion = '2.11.0'
     String glideVersion = '4.16.0'
     String mockitoVersion = '5.2.0'
-    String leakCanaryVersion = '2.14'
+    String leakCanaryVersion = '2.13'
     String kotlinCoroutinesVersion = '1.8.0'
     String firebaseMessagingVersion = '23.4.1'
     String mlKitVersion = '17.0.5'
+    String googlePayVersion = '19.3.0'
     String roomVersion = "2.6.1"
     String espressoVersion = '3.5.1'
     String serialization_version = '1.6.3'
@@ -251,6 +251,13 @@ dependencies {
     alphaImplementation "com.google.firebase:firebase-messaging-ktx:$firebaseMessagingVersion"
     devImplementation "com.google.firebase:firebase-messaging-ktx:$firebaseMessagingVersion"
     customImplementation "com.google.firebase:firebase-messaging-ktx:$firebaseMessagingVersion"
+
+    // For integrating with Google Pay for donations
+    prodImplementation "com.google.android.gms:play-services-wallet:$googlePayVersion"
+    betaImplementation "com.google.android.gms:play-services-wallet:$googlePayVersion"
+    alphaImplementation "com.google.android.gms:play-services-wallet:$googlePayVersion"
+    devImplementation "com.google.android.gms:play-services-wallet:$googlePayVersion"
+    customImplementation "com.google.android.gms:play-services-wallet:$googlePayVersion"
 
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
     implementation "com.squareup.leakcanary:plumber-android:$leakCanaryVersion"

--- a/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
@@ -1,0 +1,10 @@
+package org.wikipedia.donate
+
+import android.os.Bundle
+import org.wikipedia.activity.BaseActivity
+
+class GooglePayActivity : BaseActivity() {
+    public override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+}

--- a/app/src/extra/java/org/wikipedia/donate/GooglePayComponent.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayComponent.kt
@@ -1,0 +1,12 @@
+package org.wikipedia.donate
+
+import android.app.Activity
+
+object GooglePayComponent {
+    suspend fun isGooglePayAvailable(activity: Activity): Boolean {
+        return false
+    }
+
+    fun onGooglePayButtonClicked(activity: Activity) {
+    }
+}

--- a/app/src/fdroid/AndroidManifest.xml
+++ b/app/src/fdroid/AndroidManifest.xml
@@ -7,8 +7,15 @@
             android:value="F-Droid"
             tools:replace="android:value" />
 
+        <meta-data android:name="com.google.android.gms.wallet.api.enabled"
+            tools:node="remove"/>
+
         <service
             android:name=".push.WikipediaFirebaseMessagingService"
+            tools:node="remove"/>
+
+        <activity
+            android:name=".donate.GooglePayActivity"
             tools:node="remove"/>
 
     </application>

--- a/app/src/fdroid/java/org/wikipedia/donate/GooglePayComponent.kt
+++ b/app/src/fdroid/java/org/wikipedia/donate/GooglePayComponent.kt
@@ -1,0 +1,12 @@
+package org.wikipedia.donate
+
+import android.app.Activity
+
+object GooglePayComponent {
+    suspend fun isGooglePayAvailable(activity: Activity): Boolean {
+        return false
+    }
+
+    fun onGooglePayButtonClicked(activity: Activity) {
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,9 @@
         <!-- Opt out of metrics collection for the System WebView. -->
         <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
 
+        <!-- Necessary for Google Pay API -->
+        <meta-data android:name="com.google.android.gms.wallet.api.enabled" android:value="true" />
+
         <activity
             android:name=".main.MainActivity"
             android:windowSoftInputMode="adjustResize"
@@ -360,6 +363,9 @@
         <activity
             android:name=".talk.template.TalkTemplatesActivity"
             android:theme="@style/AppTheme" />
+
+        <activity
+            android:name=".donate.GooglePayActivity"/>
 
         <provider
             android:name=".WikipediaFileProvider"

--- a/app/src/main/java/org/wikipedia/dataclient/donate/PaymentResponseContainer.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/donate/PaymentResponseContainer.kt
@@ -2,11 +2,13 @@ package org.wikipedia.dataclient.donate
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.wikipedia.dataclient.mwapi.MwException
+import org.wikipedia.dataclient.mwapi.MwServiceError
 
 @Suppress("unused")
 @Serializable
 class PaymentResponseContainer(
-    val response: PaymentResponse?
+    val response: PaymentResponse? = null
 )
 
 @Suppress("unused")
@@ -16,9 +18,14 @@ class PaymentResponse(
     @SerialName("error_message") val errorMessage: String = "",
     @SerialName("order_id") val orderId: String = "",
     @SerialName("gateway_transaction_id") val gatewayTransactionId: String = "",
-
     val paymentMethods: List<PaymentMethod> = emptyList()
-)
+) {
+    init {
+        if (status == "error") {
+            throw MwException(MwServiceError("donate_error", errorMessage))
+        }
+    }
+}
 
 @Suppress("unused")
 @Serializable

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1667,7 +1667,7 @@
   <string name="donate_gpay_dialog_pay_button">Button that leads to the Google Pay donation screen.</string>
   <string name="donate_gpay_dialog_other_button">Button that leads to the general donation workflow in a web browser.</string>
   <string name="donate_gpay_activity_title">Title for screen where the donation amount is selected.</string>
-  <string name="donate_gpay_check_transaction_fee">Label for checkbox that adds the transaction fees to the donation amount. The %s symbol is replaced with the transaction fee amount, which will include the currency symbol.</string>
+  <string name="donate_gpay_check_transaction_fee">Label for checkbox that adds the transaction fees to the donation amount. The %s symbol is replaced with the transaction fee amount, which will include the currency symbol. Please preserve the double-percent (100%%) escaping.</string>
   <string name="donate_gpay_check_recurring">Label for checkbox that makes the donation into a recurring one.</string>
   <string name="donate_gpay_check_send_email">Label for checkbox that indicates consent to receive email communications.</string>
   <string name="donate_gpay_minimum_amount">Error message shown when the specified donation amount is less than the minimum allowed. The %s symbol is replaced with the minimum amount, which will include the currency symbol.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1665,7 +1665,7 @@
   <string name="donate_gpay_dialog_pay_button">使用 Google Pay 捐款</string>
   <string name="donate_gpay_dialog_other_button">其他支付方式</string>
   <string name="donate_gpay_activity_title">選擇金額</string>
-  <string name="donate_gpay_check_transaction_fee">我願意慷慨地添加 %s 來支付手續費，這樣維基百科就可以保有我的 100% 捐款。</string>
+  <string name="donate_gpay_check_transaction_fee">我願意慷慨地添加 %s 來支付手續費，這樣維基百科就可以保有我的 100%% 捐款。</string>
   <string name="donate_gpay_check_recurring">將此作為每月定期捐款。</string>
   <string name="donate_gpay_check_send_email">是的，維基媒體基金會可以臨時對我發送電子郵件。</string>
   <string name="donate_gpay_minimum_amount">請選擇金額（最少 %s）</string>


### PR DESCRIPTION
This sets up all the dependencies and underlying framework for Google Pay integration.
Can be merged now, to make it easier to switch between branches without doing full gradle resyncs.

* Properly make sure the F-Droid build will not have GPay libraries built into it.
* Set up stub Activity and Component (currently unused), to be completed in the full PR.
* Minor updates to model API response class.
* Tweak and clarify string resource.

https://phabricator.wikimedia.org/T362698