### PR TITLE
Fix: make sure sending data if it is from Edit Patrol

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -393,7 +393,7 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
 
         if (messagePreviewFragment.isActive) {
             EditAttemptStepEvent.logSaveAttempt(viewModel.pageTitle)
-            PatrollerExperienceEvent.logAction("publish_message_click", "pt_warning_messages")
+            sendPatrollerExperienceEvent("publish_message_click", "pt_warning_messages")
             binding.progressBar.isVisible = true
             setSaveButtonEnabled(false)
             viewModel.postReply(subject, getWikitextBody())
@@ -465,7 +465,7 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
     private fun onSaveSuccess(newRevision: Long) {
         AnonymousNotificationHelper.onEditSubmitted()
 
-        PatrollerExperienceEvent.logAction("publish_message_success", "pt_warning_messages",
+        sendPatrollerExperienceEvent("publish_message_success", "pt_warning_messages",
             PatrollerExperienceEvent.getPublishMessageActionString(isModified = viewModel.selectedTemplate != null && subjectOrBodyModified,
                 isSaved = viewModel.talkTemplateSaved, isExample = viewModel.isExampleTemplate, exampleMessage = if (viewModel.isExampleTemplate) viewModel.selectedTemplate?.title else null))
 


### PR DESCRIPTION
We should use `sendPatrollerExperienceEvent` instead of using `PatrollerExperienceEvent.logAction` directly.