### PR TITLE
Fix: correctly extract language code from Url in WikiSite

### DIFF
--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -133,13 +133,10 @@ object UriUtil {
         return removeFragment(removeLinkPrefix(url)).replace("_", " ")
     }
 
-    /** Get language variant code from a Uri, e.g. "zh.*", otherwise returns empty string.  */
+    /** Get language variant code from a Uri path, e.g. "/wiki/Foo" or "/zh-tw/Foo".
+     * It will return "zh-tw" or an empty string */
     fun getLanguageVariantFromUri(uri: Uri): String {
-        if (uri.path.isNullOrEmpty()) {
-            return ""
-        }
-        val parts = uri.path!!.split('/')
-        return if (parts.size > 1 && parts[0] != "wiki") parts[0] else ""
+        return uri.path?.split('/')?.getOrNull(1)?.takeUnless { it == "wiki" }.orEmpty()
     }
 
     /** For internal links only  */

--- a/app/src/test/java/org/wikipedia/dataclient/WikiSiteTest.kt
+++ b/app/src/test/java/org/wikipedia/dataclient/WikiSiteTest.kt
@@ -100,7 +100,31 @@ class WikiSiteTest {
 
     @Test
     fun testCtorUriLangVariant() {
-        val subject = WikiSite("zh.wikipedia.org/zh-hant/Foo")
+        var subject = WikiSite("en.wikipedia.org/wiki/Foo")
+        MatcherAssert.assertThat(subject.authority(), Matchers.`is`("en.wikipedia.org"))
+        MatcherAssert.assertThat(subject.subdomain(), Matchers.`is`("en"))
+        MatcherAssert.assertThat(subject.languageCode, Matchers.`is`("en"))
+        MatcherAssert.assertThat(subject.scheme(), Matchers.`is`("https"))
+        MatcherAssert.assertThat(subject.dbName(), Matchers.`is`("enwiki"))
+        MatcherAssert.assertThat(subject.url(), Matchers.`is`("https://en.wikipedia.org"))
+
+        subject = WikiSite("zh.wikipedia.org/zh-tw/Foo")
+        MatcherAssert.assertThat(subject.authority(), Matchers.`is`("zh.wikipedia.org"))
+        MatcherAssert.assertThat(subject.subdomain(), Matchers.`is`("zh"))
+        MatcherAssert.assertThat(subject.languageCode, Matchers.`is`("zh-tw"))
+        MatcherAssert.assertThat(subject.scheme(), Matchers.`is`("https"))
+        MatcherAssert.assertThat(subject.dbName(), Matchers.`is`("zhwiki"))
+        MatcherAssert.assertThat(subject.url(), Matchers.`is`("https://zh.wikipedia.org"))
+
+        subject = WikiSite("zh.wikipedia.org/zh-cn/Foo")
+        MatcherAssert.assertThat(subject.authority(), Matchers.`is`("zh.wikipedia.org"))
+        MatcherAssert.assertThat(subject.subdomain(), Matchers.`is`("zh"))
+        MatcherAssert.assertThat(subject.languageCode, Matchers.`is`("zh-cn"))
+        MatcherAssert.assertThat(subject.scheme(), Matchers.`is`("https"))
+        MatcherAssert.assertThat(subject.dbName(), Matchers.`is`("zhwiki"))
+        MatcherAssert.assertThat(subject.url(), Matchers.`is`("https://zh.wikipedia.org"))
+
+        subject = WikiSite("zh.wikipedia.org/zh-hant/Foo")
         MatcherAssert.assertThat(subject.authority(), Matchers.`is`("zh.wikipedia.org"))
         MatcherAssert.assertThat(subject.subdomain(), Matchers.`is`("zh"))
         MatcherAssert.assertThat(subject.languageCode, Matchers.`is`("zh-hant"))


### PR DESCRIPTION
Somehow the `UriUtil.getLanguageVariantFromUri()` does not get the correct language code from a URL, and always returns an empty string.

From the existing code, we should get the "second" from `parts` instead of the first, and that's why it is always empty.

This PR simplifies the logic (with Kotlin functions) and updates the test cases so we can go through all possible conditions. 

https://etherpad.wikimedia.org/p/DeepLinkForTests