### PR TITLE
Use coroutine on EventPlatformClient and do not send while offline

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -37,6 +37,8 @@ object EventPlatformClient {
      */
     private var ENABLED = WikipediaApp.instance.isOnline
 
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
+
     fun setStreamConfig(streamConfig: StreamConfig) {
         STREAM_CONFIGS[streamConfig.streamName] = streamConfig
     }
@@ -165,10 +167,7 @@ object EventPlatformClient {
         }
 
         private fun sendEventsForStream(streamConfig: StreamConfig, events: List<Event>) {
-            if (!WikipediaApp.instance.isOnline) {
-                return
-            }
-            CoroutineScope(Dispatchers.IO).launch(CoroutineExceptionHandler { _, caught ->
+            coroutineScope.launch(CoroutineExceptionHandler { _, caught ->
                 L.e(caught)
                 if (caught is HttpStatusException) {
                     if (caught.code >= HttpURLConnection.HTTP_INTERNAL_ERROR) {

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventService.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.analytics.eventplatform
 
-import io.reactivex.rxjava3.core.Observable
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -17,8 +16,8 @@ import retrofit2.http.POST
  */
 interface EventService {
     @POST("/v1/events?hasty=true")
-    fun postEventsHasty(@Body events: @JvmSuppressWildcards List<Event>): Observable<Response<Unit>>
+    suspend fun postEventsHasty(@Body events: @JvmSuppressWildcards List<Event>): Response<Unit>
 
     @POST("/v1/events")
-    fun postEvents(@Body events: @JvmSuppressWildcards List<Event>): Observable<Response<Unit>>
+    suspend fun postEvents(@Body events: @JvmSuppressWildcards List<Event>): Response<Unit>
 }


### PR DESCRIPTION
- Use coroutine with `CoroutineScope(Dispatchers.IO)` since we are not sending `lifecycleScope` from separate events. 
- Do not process the `sendEventsForStream()` when the device is offline.