### PR TITLE
Optimize NavTabLayout in MainFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -137,9 +137,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
         binding.mainNavTabLayout.setOnItemSelectedListener { item ->
             if (item.order == NavTab.MORE.code()) {
                 ExclusiveBottomSheetPresenter.show(childFragmentManager, MenuNavTabDialog.newInstance())
-                binding.mainNavTabLayout.selectedItemId = currentNavTab.code()
-                binding.mainNavTabLayout.findViewById<View>(currentNavTab.id).performClick()
-                return@setOnItemSelectedListener true
+                return@setOnItemSelectedListener false
             }
             currentNavTab = NavTab.of(item.order)
             val fragment = currentFragment

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -104,7 +104,6 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     private val pageChangeCallback = PageChangeCallback()
     private val disposables = CompositeDisposable()
     private var exclusiveTooltipRunnable: Runnable? = null
-    private var currentNavTab = NavTab.EXPLORE
 
     // The permissions request API doesn't take a callback, so in the event we have to
     // ask for permission to download a featured image from the feed, we'll have to hold
@@ -139,7 +138,6 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
                 ExclusiveBottomSheetPresenter.show(childFragmentManager, MenuNavTabDialog.newInstance())
                 return@setOnItemSelectedListener false
             }
-            currentNavTab = NavTab.of(item.order)
             val fragment = currentFragment
             if (fragment is FeedFragment && item.order == 0) {
                 fragment.scrollToTop()

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -104,6 +104,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     private val pageChangeCallback = PageChangeCallback()
     private val disposables = CompositeDisposable()
     private var exclusiveTooltipRunnable: Runnable? = null
+    private var currentNavTab = NavTab.EXPLORE
 
     // The permissions request API doesn't take a callback, so in the event we have to
     // ask for permission to download a featured image from the feed, we'll have to hold
@@ -133,12 +134,14 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
             it.maxLines = 2
         }
 
