### PR TITLE
GPay: use correct formula for transaction fee amount.

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
@@ -32,6 +32,7 @@ import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.UriUtil
+import kotlin.math.max
 
 class GooglePayActivity : BaseActivity() {
     private lateinit var binding: ActivityDonateBinding
@@ -158,6 +159,8 @@ class GooglePayActivity : BaseActivity() {
         val min = viewModel.minimumAmount
         val max = viewModel.maximumAmount
 
+        setTransactionFeeText(max(amount * 0.04f, viewModel.transactionFee))
+
         if (amount <= 0f || amount < min) {
             binding.donateAmountInput.error = getString(R.string.donate_gpay_minimum_amount, viewModel.currencyFormat.format(min))
             DonorExperienceEvent.submit("submission_error", "gpay", "error_reason: min_amount")
@@ -192,7 +195,7 @@ class GooglePayActivity : BaseActivity() {
 
         binding.checkBoxAllowEmail.isVisible = viewModel.emailOptInRequired
 
-        binding.checkBoxTransactionFee.text = getString(R.string.donate_gpay_check_transaction_fee, viewModel.currencyFormat.format(viewModel.transactionFee))
+        setTransactionFeeText(viewModel.transactionFee)
 
         val methods = JSONArray().put(GooglePayComponent.baseCardPaymentMethod)
         binding.payButton.initialize(ButtonOptions.newBuilder()
@@ -253,6 +256,10 @@ class GooglePayActivity : BaseActivity() {
         shouldWatchText = false
         binding.donateAmountText.setText(viewModel.decimalFormat.format(amount))
         shouldWatchText = true
+    }
+
+    private fun setTransactionFeeText(amount: Float) {
+        binding.checkBoxTransactionFee.text = getString(R.string.donate_gpay_check_transaction_fee, viewModel.currencyFormat.format(amount))
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
The transaction fee should be 4% of the donation amount, or the "minimum" transaction fee given by the API, whichever is greater.

https://phabricator.wikimedia.org/T365307