### PR TITLE
Fix: the app should hide the empty card if the content is not empty

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
@@ -118,6 +118,7 @@ class FeedFragment : Fragment(), BackPressedHandler {
                 if (feedAdapter.itemCount < 2) {
                     binding.emptyContainer.visibility = View.VISIBLE
                 } else {
+                    binding.emptyContainer.visibility = View.GONE
                     if (shouldUpdatePreviousCard) {
                         feedAdapter.notifyItemChanged(feedAdapter.itemCount - 1)
                     }


### PR DESCRIPTION
Steps to reproduce it:

1. Go to `UtcDate` and `+1` for the `day`
2. Configure the feed content to show only the top read.
3. See empty card, press the device Home button
4. Go back to the feed.

Bug: T364356