### PR TITLE
Image recs: insert into infobox only for English.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/insertmedia/InsertMediaViewModel.kt
@@ -220,7 +220,10 @@ class InsertMediaViewModel(bundle: Bundle) : ViewModel() {
                 }
             }
 
-            if (autoInsert && attemptInfobox && infoboxMatch != null) {
+            // Verify a few conditions before attempting to insert into an infobox, including
+            // whether the infobox actually exists, and whether the current language wiki is
+            // supported by our hardcoded infoboxVars.
+            if (autoInsert && attemptInfobox && infoboxMatch != null && infoboxVarsByLang.containsKey(langCode)) {
                 val infoboxStartIndex = infoboxMatch.range.first
                 val infoboxEndIndex = infoboxMatch.range.last
 


### PR DESCRIPTION
For the logic that attempts to insert the image into an infobox, we are supposed to be restricting it only to English, because we only have hardcoded infobox names and parameters in English.
But it looks like we're incorrectly _falling back_ to English, and detecting infoboxes implicitly, which can lead to undesirable cases: for example French Wikipedia also uses a template called `Infobox`, but the parameter names are different (e.g. `légende` instead of `caption`), so let's add add an explicit check.

https://phabricator.wikimedia.org/T365252