### PR TITLE
Follow-up to Google Pay integration

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
@@ -155,8 +155,8 @@ class GooglePayActivity : BaseActivity() {
 
     private fun validateInput(text: String): Boolean {
         val amount = getAmountFloat(text)
-        val min = viewModel.donationConfig?.currencyMinimumDonation?.get(viewModel.currencyCode) ?: 0f
-        val max = viewModel.donationConfig?.currencyMaximumDonation?.get(viewModel.currencyCode) ?: 0f
+        val min = viewModel.minimumAmount
+        val max = viewModel.maximumAmount
 
         if (amount <= 0f || amount < min) {
             binding.donateAmountInput.error = getString(R.string.donate_gpay_minimum_amount, viewModel.currencyFormat.format(min))

--- a/app/src/extra/java/org/wikipedia/donate/GooglePayComponent.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayComponent.kt
@@ -16,6 +16,7 @@ internal object GooglePayComponent {
 
     const val PAYMENTS_API_URL = "https://payments.wikimedia.org/"
     const val PAYMENT_METHOD_NAME = "paywithgoogle"
+    const val CURRENCY_FALLBACK = "USD"
 
     private val CURRENCIES_THREE_DECIMAL = arrayOf("BHD", "CLF", "IQD", "KWD", "LYD", "MGA", "MRO", "OMR", "TND")
     private val CURRENCIES_NO_DECIMAL = arrayOf("CLP", "DJF", "IDR", "JPY", "KMF", "KRW", "MGA", "PYG", "VND", "XAF", "XOF", "XPF")

--- a/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
@@ -32,12 +32,26 @@ class GooglePayViewModel : ViewModel() {
 
     val currencyFormat: NumberFormat = NumberFormat.getCurrencyInstance(Locale.Builder()
         .setRegion(currentCountryCode).setLanguage(WikipediaApp.instance.appOrSystemLanguageCode).build())
-    val currencyCode get() = currencyFormat.currency?.currencyCode ?: "USD"
+    val currencyCode get() = currencyFormat.currency?.currencyCode ?: GooglePayComponent.CURRENCY_FALLBACK
     val currencySymbol get() = currencyFormat.currency?.symbol ?: "$"
     val decimalFormat = GooglePayComponent.getDecimalFormat(currencyCode)
 
     val transactionFee get() = donationConfig?.currencyTransactionFees?.get(currencyCode)
         ?: donationConfig?.currencyTransactionFees?.get("default") ?: 0f
+
+    val minimumAmount get() = donationConfig?.currencyMinimumDonation?.get(currencyCode) ?: 0f
+
+    val maximumAmount: Float get() {
+        var max = donationConfig?.currencyMaximumDonation?.get(currencyCode) ?: 0f
+        if (max == 0f) {
+            val defaultMin = donationConfig?.currencyMinimumDonation?.get(GooglePayComponent.CURRENCY_FALLBACK) ?: 0f
+            if (defaultMin > 0f) {
+                max = (donationConfig?.currencyMinimumDonation?.get(currencyCode) ?: 0f) / defaultMin *
+                        (donationConfig?.currencyMaximumDonation?.get(GooglePayComponent.CURRENCY_FALLBACK) ?: 0f)
+            }
+        }
+        return max
+    }
 
     val emailOptInRequired get() = donationConfig?.countryCodeEmailOptInRequired.orEmpty().contains(currentCountryCode)
 

--- a/app/src/main/java/org/wikipedia/donate/DonateDialog.kt
+++ b/app/src/main/java/org/wikipedia/donate/DonateDialog.kt
@@ -19,6 +19,7 @@ import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.DonorExperienceEvent
 import org.wikipedia.databinding.DialogDonateBinding
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
+import org.wikipedia.settings.Prefs
 import org.wikipedia.util.CustomTabsUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.Resource
@@ -38,6 +39,7 @@ class DonateDialog : ExtendedBottomSheetDialogFragment() {
         }
 
         binding.donateGooglePayButton.setOnClickListener {
+            invalidateCampaign()
             DonorExperienceEvent.logAction("gpay_click", if (arguments?.getString(ARG_CAMPAIGN_ID).isNullOrEmpty()) "setting" else "article_banner")
             (requireActivity() as? BaseActivity)?.launchDonateActivity(
                 GooglePayComponent.getDonateActivityIntent(requireActivity(), arguments?.getString(ARG_CAMPAIGN_ID), arguments?.getString(ARG_DONATE_URL)))
@@ -81,7 +83,14 @@ class DonateDialog : ExtendedBottomSheetDialogFragment() {
 
     private fun onDonateClicked() {
         launchDonateLink(requireContext(), arguments?.getString(ARG_DONATE_URL))
+        invalidateCampaign()
         dismiss()
+    }
+
+    private fun invalidateCampaign() {
+        arguments?.getString(ARG_CAMPAIGN_ID)?.let {
+            Prefs.announcementShownDialogs = setOf(it)
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/page/campaign/CampaignDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/campaign/CampaignDialog.kt
@@ -48,10 +48,11 @@ class CampaignDialog internal constructor(private val context: Context, val camp
         val customTabUrl = Prefs.announcementCustomTabTestUrl.orEmpty().ifEmpty { url }
         if (context is BaseActivity) {
             context.launchDonateDialog(campaign.id, customTabUrl)
+            dismissDialog(false)
         } else {
             CustomTabsUtil.openInCustomTab(context, customTabUrl)
+            dismissDialog()
         }
-        dismissDialog()
     }
 
     override fun onNegativeAction() {


### PR DESCRIPTION
A couple of minor enhancements:
* Per feedback in the previous PR:
> Do we need to update the preference logic to make sure the user clicks one of the options in the GPay bottomsheet instead of saving the preference when tapping on the the dialog "Donate now"?

This is now fixed: the campaign will be considered "shown" only when the user clicks one of the buttons in the DonateDialog, instead of the primary button in CampaignDialog.
* The "maximum" donation amount is received from the API, but is only defined for USD. To apply the maximum amount for other currencies, we need to calculate the maximum based on the _proportion_ of the minimum USD to the minimum of the target currency.