### PR TITLE
Constrain number of suggested languages on initial install.

### DIFF
--- a/app/src/main/java/org/wikipedia/language/AppLanguageState.kt
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageState.kt
@@ -36,8 +36,8 @@ class AppLanguageState(context: Context) {
     val appLanguageCode: String
         get() = appLanguageCodes.first()
 
-    val remainingAvailableLanguageCodes: List<String>
-        get() = LanguageUtil.availableLanguages.filter { !_appLanguageCodes.contains(it) && appLanguageLookUpTable.isSupportedCode(it) }
+    val remainingSuggestedLanguageCodes: List<String>
+        get() = LanguageUtil.suggestedLanguagesFromSystem.filter { !_appLanguageCodes.contains(it) && appLanguageLookUpTable.isSupportedCode(it) }
 
     val systemLanguageCode: String
         get() {
@@ -143,7 +143,7 @@ class AppLanguageState(context: Context) {
     private fun initAppLanguageCodes() {
         if (_appLanguageCodes.isEmpty()) {
             if (Prefs.isInitialOnboardingEnabled) {
-                setAppLanguageCodes(remainingAvailableLanguageCodes)
+                setAppLanguageCodes(remainingSuggestedLanguageCodes)
             } else {
                 // If user has never changed app language before
                 addAppLanguageCode(systemLanguageCode)

--- a/app/src/main/java/org/wikipedia/language/LanguageUtil.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguageUtil.kt
@@ -11,11 +11,12 @@ import java.util.Locale
 
 object LanguageUtil {
 
+    private const val MAX_SUGGESTED_LANGUAGES = 8
     private const val HONG_KONG_COUNTRY_CODE = "HK"
     private const val MACAU_COUNTRY_CODE = "MO"
     private val TRADITIONAL_CHINESE_COUNTRY_CODES = listOf(Locale.TAIWAN.country, HONG_KONG_COUNTRY_CODE, MACAU_COUNTRY_CODE)
 
-    val availableLanguages: List<String>
+    val suggestedLanguagesFromSystem: List<String>
         get() {
             val languages = mutableListOf<String>()
 
@@ -76,7 +77,7 @@ object LanguageUtil {
                     }
                 }
             }
-            return languages
+            return languages.take(MAX_SUGGESTED_LANGUAGES)
         }
 
     @JvmStatic

--- a/app/src/main/java/org/wikipedia/language/LanguagesListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/language/LanguagesListViewModel.kt
@@ -16,7 +16,7 @@ import org.wikipedia.util.log.L
 
 class LanguagesListViewModel : ViewModel() {
 
-    private val suggestedLanguageCodes = WikipediaApp.instance.languageState.remainingAvailableLanguageCodes
+    private val suggestedLanguageCodes = WikipediaApp.instance.languageState.remainingSuggestedLanguageCodes
     private val nonSuggestedLanguageCodes = WikipediaApp.instance.languageState.appMruLanguageCodes.filterNot {
             suggestedLanguageCodes.contains(it) || WikipediaApp.instance.languageState.appLanguageCodes.contains(it)
         }


### PR DESCRIPTION
When first installing the app, we automatically pre-select the languages for the user, based on the keyboard Locales that the user has installed in the system.

However, on certain devices it is possible for the list of locales to be _all possible_ locales, not just the ones installed in the system. This could lead to inefficient behavior, and could lead to problems with data analytics, where the list of languages that we pass into our schemas contains all possible languages.

This will constrain the number of initial languages that get suggested, to prevent such a situation.