### PR TITLE
Follow-up to coroutines in EditSummary.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryFragment.kt
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryFragment.kt
@@ -128,7 +128,7 @@ class EditSummaryFragment : Fragment() {
     }
     override fun onStart() {
         super.onStart()
-        editSummaryHandler = EditSummaryHandler(binding.root, binding.editSummaryText, title)
+        editSummaryHandler = EditSummaryHandler(lifecycleScope, binding.root, binding.editSummaryText, title)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryHandler.kt
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryHandler.kt
@@ -4,14 +4,14 @@ import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.edit.db.EditSummary
 import org.wikipedia.page.PageTitle
 import org.wikipedia.util.L10nUtil.setConditionalTextDirection
 
-class EditSummaryHandler(private val container: View,
+class EditSummaryHandler(private val coroutineScope: CoroutineScope,
+                         private val container: View,
                          private val summaryEdit: AutoCompleteTextView,
                          title: PageTitle) {
 
@@ -19,11 +19,9 @@ class EditSummaryHandler(private val container: View,
         container.setOnClickListener { summaryEdit.requestFocus() }
         setConditionalTextDirection(summaryEdit, title.wikiSite.languageCode)
 
-        CoroutineScope(Dispatchers.Main).launch {
+        coroutineScope.launch {
             val summaries = AppDatabase.instance.editSummaryDao().getEditSummaries()
-            if (container.isAttachedToWindow) {
-                updateAutoCompleteList(summaries)
-            }
+            updateAutoCompleteList(summaries)
         }
     }
 
@@ -37,7 +35,7 @@ class EditSummaryHandler(private val container: View,
     }
 
     fun persistSummary() {
-        CoroutineScope(Dispatchers.IO).launch {
+        coroutineScope.launch {
             AppDatabase.instance.editSummaryDao().insertEditSummary(EditSummary(summary = summaryEdit.text.toString()))
         }
     }


### PR DESCRIPTION
Something to keep in mind going forward:
When doing coroutines inside "helper" classes, we should always try to inject the CoroutineScope from the parent Fragment or Activity, because the parent already has a perfectly good `lifecycleScope`, which is even better because it automatically cancels coroutines when the lifecycle ends.

In this example, if we inject the `lifecycleScope` from the parent fragment, we no longer need to check `isAttachedToWindow`.
(and it's more efficient because we don't create new instances of CoroutineScope!)