### PR TITLE
Always send final amount in canonical decimal format.

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayComponent.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayComponent.kt
@@ -11,6 +11,8 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.wikipedia.settings.Prefs
 import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.Locale
 
 internal object GooglePayComponent {
 
@@ -44,8 +46,9 @@ internal object GooglePayComponent {
         put("allowedPaymentMethods", JSONArray().put(baseCardPaymentMethod))
     }
 
-    fun getDecimalFormat(currencyCode: String): DecimalFormat {
-        return DecimalFormat(if (CURRENCIES_THREE_DECIMAL.contains(currencyCode)) "0.000" else if (CURRENCIES_NO_DECIMAL.contains(currencyCode)) "0" else "0.00")
+    fun getDecimalFormat(currencyCode: String, canonical: Boolean = false): DecimalFormat {
+        val formatSpec = if (CURRENCIES_THREE_DECIMAL.contains(currencyCode)) "0.000" else if (CURRENCIES_NO_DECIMAL.contains(currencyCode)) "0" else "0.00"
+        return if (canonical) DecimalFormat(formatSpec, DecimalFormatSymbols.getInstance(Locale.ROOT)) else DecimalFormat(formatSpec)
     }
 
     fun createPaymentsClient(activity: Activity): PaymentsClient {

--- a/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
@@ -133,9 +133,13 @@ class GooglePayViewModel : ViewModel() {
             val billingObj = infoObj.getJSONObject("billingAddress")
             val token = paymentMethodObj.getJSONObject("tokenizationData").getString("token")
 
+            // The backend expects the final amount in the canonical decimal format, instead of
+            // any localized format, e.g. comma as decimal separator.
+            val decimalFormatCanonical = GooglePayComponent.getDecimalFormat(currencyCode, true)
+
             val response = ServiceFactory.get(WikiSite(GooglePayComponent.PAYMENTS_API_URL))
                 .submitPayment(
-                    decimalFormat.format(finalAmount),
+                    decimalFormatCanonical.format(finalAmount),
                     BuildConfig.VERSION_NAME,
                     campaignId,
                     billingObj.optString("locality", ""),


### PR DESCRIPTION
The fundraising backend expects the final donation amount to be always formatted with the canonical decimal format, regardless of current locale. e.g. if the amount is 1.23, it must be sent as `1.23` instead of `1,23`.