### PR TITLE
Fix tint and logic of Edit pencil in page toolbar.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -463,6 +463,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
             }
             model.page?.let { page ->
                 page.pageProperties.protection = JsonUtil.decodeFromString(value)
+                updateQuickActionsAndMenuOptions()
             }
         }
     }
@@ -1031,19 +1032,18 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         }
         binding.pageActionsTabLayout.forEach { it as MaterialTextView
             val pageActionItem = PageActionItem.find(it.id)
-            val enabled = model.page != null && (!model.shouldLoadAsMobileWeb || (model.shouldLoadAsMobileWeb && pageActionItem.isAvailableOnMobileWeb))
+            var enabled = model.page != null && (!model.shouldLoadAsMobileWeb || (model.shouldLoadAsMobileWeb && pageActionItem.isAvailableOnMobileWeb))
             when (pageActionItem) {
                 PageActionItem.ADD_TO_WATCHLIST -> {
                     it.setText(if (model.isWatched) R.string.menu_page_unwatch else R.string.menu_page_watch)
                     it.setCompoundDrawablesWithIntrinsicBounds(0, PageActionItem.watchlistIcon(model.isWatched, model.hasWatchlistExpiry), 0, 0)
-                    it.isEnabled = enabled && AccountUtil.isLoggedIn
-                    it.alpha = if (it.isEnabled) 1f else 0.5f
+                    enabled = enabled && AccountUtil.isLoggedIn
                 }
                 PageActionItem.SAVE -> {
                     it.setCompoundDrawablesWithIntrinsicBounds(0, PageActionItem.readingListIcon(model.isInReadingList), 0, 0)
                 }
                 PageActionItem.EDIT_ARTICLE -> {
-                    it.setCompoundDrawablesRelativeWithIntrinsicBounds(0, PageActionItem.editArticleIcon(model.page?.pageProperties?.canEdit != true), 0, 0)
+                    it.setCompoundDrawablesWithIntrinsicBounds(0, PageActionItem.editArticleIcon(model.page?.pageProperties?.canEdit != true), 0, 0)
                 }
                 PageActionItem.VIEW_ON_MAP -> {
                     val geoAvailable = model.page?.pageProperties?.geo != null
@@ -1051,11 +1051,10 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
                     it.setTextColor(tintColor)
                     TextViewCompat.setCompoundDrawableTintList(it, tintColor)
                 }
-                else -> {
-                    it.isEnabled = enabled
-                    it.alpha = if (enabled) 1f else 0.5f
-                }
+                else -> { }
             }
+            it.isEnabled = enabled
+            it.alpha = if (enabled) 1f else 0.5f
         }
         sidePanelHandler.setEnabled(false)
         requireActivity().invalidateOptionsMenu()


### PR DESCRIPTION
In Dark mode, when you have the "Edit article" option configured in your toolbar (instead of the overflow menu), the tint of the icon is incorrect:

![image](https://github.com/wikimedia/apps-android-wikipedia/assets/1682214/b4c6b184-fc44-4616-9b7b-7bb3f4accbbb)

In addition, the logic of updating the toolbar icons was slightly incorrect, and could lead to the Edit icon being in the wrong state (with the "lock" icon), or being enabled even while the article is still loading.
This fixes the logic and the tinting.