### PR TITLE
Update ImagePipelineBitmapGetter to a regular helper

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
@@ -281,17 +281,15 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
 
     private fun shareImage() {
         mediaInfo?.let {
-            object : ImagePipelineBitmapGetter(ImageUrlUtil.getUrlForPreferredSize(it.thumbUrl,
-                    Constants.PREFERRED_GALLERY_IMAGE_SIZE)) {
-                override fun onSuccess(bitmap: Bitmap?) {
-                    if (!isAdded) {
-                        return
-                    }
-                    imageTitle?.let { title ->
-                        callback()?.onShare(this@GalleryItemFragment, bitmap, shareSubject, title)
-                    }
+            val imageUrl = ImageUrlUtil.getUrlForPreferredSize(it.thumbUrl, Constants.PREFERRED_GALLERY_IMAGE_SIZE)
+            ImagePipelineBitmapGetter(requireContext(), imageUrl) { bitmap ->
+                if (!isAdded) {
+                    return@ImagePipelineBitmapGetter
                 }
-            }[requireContext()]
+                imageTitle?.let { title ->
+                    callback()?.onShare(this@GalleryItemFragment, bitmap, shareSubject, title)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/wikipedia/gallery/ImagePipelineBitmapGetter.kt
+++ b/app/src/main/java/org/wikipedia/gallery/ImagePipelineBitmapGetter.kt
@@ -7,19 +7,19 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 
-abstract class ImagePipelineBitmapGetter(private val imageUrl: String?) {
+class ImagePipelineBitmapGetter(context: Context, imageUrl: String?, callback: Callback) {
+    fun interface Callback {
+        fun onSuccess(bitmap: Bitmap)
+    }
 
-    abstract fun onSuccess(bitmap: Bitmap?)
-
-    operator fun get(context: Context) {
+    init {
         Glide.with(context)
             .asBitmap()
             .load(imageUrl)
             .into(object : CustomTarget<Bitmap>() {
                 override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
-                    onSuccess(resource)
+                    callback.onSuccess(resource)
                 }
-
                 override fun onLoadCleared(placeholder: Drawable?) {}
             })
     }

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -375,12 +375,8 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
             if (!isAdded) {
                 return@ImagePipelineBitmapGetter
             }
-            if (bitmap != null) {
-                ShareUtil.shareImage(requireContext(), bitmap, File(thumbUrl).name,
-                    ShareUtil.getFeaturedImageShareSubject(requireContext(), card.age()), fullSizeUrl)
-            } else {
-                FeedbackUtil.showMessage(this@MainFragment, getString(R.string.gallery_share_error, card.baseImage().title))
-            }
+            ShareUtil.shareImage(requireContext(), bitmap, File(thumbUrl).name,
+                ShareUtil.getFeaturedImageShareSubject(requireContext(), card.age()), fullSizeUrl)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -6,7 +6,6 @@ import android.app.ActivityOptions
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Bitmap
 import android.os.Build
 import android.os.Bundle
 import android.speech.RecognizerIntent
@@ -372,16 +371,17 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     override fun onFeedShareImage(card: FeaturedImageCard) {
         val thumbUrl = card.baseImage().thumbnailUrl
         val fullSizeUrl = card.baseImage().original.source
-        object : ImagePipelineBitmapGetter(thumbUrl) {
-            override fun onSuccess(bitmap: Bitmap?) {
-                if (bitmap != null) {
-                    ShareUtil.shareImage(requireContext(), bitmap, File(thumbUrl).name,
-                            ShareUtil.getFeaturedImageShareSubject(requireContext(), card.age()), fullSizeUrl)
-                } else {
-                    FeedbackUtil.showMessage(this@MainFragment, getString(R.string.gallery_share_error, card.baseImage().title))
-                }
+        ImagePipelineBitmapGetter(requireContext(), thumbUrl) { bitmap ->
+            if (!isAdded) {
+                return@ImagePipelineBitmapGetter
             }
-        }[requireContext()]
+            if (bitmap != null) {
+                ShareUtil.shareImage(requireContext(), bitmap, File(thumbUrl).name,
+                    ShareUtil.getFeaturedImageShareSubject(requireContext(), card.age()), fullSizeUrl)
+            } else {
+                FeedbackUtil.showMessage(this@MainFragment, getString(R.string.gallery_share_error, card.baseImage().title))
+            }
+        }
     }
 
     override fun onFeedDownloadImage(image: FeaturedImage) {

--- a/app/src/main/java/org/wikipedia/richtext/CustomHtmlParser.kt
+++ b/app/src/main/java/org/wikipedia/richtext/CustomHtmlParser.kt
@@ -21,11 +21,9 @@ import androidx.core.text.HtmlCompat
 import androidx.core.text.getSpans
 import androidx.core.text.parseAsHtml
 import androidx.core.text.toSpanned
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.target.CustomTarget
-import com.bumptech.glide.request.transition.Transition
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.gallery.ImagePipelineBitmapGetter
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.WhiteBackgroundTransformation
@@ -148,21 +146,15 @@ class CustomHtmlParser(private val handler: TagHandler) : TagHandler, ContentHan
                             uri = Service.COMMONS_URL + uri.replace("./", "")
                         }
 
-                        Glide.with(view)
-                            .asBitmap()
-                            .load(uri)
-                            .into(object : CustomTarget<Bitmap>() {
-                                override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
-                                    if (!drawable.bitmap.isRecycled) {
-                                        drawable.bitmap.applyCanvas {
-                                            drawBitmap(resource, Rect(0, 0, resource.width, resource.height), drawable.bounds, null)
-                                        }
-                                        WhiteBackgroundTransformation.maybeDimImage(drawable.bitmap)
-                                        view.postInvalidate()
-                                    }
+                        ImagePipelineBitmapGetter(view.context, uri) { bitmap ->
+                            if (!drawable.bitmap.isRecycled) {
+                                drawable.bitmap.applyCanvas {
+                                    drawBitmap(bitmap, Rect(0, 0, bitmap.width, bitmap.height), drawable.bounds, null)
                                 }
-                                override fun onLoadCleared(placeholder: Drawable?) { }
-                            })
+                                WhiteBackgroundTransformation.maybeDimImage(drawable.bitmap)
+                                view.postInvalidate()
+                            }
+                        }
                     }
                 }
             } else if (tag == "a") {


### PR DESCRIPTION
The `ImagePipelineBitmapGetter` is an abstract class, but is used as a regular helper object instead of an abstract object.

This PR removes the `abstract` type from the class and adds a `Callback` to the parameter to use `lambda` when using it.