### PR TITLE
Hygiene: remove unnecessary usages of withContext{}

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/MachineGeneratedArticleDescriptionsAnalyticsHelper.kt
@@ -1,8 +1,6 @@
 package org.wikipedia.analytics.eventplatform
 
 import android.content.Context
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.dataclient.ServiceFactory
@@ -121,11 +119,10 @@ class MachineGeneratedArticleDescriptionsAnalyticsHelper {
             return str.replace(".", "%2E").replace(":", "%3A")
         }
 
-        suspend fun setUserExperienced() =
-            withContext(Dispatchers.Default) {
-                val totalContributions = ServiceFactory.get(WikipediaApp.instance.wikiSite)
-                    .globalUserInfo(AccountUtil.userName!!).query?.globalUserInfo?.editCount ?: 0
-                Prefs.suggestedEditsMachineGeneratedDescriptionsIsExperienced = totalContributions > 50
-            }
+        suspend fun setUserExperienced() {
+            val totalContributions = ServiceFactory.get(WikipediaApp.instance.wikiSite)
+                .globalUserInfo(AccountUtil.userName!!).query?.globalUserInfo?.editCount ?: 0
+            Prefs.suggestedEditsMachineGeneratedDescriptionsIsExperienced = totalContributions > 50
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
@@ -35,10 +35,8 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.functions.Consumer
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
@@ -322,14 +320,12 @@ class ReadingListFragment : Fragment(), MenuProvider, ReadingListItemActionsDial
                         FeedbackUtil.showError(requireActivity(), throwable)
                         requireActivity().finish()
                     }) {
-                        withContext(Dispatchers.Main) {
-                            readingList = ReadingListsReceiveHelper.receiveReadingLists(requireContext(), encodedJson)
-                            readingList?.let {
-                                ReadingListsAnalyticsHelper.logReceivePreview(requireContext(), it)
-                                binding.searchEmptyView.setEmptyText(getString(R.string.search_reading_list_no_results, it.title))
-                            }
-                            update()
+                        readingList = ReadingListsReceiveHelper.receiveReadingLists(requireContext(), encodedJson)
+                        readingList?.let {
+                            ReadingListsAnalyticsHelper.logReceivePreview(requireContext(), it)
+                            binding.searchEmptyView.setEmptyText(getString(R.string.search_reading_list_no_results, it.title))
                         }
+                        update()
                     }
                 }
             } else {

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
@@ -5,9 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.dataclient.ServiceFactory
@@ -96,20 +94,18 @@ class TalkReplyViewModel(bundle: Bundle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             saveTemplateData.postValue(Resource.Error(throwable))
         }) {
-            withContext(Dispatchers.IO) {
-                talkTemplate.apply {
-                    this.title = title
-                    this.subject = subject
-                    this.message = body
-                }
-                talkTemplatesRepository.updateTemplate(talkTemplate)
-                talkTemplatesList.find { it == talkTemplate }?.apply {
-                    this.title = title
-                    this.subject = subject
-                    this.message = body
-                }
-                saveTemplateData.postValue(Resource.Success(talkTemplate))
+            talkTemplate.apply {
+                this.title = title
+                this.subject = subject
+                this.message = body
             }
+            talkTemplatesRepository.updateTemplate(talkTemplate)
+            talkTemplatesList.find { it == talkTemplate }?.apply {
+                this.title = title
+                this.subject = subject
+                this.message = body
+            }
+            saveTemplateData.postValue(Resource.Success(talkTemplate))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
@@ -137,12 +137,10 @@ class TalkTopicsViewModel(var pageTitle: PageTitle, private val sidePanel: Boole
     fun markAsSeen(threadItem: ThreadItem?, force: Boolean = false) {
         threadSha(threadItem)?.let {
             viewModelScope.launch(actionHandler) {
-                withContext(Dispatchers.Main) {
-                    if (topicSeen(threadItem) && !force) {
-                        talkPageDao.deleteTalkPageSeen(it)
-                    } else {
-                        talkPageDao.insertTalkPageSeen(TalkPageSeen(it))
-                    }
+                if (topicSeen(threadItem) && !force) {
+                    talkPageDao.deleteTalkPageSeen(it)
+                } else {
+                    talkPageDao.insertTalkPageSeen(TalkPageSeen(it))
                 }
             }
         }


### PR DESCRIPTION
From our early days of using coroutines, when we assumed that all `suspend` calls must be wrapped in `withContext()`.