### PR TITLE
Fix: able to search tabs/history when the length of the search term >= 2

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
@@ -72,7 +72,7 @@ class SearchResultsViewModel : ViewModel() {
                 var response: MwQueryResponse? = null
                 val resultList = mutableListOf<SearchResult>()
                 if (prefixSearch) {
-                    if (searchTerm.length > 2 && invokeSource != Constants.InvokeSource.PLACES) {
+                    if (searchTerm.length >= 2 && invokeSource != Constants.InvokeSource.PLACES) {
                         withContext(Dispatchers.IO) {
                             listOf(async {
                                 getSearchResultsFromTabs(searchTerm)
@@ -147,12 +147,10 @@ class SearchResultsViewModel : ViewModel() {
         }
 
         private fun getSearchResultsFromTabs(searchTerm: String): SearchResults {
-            if (searchTerm.length >= 2) {
-                WikipediaApp.instance.tabList.forEach { tab ->
-                    tab.backStackPositionTitle?.let {
-                        if (StringUtil.fromHtml(it.displayText).contains(searchTerm, true)) {
-                            return SearchResults(mutableListOf(SearchResult(it, SearchResult.SearchResultType.TAB_LIST)))
-                        }
+            WikipediaApp.instance.tabList.forEach { tab ->
+                tab.backStackPositionTitle?.let {
+                    if (StringUtil.fromHtml(it.displayText).contains(searchTerm, true)) {
+                        return SearchResults(mutableListOf(SearchResult(it, SearchResult.SearchResultType.TAB_LIST)))
                     }
                 }
             }


### PR DESCRIPTION
In the logic block of searching tabs/history, the condition is `searchTerm.length > 2`. It makes sense for English but not non-English articles (e.g. Chinese). For example, "Captial" in Chinese is "首府", and the length is `2`.

Also, in the `getSearchResultsFromTabs`, the logic is `searchTerm.length >= 2`, which is inconsistent with the one in the `prefixSearch` if block. 

Bug: T364351