### PR TITLE
Improve integration with Metrics Platform library lifecycle.

### DIFF
--- a/app/src/main/java/org/wikipedia/ActivityLifecycleHandler.kt
+++ b/app/src/main/java/org/wikipedia/ActivityLifecycleHandler.kt
@@ -6,8 +6,6 @@ import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
-import org.wikipedia.analytics.eventplatform.EventPlatformClient
-import org.wikipedia.analytics.metricsplatform.MetricsPlatform
 import org.wikipedia.main.MainActivity
 import org.wikipedia.settings.Prefs
 import org.wikipedia.theme.Theme
@@ -47,13 +45,10 @@ class ActivityLifecycleHandler : ActivityLifecycleCallbacks, ComponentCallbacks2
 
     override fun onActivityResumed(activity: Activity) {
         isAnyActivityResumed = true
-        MetricsPlatform.client.onAppResume()
     }
 
     override fun onActivityPaused(activity: Activity) {
         isAnyActivityResumed = false
-        MetricsPlatform.client.onAppPause()
-        EventPlatformClient.flushCachedEvents()
     }
 
     override fun onActivityStopped(activity: Activity) {}
@@ -63,10 +58,6 @@ class ActivityLifecycleHandler : ActivityLifecycleCallbacks, ComponentCallbacks2
     override fun onActivityDestroyed(activity: Activity) {
         if (activity is MainActivity) {
             haveMainActivity = false
-        }
-        if (activity.isTaskRoot) {
-            MetricsPlatform.client.onAppClose()
-            EventPlatformClient.flushCachedEvents()
         }
     }
 

--- a/app/src/main/java/org/wikipedia/ActivityLifecycleHandler.kt
+++ b/app/src/main/java/org/wikipedia/ActivityLifecycleHandler.kt
@@ -7,6 +7,7 @@ import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import org.wikipedia.analytics.eventplatform.EventPlatformClient
+import org.wikipedia.analytics.metricsplatform.MetricsPlatform
 import org.wikipedia.main.MainActivity
 import org.wikipedia.settings.Prefs
 import org.wikipedia.theme.Theme
@@ -46,10 +47,13 @@ class ActivityLifecycleHandler : ActivityLifecycleCallbacks, ComponentCallbacks2
 
     override fun onActivityResumed(activity: Activity) {
         isAnyActivityResumed = true
+        MetricsPlatform.client.onAppResume()
     }
 
     override fun onActivityPaused(activity: Activity) {
         isAnyActivityResumed = false
+        MetricsPlatform.client.onAppPause()
+        EventPlatformClient.flushCachedEvents()
     }
 
     override fun onActivityStopped(activity: Activity) {}
@@ -60,15 +64,15 @@ class ActivityLifecycleHandler : ActivityLifecycleCallbacks, ComponentCallbacks2
         if (activity is MainActivity) {
             haveMainActivity = false
         }
+        if (activity.isTaskRoot) {
+            MetricsPlatform.client.onAppClose()
+            EventPlatformClient.flushCachedEvents()
+        }
     }
 
     override fun onConfigurationChanged(configuration: Configuration) {}
 
     override fun onLowMemory() {}
 
-    override fun onTrimMemory(trimMemoryType: Int) {
-        if (trimMemoryType == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
-            EventPlatformClient.flushCachedEvents()
-        }
-    }
+    override fun onTrimMemory(trimMemoryType: Int) {}
 }

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -21,7 +21,9 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.BreadcrumbsContextHelper
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.analytics.eventplatform.EventPlatformClient
 import org.wikipedia.analytics.eventplatform.NotificationInteractionEvent
+import org.wikipedia.analytics.metricsplatform.MetricsPlatform
 import org.wikipedia.appshortcuts.AppShortcuts
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.connectivity.ConnectionStateMonitor
@@ -119,14 +121,17 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
         super.onDestroy()
     }
 
-    override fun onStop() {
+    override fun onPause() {
+        super.onPause()
         WikipediaApp.instance.appSessionEvent.persistSession()
-        super.onStop()
+        MetricsPlatform.client.onAppPause()
+        EventPlatformClient.flushCachedEvents()
     }
 
     override fun onResume() {
         super.onResume()
         WikipediaApp.instance.appSessionEvent.touchSession()
+        MetricsPlatform.client.onAppResume()
         BreadCrumbLogEvent.logScreenShown(this)
 
         // allow this activity's exclusive bus methods to override any existing ones.


### PR DESCRIPTION
There is one thing I noticed that might account for discrepancies seen between MP and MEP versions of certain events:
When the app is closed (which we were determining via an `onTrimMemory()` callback) we explicitly flush any unsent events in the MEP queue, but we were not doing the same for the MP queue.

Let's update the logic so that:
* We no longer rely on the `onTrimMemory` event, which does not behave consistently across devices and OS versions.
* We instead rely on our BaseActivity class to explicitly flush events in both MP and MEP at the same time.

https://phabricator.wikimedia.org/T363610