-        FeedbackUtil.setButtonTooltip(binding.navMoreContainer)
-        binding.navMoreContainer.setOnClickListener {
-            ExclusiveBottomSheetPresenter.show(childFragmentManager, MenuNavTabDialog.newInstance())
-        }
-
         binding.mainNavTabLayout.setOnItemSelectedListener { item ->
+            if (item.order == NavTab.MORE.code()) {
+                ExclusiveBottomSheetPresenter.show(childFragmentManager, MenuNavTabDialog.newInstance())
+                binding.mainNavTabLayout.selectedItemId = currentNavTab.code()
+                binding.mainNavTabLayout.findViewById<View>(currentNavTab.id).performClick()
+                return@setOnItemSelectedListener true
+            }
+            currentNavTab = NavTab.of(item.order)
             val fragment = currentFragment
             if (fragment is FeedFragment && item.order == 0) {
                 fragment.scrollToTop()
@@ -461,7 +464,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
 
     fun setBottomNavVisible(visible: Boolean) {
         binding.mainNavTabBorder.isVisible = visible
-        binding.mainNavTabContainer.isVisible = visible
+        binding.mainNavTabLayout.isVisible = visible
     }
 
     fun onGoOffline() {
@@ -561,7 +564,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
         if (Prefs.showOneTimePlacesMainNavOnboardingTooltip && Prefs.exploreFeedVisitCount > SHOW_PLACES_MAIN_NAV_TOOLTIP) {
             enqueueTooltip {
                 PlacesEvent.logImpression("main_nav_tooltip")
-                FeedbackUtil.showTooltip(requireActivity(), binding.navMoreContainer,
+                FeedbackUtil.showTooltip(requireActivity(), binding.mainNavTabLayout.findViewById(NavTab.MORE.id),
                     getString(R.string.places_nav_tab_tooltip_message), aboveOrBelow = true, autoDismiss = false, showDismissButton = true).setOnBalloonDismissListener {
                     Prefs.showOneTimePlacesMainNavOnboardingTooltip = false
                     PlacesEvent.logAction("dismiss_click", "main_nav_tooltip")

--- a/app/src/main/java/org/wikipedia/navtab/NavTab.kt
+++ b/app/src/main/java/org/wikipedia/navtab/NavTab.kt
@@ -35,6 +35,11 @@ enum class NavTab constructor(
         override fun newInstance(): Fragment {
             return SuggestedEditsTasksFragment.newInstance()
         }
+    },
+    MORE(R.string.nav_item_more, R.id.nav_tab_more, R.drawable.ic_menu_white_24dp) {
+        override fun newInstance(): Fragment {
+            return Fragment()
+        }
     };
 
     abstract fun newInstance(): Fragment

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -28,61 +28,23 @@
         android:background="?attr/border_color"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/main_nav_tab_container"/>
+        app:layout_constraintBottom_toTopOf="@id/main_nav_tab_layout"/>
 
-    <LinearLayout
-        android:id="@+id/main_nav_tab_container"
+    <org.wikipedia.navtab.NavTabLayout
+        android:id="@+id/main_nav_tab_layout"
         android:background="?attr/paper_color"
         android:layout_width="match_parent"
         android:layout_height="@dimen/nav_bar_height"
-        android:baselineAligned="false"
-        android:orientation="horizontal"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:itemIconTint="@color/color_state_nav_tab"
+        app:itemTextAppearanceActive="@style/BottomNavigationTextAppearance.Active"
+        app:itemTextAppearanceInactive="@style/BottomNavigationTextAppearance"
+        app:itemTextColor="@color/color_state_nav_tab"
+        app:labelVisibilityMode="labeled"
+        app:tabGravity="fill"
+        app:itemPaddingTop="8dp"
+        app:elevation="0dp"/>
 
-        <org.wikipedia.navtab.NavTabLayout
-            android:id="@+id/main_nav_tab_layout"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="0.8"
-            app:itemIconTint="@color/color_state_nav_tab"
-            app:itemTextAppearanceActive="@style/BottomNavigationTextAppearance.Active"
-            app:itemTextAppearanceInactive="@style/BottomNavigationTextAppearance"
-            app:itemTextColor="@color/color_state_nav_tab"
-            app:labelVisibilityMode="labeled"
-            app:tabGravity="fill"
-            app:itemPaddingTop="8dp"
-            app:elevation="0dp"/>
-
-        <FrameLayout
-            android:id="@+id/nav_more_container"
-            android:layout_width="0dp"
-            android:layout_weight="0.2"
-            android:layout_height="match_parent"
-            android:contentDescription="@string/nav_item_more"
-            android:background="?attr/selectableItemBackground">
-
-            <ImageView
-                android:id="@+id/menu_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@null"
-                android:layout_marginTop="12dp"
-                android:layout_gravity="center_horizontal"
-                app:tint="?attr/placeholder_color"
-                app:srcCompat="@drawable/ic_menu_white_24dp" />
-
-            <TextView
-                style="@style/BottomNavigationTextAppearance"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="44dp"
-                android:textAlignment="center"
-                android:text="@string/nav_item_more"
-                android:textColor="?attr/placeholder_color"/>
-
-        </FrameLayout>
-    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -4,6 +4,7 @@
     <item name="nav_tab_reading_lists" type="id" />
     <item name="nav_tab_search" type="id" />
     <item name="nav_tab_edits" type="id" />
+    <item name="nav_tab_more" type="id" />
     <item name="page_save" type="id" />
     <item name="page_language" type="id" />
     <item name="page_find_in_article" type="id" />


### PR DESCRIPTION
Currently, we put the "More" button on the side of `NavTabLayout`, but it does not behave like the other buttons. When running the app in a tablet landscape mode, the "More" button is not positioned properly.

This PR removes the views and moves "More" to be a NavTab enum member.

Before:
![Screenshot_20240530-152928](https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/f3365ceb-771b-42e2-bb8f-f383abe29c77)
After:
![Screenshot_20240530-152938](https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/f966fdca-afa2-459c-8efe-2ac8a063dccd)
