### PR TITLE
Reduce false positives in Image Recs by checking for existing thumbnail.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -714,7 +714,7 @@ interface Service {
         @Query("ggtlimit") count: Int
     ): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&generator=search&gsrsearch=hasrecommendation%3Aimage&gsrnamespace=0&gsrsort=random&prop=growthimagesuggestiondata|revisions&rvprop=ids|timestamp|flags|comment|user|content&rvslots=main&rvsection=0")
+    @GET(MW_API_PREFIX + "action=query&generator=search&gsrsearch=hasrecommendation%3Aimage&gsrnamespace=0&gsrsort=random&prop=growthimagesuggestiondata|revisions|pageimages&rvprop=ids|timestamp|flags|comment|user|content&rvslots=main&rvsection=0")
     suspend fun getPagesWithImageRecommendations(
         @Query("gsrlimit") count: Int
     ): MwQueryResponse

--- a/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
@@ -332,7 +332,7 @@ object EditingSuggestionsProvider {
                             .getPagesWithImageRecommendations(10)
                         // TODO: make use of continuation parameter?
                         response.query?.pages?.forEach { page ->
-                            if (page.thumbUrl() == null && page.growthimagesuggestiondata?.get(0)?.images?.get(0) != null) {
+                            if (page.thumbUrl().isNullOrEmpty() && page.growthimagesuggestiondata?.get(0)?.images?.get(0) != null) {
                                 articlesWithImageRecommendationsCache.push(page)
                             }
                         }

--- a/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
@@ -331,9 +331,9 @@ object EditingSuggestionsProvider {
                         val response = ServiceFactory.get(WikiSite.forLanguageCode(articlesWithImageRecommendationsCacheLang))
                             .getPagesWithImageRecommendations(10)
                         // TODO: make use of continuation parameter?
-                        response.query?.pages?.forEach {
-                            if (it.growthimagesuggestiondata?.get(0)?.images != null) {
-                                articlesWithImageRecommendationsCache.push(it)
+                        response.query?.pages?.forEach { page ->
+                            if (page.thumbUrl() == null && page.growthimagesuggestiondata?.get(0)?.images?.get(0) != null) {
+                                articlesWithImageRecommendationsCache.push(page)
                             }
                         }
                     }


### PR DESCRIPTION
Once in a while the Image Recommendations API will produce a false positive (i.e. an article that already has an image), which can lead to confusion.
We can reduce the incidence of false positives by checking whether the Page response (which we already have) contains a `thumbnail` element, implying that the API believes the article already has an image.