### PR TITLE
Make Location permissions not required in manifest.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,8 +37,8 @@
     <!-- For keeping the device awake while performing background tasks, such as syncing offline articles. -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:required="false" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:required="false" />
 
     <!--
         Don't let Google Play filter out devices that just have fake touch


### PR DESCRIPTION
This adds `required="false"` to our location permissions, which we should've done initially.

This is actually preventing the app from being compatible/installable on certain devices that don't have GPS hardware, such as Kindle Fire etc. (If you look at our Amazon Appstore listing, our device support list is suddenly missing numerous devices for this reason.)