### PR TITLE
GPay: Fix setting language for currency NumberFormat.

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
@@ -27,11 +27,11 @@ import kotlin.math.abs
 
 class GooglePayViewModel : ViewModel() {
     val uiState = MutableStateFlow(Resource<DonationConfig>())
-    var donationConfig: DonationConfig? = null
+    private var donationConfig: DonationConfig? = null
     private val currentCountryCode get() = GeoUtil.geoIPCountry.orEmpty()
 
     val currencyFormat: NumberFormat = NumberFormat.getCurrencyInstance(Locale.Builder()
-        .setRegion(currentCountryCode).setLanguage(WikipediaApp.instance.appOrSystemLanguageCode).build())
+        .setLocale(Locale.getDefault()).setRegion(currentCountryCode).build())
     val currencyCode get() = currencyFormat.currency?.currencyCode ?: GooglePayComponent.CURRENCY_FALLBACK
     val currencySymbol get() = currencyFormat.currency?.symbol ?: "$"
     val decimalFormat = GooglePayComponent.getDecimalFormat(currencyCode)


### PR DESCRIPTION
For the NumberFormat of the currency, we were unnecessarily giving it the current app language, which might be a language or variant that's unsupported by the NumberFormat system. Instead, we can simply initialize it with the default `Locale`, which picks up the current language of the device.

https://phabricator.wikimedia.org/T365278