### PR TITLE
Remove the dialog of removing duplicated language variants

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.kt
+++ b/app/src/main/java/org/wikipedia/Constants.kt
@@ -69,7 +69,6 @@ object Constants {
         INTENT_PROCESS_TEXT("intentProcessText"),
         INTENT_SHARE("intentShare"),
         INTENT_UNKNOWN("intentUnknown"),
-        LANG_VARIANT_DIALOG("lang_variant_dialog"),
         LEAD_IMAGE("leadImage"),
         LINK_PREVIEW_MENU("linkPreviewMenu"),
         MOST_READ_ACTIVITY("mostRead"),

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
@@ -31,7 +31,6 @@ import org.wikipedia.feed.topread.TopReadArticlesActivity
 import org.wikipedia.feed.topread.TopReadListCard
 import org.wikipedia.feed.view.FeedAdapter
 import org.wikipedia.history.HistoryEntry
-import org.wikipedia.language.AppLanguageLookUpTable
 import org.wikipedia.random.RandomActivity
 import org.wikipedia.readinglist.sync.ReadingListSyncAdapter
 import org.wikipedia.settings.Prefs
@@ -131,23 +130,8 @@ class FeedFragment : Fragment(), BackPressedHandler {
         return binding.root
     }
 
-    private fun showRemoveChineseVariantPrompt() {
-        if (app.languageState.appLanguageCodes.contains(AppLanguageLookUpTable.TRADITIONAL_CHINESE_LANGUAGE_CODE) &&
-            app.languageState.appLanguageCodes.contains(AppLanguageLookUpTable.SIMPLIFIED_CHINESE_LANGUAGE_CODE) &&
-            Prefs.shouldShowRemoveChineseVariantPrompt) {
-            MaterialAlertDialogBuilder(requireActivity())
-                .setTitle(R.string.dialog_of_remove_chinese_variants_from_app_lang_title)
-                .setMessage(R.string.dialog_of_remove_chinese_variants_from_app_lang_text)
-                .setPositiveButton(R.string.dialog_of_remove_chinese_variants_from_app_lang_edit) { _, _ -> showLanguagesActivity(InvokeSource.LANG_VARIANT_DIALOG) }
-                .setNegativeButton(R.string.dialog_of_remove_chinese_variants_from_app_lang_no, null)
-                .show()
-        }
-        Prefs.shouldShowRemoveChineseVariantPrompt = false
-    }
-
     override fun onResume() {
         super.onResume()
-        showRemoveChineseVariantPrompt()
 
         // Explicitly invalidate the feed adapter, since it occasionally crashes the StaggeredGridLayout
         // on certain devices. (TODO: investigate further)

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -372,10 +372,6 @@ object Prefs {
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_multilingual_search_tooltip_shown, true)
         set(enabled) = PrefsIoUtil.setBoolean(R.string.preference_key_multilingual_search_tooltip_shown, enabled)
 
-    var shouldShowRemoveChineseVariantPrompt
-        get() = PrefsIoUtil.getBoolean(R.string.preference_key_show_remove_chinese_variant_prompt, true)
-        set(enabled) = PrefsIoUtil.setBoolean(R.string.preference_key_show_remove_chinese_variant_prompt, enabled)
-
     var remoteNotificationsSeenTime
         get() = PrefsIoUtil.getString(R.string.preference_key_remote_notifications_seen_time, "").orEmpty()
         set(seenTime) = PrefsIoUtil.setString(R.string.preference_key_remote_notifications_seen_time, seenTime)

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -327,6 +327,4 @@
   <string name="wikipedia_languages_add_language_text">Voeg taal by</string>
   <string name="wikipedia_languages_remove_text">Verwyder taal</string>
   <string name="wikipedia_languages_remove_action_mode_title">Verwyder taal</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Wysig tale</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nee, dankie</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1156,10 +1156,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">احتفظ بلغة ويكيبيديا واحدة على الأقل للبحث عن المحتوى وقراءته.</string>
   <string name="more_language_options">المزيد</string>
   <string name="add_wikipedia_languages_text">أضف لغات ويكيبيديا</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">هل تريد إزالة متغير صيني من لغات تطبيقك؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">لديك حاليا مجموعة من المتغيرات الصينية التقليدية والمبسطة في لغات تطبيقك، تحديث إعدادات لغات تطبيقك؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">تعديل اللغات</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">لا شكرًا</string>
   <string name="remove_language_dialog_cancel_button_text">إلغاء</string>
   <string name="remove_language_dialog_ok_button_text">حسنا</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">حسنا</string>

--- a/app/src/main/res/values-ary/strings.xml
+++ b/app/src/main/res/values-ary/strings.xml
@@ -372,8 +372,7 @@
   <string name="wikipedia_languages_add_language_text">زيد لوغة</string>
   <string name="more_language_options">كتر</string>
   <string name="add_wikipedia_languages_text">زيد لوغات د ويكيپيديا</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">لا شكرا</string>
-  <string name="remove_language_dialog_cancel_button_text">لغي</string>
+    <string name="remove_language_dialog_cancel_button_text">لغي</string>
   <string name="remove_language_dialog_ok_button_text">واخا</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">واخا</string>
   <string name="protected_page_warning_dialog_ok_button_text">واخا</string>

--- a/app/src/main/res/values-ary/strings.xml
+++ b/app/src/main/res/values-ary/strings.xml
@@ -372,7 +372,7 @@
   <string name="wikipedia_languages_add_language_text">زيد لوغة</string>
   <string name="more_language_options">كتر</string>
   <string name="add_wikipedia_languages_text">زيد لوغات د ويكيپيديا</string>
-    <string name="remove_language_dialog_cancel_button_text">لغي</string>
+  <string name="remove_language_dialog_cancel_button_text">لغي</string>
   <string name="remove_language_dialog_ok_button_text">واخا</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">واخا</string>
   <string name="protected_page_warning_dialog_ok_button_text">واخا</string>

--- a/app/src/main/res/values-as/strings.xml
+++ b/app/src/main/res/values-as/strings.xml
@@ -751,8 +751,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">অন্ততঃ এটা ৱিকিপিডিয়া ভাষা ৰাখক যাৰ পৰা বিষয় সন্ধান কৰিব আৰু পঢ়িব পাৰি।</string>
   <string name="more_language_options">অধিক</string>
   <string name="add_wikipedia_languages_text">ৱিকিপিডিয়াৰ ভাষা যোগ কৰক</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ভাষাৰ সালসলনি কৰক</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">নালাগে দিয়ক</string>
   <string name="remove_language_dialog_cancel_button_text">বাতিল কৰক</string>
   <string name="remove_language_dialog_ok_button_text">বাৰু</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">বাৰু</string>

--- a/app/src/main/res/values-ast/strings.xml
+++ b/app/src/main/res/values-ast/strings.xml
@@ -772,10 +772,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Dexa polo menos una llingua de Wikipedia pa buscar y lleer el conteníu.</string>
   <string name="more_language_options">más</string>
   <string name="add_wikipedia_languages_text">Añadir idiomes de Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">¿Quitar una variante del chinu de los idiomes de l\'aplicación?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Agora tienes definíos tanto\'l chinu tradicional como\'l simplificáu nos idiomes de l\'aplicación. ¿Anovar la configuración llingüística de la app?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Editar llingües</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Non, gracies</string>
   <string name="remove_language_dialog_cancel_button_text">Zarrar</string>
   <string name="remove_language_dialog_ok_button_text">Aceutar</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Aceutar</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -613,7 +613,7 @@
   <string name="wikipedia_languages_your_languages_text">Sizin dilləriniz</string>
   <string name="wikipedia_languages_add_language_text">Dil əlavə et</string>
   <string name="wikipedia_languages_remove_text">Dili sil</string>
-    <string name="remove_language_dialog_cancel_button_text">İmtina</string>
+  <string name="remove_language_dialog_cancel_button_text">İmtina</string>
   <string name="edit_type_all">Bütün töhfələr</string>
   <string name="wikitext_bold">Qalın</string>
   <string name="wikitext_template">Şablon</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -613,8 +613,7 @@
   <string name="wikipedia_languages_your_languages_text">Sizin dilləriniz</string>
   <string name="wikipedia_languages_add_language_text">Dil əlavə et</string>
   <string name="wikipedia_languages_remove_text">Dili sil</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Yox, təşəkkür</string>
-  <string name="remove_language_dialog_cancel_button_text">İmtina</string>
+    <string name="remove_language_dialog_cancel_button_text">İmtina</string>
   <string name="edit_type_all">Bütün töhfələr</string>
   <string name="wikitext_bold">Qalın</string>
   <string name="wikitext_template">Şablon</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -1112,10 +1112,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Zadržite bar jedan jezik za pretragu i čitanje.</string>
   <string name="more_language_options">još</string>
   <string name="add_wikipedia_languages_text">Dodaj jezike Vikipedije</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Ukloniti varijantu kineskog sa liste jezika?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Trenutno imate i tradicionalni i pojednostavljeni kineski u jezicima aplikacije. Promeniti podešavanja jezika?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Uredi jezike</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ne, hvala</string>
   <string name="remove_language_dialog_cancel_button_text">Otkaži</string>
   <string name="remove_language_dialog_ok_button_text">U redu</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">U redu</string>

--- a/app/src/main/res/values-b+tg+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+tg+Cyrl/strings.xml
@@ -211,8 +211,6 @@
   <string name="suggested_edits_encouragement_message">%s, шуморо барои вироишатон ташаккур кард. Шумо метавонед роҳҳои зиёде барои саҳм ба Википедиа ёбед.</string>
   <string name="suggested_edits_last_edited">Охирин вироиш</string>
   <string name="suggested_edits_last_edited_never">Ҳеҷгоҳ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Вироиши забонҳо</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Не,раҳмат</string>
   <string name="remove_language_dialog_cancel_button_text">Тамом кардан</string>
   <string name="remove_language_dialog_ok_button_text">Таъйид</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Таъйид</string>

--- a/app/src/main/res/values-b+tt+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+tt+Cyrl/strings.xml
@@ -1138,10 +1138,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Эчтәлекне эзләү һәм уку өчен Википедиянең бер генә телен булса да кулланыгыз.</string>
   <string name="more_language_options">күбрәк</string>
   <string name="add_wikipedia_languages_text">Википедия телләрен өстәгез</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Сезнең кушымта телләреннән кытай вариантын бетерергәме?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Хәзерге вакытта сезнең кушымтада кытай теленең традицион һәм гадиләштерелгән вариантлары урнаштырылган. Кушымтаның тел көйләүләрен яңартыргамы?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Телләрне мөхәррирләргә</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Юк, рәхмәт</string>
   <string name="remove_language_dialog_cancel_button_text">Кире кайтарырга</string>
   <string name="remove_language_dialog_ok_button_text">Ярар</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Ярар</string>

--- a/app/src/main/res/values-ba/strings.xml
+++ b/app/src/main/res/values-ba/strings.xml
@@ -1143,10 +1143,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Эҙләү һәм уҡыу өсөн бер телде булһа ла ҡалдырығыҙ.</string>
   <string name="more_language_options">күберәк телдәр</string>
   <string name="add_wikipedia_languages_text">Википедия телдәрен өҫтәү</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Ҡытай телен телдәр исемлегегеҙҙән юйырғамы?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Әлеге ваҡытта ҡушымтағыҙҙа Ҡытай теленең традицион һәм ябай варианттары ҡуйылған. Телдәрҙе яңыртырға теләйһегеҙме?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Телдәрҙе мөхәррирләргә</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Юҡ, рәхмәт</string>
   <string name="remove_language_dialog_cancel_button_text">Кире алырға</string>
   <string name="remove_language_dialog_ok_button_text">Яҡшы</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Яҡшы</string>

--- a/app/src/main/res/values-ban/strings.xml
+++ b/app/src/main/res/values-ban/strings.xml
@@ -727,8 +727,6 @@
   <string name="wikipedia_languages_remove_text">Usap basa</string>
   <string name="wikipedia_languages_remove_action_mode_title">Usap basa</string>
   <string name="add_wikipedia_languages_text">Weweh basa Wikipédia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Uah basa</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nénten, suksma</string>
   <string name="remove_language_dialog_cancel_button_text">Wangdé</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -1231,10 +1231,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Выкарыстоўвайце хаця б адну мову Вікіпедыі для пошуку і чытання кантэнту.</string>
   <string name="more_language_options">болей</string>
   <string name="add_wikipedia_languages_text">Дадаць мову Вікіпедыі</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Выдаліць варыянт кітайскай мовы з вашых моў праграмы?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Зараз сярод моў вашай праграмы ўсталяваны як традыцыйны, так і спрошчаны варыянты кітайскай мовы. Абнавіць налады моў вашай праграмы?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Рэдагаваць мовы</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Не, дзякуй</string>
   <string name="remove_language_dialog_cancel_button_text">Скасаваць</string>
   <string name="remove_language_dialog_ok_button_text">Добра</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Добра</string>

--- a/app/src/main/res/values-bew/strings.xml
+++ b/app/src/main/res/values-bew/strings.xml
@@ -1131,10 +1131,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Bikin paling kaga\' atu basa Wikipédia bakal nyari ama ngebaca isi.</string>
   <string name="more_language_options">laènnya</string>
   <string name="add_wikipedia_languages_text">Tambah basa Wikipédi</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Apus ragem basa Tionghoa deri lu punya basa aplikasi?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Lu sekarang ni lagi ada punya ragem Terdisionil ama Ringkes nyang kesetèl di lu punya basa aplikasi. Perbaruin lu punya penyetèlan basa aplikasi?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Permak basa</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Kaga\', makasi</string>
   <string name="remove_language_dialog_cancel_button_text">Urungin</string>
   <string name="remove_language_dialog_ok_button_text">Baè\'</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Baè\'</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1037,10 +1037,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Оставете поне един език на Уикипедия, на който да търсите и да четете съдържание.</string>
   <string name="more_language_options">още</string>
   <string name="add_wikipedia_languages_text">Добавяне на езици на Уикипедия</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Премахване на китайски вариант от езиците на приложението Ви?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Към момента имате както традиционен, така и опростен китайски вариант в езиците на приложението. Промяна на езиковите Ви настройки на приложението?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Редактиране на езици</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Не, благодаря</string>
   <string name="remove_language_dialog_cancel_button_text">Отказ</string>
   <string name="remove_language_dialog_ok_button_text">Добре</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Добре</string>

--- a/app/src/main/res/values-blk/strings.xml
+++ b/app/src/main/res/values-blk/strings.xml
@@ -898,8 +898,6 @@
   <string name="wikipedia_languages_remove_text">ဖုဲင်းထန်ႏထိုꩻ ဘာႏသာႏငဝ်းငွါ</string>
   <string name="wikipedia_languages_remove_action_mode_title">ဖုဲင်းထန်ႏထိုꩻဘာႏသာႏငဝ်းငွါ</string>
   <string name="more_language_options">ထဲင်း</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">မွဉ်းဖျင်ဘာႏသာႏငဝ်းငွါဖိုင်ႏ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">လိုႏတဝ်း၊ ကေꩻဇူꩻတန်ငါႏသြ</string>
   <string name="remove_language_dialog_cancel_button_text">မာꩻတဝ်းဒွုမ်</string>
   <string name="remove_language_dialog_ok_button_text">မွေးသွူ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">မွေးသွူ</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -976,8 +976,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">সমস্ত ভাষা সরানো যাবে না</string>
   <string name="more_language_options">আরো</string>
   <string name="add_wikipedia_languages_text">উইকিপিডিয়ার ভাষা যোগ করুন</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ভাষা সম্পাদনা করুন</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">না ধন্যবাদ</string>
   <string name="remove_language_dialog_cancel_button_text">বাতিল</string>
   <string name="remove_language_dialog_ok_button_text">ঠিক আছে</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ঠিক আছে</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -1063,8 +1063,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">Ne c\'haller ket lemel an holl yezhoù</string>
   <string name="more_language_options">muioc\'h</string>
   <string name="add_wikipedia_languages_text">Ouzhpennañ yezhoù Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Kemmañ ar yezhoù</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nann, trugarez</string>
   <string name="remove_language_dialog_cancel_button_text">Nullañ</string>
   <string name="remove_language_dialog_ok_button_text">Mat eo</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Mat eo</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1175,10 +1175,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Mantingueu com a mínim una llengua de Viquipèdia a partir de la qual cercar i llegir contingut.</string>
   <string name="more_language_options">més</string>
   <string name="add_wikipedia_languages_text">Afegeix llengües de la Viquipèdia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Voleu suprimir una variant xinesa les llengües de l\'aplicació?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Ara teniu les variants tradicional i simplificada del xinès a les llengües de l\'aplicació? Voleu actualitzar la configuració de llengües de l\'aplicació?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Modifica les llengües</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">No, gràcies</string>
   <string name="remove_language_dialog_cancel_button_text">Cancel·la</string>
   <string name="remove_language_dialog_ok_button_text">D’acord</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">D’acord</string>

--- a/app/src/main/res/values-ce/strings.xml
+++ b/app/src/main/res/values-ce/strings.xml
@@ -199,7 +199,7 @@
     <item quantity="other">%d шо хьалкха</item>
   </plurals>
   <string name="add_wikipedia_languages_text">ТӀетоха меттанаш Википедехь</string>
-    <string name="templates_description_incomplete">Кепаш кхуллуш йу декъашхоша, цундела уьш хила мега чулацам кхачаме боцуш</string>
+  <string name="templates_description_incomplete">Кепаш кхуллуш йу декъашхоша, цундела уьш хила мега чулацам кхачаме боцуш</string>
   <string name="main_tooltip_watchlist_title">Тергаме могӀам</string>
   <string name="talk_title">Дийцар</string>
   <string name="talk_user_title">Дийцар: %s</string>

--- a/app/src/main/res/values-ce/strings.xml
+++ b/app/src/main/res/values-ce/strings.xml
@@ -199,9 +199,7 @@
     <item quantity="other">%d шо хьалкха</item>
   </plurals>
   <string name="add_wikipedia_languages_text">ТӀетоха меттанаш Википедехь</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">ДӀабаккха цийн мотт могӀаман йукъара?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Хийца меттанаш</string>
-  <string name="templates_description_incomplete">Кепаш кхуллуш йу декъашхоша, цундела уьш хила мега чулацам кхачаме боцуш</string>
+    <string name="templates_description_incomplete">Кепаш кхуллуш йу декъашхоша, цундела уьш хила мега чулацам кхачаме боцуш</string>
   <string name="main_tooltip_watchlist_title">Тергаме могӀам</string>
   <string name="talk_title">Дийцар</string>
   <string name="talk_user_title">Дийцар: %s</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -1017,10 +1017,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">لایەنی کەم یەک زنامی ویکیپیدیا بھێڵەرەوە تاکوو لەڕێیەوە بتوانیت ناوەڕۆک بخوێنیتەوە و پێیدا بگەڕێیت.</string>
   <string name="more_language_options">زیاتر</string>
   <string name="add_wikipedia_languages_text">زیادکردنی زمانەکانی ویکیپیدیا</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">جۆرێکی چینی لە زمانەکانی بەرنامەکەتدا لادەبەیت؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">لە ئێستادا هەردوو جۆری دێرین و ئاسانکراوی زمانی چینیت بە زمانی بەرنامەکانت داندراوە. ڕێکخستنەکانی زمانەکانی بەرنامەکەت نوێ دەکەیتەوە؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">دەستکاریکردنی زمانەکان</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">نا سپاس</string>
   <string name="remove_language_dialog_cancel_button_text">ھەڵوەشاندنەوە</string>
   <string name="remove_language_dialog_ok_button_text">باشە</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">باشە</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1140,10 +1140,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Udržujte si alespoň jeden jazyk Wikipedie, ze kterého můžete vyhledávat a číst obsah.</string>
   <string name="more_language_options">více</string>
   <string name="add_wikipedia_languages_text">Přidat jazyky Wikipedie</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Chcete odebrat čínskou variantu z jazyků aplikace?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">V současné době máte ve svých jazycích aplikaci nastavenou jak Tradiční, tak Zjednodušenou čínštinu. Chcete aktualizovat nastavení jazyků aplikace?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Upravit jazyky</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ne, děkuji</string>
   <string name="remove_language_dialog_cancel_button_text">Zrušit</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1187,10 +1187,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Behold mindst et Wikipedia-sprog som du kan søge og læse indhold på.</string>
   <string name="more_language_options">mere</string>
   <string name="add_wikipedia_languages_text">Tilføj Wikipedia sprog</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Fjern en kinesisk variant fra dine app sprog?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Du har både traditionel og forenklet kinesisk blandt dine sprog i appen. Vil du opdatere sprogindstillingerne?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Rediger sprog</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nej tak</string>
   <string name="remove_language_dialog_cancel_button_text">Annullér</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-dag/strings.xml
+++ b/app/src/main/res/values-dag/strings.xml
@@ -1131,10 +1131,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Chɛli kamani zuliya yini ani tooi mali shɛli vihiri karindi lahabaya Wikipedia zuɣu</string>
   <string name="more_language_options">Pahima</string>
   <string name="add_wikipedia_languages_text">Pahami Wikipedia zuɣu bala</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Yihimi Chaanasili niŋsim a app maa bala puuni?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Saha ŋɔ a na malila bini dingbaai Chaanasili kali niŋsim ni din ŋmani li a app maa bala puuni. Maalini a app bala malizali kpatuɣa yaɣili niŋ?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Malimi bala niŋ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Aayi, mbo</string>
   <string name="remove_language_dialog_cancel_button_text">Nyahima</string>
   <string name="remove_language_dialog_ok_button_text">Tɔ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Tɔ</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1194,10 +1194,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Mindestens eine Wikipedia-Sprache für die Suche und das Lesen von Inhalten behalten.</string>
   <string name="more_language_options">mehr</string>
   <string name="add_wikipedia_languages_text">Wikipedia-Sprachen hinzufügen</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Eine chinesische Variante von deinen App-Sprachen entfernen?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Du hast derzeit sowohl die Variantensätze für das traditionelle als auch für das vereinfachte Chinesisch in deinen App-Sprachen. Einstellungen für deine App-Sprachen aktualisieren?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Sprachen bearbeiten</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nein danke</string>
   <string name="remove_language_dialog_cancel_button_text">Abbrechen</string>
   <string name="remove_language_dialog_ok_button_text">Okay</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Okay</string>

--- a/app/src/main/res/values-dga/strings.xml
+++ b/app/src/main/res/values-dga/strings.xml
@@ -1098,8 +1098,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">Koŋ baŋ iri a kɔkɔɛ zaa</string>
   <string name="more_language_options">Yaga</string>
   <string name="add_wikipedia_languages_text">Paahi Wikipiideɛ kɔkɔɛ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Poɔ kɔkɔɛ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Bareka kyebe</string>
   <string name="remove_language_dialog_cancel_button_text">Ŋmaa o</string>
   <string name="remove_language_dialog_ok_button_text">Tɔɔ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Tɔɔ</string>

--- a/app/src/main/res/values-diq/strings.xml
+++ b/app/src/main/res/values-diq/strings.xml
@@ -616,9 +616,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">Zıwani pêro nêdariyayê we</string>
   <string name="more_language_options">zêde</string>
   <string name="add_wikipedia_languages_text">Zıwanê Wikipediya cı kerê</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Zıwananê aplikasyoni ra varyasyonê Çinki wa wedariyo?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Zıwana bıvurnê</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nê, teşekur</string>
   <string name="remove_language_dialog_cancel_button_text">Bıtexelne</string>
   <string name="remove_language_dialog_ok_button_text">TEMAM</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">TEMAM</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -928,9 +928,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Κρατήστε τουλάχιστον μια γλώσσα Βικιπαίδειας από την οποία θα γίνεται αναζήτηση και ανάγνωση περιεχομένου.</string>
   <string name="more_language_options">περισσότερα</string>
   <string name="add_wikipedia_languages_text">Πρόσθεση γλωσσών Βικιπαίδειας</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Αφαίρεση μιας Κινεζικής παραλλαγής από τις γλώσσες εφαρμογής σας;</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Επεξεργασία γλωσσών</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Όχι, ευχαριστώ</string>
   <string name="remove_language_dialog_cancel_button_text">Ακύρωση</string>
   <string name="remove_language_dialog_ok_button_text">Εντάξει</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Εντάξει</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -759,10 +759,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Lasu almenaŭ unu Vikipedian lingvon por serĉado kaj legado de enhavo.</string>
   <string name="more_language_options">pli</string>
   <string name="add_wikipedia_languages_text">Aldoni vikipediajn lingvojn</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Forigi ĉinan varianton el viaj aplikaĵaj lingvoj?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Vi aktuale havas kaj tradician kaj simpligitan formojn de ĉina lingvo en viaj aplikaĵaj lingvoj. Ĉu ĝisdatigi la lingvo-agordojn de la aplikaĵo?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Redakti lingvojn</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ne, dankon</string>
   <string name="remove_language_dialog_cancel_button_text">Nuligi</string>
   <string name="remove_language_dialog_ok_button_text">Bone</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Bone</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1207,10 +1207,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Conserva al menos un idioma Wikipedia por el cual buscar y leer contenido.</string>
   <string name="more_language_options">más</string>
   <string name="add_wikipedia_languages_text">Añadir idiomas de Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">¿Quieres quitar una variante del chino de los idiomas de la aplicación?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Ahora tienes definidos tanto el chino tradicional como el simplificado en los idiomas de la aplicación. ¿Quieres actualizar la configuración lingüística?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Editar idiomas</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">No, gracias</string>
   <string name="remove_language_dialog_cancel_button_text">Cancelar</string>
   <string name="remove_language_dialog_ok_button_text">Aceptar</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Aceptar</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -708,10 +708,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Gorde ezazu behintzat Wikipedia hizkuntza bat zeinetatik edukia bilatu eta irakurri ahalko duzun.</string>
   <string name="more_language_options">gehiago</string>
   <string name="add_wikipedia_languages_text">Wikipedia hizkuntzak gehitu</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Txineraren aldaera bat kendu nahi duzu zure aplikazioaren hizkuntzetatik?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Orain txineraren bi aldaerak, bai tradizionala bai sinplifikatua dituzu zure aplikazioaren hizkuntzetan. Zure aplikazioaren hizkuntza ezarpenak eguneratu nahi dituzu?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Hizkuntzak aldatu</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ez, eskerrik asko</string>
   <string name="remove_language_dialog_ok_button_text">Ados</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Ados</string>
   <string name="protected_page_warning_dialog_ok_button_text">Ados</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1137,10 +1137,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">دست‌کم یک زبان را برای جستجو و مطالعهٔ محتوای ویکی‌پدیا نگه دارید.</string>
   <string name="more_language_options">بیشتر</string>
   <string name="add_wikipedia_languages_text">افزودن زبان‌های ویکی‌پدیا</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">آیا می‌خواهید چینی از بخش زبان‌های نرم‌افزار حذف شود؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">اکنون هر دو زبان ساده و سنتی چینی در نرم‌افزار شما فعال شده است. تنظیمات زبان نرم‌افزار روزآمد شود؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ویرایش زبان‌ها</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">نه ممنون</string>
   <string name="remove_language_dialog_cancel_button_text">لغو</string>
   <string name="remove_language_dialog_ok_button_text">تأیید</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">تأیید</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1175,10 +1175,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Pidä vähintään yksi Wikipedian kieli jolla hakea ja lukea sisältöä.</string>
   <string name="more_language_options">lisää</string>
   <string name="add_wikipedia_languages_text">Lisää Wikipedia-kieliä</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Poista kiinan kielen muoto sovelluksen kielistä?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Sinulla on tällä hetkellä valittuna sekä perinteisen että yksinkertaistetun kiinan muotoja. Haluatko päivittää kieliasetuksiasi?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Muokkaa kieliä</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ei kiitos</string>
   <string name="remove_language_dialog_cancel_button_text">Peruuta</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1218,10 +1218,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Gardez au moins une langue de Wikipédia avec laquelle vous pourrez chercher et lire du contenu.</string>
   <string name="more_language_options">plus</string>
   <string name="add_wikipedia_languages_text">Ajouter des langues de Wikipédia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Supprimer une variante chinoise des langues de votre application ?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Vous avez actuellement les deux variantes chinoises (traditionnelle et simplifiée) définies dans vos langues de l’application. Mettre à jour vos paramètres de langue de l’application ?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Modifier les langues</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Non merci</string>
   <string name="remove_language_dialog_cancel_button_text">Annuler</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-fy/strings.xml
+++ b/app/src/main/res/values-fy/strings.xml
@@ -884,10 +884,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Hâld teminsten ien Wikipedy-taal om ynhâld yn te sykjen en te lêzen.</string>
   <string name="more_language_options">mear</string>
   <string name="add_wikipedia_languages_text">Wikipedy-talen tafoegje</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">In Sineesk-fariant út jo app-talen fuorthelje?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Jo hawwe no sawol de farianten Tradisjoneel as Ferienfâldige Sineesk ynsteld yn jo app-talen. De taalynstellings fan jo app oanpasse?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Talen oanpasse</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nee tanke</string>
   <string name="remove_language_dialog_cancel_button_text">Annulearje</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -742,10 +742,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Coinnigh teanga Vicipéide amháin ar a laghad a bhféadfar é a úsáid chun ábhar a chuardach agus a léamh.</string>
   <string name="more_language_options">tuilleadh</string>
   <string name="add_wikipedia_languages_text">Cuir teangacha Vicipéide leis</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Bain leagan den tSínis amach ó do chuid teangacha san aip?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Faoi láthair tá an dá cheann den tSínis Traidisiúnta agus an tSínis Shimplithe socraithe agat i do chuid teangacha san aip. Nuashonraigh do chuid socruithe teangacha san aip?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Cuir teangacha in eagar</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ní dhéanfaidh mé é</string>
   <string name="remove_language_dialog_cancel_button_text">Cealaigh</string>
   <string name="remove_language_dialog_ok_button_text">Bain</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Scrios</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -804,10 +804,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Manteña polo menos unha lingua de Wikipedia na que procurar e ler contido.</string>
   <string name="more_language_options">máis</string>
   <string name="add_wikipedia_languages_text">Engadir linguas de Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Quere quitar unha variante do chinés das linguas da aplicación?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Agora ten definidos tanto o chinés tradicional como o simplificado nas linguas da aplicación. Quere actualizar a configuración das linguas?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Editar linguas</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">No, grazas</string>
   <string name="remove_language_dialog_cancel_button_text">Cancelar</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-gn/strings.xml
+++ b/app/src/main/res/values-gn/strings.xml
@@ -346,8 +346,7 @@
   </plurals>
   <string name="more_language_options">ehechave</string>
   <string name="add_wikipedia_languages_text">Emoĩve Vikipetã ñe\'ẽ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nahániri</string>
-  <string name="remove_language_dialog_cancel_button_text">Eheja</string>
+    <string name="remove_language_dialog_cancel_button_text">Eheja</string>
   <string name="remove_language_dialog_ok_button_text">Oĩma</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Oĩma</string>
   <string name="protected_page_warning_dialog_ok_button_text">Oĩma</string>

--- a/app/src/main/res/values-gn/strings.xml
+++ b/app/src/main/res/values-gn/strings.xml
@@ -346,7 +346,7 @@
   </plurals>
   <string name="more_language_options">ehechave</string>
   <string name="add_wikipedia_languages_text">Emoĩve Vikipetã ñe\'ẽ</string>
-    <string name="remove_language_dialog_cancel_button_text">Eheja</string>
+  <string name="remove_language_dialog_cancel_button_text">Eheja</string>
   <string name="remove_language_dialog_ok_button_text">Oĩma</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Oĩma</string>
   <string name="protected_page_warning_dialog_ok_button_text">Oĩma</string>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -1144,10 +1144,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Ku ajiye akalla harshe ɗaya na Wikipedia daga abin da za a bincika da karanta abun ciki.</string>
   <string name="more_language_options">ƙari</string>
   <string name="add_wikipedia_languages_text">Ƙara harsunan Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Cire bambancin Sinanci daga yarukan aikace-aikacenku?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">A halin yanzu kuna da bambance-bambance na gargajiya da na sauƙaƙe na Sinanci a cikin yarukan aikace-aikacenku. Sabunta saitunan harsunan aikace-aikacenku?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Gyara harsuna</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">A\'a Nagode</string>
   <string name="remove_language_dialog_cancel_button_text">Soke</string>
   <string name="remove_language_dialog_ok_button_text">Yayi</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Yayi</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1159,10 +1159,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">कम से कम एक विकिपीडिया भाषा रखें जिससे सामग्री को खोजा और पढ़ा जा सके।</string>
   <string name="more_language_options">अधिक</string>
   <string name="add_wikipedia_languages_text">विकिपीडिया भाषाएँ जोड़ें</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">अपने ऐप्लिकेशन की भाषाओं से एक चीनी संस्करण निकालें?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">वर्तमान में आपके पास पारंपरिक और सरलीकृत दोनों प्रकार के चीनी प्रकार हैं जो आपकी ऐप भाषाओं में सेट हैं। अपनी ऐप भाषा सेटिंग अपडेट करें?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">भाषाएं संपादित करें</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">নাই, নালাগে দিয়ক</string>
   <string name="remove_language_dialog_cancel_button_text">रद्द करें</string>
   <string name="remove_language_dialog_ok_button_text">ठीक है</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ठीक है</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -780,10 +780,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Zadržite barem jedan jezik za pretragu i čitanje sadržaja.</string>
   <string name="more_language_options">više</string>
   <string name="add_wikipedia_languages_text">Dodaj jezike Wikipedije</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Želite li ukloniti inačicu kineskog u postavkama jezika?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Trenutačno imate i tradicionalni i pojednostavljeni kineski u jezicima aplikacije. Želite li promijeniti postavke jezika?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Uredi jezike</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ne, hvala</string>
   <string name="remove_language_dialog_cancel_button_text">Odustani</string>
   <string name="remove_language_dialog_ok_button_text">U redu</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">U redu</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1176,10 +1176,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Tarts meg legalább egy Wikipédia nyelvet, amin keresni és olvasni szeretnél.</string>
   <string name="more_language_options">több</string>
   <string name="add_wikipedia_languages_text">Wikipédia-nyelvek hozzáadása</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Eltávolítod valamelyik kínai változatot az alkalmazás nyelvei közül?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Jelenleg mind a hagyományos, mind az egyszerűsített kínai nyelvi változat is be van állítva az alkalmazásban. Módosítod az alkalmazás nyelvi beállításait?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Nyelvek szerkesztése</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Köszönöm, nem</string>
   <string name="remove_language_dialog_cancel_button_text">Mégse</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -407,9 +407,6 @@
   </plurals>
   <string name="more_language_options">ավելին</string>
   <string name="add_wikipedia_languages_text">Ավելացնել Վիքիպեդիայի լեզուներ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Հեռացնե՞լ չինարեն ձեր հավելվածի լեզուներից</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Խմբագրել լեզուներ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ոչ, շնորհակալություն</string>
   <string name="remove_language_dialog_cancel_button_text">Չեղարկել</string>
   <string name="remove_language_dialog_ok_button_text">Լավ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Լավ</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -1176,10 +1176,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Mantene al minus un lingua de Wikipedia in le qual cercar e leger contento.</string>
   <string name="more_language_options">plus</string>
   <string name="add_wikipedia_languages_text">Adder linguas de Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Remover un variante chinese del linguas de tu application?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Tu ha actualmente le duo variantes chinese, traditional e simplificate, definite in le linguas de tu application. Actualisar le parametros de linguas de tu application?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Modificar linguas</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">No, gratias</string>
   <string name="remove_language_dialog_cancel_button_text">Cancellar</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1139,10 +1139,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Buat setidaknya satu bahasa Wikipedia yang dapat digunakan untuk mencari dan membaca konten.</string>
   <string name="more_language_options">lainnya</string>
   <string name="add_wikipedia_languages_text">Tambah bahasa Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Hapus varian Tionghoa dari bahasa aplikasi Anda?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Saat ini Anda memiliki varian bahasa Tionghoa Tradisional dan Sederhana yang disetel dalam bahasa aplikasi Anda. Perbarui pengaturan bahasa aplikasi Anda?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Sunting bahasa</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Tidak, terima kasih</string>
   <string name="remove_language_dialog_cancel_button_text">Batal</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-inh/strings.xml
+++ b/app/src/main/res/values-inh/strings.xml
@@ -1121,10 +1121,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Цхьа мотт мукъагӀа бита бéза хьа, дéша а лаха а йиш хургйолаш</string>
   <string name="more_language_options">кхы а да метташ</string>
   <string name="add_wikipedia_languages_text">Википеден метташ тӀатоха</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Метташта юкъера ченкий мотт дӀабаккха безий?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Къаьнара ченкий а цхьалха ченкий а метташ да хьога. Царех цаӀ дӀабаккха йиш хургйолаш, меттай оттамаш кердадаха дезий?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Метташ хувца</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Эшац, хӀанзара оттамаш дита.</string>
   <string name="remove_language_dialog_cancel_button_text">А</string>
   <string name="remove_language_dialog_ok_button_text">ХӀАЪА</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ХӀАЪА</string>

--- a/app/src/main/res/values-io/strings.xml
+++ b/app/src/main/res/values-io/strings.xml
@@ -1019,10 +1019,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Mantenez adminime 1 idiomo de Wikipedio de quon tu povos serchar e lektar kontenajo.</string>
   <string name="more_language_options">pluse</string>
   <string name="add_wikipedia_languages_text">Adjuntez idiomi de Wikipedio</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Ka removar varianto de Chiniana de vua \'\'app\'\' pri lingui?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Nun vu havas ambe Chiniana varianti Simpligita e Tradicionala en l\'idiomi de vua \'\'app\'\'. Ka vu deziras aktualigar l\'ajusti pri idiomi dil \'\'app\'\'?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Redaktar lingui</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ne, danko</string>
   <string name="remove_language_dialog_cancel_button_text">Nuligar</string>
   <string name="remove_language_dialog_ok_button_text">O.K.</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">O.K.</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -1136,10 +1136,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Haltu að minnsta kosti einu Wikipedia-tungumáli til að leita að og lesa efni.</string>
   <string name="more_language_options">meira</string>
   <string name="add_wikipedia_languages_text">Bæta við Wikipedia-tungumálum</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Fjarlægja tilbrigði kínversku úr tungumálum forritsins?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Þú ert núna með bæði hefðbundna og einfalda kínversku í tungumálum forritsins. Á að uppfæra tungumálastillingar þess?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Breyta tungumálum</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nei, takk</string>
   <string name="remove_language_dialog_cancel_button_text">Hætta við</string>
   <string name="remove_language_dialog_ok_button_text">Í lagi</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Í lagi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1181,10 +1181,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Mantieni almeno una lingua Wikipedia da cui potrai cercare e leggere il contenuto.</string>
   <string name="more_language_options">altro</string>
   <string name="add_wikipedia_languages_text">Aggiungi le lingue di Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Rimuovere una variante cinese dalle lingue della tua app?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Al momento hai varianti del cinese tradizionale e del cinese semplificato impostate nelle lingue dell\'applicazione. Aggiorna le impostazioni della lingua dell\'applicazione?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Modifica lingue</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">No, grazie</string>
   <string name="remove_language_dialog_cancel_button_text">Annulla</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1282,10 +1282,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">יש להשאיר לפחות שפת ויקיפדיה אחת שבה ברצונך לחפש ולקרוא תוכן.</string>
   <string name="more_language_options">עוד</string>
   <string name="add_wikipedia_languages_text">הוספת שפות ויקיפדיה</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">להסיר הגוון אחד של סינית מהגדרות השפה של היישום?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">כרגע מוגדרות גם סינית מסורתית וגם סינית מפושטת בהגדרות השפה של היישום שלך. האם ברצונך לעדכן את הגדרות השפה של היישום?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">עריכת השפות</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">לא, תודה</string>
   <string name="remove_language_dialog_cancel_button_text">ביטול</string>
   <string name="remove_language_dialog_ok_button_text">אישור</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">אישור</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1193,10 +1193,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">検索して内容を読むためにはウィキペディアの言語が少なくとも1つは必要です。</string>
   <string name="more_language_options">もっと見る</string>
   <string name="add_wikipedia_languages_text">ウィキペディアの言語を追加</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">中国語の文字違い版をアプリの言語から削除しますか?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">現在、繁体字と簡体字の両方の中国語版をアプリの言語として指定しています。アプリの言語設定を更新しますか?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">言語の設定を編集</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">いいえ、結構です。</string>
   <string name="remove_language_dialog_cancel_button_text">キャンセル</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-ji/strings.xml
+++ b/app/src/main/res/values-ji/strings.xml
@@ -276,7 +276,7 @@
   <string name="onboarding_welcome_title_v2">די פֿרייע ענציקלאפעדיע\n…אין מער ווי 300 שפראכן</string>
   <string name="app_shortcuts_search">זוכן</string>
   <string name="more_language_options">נאָך</string>
-    <string name="remove_language_dialog_cancel_button_text">אַנולירן</string>
+  <string name="remove_language_dialog_cancel_button_text">אַנולירן</string>
   <string name="account_editing_blocked_dialog_cancel_button_text">אַנולירן</string>
   <string name="wikitext_link">לינק</string>
   <string name="wikitext_template">מוסטער</string>

--- a/app/src/main/res/values-ji/strings.xml
+++ b/app/src/main/res/values-ji/strings.xml
@@ -276,8 +276,7 @@
   <string name="onboarding_welcome_title_v2">די פֿרייע ענציקלאפעדיע\n…אין מער ווי 300 שפראכן</string>
   <string name="app_shortcuts_search">זוכן</string>
   <string name="more_language_options">נאָך</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">רעדאקטירן שפראכן</string>
-  <string name="remove_language_dialog_cancel_button_text">אַנולירן</string>
+    <string name="remove_language_dialog_cancel_button_text">אַנולירן</string>
   <string name="account_editing_blocked_dialog_cancel_button_text">אַנולירן</string>
   <string name="wikitext_link">לינק</string>
   <string name="wikitext_template">מוסטער</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -636,9 +636,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">Ora bisa ngilangi kabèh basa</string>
   <string name="more_language_options">liyané</string>
   <string name="add_wikipedia_languages_text">Tambah basa Wikipédia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Buwang varian Cina saka basa aplikasiné panjenengan?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Besut basa</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ora, suwun</string>
   <string name="remove_language_dialog_cancel_button_text">Wurung</string>
   <string name="remove_language_dialog_ok_button_text">YA</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">YA</string>

--- a/app/src/main/res/values-kcg/strings.xml
+++ b/app/src/main/res/values-kcg/strings.xml
@@ -631,8 +631,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">Si̱ mi̱n nga a̱mgba̱m lilyem wu bah</string>
   <string name="more_language_options">nkyang njhyang</string>
   <string name="add_wikipedia_languages_text">Mbeang lilyem Wikipidya</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Jhyuk lilyem</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Kaai a̱gwai</string>
   <string name="remove_language_dialog_cancel_button_text">Lyang</string>
   <string name="remove_language_dialog_ok_button_text">Ndei</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Ndei</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -368,7 +368,7 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">ទុកយ៉ាងហោចណាស់មួយភាសាវិគីភីឌាសម្រាប់ស្វែងរកនិងអាចខ្លឹមសារអត្ថបទ។</string>
   <string name="more_language_options">បន្ថែមទៀត</string>
   <string name="add_wikipedia_languages_text">បន្ថែមភាសាវិគីភីឌា</string>
-    <string name="edit_type_all">វិភាគទានទាំងអស់</string>
+  <string name="edit_type_all">វិភាគទានទាំងអស់</string>
   <string name="main_drawer_help">ជំនួយ</string>
   <string name="main_drawer_login">កត់ឈ្មោះចូល / ចូលរួមជាមួយវិគីភីឌា</string>
   <string name="revision_diff_from">ពី៖</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -368,8 +368,7 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">ទុកយ៉ាងហោចណាស់មួយភាសាវិគីភីឌាសម្រាប់ស្វែងរកនិងអាចខ្លឹមសារអត្ថបទ។</string>
   <string name="more_language_options">បន្ថែមទៀត</string>
   <string name="add_wikipedia_languages_text">បន្ថែមភាសាវិគីភីឌា</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">ទេ, អរគុណហើយ</string>
-  <string name="edit_type_all">វិភាគទានទាំងអស់</string>
+    <string name="edit_type_all">វិភាគទានទាំងអស់</string>
   <string name="main_drawer_help">ជំនួយ</string>
   <string name="main_drawer_login">កត់ឈ្មោះចូល / ចូលរួមជាមួយវិគីភីឌា</string>
   <string name="revision_diff_from">ពី៖</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -439,8 +439,7 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">ಎಲ್ಲಾ ಭಾಷೆಗಳನ್ನು ತೆಗೆಯಲು ಆಗುವುದಿಲ್ಲ</string>
   <string name="more_language_options">ಇನ್ನಷ್ಟು</string>
   <string name="add_wikipedia_languages_text">ವಿಕಿಪೀಡಿಯ ಭಾಷೆಗಳನ್ನು ಸೇರಿಸಿ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ಭಾಷೆಗಳನ್ನು ಸಂಪಾದಿಸಿ</string>
-  <string name="remove_language_dialog_cancel_button_text">ರದ್ದುಮಾಡಿ</string>
+    <string name="remove_language_dialog_cancel_button_text">ರದ್ದುಮಾಡಿ</string>
   <string name="remove_language_dialog_ok_button_text">ಸರಿ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ಸರಿ</string>
   <string name="protected_page_warning_dialog_ok_button_text">ಸರಿ</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -439,7 +439,7 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">ಎಲ್ಲಾ ಭಾಷೆಗಳನ್ನು ತೆಗೆಯಲು ಆಗುವುದಿಲ್ಲ</string>
   <string name="more_language_options">ಇನ್ನಷ್ಟು</string>
   <string name="add_wikipedia_languages_text">ವಿಕಿಪೀಡಿಯ ಭಾಷೆಗಳನ್ನು ಸೇರಿಸಿ</string>
-    <string name="remove_language_dialog_cancel_button_text">ರದ್ದುಮಾಡಿ</string>
+  <string name="remove_language_dialog_cancel_button_text">ರದ್ದುಮಾಡಿ</string>
   <string name="remove_language_dialog_ok_button_text">ಸರಿ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ಸರಿ</string>
   <string name="protected_page_warning_dialog_ok_button_text">ಸರಿ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1146,10 +1146,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">내용을 검색하고 읽을 위키백과 언어는 적어도 하나를 유지하십시오.</string>
   <string name="more_language_options">더 보기</string>
   <string name="add_wikipedia_languages_text">위키백과 언어 추가</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">앱 언어에서 중국어를 제거하시겠습니까?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">현재 앱 언어에서 정체 중국어와 간체 중국어가 설정되어 있습니다. 앱 언어 설정을 업데이트하시겠습니까?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">언어 편집</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">괜찮습니다</string>
   <string name="remove_language_dialog_cancel_button_text">취소</string>
   <string name="remove_language_dialog_ok_button_text">확인</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">확인</string>

--- a/app/src/main/res/values-krc/strings.xml
+++ b/app/src/main/res/values-krc/strings.xml
@@ -1170,10 +1170,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Ичиндегини окъур эмда ичиндегиде излеу этер ючюн эм азы бла бир Википедия тилни къоюгъуз.</string>
   <string name="more_language_options">энтда</string>
   <string name="add_wikipedia_languages_text">Википедия тилле къош</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Къошагъыгъызны тиллеринден къытай тил къоратылсынмы?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Къошагъыгъызны тиллеринде эртдеден келген эмда къысхартылгъан Къытай тил вариантлары барды. Къошагъыгъызны тиллерини джарашдырыуу джангыртылсынмы?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Тиллени тюзет</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Огъай, сау болугъуз</string>
   <string name="remove_language_dialog_cancel_button_text">Ызына ал</string>
   <string name="remove_language_dialog_ok_button_text">ОК</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ОК</string>

--- a/app/src/main/res/values-ks/strings.xml
+++ b/app/src/main/res/values-ks/strings.xml
@@ -607,8 +607,6 @@
   <string name="wikipedia_languages_remove_action_mode_title">زَبان ہَٹٲوِو</string>
   <string name="more_language_options">بێیہِ</string>
   <string name="add_wikipedia_languages_text">ویٖکیٖپیٖڈیا زبان کٕریٚو جمع/ایٚڈ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">زبانہٕ کٕریٚو جمع/ایٚڈ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">نَہ، شُکریا</string>
   <string name="remove_language_dialog_cancel_button_text">مَنسوٗخ</string>
   <string name="remove_language_dialog_ok_button_text">ٹھیٖک چھُ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ٹھیٖک چھُ</string>

--- a/app/src/main/res/values-kum/strings.xml
+++ b/app/src/main/res/values-kum/strings.xml
@@ -217,8 +217,6 @@
   <string name="wikipedia_languages_remove_text">Тилни тайдырмакъ</string>
   <string name="wikipedia_languages_remove_action_mode_title">Тилни тайдырмакъ</string>
   <string name="more_language_options">дагъы</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Тиллени тюзлемек</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ёкъ савбол</string>
   <string name="wikitext_bold">Къалын</string>
   <string name="wikitext_italic">Авункъу</string>
   <string name="wikitext_link">Байланыв</string>

--- a/app/src/main/res/values-kus/strings.xml
+++ b/app/src/main/res/values-kus/strings.xml
@@ -865,9 +865,6 @@
   <string name="on_this_day_dialog_previous_month">Nwadig kanɛ gaad la</string>
   <string name="more_language_options">Bɛdigʋ</string>
   <string name="add_wikipedia_languages_text">Paasim Wikipiidia pian\'ad buudinam</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Yis Chinese pian\'adi fʋ app buudi pian\'adnaminɛɛ?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Dɛmisim buudi pian\'adnam</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ayei m pʋ\'ʋsya</string>
   <string name="remove_language_dialog_cancel_button_text">Basim</string>
   <string name="remove_language_dialog_ok_button_text">Awɔɔ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Awɔɔ</string>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -986,10 +986,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">D\'Sprooche kënnen net all ewechgeholl ginn</string>
   <string name="more_language_options">méi</string>
   <string name="add_wikipedia_languages_text">Wikipedia-Sproochen derbäisetzen</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Eng chineesesch Variant vun Ären App Sproochen ewechhuelen?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Dir hutt elo souwuel déi traditionell wéi déi vereinfacht chineesesch Variant an Ären App sproochen agestallt. Wëllt Dir d\'Astellunge vun de Sprooche vun Ären Appen änneren?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Sproochen änneren</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nee, merci</string>
   <string name="remove_language_dialog_cancel_button_text">Ofbriechen</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -972,10 +972,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Išlaikykite bent vieną Vikipedijos kalbą, kuria ieškoti ir skaityti turinį</string>
   <string name="more_language_options">daugiau</string>
   <string name="add_wikipedia_languages_text">Pridėti Vikipedijos kalbas</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Pašalinti kinų variantą iš jūsų programėlės kalbų?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Šiuo metu turite tradicinės ir supaprastintos kinų kalbos variantus savo programėlės kalbose. Atnaujinti jūsų programėlės kalbų nustatymus?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Keisti kalbas</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ne, ačiū</string>
   <string name="remove_language_dialog_cancel_button_text">Atšaukti</string>
   <string name="remove_language_dialog_ok_button_text">Gerai</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Gerai</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -345,8 +345,6 @@
   <string name="wikipedia_languages_remove_dialog_title" fuzzy="true">Noņemt izvēlētās valodas?</string>
   <string name="wikipedia_languages_remove_warning_dialog_title">Nevar noņemt visas valodas</string>
   <string name="more_language_options">vairāk</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Labot valodas</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nē, paldies</string>
   <string name="remove_language_dialog_cancel_button_text">Atcelt</string>
   <string name="remove_language_dialog_ok_button_text">Labi</string>
   <string name="account_editing_blocked_dialog_cancel_button_text">Atcelt</string>

--- a/app/src/main/res/values-mhr/strings.xml
+++ b/app/src/main/res/values-mhr/strings.xml
@@ -704,7 +704,7 @@
   <string name="onboarding_welcome_title_v2">Эрыкан энциклопедий\n…300 деч шукырак йылме дене</string>
   <string name="app_shortcuts_random">Чокым</string>
   <string name="app_shortcuts_search">Кычалаш</string>
-    <string name="remove_language_dialog_cancel_button_text">Чараш</string>
+  <string name="remove_language_dialog_cancel_button_text">Чараш</string>
   <string name="remove_language_dialog_ok_button_text">Йӧра</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Йӧра</string>
   <string name="protected_page_warning_dialog_ok_button_text">Йӧра</string>

--- a/app/src/main/res/values-mhr/strings.xml
+++ b/app/src/main/res/values-mhr/strings.xml
@@ -704,8 +704,7 @@
   <string name="onboarding_welcome_title_v2">Эрыкан энциклопедий\n…300 деч шукырак йылме дене</string>
   <string name="app_shortcuts_random">Чокым</string>
   <string name="app_shortcuts_search">Кычалаш</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Уке, тау</string>
-  <string name="remove_language_dialog_cancel_button_text">Чараш</string>
+    <string name="remove_language_dialog_cancel_button_text">Чараш</string>
   <string name="remove_language_dialog_ok_button_text">Йӧра</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Йӧра</string>
   <string name="protected_page_warning_dialog_ok_button_text">Йӧра</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -1181,10 +1181,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Задржете барем еден јазик на Википедија од кој ќе пребарувате и читате содржини.</string>
   <string name="more_language_options">повеќе</string>
   <string name="add_wikipedia_languages_text">Додај јазици</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Да отстранам кинеска варијанта од јазиците на прилогот?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Тековно имате и традиционален и упростен кинески во јазиците на прилогот. Да ги изменам јазичните поставки?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Измени јазици</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Не, благодарам</string>
   <string name="remove_language_dialog_cancel_button_text">Откажи</string>
   <string name="remove_language_dialog_ok_button_text">ОК</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ОК</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -492,8 +492,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">വായിക്കുവാനും തിരയുവാനും ഒരു വിക്കിപീഡിയ ഭാഷയെങ്കിലും നിലനിർത്തുക.</string>
   <string name="more_language_options">കൂടുതൽ</string>
   <string name="add_wikipedia_languages_text">വിക്കിപീഡിയ ഭാഷകൾ ചേർക്കുക</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ഭാഷകൾ തിരുത്തുക</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">വേണ്ട, നന്ദി</string>
   <string name="remove_language_dialog_cancel_button_text">റദ്ദാക്കുക</string>
   <string name="remove_language_dialog_ok_button_text">ശരി</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ശരി</string>

--- a/app/src/main/res/values-mnw/strings.xml
+++ b/app/src/main/res/values-mnw/strings.xml
@@ -965,10 +965,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">အောန်အိုတ် ဒးစိုတ်လဝ် အရေဝ်ဘာသာ ဝဳကဳပဳဒဳယာ မွဲ နူ ဒၞာဲမာတိကာ သွက်ဂွံဂၠာဲ ကေုာံ သွက်ဂွံဗှ်၊၊</string>
   <string name="more_language_options">ဗွဲမဂလိုင်</string>
   <string name="add_wikipedia_languages_text">စုတ် အရေဝ်ဘာသာ ဝဳကဳပဳဒဳယာဂမၠိုင်</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">ပတိတ်ထောအ် အရေဝ်ကြုက် မူတၞဟ်ခြာ နူ အရေဝ်ဘာသာ app？</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">ပြဟ်ဟ်ဏအ် ပ္ဍဲ အရေဝ်ဘာသာ app မၞးဂှ် နွံဒၟံင် အရေဝ်ကြုက် ခေတ်တြေံကီု သီုကဵု အရေဝ်ကြုက် ခေတ်တၟိ၊၊ ကလေင်ဗဟဵုတၟိပတိုန် ဒၞာဲမဖျေဟ်ဒၞာဲ အရေဝ်ဘာသာ app ဟာ？</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ပလေဝ် အရေဝ်ဘာသာဂမၠိုင်</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">ဟအှ်ေ တင်ဂုန်ရ၊၊</string>
   <string name="remove_language_dialog_cancel_button_text">တးပဲါ</string>
   <string name="remove_language_dialog_ok_button_text">ခိုဟ်</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ခိုဟ်</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -888,10 +888,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Pastikan sekurang-kurangnya satu bahasa Wikipedia yang boleh digunakan untuk mencari dan membaca kandungan.</string>
   <string name="more_language_options">lagi</string>
   <string name="add_wikipedia_languages_text">Tambah bahasa Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Buang variasi Cina dari bahasa apl anda?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Anda kini mempunyai kedua-dua varian Cina Tradisional dan Sederhana yang ditetapkan dalam bahasa apl anda. Kemas kini tetapan apl aplikasi anda?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Sunting bahasa</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Tak apalah</string>
   <string name="remove_language_dialog_cancel_button_text">Batalkan</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -900,9 +900,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">အကြောင်းအရာ ရှာဖွေ၊ ဖတ်ရှုရန် ဝီကီပီးဒီးယား ဘာသာစကား အနည်းဆုံး ၁ ခု ထားရှိပါ။</string>
   <string name="more_language_options">ပို၍</string>
   <string name="add_wikipedia_languages_text">ဝီကီပီဒီးယား ဘာသာစကားများ ပေါင်းထည့်ရန်</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">သင်၏ app ဘာသာစကားများမှ တရုတ်မူကွဲကို ဖယ်ရှားမှာလား</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ဘာသာစကားများ တည်းဖြတ်ရန်</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">မလိုပါ၊ ကျေးဇူးတင်ပါသည်။</string>
   <string name="remove_language_dialog_cancel_button_text">မလုပ်တော့ပါ</string>
   <string name="remove_language_dialog_ok_button_text">အိုကေ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">အိုကေ</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1166,10 +1166,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Behold minst ett Wikipedia-språk som du kan søke og lese innhold på</string>
   <string name="more_language_options">mer</string>
   <string name="add_wikipedia_languages_text">Legg til Wikipedia-språk</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Fjerne en kinesisk variant fra språkene dine?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Du har både tradisjonell og forenklet kinesisk i språkene dine. Vil du oppdatere språkinnstillingene?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Rediger språk</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nei takk</string>
   <string name="remove_language_dialog_cancel_button_text">Avbryt</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -675,8 +675,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">सबै भाषा हटाउन सकिएन</string>
   <string name="more_language_options">थप</string>
   <string name="add_wikipedia_languages_text">विकिपिडिया भाषाहरू थप्नुहोस्</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">भाषाहरू सम्पादन गर्नुहोस्</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">पर्दैन धन्यवाद</string>
   <string name="remove_language_dialog_cancel_button_text">रद्द गर्नुहोस्</string>
   <string name="remove_language_dialog_ok_button_text">हुन्छ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">हुन्छ</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1192,10 +1192,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Houd ten minste één Wikipedia-taal waarin u inhoud kunt zoeken en lezen.</string>
   <string name="more_language_options">meer</string>
   <string name="add_wikipedia_languages_text">Voeg Wikipedia-talen toe</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Verwijder een Chinees-variant uit uw talen in de app?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">U heeft momenteel zowel traditioneel als versimpeld Chinees in de talen van uw app. Wilt u de app-instellingen voor talen bijwerken?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Talen aanpassen</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nee, bedankt</string>
   <string name="remove_language_dialog_cancel_button_text">Annuleren</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-nqo/strings.xml
+++ b/app/src/main/res/values-nqo/strings.xml
@@ -969,9 +969,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">ߞߊ߲߫ ߞߋߟߋ߲߫ ߛߎߥߊ߲ߘߌ߫ ߥߞߌߔߋߘߌߦߊ ߞߊ߲߬ ߌ ߘߌ߫ ߢߌߣߌ߲ߠߌ߲ ߣߌ߫ ߘߐ߬ߞߊ߬ߙߊ߲߬ߠߌ߲ ߞߍ߫ ߡߍ߲ ߘߐ߫.</string>
   <string name="more_language_options">ߡߞߊ߬ߝߏ߬ ߜߘߍ߫ ߟߎ߫</string>
   <string name="add_wikipedia_languages_text">ߥߞߌ-ߔߘߋߞߎ ߞߊ߲ ߠߎ߬ ߟߊߘߏ߲߬</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">ߛ߭ߌߣߌ߲ߞߊߞߊ߲ ߓߐ߫ ߌ ߟߊ߫ ߟߥߊ߬ߟߌ߬ߟߊ߲ ߞߊ߲ߦߊ ߟߊ߫؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ߞߊ߲ ߠߎ߬ ߡߊߦߟߍ߬ߡߊ߲߫</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">ߒ߬ߒ߫ ߌ ߞߎߟߎ߲ߖߋ߫</string>
   <string name="remove_language_dialog_cancel_button_text">ߊ߬ ߘߐߛߊ߬</string>
   <string name="remove_language_dialog_ok_button_text">ߏ߬ߞߍ߫</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ߏ߬ߞߍ߫</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1086,10 +1086,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Zachowaj przynajmniej jeden język Wikipedii, z którego można wyszukiwać i czytać treści.</string>
   <string name="more_language_options">więcej</string>
   <string name="add_wikipedia_languages_text">Dodaj języki Wikipedii</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Usunąć wariant chiński z języków aplikacji?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Obecnie w językach aplikacji masz ustawione zarówno tradycyjne, jak i uproszczone chińskie warianty. Zaktualizować ustawienia języków aplikacji?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Edytuj języki</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nie, dziękuję</string>
   <string name="remove_language_dialog_cancel_button_text">Anuluj</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1198,10 +1198,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Mantenha pelo menos um idioma do Wikipedia para pesquisar e ler conteúdo.</string>
   <string name="more_language_options">mais</string>
   <string name="add_wikipedia_languages_text">Adicionar idiomas da Wikipédia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Remover uma variante chinesa dos seus idiomas do aplicativo?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Atualmente, você tem variantes de chinês tradicional e simplificado definidas nos idiomas do aplicativo. Atualize as configurações de idiomas do seu aplicativo?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Editar idiomas</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Não, obrigado</string>
   <string name="remove_language_dialog_cancel_button_text">Cancelar</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1176,10 +1176,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Mantenha pelo menos uma língua da Wikipédia para pesquisar e ler o conteúdo.</string>
   <string name="more_language_options">mais</string>
   <string name="add_wikipedia_languages_text">Adicione as línguas da Wikipédia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Remover uma variante do chinês das suas línguas da aplicação?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Neste momento tem as variantes tradicional e simplificado do chinês definidas nas suas línguas da aplicação. Atualizar as definições das suas línguas da aplicação?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Editar línguas</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Não, obrigado</string>
   <string name="remove_language_dialog_cancel_button_text">Cancelar</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1209,10 +1209,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Content of the dialog that pop-ups after users wanted to delete all wikipedia languages in the action mode.</string>
   <string name="more_language_options">Button text indicating there are more languages available to be selected.\n{{Identical|More}}</string>
   <string name="add_wikipedia_languages_text">Button text suggesting user to add more languages to the app to read in.</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Title of the dialog that prompts to the users about removing a Chinese variant from the app languages.</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Description of the dialog that prompts to the users about removing a Chinese variant from the app languages.</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Affirmative answer to open the Wikipedia languages page to manage the existing languages that have been set up.</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Negative answer to keep the existing app languages settings.</string>
   <string name="remove_language_dialog_cancel_button_text">Negative action button text in pop-up dialog for removing a language from app languages list.\n{{Identical|Cancel}}</string>
   <string name="remove_language_dialog_ok_button_text">Positive action button text in pop-up dialog for removing a language from app languages list.</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Acknowledgement button text in warning pop-up dialog when user tries to delete all languages from app languages list.\n{{Identical|OK}}</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1108,10 +1108,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Păstrați cel puțin o limbă Wikipedia din care să căutați și să citiți conținut.</string>
   <string name="more_language_options">mai mult</string>
   <string name="add_wikipedia_languages_text">Adaugă limbi Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Eliminați o variantă chineză din limbile aplicației dvs.?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">În prezent, aveți variante de chineză tradiționale și simplificate setate în limbile aplicației dvs. Actualizați setările limbilor din aplicație?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Modifică limbile</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nu, mulțumesc</string>
   <string name="remove_language_dialog_cancel_button_text">Anulează</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1272,10 +1272,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Оставьте, по меньшей мере, один язык для поиска и чтения.</string>
   <string name="more_language_options">ещё языки</string>
   <string name="add_wikipedia_languages_text">Добавить языки Википедии</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Удалить китайский из списка языков?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">У вас в наличии и традиционный, и упрощённый китайские языки. Обновить языковые настройки, с возможностью удалить один из вариантов?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Редактировать языки</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Использовать текущие настройки</string>
   <string name="remove_language_dialog_cancel_button_text">Отмена</string>
   <string name="remove_language_dialog_ok_button_text">ОК</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ОК</string>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -173,6 +173,4 @@
   <string name="color_theme_dark">श्यामम्</string>
   <string name="user_option_sync_label">इष्टतमानि</string>
   <string name="onboarding_welcome_title_v2" fuzzy="true"> निःशुल्कः ज्ञानकोशः...प्रायः ३०० भाषासु</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">भाषासम्पादनम्</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">मास्तु, धन्यवादः</string>
 </resources>

--- a/app/src/main/res/values-sah/strings.xml
+++ b/app/src/main/res/values-sah/strings.xml
@@ -684,10 +684,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Көрдүүргэ уонна ааҕарга саатар биир тылы хааллар.</string>
   <string name="more_language_options">эбии</string>
   <string name="add_wikipedia_languages_text">Бикипиэдьийэ тылларын эп</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Тыллар испииһэктэриттэн кытай тылын сотоҕун дуо?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Эйиэхэ үгэс курдук туттуллар да, судургу да кытай тыллара турбуттар. Биирин сото таарыйа, нарылааһыны саҥаттан оҥороҕун дуо?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Тыллары уларыт</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Суох, махтанабын</string>
   <string name="remove_language_dialog_cancel_button_text">Салҕаама</string>
   <string name="remove_language_dialog_ok_button_text">Сөп</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Сөп</string>

--- a/app/src/main/res/values-scn/strings.xml
+++ b/app/src/main/res/values-scn/strings.xml
@@ -385,8 +385,6 @@
   <string name="wikipedia_languages_add_language_text">Agghiunci lingua</string>
   <string name="more_language_options">àutru</string>
   <string name="add_wikipedia_languages_text">Agghiunci li lingui di Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Cancia lingui</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">No, grazzi</string>
   <string name="remove_language_dialog_cancel_button_text">Annulla</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-sd/strings.xml
+++ b/app/src/main/res/values-sd/strings.xml
@@ -1071,9 +1071,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">گهٽ ۾ گهٽ ھڪ وڪيپيڊيا ٻولي رکو جنھن ۾ مواد ڳولي ۽ پڙھي سگهجي.</string>
   <string name="more_language_options">وڌيڪ</string>
   <string name="add_wikipedia_languages_text">وڪيپيڊيا ٻوليون شامل ڪريو</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">پنھنجي ايپ جي ٻولين مان ڪو چيني ويرينٽ هٽايو؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ٻوليون سنواريو</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">نہ مھرباني</string>
   <string name="remove_language_dialog_cancel_button_text">رد</string>
   <string name="remove_language_dialog_ok_button_text">ٺيڪ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ٺيڪ</string>

--- a/app/src/main/res/values-sdh/strings.xml
+++ b/app/src/main/res/values-sdh/strings.xml
@@ -241,8 +241,6 @@
   <string name="wikipedia_languages_remove_action_mode_title">لاوردن زوان</string>
   <string name="more_language_options">فێشتر</string>
   <string name="add_wikipedia_languages_text">ئزافەکردن زوانەیل ویکیپیدیا</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">دەسکاریکردن زوانەیل</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">نە سپاس</string>
   <string name="remove_language_dialog_cancel_button_text">هەڵوەشاننەوە</string>
   <string name="remove_language_dialog_ok_button_text">باشە</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">باشە</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -440,8 +440,6 @@
   <string name="wikipedia_languages_remove_text">Sihko giela</string>
   <string name="wikipedia_languages_remove_action_mode_title">Sihko giela</string>
   <string name="add_wikipedia_languages_text">Lasit Wikipedia-gielaid</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Rievdat gielaid</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ii giitu</string>
   <string name="remove_language_dialog_cancel_button_text">Gaskkalduhte</string>
   <string name="account_editing_blocked_dialog_cancel_button_text">Gaskkalduhte</string>
   <string name="wikitext_bold">Buoiddesčála</string>

--- a/app/src/main/res/values-shn/strings.xml
+++ b/app/src/main/res/values-shn/strings.xml
@@ -648,10 +648,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">တွၼ်ႈတႃႇ ၶူၼ်ႉႁႃ လႄႈ လူဢၢၼ်ႇ လမ်းၼႂ်းၼၼ်ႉ တီႈၽႃႇသႃႇၵႂၢမ်း ဝီႇၶီႇၽီးတီးယႃးၼၼ်ႉ ၵဵပ်းသႂ်ႇဝႆႉပၼ် တီႈဢေႇသုတ်းမၼ်း တႃႇဢၼ်ၼိုင်ႈ။</string>
   <string name="more_language_options">ၼမ်လိူဝ်</string>
   <string name="add_wikipedia_languages_text">ထႅမ်သႂ်ႇ ၽႃႇသႃႇၵႂၢမ်း ဝီႇၶီႇၽီးတီးယႃး</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">တေထွၼ်ပႅတ်ႈ ပိူင်ပႅၵ်ႇ​ႄႇ ၵႃႈတီႈ ၽႃႇသႃႇၵႂၢမ်းဢႅပ်ႉၸဝ်ႈၵဝ်ႇၼၼ်ႉၼႄႇ?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">ယၢမ်းလဵဝ် တီႈၽႃႇသႃႇၵႂၢမ်းဢႅပ်ႉၸဝ်ႈၵဝ်ႇၼၼ်ႉ မီးဝႆႉ ပိူင်ပႅၵ်ႇၽႃႇသႃႇၶႄႇၽိင်ႈ လႄႈ မိူင်ႈလူင် တင်းသွင်ဢၼ်။ တေဢၢပ်ႉတဵတ်ႉ ၵၢၼ်တင်ႈ ၽႃႇသႃႇၵႂၢမ်းဢႅပ်ႉ ၸဝ်ႈၵဝ်ႇၼႄႇ?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">မႄးထတ်း ၽႃႇသႃႇၵႂၢမ်း</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">ပႆႇၵွၼ်ႇ</string>
   <string name="remove_language_dialog_cancel_button_text">ယုၵ်ႉလိူၵ်ႈ</string>
   <string name="remove_language_dialog_ok_button_text">ဢူဝ်ႇၶေႇ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ဢူဝ်ႇၶေႇ</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1100,10 +1100,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Udržujte si aspoň jeden jazyk Wikipédie, z ktorého môžete vyhľadávať a čítať obsah.</string>
   <string name="more_language_options">viac</string>
   <string name="add_wikipedia_languages_text">Pridať jazyky</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Chcete odstrániť variant čínštiny z vašich jazykov?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Vo vašich jazykoch máte tradičnú a zjednodušené čínštinu. Chcete aktualizovať svoje nastavenia jazyka?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Upraviť jazyky</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nie, vďaka</string>
   <string name="remove_language_dialog_cancel_button_text">Zrušiť</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-skr/strings.xml
+++ b/app/src/main/res/values-skr/strings.xml
@@ -514,8 +514,6 @@
   <string name="wikipedia_languages_remove_text">زبان ہٹاؤ</string>
   <string name="wikipedia_languages_remove_action_mode_title">زبان ہٹاؤ</string>
   <string name="more_language_options">ٻئے</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">زباناں وچ تبدیلی کرو</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">کو، شکریہ</string>
   <string name="remove_language_dialog_cancel_button_text">منسوخ</string>
   <string name="remove_language_dialog_ok_button_text">ٹھیک ہے</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ٹھیک ہے</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1238,10 +1238,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Ohranite vsaj en jezik Wikipedije, v katerem lahko pregledujete in berete vsebino.</string>
   <string name="more_language_options">več</string>
   <string name="add_wikipedia_languages_text">Dodaj jezike Wikipedije</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Želite med jeziki aplikacije odstraniti različico kitajščine?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Trenutno imate med jeziki aplikacije tradicionalno in poenostavljeno različico kitajščine. Želite jezikovne nastavitve posodobiti?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Uredi jezike</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ne, hvala</string>
   <string name="remove_language_dialog_cancel_button_text">Prekliči</string>
   <string name="remove_language_dialog_ok_button_text">V redu</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">V redu</string>

--- a/app/src/main/res/values-sms/strings.xml
+++ b/app/src/main/res/values-sms/strings.xml
@@ -335,8 +335,7 @@
   <string name="wikipedia_languages_remove_text">Jaukkâd ǩiõl</string>
   <string name="wikipedia_languages_remove_action_mode_title">Jaukkâd ǩiõl</string>
   <string name="add_wikipedia_languages_text">Lââʹzzet Wikipedia-ǩiõlid</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Muuʹtt ǩiõlid</string>
-  <string name="remove_language_dialog_cancel_button_text">Jõõsk</string>
+    <string name="remove_language_dialog_cancel_button_text">Jõõsk</string>
   <string name="account_editing_blocked_dialog_cancel_button_text">Jõõsk</string>
   <string name="edit_type_all">Puk muttâz</string>
   <string name="wikitext_link">Liŋkk</string>

--- a/app/src/main/res/values-sms/strings.xml
+++ b/app/src/main/res/values-sms/strings.xml
@@ -335,7 +335,7 @@
   <string name="wikipedia_languages_remove_text">Jaukkâd ǩiõl</string>
   <string name="wikipedia_languages_remove_action_mode_title">Jaukkâd ǩiõl</string>
   <string name="add_wikipedia_languages_text">Lââʹzzet Wikipedia-ǩiõlid</string>
-    <string name="remove_language_dialog_cancel_button_text">Jõõsk</string>
+  <string name="remove_language_dialog_cancel_button_text">Jõõsk</string>
   <string name="account_editing_blocked_dialog_cancel_button_text">Jõõsk</string>
   <string name="edit_type_all">Puk muttâz</string>
   <string name="wikitext_link">Liŋkk</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -108,8 +108,4 @@
   <string name="enable_location_service">Aktivizo</string>
   <string name="color_theme_select">Tema</string>
   <string name="onboarding_welcome_title_v2" fuzzy="true">Enciklopedia falas\n...afersisht ne 300 gjuhe</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Largo nje variant ne Gjuhen Kineze nga gjuhet ne aplikacionin tuaj?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">You tani keni setin e varianteve te te dyjave te asaj Tradicionale dhe Kineze te thjeshtesuar ne gjuhet e aplikacionit.\nRino rradhitjen e gjuhes ne aplikacionin tuaj?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Hyn tek gjuhet</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Jo faleminderit</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1155,10 +1155,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Задржите бар један језик за претрагу и читање.</string>
   <string name="more_language_options">још</string>
   <string name="add_wikipedia_languages_text">Додај језике Википедије</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Уклонити варијанту кинеског са листе језика?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Тренутно имате и традиционални и поједностављени кинески у језицима апликације. Променити подешавања језика?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Уреди језике</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Не, хвала</string>
   <string name="remove_language_dialog_cancel_button_text">Откажи</string>
   <string name="remove_language_dialog_ok_button_text">У реду</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">У реду</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1182,10 +1182,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Behåll minst ett Wikipedia-språk att söka och läsa innehåll på.</string>
   <string name="more_language_options">fler</string>
   <string name="add_wikipedia_languages_text">Lägg till Wikipedia-språk</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Ta bort en kinesisk variant från dina appspråk?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Du har för tillfället både den traditionella och förenklade varianterna av kinesiska i dina appspråk. Uppdatera inställningar för dina appspråk?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Redigera språk</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Nej tack</string>
   <string name="remove_language_dialog_cancel_button_text">Avbryt</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -538,6 +538,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">அனைத்து மொழிகளையும் நீக்க இயலவில்லை</string>
   <string name="more_language_options">மேலும்</string>
   <string name="add_wikipedia_languages_text">விக்கிபீடியா மொழிகளைச் சேர்க்கவும்</string>
-    <string name="main_drawer_help">உதவி</string>
+  <string name="main_drawer_help">உதவி</string>
   <string name="main_drawer_login">விக்கிபீடியாவில் புகுபதிக / இணைக</string>
 </resources>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -538,7 +538,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">அனைத்து மொழிகளையும் நீக்க இயலவில்லை</string>
   <string name="more_language_options">மேலும்</string>
   <string name="add_wikipedia_languages_text">விக்கிபீடியா மொழிகளைச் சேர்க்கவும்</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">மொழிகளைத் தொகு</string>
-  <string name="main_drawer_help">உதவி</string>
+    <string name="main_drawer_help">உதவி</string>
   <string name="main_drawer_login">விக்கிபீடியாவில் புகுபதிக / இணைக</string>
 </resources>

--- a/app/src/main/res/values-tcy/strings.xml
+++ b/app/src/main/res/values-tcy/strings.xml
@@ -376,8 +376,7 @@
   <string name="wikipedia_languages_remove_text">ಬಾಸೆನ್ ದೆಪ್ಪುಲೆ</string>
   <string name="more_language_options">ನನಾತ್</string>
   <string name="add_wikipedia_languages_text">ವಿಕಿಪೀಡಿಯಾ ಬಾಸೆಲೇನ್ ಸೇರಲೇ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ಬಾಸೆನ್ ಸೇರಾಲೆ</string>
-  <string name="edit_type_all">ಮಾತ ಕಾನಿಕೆಲು</string>
+    <string name="edit_type_all">ಮಾತ ಕಾನಿಕೆಲು</string>
   <string name="preview_edit_summarize_edit_hint">ಈರ್ ಇ ಪುಟೊನ್ ವಾ ನಮೂಡೆಡ್ ಎಡ್ಡೆ ಮಲ್ತರ್?</string>
   <string name="patroller_saved_message_title_art_imp">ಲೇಕನ ಸುದಾರಣೆ ಸಲಹೆ</string>
   <string name="talk_templates_menu_edit_title">ಸಂಪೊಲಿಪುಲೆ</string>

--- a/app/src/main/res/values-tcy/strings.xml
+++ b/app/src/main/res/values-tcy/strings.xml
@@ -376,7 +376,7 @@
   <string name="wikipedia_languages_remove_text">ಬಾಸೆನ್ ದೆಪ್ಪುಲೆ</string>
   <string name="more_language_options">ನನಾತ್</string>
   <string name="add_wikipedia_languages_text">ವಿಕಿಪೀಡಿಯಾ ಬಾಸೆಲೇನ್ ಸೇರಲೇ</string>
-    <string name="edit_type_all">ಮಾತ ಕಾನಿಕೆಲು</string>
+  <string name="edit_type_all">ಮಾತ ಕಾನಿಕೆಲು</string>
   <string name="preview_edit_summarize_edit_hint">ಈರ್ ಇ ಪುಟೊನ್ ವಾ ನಮೂಡೆಡ್ ಎಡ್ಡೆ ಮಲ್ತರ್?</string>
   <string name="patroller_saved_message_title_art_imp">ಲೇಕನ ಸುದಾರಣೆ ಸಲಹೆ</string>
   <string name="talk_templates_menu_edit_title">ಸಂಪೊಲಿಪುಲೆ</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -1003,10 +1003,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">కనీసం ఒక్క వికీపీడియా భాషనైనా ఉంచండి - కంటెంటును వెతకడం, చదవడం చెయ్యాలిగా.</string>
   <string name="more_language_options">మరిన్ని</string>
   <string name="add_wikipedia_languages_text">వికీపీడియా భాషలను చేర్చు</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">మీ యాప్ భాషల నుండి ఓ చైనీసు రకాన్ని తీసెయ్యమంటారా?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">మీ యాప్ భాషల్లో ప్రస్తుతం సాంప్రదాయిక చైనీసు, సరళీకృత చైనీసు రెండూ ఉన్నాయి. మీ యాప్‌లో భాషా అమరికలను తాజాకరిస్తారా?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">భాషలను సవరించు</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">వద్దులే</string>
   <string name="remove_language_dialog_cancel_button_text">రద్దుచేయి</string>
   <string name="remove_language_dialog_ok_button_text">సరే</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">సరే</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -929,10 +929,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">เหลือภาษาของวิกิพีเดียไว้อย่างน้อยหนึ่งภาษาเพื่อให้สามารถใช้ค้นหาและอ่านเนื้อหาได้</string>
   <string name="more_language_options">เพิ่มเติม</string>
   <string name="add_wikipedia_languages_text">เพิ่มภาษาของวิกิพีเดีย</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">เอารูปแบบภาษาจีนออกจากภาษาแอปของคุณหรือไม่</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">ขณะนี้คุณตั้งค่ารูปแบบภาษาจีนทั้งตัวเต็มและตัวย่อไว้ในภาษาแอปของคุณ ปรับปรุงการตั้งค่าภาษาแอปของคุณหรือไม่</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">แก้ไขภาษา</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">ไม่ขอบคุณ</string>
   <string name="remove_language_dialog_cancel_button_text">ยกเลิก</string>
   <string name="remove_language_dialog_ok_button_text">ตกลง</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ตกลง</string>

--- a/app/src/main/res/values-ti/strings.xml
+++ b/app/src/main/res/values-ti/strings.xml
@@ -504,8 +504,6 @@
   <string name="wikipedia_languages_remove_action_mode_title">ቋንቋ ኣልግስ</string>
   <string name="more_language_options">ተወሳኺ</string>
   <string name="add_wikipedia_languages_text">ናይ ዊኪፐድያ ቋንቋታት ወስኽ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">ቋንቋታት ኣመዓራርይ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">ኣይፋል፣ የቐንየለይ</string>
   <string name="remove_language_dialog_cancel_button_text">ኣትርፍ</string>
   <string name="remove_language_dialog_ok_button_text">ሕራይ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ሕራይ</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -1076,10 +1076,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Magtira ng di bababa sa isang wika ng Wikipedia na magagamit mo sa paghahanap at pagbabása.</string>
   <string name="more_language_options">karagdagan</string>
   <string name="add_wikipedia_languages_text">Magdagdag ng wika ng Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Tanggalin ang isang baryante ng wikang Tsino mula sa mga wika mo?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Kasalukuyan kang gumagamit ng parehong Tradisyonal at Pinasimpleng wikang Tsino na baryante sa mga wika mo. Ia-update mo ba ang mga wika sa Settings mo?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Isaayos ang mga wika</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Salamat na lang</string>
   <string name="remove_language_dialog_cancel_button_text">Ikansela</string>
   <string name="remove_language_dialog_ok_button_text">Sige</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Sige</string>

--- a/app/src/main/res/values-tly/strings.xml
+++ b/app/src/main/res/values-tly/strings.xml
@@ -777,9 +777,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">Həmmə zyvonon mole əbyni</string>
   <string name="more_language_options">hənijən zyvonon</string>
   <string name="add_wikipedia_languages_text">Ce Vikipedia zyvonon əlovə kardej</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Cini zyvon ce zyvonon sijohiku mole?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Zyvonon sərost kardej</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ne, səǧbi</string>
   <string name="remove_language_dialog_cancel_button_text">Ohaštej</string>
   <string name="remove_language_dialog_ok_button_text">COK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">COK</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1191,10 +1191,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">İçeriği okumak ve içerikte arama yapmak için en az bir Vikipedi dili bırakın</string>
   <string name="more_language_options">daha fazla</string>
   <string name="add_wikipedia_languages_text">Vikipedi dilleri ekleyin</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Uygulama dillerinden bir Çin varyasyonunu kaldırılsın mı?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Uygulama dillerinde hem geleneksel hem de basit Çince varyasyonları seçili. Uygulama dilleri ayarlarını güncellemek istiyor musunuz?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Dilleri değiştir</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Hayır, teşekkürler</string>
   <string name="remove_language_dialog_cancel_button_text">İptal</string>
   <string name="remove_language_dialog_ok_button_text">Tamam</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Tamam</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1253,10 +1253,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Залиште хоча б одну мову Вікіпедії, якою шукатимете й читатимете матеріали.</string>
   <string name="more_language_options">більше</string>
   <string name="add_wikipedia_languages_text">Додати мови Вікіпедії</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Вилучити китайський варіант з мов вашого додатку?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Зараз у мовах вашого додатку є і традиційна, і спрощена китайська. Оновити мовні налаштування додатку?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Редагувати мови</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ні, дякую</string>
   <string name="remove_language_dialog_cancel_button_text">Скасувати</string>
   <string name="remove_language_dialog_ok_button_text">Гаразд</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">Гаразд</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -664,9 +664,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">کم از کم ویکیپیڈیا کی ایک زبان کو برقرار رکھیں جس سے تلاش کیا اور مواد کا مطالعہ کیا جا سکے۔</string>
   <string name="more_language_options">مزید</string>
   <string name="add_wikipedia_languages_text">ویکیپیڈیا کی زبانیں شامل کریں</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">اپنی ایپ کی زبانوں سے Chinese variant کو ختم کرنا چاہتے ہیں؟</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">زبانوں میں ترمیم</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">نہیں شکریہ</string>
   <string name="remove_language_dialog_cancel_button_text">منسوخ</string>
   <string name="remove_language_dialog_ok_button_text">ٹھیک</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ٹھیک</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -1152,10 +1152,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Maqolani qidirish va oʻqish uchun kamida bitta Vikipediya tilini saqlang.</string>
   <string name="more_language_options">batafsil</string>
   <string name="add_wikipedia_languages_text">Vikipediya tillarini qoʻshish</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Ilova tillaridan xitoycha variant olib tashlansinmi?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Hozirda sizning ilovalaringiz tillarida anʼanaviy va soddalashtirilgan xitoycha variantlar mavjud. Ilova tillari tanlovlarini yangilaysizmi?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Tillarni tahrilamoq</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Yo‘q, rahmat</string>
   <string name="remove_language_dialog_cancel_button_text">Bekor qilish</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1044,10 +1044,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">Hãy giữ lại ít nhất một ngôn ngữ Wikipedia để tìm và đọc nội dung.</string>
   <string name="more_language_options">thêm</string>
   <string name="add_wikipedia_languages_text">Thêm ngôn ngữ Wikipedia</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Xóa biến thể tiếng Trung khỏi các ngôn ngữ ứng dụng của bạn?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Tiếng Trung phồn thể và giản thể đều được kích hoạt trong ngôn ngữ ứng dụng của bạn. Bạn có muốn cập nhật tùy chọn ngôn ngữ ứng dụng?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Sửa ngôn ngữ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Thôi</string>
   <string name="remove_language_dialog_cancel_button_text">Hủy bỏ</string>
   <string name="remove_language_dialog_ok_button_text">OK</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/values-yrl/strings.xml
+++ b/app/src/main/res/values-yrl/strings.xml
@@ -481,10 +481,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_title">Yawá ti umurú umuçaká panhẽ nhẽẽga\'etá</string>
   <string name="more_language_options">Yawá píri</string>
   <string name="add_wikipedia_languages_text">Umburipíri Wikipediya nhẽẽga\'etá</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Umuçaká yepé Xinawara nũgara ne mburipawa nhẽẽga\'etá çuiwara?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">Kuiriwara, ĩdé rerikú Xinawara Rikuçawara açui Pupuyawara tauçurimũ\'ana ne mburipawa nhẽẽga\'etá yumukaturuçawa upé. Umukuiriwara ne mburipawa nhẽẽga yumukaturuçawa\'etá?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Umurupiawa nhẽẽga\'etá</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">Ĩti, kuekatú</string>
   <string name="remove_language_dialog_cancel_button_text">Umuamunika</string>
   <string name="remove_language_dialog_ok_button_text">KATÚ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">KATÚ</string>

--- a/app/src/main/res/values-zgh/strings.xml
+++ b/app/src/main/res/values-zgh/strings.xml
@@ -302,8 +302,7 @@
   <string name="wikipedia_languages_remove_action_mode_title">ⴽⴽⵙ ⵜⵓⵜⵍⴰⵢⵜ</string>
   <string name="more_language_options">ⵓⴳⴳⴰⵔ</string>
   <string name="add_wikipedia_languages_text">ⵔⵏⵓ ⵜⵓⵜⵍⴰⵢⵉⵏ ⵏ ⵡⵉⴽⵉⴱⵉⴷⵢⴰ</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">ⵓⵀⵓ, ⵜⴰⵏⵎⵎⵉⵔⵜ</string>
-  <string name="remove_language_dialog_cancel_button_text">ⵙⵔ</string>
+    <string name="remove_language_dialog_cancel_button_text">ⵙⵔ</string>
   <string name="remove_language_dialog_ok_button_text">ⵡⴰⵅⵅⴰ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ⵡⴰⵅⵅⴰ</string>
   <string name="protected_page_warning_dialog_ok_button_text">ⵡⴰⵅⵅⴰ</string>

--- a/app/src/main/res/values-zgh/strings.xml
+++ b/app/src/main/res/values-zgh/strings.xml
@@ -302,7 +302,7 @@
   <string name="wikipedia_languages_remove_action_mode_title">ⴽⴽⵙ ⵜⵓⵜⵍⴰⵢⵜ</string>
   <string name="more_language_options">ⵓⴳⴳⴰⵔ</string>
   <string name="add_wikipedia_languages_text">ⵔⵏⵓ ⵜⵓⵜⵍⴰⵢⵉⵏ ⵏ ⵡⵉⴽⵉⴱⵉⴷⵢⴰ</string>
-    <string name="remove_language_dialog_cancel_button_text">ⵙⵔ</string>
+  <string name="remove_language_dialog_cancel_button_text">ⵙⵔ</string>
   <string name="remove_language_dialog_ok_button_text">ⵡⴰⵅⵅⴰ</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">ⵡⴰⵅⵅⴰ</string>
   <string name="protected_page_warning_dialog_ok_button_text">ⵡⴰⵅⵅⴰ</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1208,10 +1208,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">請保留至少一種用在搜尋與閱讀內容的維基語言。</string>
   <string name="more_language_options">更多</string>
   <string name="add_wikipedia_languages_text">新增維基百科語言</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">從您的應用程式語言裡移除中文異體?</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">在您的應用程式語言裡，目前有繁體與簡體的中文異體設定。要更新您的應用程式語言設定嗎？</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">編輯語言</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">不用了，謝謝</string>
   <string name="remove_language_dialog_cancel_button_text">取消</string>
   <string name="remove_language_dialog_ok_button_text">確認</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">確認</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1222,10 +1222,6 @@
   <string name="wikipedia_languages_remove_warning_dialog_content">请保持至少一种维基百科语言供搜索和阅读内容。</string>
   <string name="more_language_options">更多</string>
   <string name="add_wikipedia_languages_text">添加维基百科语言</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_title">从您的应用语言中移除一种中文变体？</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_text">目前，您已在您的应用程序语言中同时设置了繁体中文版本和简体中文版本。更新您的应用语言设置？</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">编辑语言</string>
-  <string name="dialog_of_remove_chinese_variants_from_app_lang_no">不，谢谢</string>
   <string name="remove_language_dialog_cancel_button_text">取消</string>
   <string name="remove_language_dialog_ok_button_text">确定</string>
   <string name="remove_all_language_warning_dialog_ok_button_text">确定</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -84,7 +84,6 @@
     <string name="preference_key_reading_lists_first_time_sync">readingListsFirstTimeSyncV2</string>
     <string name="preference_key_about_wikipedia_app">aboutWikipediaApp</string>
     <string name="preference_key_logout">logOut</string>
-    <string name="preference_key_show_remove_chinese_variant_prompt">showRemoveChineseVariantPrompt</string>
     <string name="preference_key_download_only_over_wifi">downloadOnlyOverWiFi</string>
     <string name="preference_key_download_reading_list_articles">downloadReadingListArticles</string>
     <string name="preference_key_remote_notifications_seen_time">remoteNotificationsSeenTime</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1250,10 +1250,6 @@
     <string name="wikipedia_languages_remove_warning_dialog_content">Keep at least one Wikipedia language from which to search and read content.</string>
     <string name="more_language_options">more</string>
     <string name="add_wikipedia_languages_text">Add Wikipedia languages</string>
-    <string name="dialog_of_remove_chinese_variants_from_app_lang_title">Remove a Chinese variant from your app languages?</string>
-    <string name="dialog_of_remove_chinese_variants_from_app_lang_text">You currently have both Traditional and Simplified Chinese variants set in your app languages. Update your app languages settings?</string>
-    <string name="dialog_of_remove_chinese_variants_from_app_lang_edit">Edit languages</string>
-    <string name="dialog_of_remove_chinese_variants_from_app_lang_no">No thanks</string>
     <string name="remove_language_dialog_cancel_button_text">Cancel</string>
     <string name="remove_language_dialog_ok_button_text">OK</string>
     <string name="remove_all_language_warning_dialog_ok_button_text">OK</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -264,10 +264,6 @@
             android:title="@string/preference_key_reading_lists_first_time_sync" />
 
         <org.wikipedia.settings.SwitchPreferenceMultiLine
-            android:key="@string/preference_key_show_remove_chinese_variant_prompt"
-            android:title="@string/preference_key_show_remove_chinese_variant_prompt" />
-
-        <org.wikipedia.settings.SwitchPreferenceMultiLine
             android:key="@string/preference_key_show_description_edit_success_prompt"
             android:title="@string/preference_key_show_description_edit_success_prompt" />
 


### PR DESCRIPTION
This removes the related resources of "Remove duplicated language variants" dialog since it was targeting `zh-hant` and `zh-hans` and now it is no longer valid for the new settings.