### PR TITLE
Fix unintended parsing of language variant code from /w/ URLs.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/UriUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/UriUtil.kt
@@ -136,7 +136,7 @@ object UriUtil {
     /** Get language variant code from a Uri path, e.g. "/wiki/Foo" or "/zh-tw/Foo".
      * It will return "zh-tw" or an empty string */
     fun getLanguageVariantFromUri(uri: Uri): String {
-        return uri.path?.split('/')?.getOrNull(1)?.takeUnless { it == "wiki" }.orEmpty()
+        return uri.path?.split('/')?.getOrNull(1)?.takeUnless { it == "wiki" || it == "w" }.orEmpty()
     }
 
     /** For internal links only  */


### PR DESCRIPTION
The recent updates to `getLanguageVariantFromUri()` introduced a slight issue where certain URLs are now being parsed incorrectly.
For example, URLs that have a path of `/w/...` (which includes things like Diff links, API urls, etc) will be incorrectly parsed as having a language variant of `w`.

This fixes the issue by explicitly excluding the `/w/` case in addition to the `/wiki/` case.

https://phabricator.wikimedia.org/T366865