### PR TITLE
Refactoring Wiktionary to use Coroutine and ViewModel

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.kt
+++ b/app/src/main/java/org/wikipedia/Constants.kt
@@ -18,6 +18,7 @@ object Constants {
 
     const val ARG_TITLE = "title"
     const val ARG_WIKISITE = "wikiSite"
+    const val ARG_TEXT = "text"
     const val INTENT_APP_SHORTCUT_CONTINUE_READING = "appShortcutContinueReading"
     const val INTENT_APP_SHORTCUT_RANDOMIZER = "appShortcutRandomizer"
     const val INTENT_APP_SHORTCUT_SEARCH = "appShortcutSearch"

--- a/app/src/main/java/org/wikipedia/dataclient/RestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.kt
@@ -73,16 +73,9 @@ interface RestService {
         @Path("title") title: String
     ): PageSummary
 
-    // todo: this Content Service-only endpoint is under page/ but that implementation detail should
-    //       probably not be reflected here. Move to WordDefinitionClient
-    /**
-     * Gets selected Wiktionary content for a given title derived from user-selected text
-     *
-     * @param title the Wiktionary page title derived from user-selected Wikipedia article text
-     */
     @Headers("Accept: $ACCEPT_HEADER_DEFINITION")
     @GET("page/definition/{title}")
-    fun getDefinition(@Path("title") title: String): Observable<Map<String, List<RbDefinition.Usage>>>
+    suspend fun getDefinition(@Path("title") title: String): Map<String, List<RbDefinition.Usage>>
 
     @GET("page/random/summary")
     @Headers("Accept: $ACCEPT_HEADER_SUMMARY")

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/RbDefinition.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/RbDefinition.kt
@@ -3,7 +3,7 @@ package org.wikipedia.dataclient.restbase
 import kotlinx.serialization.Serializable
 
 @Serializable
-class RbDefinition(val usagesByLang: Map<String, List<Usage>>) {
+class RbDefinition {
 
     @Serializable
     class Usage(val partOfSpeech: String = "", val definitions: List<Definition>)

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
@@ -5,26 +5,25 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
-import io.reactivex.rxjava3.disposables.CompositeDisposable
-import io.reactivex.rxjava3.schedulers.Schedulers
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.launch
+import org.wikipedia.Constants
 import org.wikipedia.activity.FragmentUtil
 import org.wikipedia.databinding.DialogWiktionaryBinding
 import org.wikipedia.databinding.ItemWiktionaryDefinitionWithExamplesBinding
 import org.wikipedia.databinding.ItemWiktionaryDefinitionsListBinding
 import org.wikipedia.databinding.ItemWiktionaryExampleBinding
-import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.restbase.RbDefinition
 import org.wikipedia.dataclient.restbase.RbDefinition.Usage
-import org.wikipedia.extensions.parcelable
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.page.PageTitle
 import org.wikipedia.util.L10nUtil
+import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
-import org.wikipedia.util.log.L
-import java.util.Locale
 
 class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
 
@@ -34,79 +33,58 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
 
     private var _binding: DialogWiktionaryBinding? = null
     private val binding get() = _binding!!
-
-    private lateinit var pageTitle: PageTitle
-    private lateinit var selectedText: String
-    private var currentDefinition: RbDefinition? = null
-    private val disposables = CompositeDisposable()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        pageTitle = requireArguments().parcelable(TITLE)!!
-        selectedText = requireArguments().getString(SELECTED_TEXT)!!
-    }
-
-    override fun onDestroyView() {
-        disposables.clear()
-        _binding = null
-        super.onDestroyView()
-    }
+    private val viewModel: WiktionaryViewModel by viewModels { WiktionaryViewModel.Factory(requireArguments()) }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View {
         _binding = DialogWiktionaryBinding.inflate(inflater, container, false)
-        binding.wiktionaryDefinitionDialogTitle.text = sanitizeForDialogTitle(selectedText)
-        L10nUtil.setConditionalLayoutDirection(binding.root, pageTitle.wikiSite.languageCode)
-        loadDefinitions()
         return binding.root
     }
 
-    private fun loadDefinitions() {
-        if (selectedText.trim().isEmpty()) {
-            displayNoDefinitionsFound()
-            return
-        }
-
-        // TODO: centralize the Wiktionary domain better. Maybe a SharedPreference that defaults to
-        val finalSelectedText = StringUtil.addUnderscores(selectedText)
-        disposables.add(ServiceFactory.getRest(WikiSite(pageTitle.wikiSite.subdomain() + WIKTIONARY_DOMAIN)).getDefinition(finalSelectedText)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .onErrorReturn {
-                    L.w("Cannot find the definition. Try to use lowercase text.")
-                    ServiceFactory.getRest(WikiSite(pageTitle.wikiSite.subdomain() + WIKTIONARY_DOMAIN))
-                        .getDefinition(finalSelectedText.lowercase(Locale.getDefault())).blockingFirst()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.wiktionaryDefinitionDialogTitle.text = sanitizeForDialogTitle(viewModel.selectedText)
+        L10nUtil.setConditionalLayoutDirection(binding.root, viewModel.pageTitle.wikiSite.languageCode)
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                launch {
+                    viewModel.uiState.collect {
+                        when (it) {
+                            is Resource.Loading -> onLoading()
+                            is Resource.Success -> onSuccess(it.data)
+                            is Resource.Error -> onError()
+                        }
+                    }
                 }
-                .map { usages -> RbDefinition(usages) }
-                .subscribe({ definition ->
-                    binding.dialogWiktionaryProgress.visibility = View.GONE
-                    currentDefinition = definition
-                    layOutDefinitionsByUsage()
-                }) { throwable ->
-                    displayNoDefinitionsFound()
-                    L.e(throwable)
-                })
+            }
+        }
     }
 
-    private fun displayNoDefinitionsFound() {
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+
+    private fun onLoading() {
+        binding.wiktionaryNoDefinitionsFound.visibility = View.GONE
+        binding.dialogWiktionaryProgress.visibility = View.VISIBLE
+    }
+
+    private fun onError() {
         binding.wiktionaryNoDefinitionsFound.visibility = View.VISIBLE
         binding.dialogWiktionaryProgress.visibility = View.GONE
     }
 
-    private fun layOutDefinitionsByUsage() {
-        currentDefinition?.usagesByLang?.get("en")?.let { usageList ->
-            if (usageList.isEmpty()) {
-                displayNoDefinitionsFound()
-                return
-            }
-            usageList.forEach {
-                binding.wiktionaryDefinitionsByPartOfSpeech.addView(layOutUsage(it))
-            }
+    private fun onSuccess(usageList: List<Usage>) {
+        binding.wiktionaryNoDefinitionsFound.visibility = View.GONE
+        binding.dialogWiktionaryProgress.visibility = View.GONE
+        usageList.forEach {
+            binding.wiktionaryDefinitionsByPartOfSpeech.addView(layOutUsage(it))
         }
     }
 
     private fun layOutUsage(currentUsage: Usage): View {
-        val usageBinding = ItemWiktionaryDefinitionsListBinding.inflate(LayoutInflater.from(context), binding.root, false)
+        val usageBinding = ItemWiktionaryDefinitionsListBinding.inflate(layoutInflater, binding.root, false)
         usageBinding.wiktionaryPartOfSpeech.text = currentUsage.partOfSpeech
         for (i in currentUsage.definitions.indices) {
             usageBinding.listWiktionaryDefinitionsWithExamples.addView(layOutDefinitionWithExamples(currentUsage.definitions[i], i + 1))
@@ -115,7 +93,7 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
     }
 
     private fun layOutDefinitionWithExamples(currentDefinition: RbDefinition.Definition, count: Int): View {
-        val definitionBinding = ItemWiktionaryDefinitionWithExamplesBinding.inflate(LayoutInflater.from(context), binding.root, false)
+        val definitionBinding = ItemWiktionaryDefinitionWithExamplesBinding.inflate(layoutInflater, binding.root, false)
         val definitionWithCount = "$count. ${currentDefinition.definition}"
         definitionBinding.wiktionaryDefinition.text = StringUtil.fromHtml(definitionWithCount)
         definitionBinding.wiktionaryDefinition.movementMethod = linkMovementMethod
@@ -126,7 +104,7 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
     }
 
     private fun layoutExamples(example: String): View {
-        val exampleBinding = ItemWiktionaryExampleBinding.inflate(LayoutInflater.from(context), binding.root, false)
+        val exampleBinding = ItemWiktionaryExampleBinding.inflate(layoutInflater, binding.root, false)
         exampleBinding.itemWiktionaryExample.text = StringUtil.fromHtml(example)
         exampleBinding.itemWiktionaryExample.movementMethod = linkMovementMethod
         return exampleBinding.root
@@ -161,11 +139,9 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
     }
 
     companion object {
-        private const val WIKTIONARY_DOMAIN = ".wiktionary.org"
-        private const val TITLE = "title"
-        private const val SELECTED_TEXT = "selected_text"
         private const val PATH_WIKI = "/wiki/"
         private const val PATH_CURRENT = "./"
+        const val WIKTIONARY_DOMAIN = ".wiktionary.org"
 
         // Try to get the correct definition from glossary terms: https://en.wiktionary.org/wiki/Appendix:Glossary
         private const val GLOSSARY_OF_TERMS = ":Glossary"
@@ -174,7 +150,7 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
 
         fun newInstance(title: PageTitle, selectedText: String): WiktionaryDialog {
             return WiktionaryDialog().apply {
-                arguments = bundleOf(TITLE to title, SELECTED_TEXT to selectedText)
+                arguments = bundleOf(Constants.ARG_TITLE to title, Constants.ARG_TEXT to selectedText)
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
@@ -17,7 +17,6 @@ import org.wikipedia.databinding.ItemWiktionaryDefinitionWithExamplesBinding
 import org.wikipedia.databinding.ItemWiktionaryDefinitionsListBinding
 import org.wikipedia.databinding.ItemWiktionaryExampleBinding
 import org.wikipedia.dataclient.restbase.RbDefinition
-import org.wikipedia.dataclient.restbase.RbDefinition.Usage
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.page.PageTitle
@@ -75,7 +74,7 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
         binding.dialogWiktionaryProgress.visibility = View.GONE
     }
 
-    private fun onSuccess(usageList: List<Usage>) {
+    private fun onSuccess(usageList: List<RbDefinition.Usage>) {
         binding.wiktionaryNoDefinitionsFound.visibility = View.GONE
         binding.dialogWiktionaryProgress.visibility = View.GONE
         usageList.forEach {
@@ -83,7 +82,7 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
         }
     }
 
-    private fun layOutUsage(currentUsage: Usage): View {
+    private fun layOutUsage(currentUsage: RbDefinition.Usage): View {
         val usageBinding = ItemWiktionaryDefinitionsListBinding.inflate(layoutInflater, binding.root, false)
         usageBinding.wiktionaryPartOfSpeech.text = currentUsage.partOfSpeech
         for (i in currentUsage.definitions.indices) {

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryViewModel.kt
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryViewModel.kt
@@ -22,7 +22,6 @@ import java.util.Locale
 class WiktionaryViewModel(bundle: Bundle) : ViewModel() {
 
     private val handler = CoroutineExceptionHandler { _, throwable ->
-        L.d("response 2: Error occurred: $throwable")
         _uiState.value = Resource.Error(throwable)
     }
 
@@ -41,7 +40,6 @@ class WiktionaryViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(handler) {
             if (selectedText.isNullOrEmpty()) {
                 definitionsNotFound()
-                L.d("response 1: $selectedText")
                 return@launch
             }
             val query = StringUtil.addUnderscores(selectedText)

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryViewModel.kt
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryViewModel.kt
@@ -1,0 +1,79 @@
+package org.wikipedia.wiktionary
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.wikipedia.Constants
+import org.wikipedia.dataclient.ServiceFactory
+import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.restbase.RbDefinition
+import org.wikipedia.extensions.parcelable
+import org.wikipedia.page.PageTitle
+import org.wikipedia.util.Resource
+import org.wikipedia.util.StringUtil
+import org.wikipedia.util.log.L
+import java.util.Locale
+
+class WiktionaryViewModel(bundle: Bundle) : ViewModel() {
+
+    private val handler = CoroutineExceptionHandler { _, throwable ->
+        L.d("response 2: Error occurred: $throwable")
+        _uiState.value = Resource.Error(throwable)
+    }
+
+    val pageTitle = bundle.parcelable<PageTitle>(Constants.ARG_TITLE)!!
+    var selectedText = bundle.getString(Constants.ARG_TEXT)
+
+    private val _uiState = MutableStateFlow(Resource<List<RbDefinition.Usage>>())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        loadDefinitions()
+    }
+
+    private fun loadDefinitions() {
+        _uiState.value = Resource.Loading()
+        viewModelScope.launch(handler) {
+            if (selectedText.isNullOrEmpty()) {
+                definitionsNotFound()
+                L.d("response 1: $selectedText")
+                return@launch
+            }
+            val query = StringUtil.addUnderscores(selectedText)
+            val response = try {
+                ServiceFactory.getRest(WikiSite(pageTitle.wikiSite.subdomain() + WiktionaryDialog.WIKTIONARY_DOMAIN))
+                    .getDefinition(query)
+            } catch (e: Exception) {
+                L.w("Cannot find the definition. Try to use lowercase text.")
+                ServiceFactory.getRest(WikiSite(pageTitle.wikiSite.subdomain() + WiktionaryDialog.WIKTIONARY_DOMAIN))
+                    .getDefinition(query.lowercase(Locale.getDefault()))
+            }
+
+            response[pageTitle.wikiSite.languageCode]?.let { usageList ->
+                if (usageList.isEmpty()) {
+                    definitionsNotFound()
+                } else {
+                    _uiState.value = Resource.Success(usageList)
+                }
+            } ?: run {
+                definitionsNotFound()
+            }
+        }
+    }
+
+    private fun definitionsNotFound() {
+        _uiState.value = Resource.Error(Throwable("Definitions not found."))
+    }
+
+    class Factory(private val bundle: Bundle) : ViewModelProvider.Factory {
+        @Suppress("unchecked_cast")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return WiktionaryViewModel(bundle) as T
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_wiktionary.xml
+++ b/app/src/main/res/layout/dialog_wiktionary.xml
@@ -75,6 +75,7 @@
         android:id="@+id/dialog_wiktionary_progress"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        android:visibility="gone"/>
 
 </FrameLayout>


### PR DESCRIPTION
- Use coroutine and ViewModel.
- Update the logic of showing `ProgressBar` and `ErrorView` to match the current structure.
- Update `RbDefinition` to remove `usagesByLang`.
- Add a new `ARG_TEXT` in `Constants` to send plain text.
- Use `response[pageTitle.wikiSite.languageCode]` instead of a hard-coded "en" when mapping.