### PR TITLE
Fix RTL awareness when inserting images into wikitext.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaViewModel.kt
@@ -182,7 +182,7 @@ class InsertMediaViewModel(bundle: Bundle) : ViewModel() {
             magicWords[imageType]?.let { type ->
                 template += "|$type"
             }
-            if (imagePos != defaultImagePositionForLang(langCode)) {
+            if (!(imageType == IMAGE_TYPE_THUMBNAIL && imagePos == defaultImagePositionForLang(langCode))) {
                 magicWords[imagePos]?.let { pos ->
                     template += "|$pos"
                 }

--- a/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaViewModel.kt
@@ -18,6 +18,7 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.extensions.parcelable
 import org.wikipedia.page.PageTitle
 import org.wikipedia.staticdata.FileAliasData
+import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 
@@ -30,7 +31,7 @@ class InsertMediaViewModel(bundle: Bundle) : ViewModel() {
     var selectedImage = bundle.parcelable<PageTitle>(InsertMediaActivity.EXTRA_IMAGE_TITLE)
     var selectedImageSource = bundle.getString(InsertMediaActivity.EXTRA_IMAGE_SOURCE).orEmpty()
     var selectedImageSourceProjects = bundle.getString(InsertMediaActivity.EXTRA_IMAGE_SOURCE_PROJECTS).orEmpty()
-    var imagePosition: String = bundle.getString(InsertMediaActivity.RESULT_IMAGE_POS, IMAGE_POSITION_RIGHT)
+    var imagePosition: String = bundle.getString(InsertMediaActivity.RESULT_IMAGE_POS, defaultImagePositionForLang(wikiSite.languageCode))
     var imageType: String = bundle.getString(InsertMediaActivity.RESULT_IMAGE_TYPE, IMAGE_TYPE_THUMBNAIL)
     var imageSize: String = bundle.getString(InsertMediaActivity.RESULT_IMAGE_SIZE, IMAGE_SIZE_DEFAULT)
 
@@ -164,6 +165,10 @@ class InsertMediaViewModel(bundle: Bundle) : ViewModel() {
             magicWords[IMAGE_ALT_TEXT] = "alt=$1"
         }
 
+        fun defaultImagePositionForLang(langCode: String): String {
+            return if (L10nUtil.isLangRTL(langCode)) IMAGE_POSITION_LEFT else IMAGE_POSITION_RIGHT
+        }
+
         fun insertImageIntoWikiText(langCode: String, oldWikiText: String, imageTitle: String, imageCaption: String,
                                     imageAltText: String, imageSize: String, imageType: String, imagePos: String,
                                     cursorPos: Int = 0, autoInsert: Boolean = false, attemptInfobox: Boolean = false): Triple<String, Boolean, Pair<Int, Int>> {
@@ -177,8 +182,10 @@ class InsertMediaViewModel(bundle: Bundle) : ViewModel() {
             magicWords[imageType]?.let { type ->
                 template += "|$type"
             }
-            magicWords[imagePos]?.let { pos ->
-                template += "|$pos"
+            if (imagePos != defaultImagePositionForLang(langCode)) {
+                magicWords[imagePos]?.let { pos ->
+                    template += "|$pos"
+                }
             }
             if (imageAltText.isNotEmpty()) {
                 template += "|" + magicWords[IMAGE_ALT_TEXT].orEmpty().replace("$1", imageAltText)

--- a/app/src/test/java/org/wikipedia/edit/insertmedia/InsertMediaTest.kt
+++ b/app/src/test/java/org/wikipedia/edit/insertmedia/InsertMediaTest.kt
@@ -24,7 +24,7 @@ class InsertMediaTest {
                 "de Bourbon-Montpensier — SiefarWikiFr |url=http://siefar.org/dictionnaire/fr/Gabrielle_de_Bourbon-Montpensier" +
                 " |access-date=2021-07-21 |website=siefar.org}}</ref>\n"
 
-        val expected = "[[File:Test_image.jpg|thumb|right|alt=Bar|Foo]]\n'''Gabrielle de Bourbon''' or '''Gabrielle de Bourbon-Montpensier''' " +
+        val expected = "[[File:Test_image.jpg|thumb|left|alt=Bar|Foo]]\n'''Gabrielle de Bourbon''' or '''Gabrielle de Bourbon-Montpensier''' " +
                 "(c.[[1447]]–30 November [[1516]]), princess of [[Talmont-Saint-Hilaire|Talmont]], " +
                 "was a French [[author]] and daughter of the [[House of Bourbon]].\n" +
                 "\n== Biography ==\nShe was the oldest daughter of [[Louis I, Count of Montpensier]] " +
@@ -33,7 +33,7 @@ class InsertMediaTest {
                 " |access-date=2021-07-21 |website=siefar.org}}</ref>\n"
 
         MatcherAssert.assertThat(InsertMediaViewModel.insertImageIntoWikiText("en", wikitext, "Test_image.jpg", "Foo",
-            "Bar", InsertMediaViewModel.IMAGE_SIZE_DEFAULT, InsertMediaViewModel.IMAGE_TYPE_THUMBNAIL, InsertMediaViewModel.IMAGE_POSITION_RIGHT,
+            "Bar", InsertMediaViewModel.IMAGE_SIZE_DEFAULT, InsertMediaViewModel.IMAGE_TYPE_THUMBNAIL, InsertMediaViewModel.IMAGE_POSITION_LEFT,
             0, true, true).first, Matchers.`is`(expected))
     }
 
@@ -51,7 +51,7 @@ class InsertMediaTest {
 
         val expected = "{{HatnoteTemplate}}\n" +
                 "{{Short description|Example description}}\n" +
-                "[[File:Test_image.jpg|thumb|right|alt=Bar|Foo]]\n'''Gabrielle de Bourbon''' or '''Gabrielle de Bourbon-Montpensier''' " +
+                "[[File:Test_image.jpg|thumb|left|alt=Bar|Foo]]\n'''Gabrielle de Bourbon''' or '''Gabrielle de Bourbon-Montpensier''' " +
                 "(c.[[1447]]–30 November [[1516]]), princess of [[Talmont-Saint-Hilaire|Talmont]], " +
                 "was a French [[author]] and daughter of the [[House of Bourbon]].\n" +
                 "\n== Biography ==\nShe was the oldest daughter of [[Louis I, Count of Montpensier]] " +
@@ -60,7 +60,7 @@ class InsertMediaTest {
                 " |access-date=2021-07-21 |website=siefar.org}}</ref>\n"
 
         MatcherAssert.assertThat(InsertMediaViewModel.insertImageIntoWikiText("en", wikitext, "Test_image.jpg", "Foo",
-            "Bar", InsertMediaViewModel.IMAGE_SIZE_DEFAULT, InsertMediaViewModel.IMAGE_TYPE_THUMBNAIL, InsertMediaViewModel.IMAGE_POSITION_RIGHT,
+            "Bar", InsertMediaViewModel.IMAGE_SIZE_DEFAULT, InsertMediaViewModel.IMAGE_TYPE_THUMBNAIL, InsertMediaViewModel.IMAGE_POSITION_LEFT,
             0, true, true).first, Matchers.`is`(expected))
     }
 
@@ -75,7 +75,7 @@ class InsertMediaTest {
                 "de Bourbon-Montpensier — SiefarWikiFr |url=http://siefar.org/dictionnaire/fr/Gabrielle_de_Bourbon-Montpensier" +
                 " |access-date=2021-07-21 |website=siefar.org}}</ref>\n"
 
-        val expected = "[[File:Test_image.jpg|thumb|right|alt=Bar|Foo]]\n" +
+        val expected = "[[File:Test_image.jpg|thumb|alt=Bar|Foo]]\n" +
                 "{{Invalid template}\n" +
                 "'''Gabrielle de Bourbon''' or '''Gabrielle de Bourbon-Montpensier''' " +
                 "(c.[[1447]]–30 November [[1516]]), princess of [[Talmont-Saint-Hilaire|Talmont]], " +
@@ -235,7 +235,7 @@ class InsertMediaTest {
                 "| image = Test_image.jpg\n" +
                 "| authority = Dejean, 1831\n" +
                 "}}\n\n" +
-                "[[File:Test_image.jpg|thumb|right|alt=Bar|Foo]]\n" +
+                "[[File:Test_image.jpg|thumb|alt=Bar|Foo]]\n" +
                 "'''''Carabus goryi''''' is a species of [[ground beetle]] in the family [[Carabidae]]." +
                 "It is found in North America.<ref name=itis/><ref name=gbif/><ref name=buglink/><ref" +
                 "name=Bousquet2012/>\n"


### PR DESCRIPTION
When inserting images into wikitext (whether through Image Recommendations or the regular editor), we should check if the wiki is RTL, and use the corresponding `left` or `right` alignment, instead of always defaulting to `right`.

In addition, if the user doesn't change the default alignment, then we can just omit it from the insertion, since the `thumb` parameter automatically uses the wiki default for alignment.