### PR TITLE
Fix: add additional try and catch block for loading lead images info in offline

### DIFF
--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
@@ -97,7 +97,7 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
     private fun updateCallToAction() {
         dispose()
         pageHeaderView.callToActionText = null
-        if (!AccountUtil.isLoggedIn || leadImageUrl?.contains(Service.URL_FRAGMENT_FROM_COMMONS) != true || page == null) {
+        if (!WikipediaApp.instance.isOnline || !AccountUtil.isLoggedIn || leadImageUrl?.contains(Service.URL_FRAGMENT_FROM_COMMONS) != true || page == null) {
             return
         }
         title?.let {

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
@@ -106,7 +106,7 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
                 finalizeCallToAction()
                 return
             }
-            handlerJob = parentFragment.lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
+            handlerJob = parentFragment.viewLifecycleOwner.lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
                 L.e(throwable)
             }) {
                 lastImageTitleForCallToAction = imageTitle

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
@@ -3,11 +3,10 @@ package org.wikipedia.page.leadimages
 import android.net.Uri
 import androidx.core.app.ActivityOptionsCompat
 import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.Constants.ImageEditType
 import org.wikipedia.Constants.InvokeSource
@@ -107,42 +106,38 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
                 finalizeCallToAction()
                 return
             }
-            handlerJob = parentFragment.lifecycleScope.launch {
-                withContext(Dispatchers.Main) {
-                    try {
-                        lastImageTitleForCallToAction = imageTitle
-                        val isProtected = ServiceFactory.get(Constants.commonsWikiSite)
-                            .getProtectionInfoSuspend(imageTitle).query?.isEditProtected ?: false
-                        if (!isProtected) {
-                            val firstEntity = async {
-                                ServiceFactory.get(Constants.commonsWikiSite).getEntitiesByTitleSuspend(imageTitle, Constants.COMMONS_DB_NAME).first
-                            }
-                            val firstImageInfo = async {
-                                ServiceFactory.get(Constants.commonsWikiSite).getImageInfoSuspend(imageTitle, Constants.COMMONS_DB_NAME).query?.firstPage()
-                            }
-                            val labelMap = firstEntity.await()?.labels?.values?.associate { v -> v.language to v.value }.orEmpty()
-                            val depicts = ImageTagsProvider.getDepictsClaims(firstEntity.await()?.getStatements().orEmpty())
-                            imagePage = firstImageInfo.await()
-                            captionSourcePageTitle = PageTitle(imageTitle, WikiSite(Service.COMMONS_URL, it.wikiSite.languageCode))
-                            captionSourcePageTitle!!.description = labelMap[it.wikiSite.languageCode]
-                            if (!labelMap.containsKey(it.wikiSite.languageCode)) {
-                                imageEditType = ImageEditType.ADD_CAPTION
-                            }
-                            if (WikipediaApp.instance.languageState.appLanguageCodes.size >= Constants.MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
-                                WikipediaApp.instance.languageState.appLanguageCodes.firstOrNull { lang -> !labelMap.containsKey(lang) }?.run {
-                                    imageEditType = ImageEditType.ADD_CAPTION_TRANSLATION
-                                    captionTargetPageTitle = PageTitle(imageTitle, WikiSite(Service.COMMONS_URL, this))
-                                }
-                            }
-                            if (imageEditType != ImageEditType.ADD_CAPTION && depicts.isEmpty()) {
-                                imageEditType = ImageEditType.ADD_TAGS
-                            }
+            handlerJob = parentFragment.lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
+                L.e(throwable)
+            }) {
+                lastImageTitleForCallToAction = imageTitle
+                val isProtected = ServiceFactory.get(Constants.commonsWikiSite)
+                    .getProtectionInfoSuspend(imageTitle).query?.isEditProtected ?: false
+                if (!isProtected) {
+                    val firstEntity = async {
+                        ServiceFactory.get(Constants.commonsWikiSite).getEntitiesByTitleSuspend(imageTitle, Constants.COMMONS_DB_NAME).first
+                    }
+                    val firstImageInfo = async {
+                        ServiceFactory.get(Constants.commonsWikiSite).getImageInfoSuspend(imageTitle, Constants.COMMONS_DB_NAME).query?.firstPage()
+                    }
+                    val labelMap = firstEntity.await()?.labels?.values?.associate { v -> v.language to v.value }.orEmpty()
+                    val depicts = ImageTagsProvider.getDepictsClaims(firstEntity.await()?.getStatements().orEmpty())
+                    imagePage = firstImageInfo.await()
+                    captionSourcePageTitle = PageTitle(imageTitle, WikiSite(Service.COMMONS_URL, it.wikiSite.languageCode))
+                    captionSourcePageTitle!!.description = labelMap[it.wikiSite.languageCode]
+                    if (!labelMap.containsKey(it.wikiSite.languageCode)) {
+                        imageEditType = ImageEditType.ADD_CAPTION
+                    }
+                    if (WikipediaApp.instance.languageState.appLanguageCodes.size >= Constants.MIN_LANGUAGES_TO_UNLOCK_TRANSLATION) {
+                        WikipediaApp.instance.languageState.appLanguageCodes.firstOrNull { lang -> !labelMap.containsKey(lang) }?.run {
+                            imageEditType = ImageEditType.ADD_CAPTION_TRANSLATION
+                            captionTargetPageTitle = PageTitle(imageTitle, WikiSite(Service.COMMONS_URL, this))
                         }
-                        finalizeCallToAction()
-                    } catch (e: Exception) {
-                        L.w(e)
+                    }
+                    if (imageEditType != ImageEditType.ADD_CAPTION && depicts.isEmpty()) {
+                        imageEditType = ImageEditType.ADD_TAGS
                     }
                 }
+                finalizeCallToAction()
             }
         }
     }


### PR DESCRIPTION
In the previous RxJava one, we ignore the case when the device is offline. This PR adds logic to check if the device is online and a try-and-catch block to prevent crashes. 