### PR TITLE
Do not reload the feed content onResume in FeedFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
@@ -149,10 +149,6 @@ class FeedFragment : Fragment(), BackPressedHandler {
     override fun onResume() {
         super.onResume()
         showRemoveChineseVariantPrompt()
-
-        // Explicitly invalidate the feed adapter, since it occasionally crashes the StaggeredGridLayout
-        // on certain devices. (TODO: investigate further)
-        feedAdapter.notifyDataSetChanged()
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
The original PR of adding the code was: #1300

The issue should be fixed now since it has been almost 4 years.