### PR TITLE
Correctly assign Job in CaptchaHandler.

### DIFF
--- a/app/src/main/java/org/wikipedia/captcha/CaptchaHandler.kt
+++ b/app/src/main/java/org/wikipedia/captcha/CaptchaHandler.kt
@@ -57,7 +57,7 @@ class CaptchaHandler(private val activity: AppCompatActivity, private val wiki: 
 
     fun requestNewCaptcha() {
         binding.captchaImageProgress.visibility = View.VISIBLE
-        activity.lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
+        clientJob = activity.lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
             cancelCaptcha()
             FeedbackUtil.showError(activity, throwable)
         }) {


### PR DESCRIPTION
In #4641 we switched to using a coroutine to fetch the captcha, but the coroutine was never actually assigned to the `clientJob` variable, so it would never be cancellable.