### PR TITLE
Use new MW REST endpoints for reading lists.

### DIFF
--- a/app/src/extra/java/org/wikipedia/push/WikipediaFirebaseMessagingService.kt
+++ b/app/src/extra/java/org/wikipedia/push/WikipediaFirebaseMessagingService.kt
@@ -102,7 +102,7 @@ class WikipediaFirebaseMessagingService : FirebaseMessagingService() {
                                 Prefs.pushNotificationTokenOld = ""
                             }, {
                                 L.e(it)
-                                if (it is MwException && it.error.title == "echo-push-token-not-found") {
+                                if (it is MwException && it.error.key == "echo-push-token-not-found") {
                                     // token was not found in the database, so consider it gone.
                                     Prefs.pushNotificationTokenOld = ""
                                 }
@@ -121,7 +121,7 @@ class WikipediaFirebaseMessagingService : FirebaseMessagingService() {
                         Prefs.isPushNotificationTokenSubscribed = true
                     }, {
                         L.e(it)
-                        if (it is MwException && it.error.title == "echo-push-token-exists") {
+                        if (it is MwException && it.error.key == "echo-push-token-exists") {
                             // token already exists in the database, so consider it subscribed.
                             Prefs.isPushNotificationTokenSubscribed = true
                         }

--- a/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
@@ -4,10 +4,16 @@ import org.wikipedia.dataclient.growthtasks.GrowthImageSuggestion
 import org.wikipedia.dataclient.restbase.DiffResponse
 import org.wikipedia.dataclient.restbase.EditCount
 import org.wikipedia.dataclient.restbase.Revision
+import org.wikipedia.readinglist.sync.SyncedReadingLists
+import retrofit2.Call
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface CoreRestService {
 
@@ -33,6 +39,78 @@ interface CoreRestService {
         @Path("title") title: String,
         @Body body: GrowthImageSuggestion.AddImageFeedbackBody
     )
+
+    // ------- Reading lists -------
+    @POST("readinglists/v0/lists/setup")
+    fun setupReadingLists(@Query("csrf_token") token: String?): Call<Unit>
+
+    @POST("readinglists/v0/lists/teardown")
+    fun tearDownReadingLists(@Query("csrf_token") token: String?): Call<Unit>
+
+    @Headers("Cache-Control: no-cache")
+    @GET("readinglists/v0/lists")
+    fun getReadingLists(@Query("next") next: String?): Call<SyncedReadingLists>
+
+    @POST("readinglists/v0/lists")
+    fun createReadingList(
+        @Query("csrf_token") token: String?,
+        @Body list: SyncedReadingLists.RemoteReadingList?
+    ): Call<SyncedReadingLists.RemoteIdResponse>
+
+    @PUT("readinglists/v0/lists/{id}")
+    fun updateReadingList(
+        @Path("id") listId: Long, @Query("csrf_token") token: String?,
+        @Body list: SyncedReadingLists.RemoteReadingList?
+    ): Call<Unit>
+
+    @DELETE("readinglists/v0/lists/{id}")
+    fun deleteReadingList(
+        @Path("id") listId: Long,
+        @Query("csrf_token") token: String?
+    ): Call<Unit>
+
+    @Headers("Cache-Control: no-cache")
+    @GET("readinglists/v0/lists/changes/since/{date}")
+    fun getReadingListChangesSince(
+        @Path("date") iso8601Date: String?,
+        @Query("next") next: String?
+    ): Call<SyncedReadingLists>
+
+    @Headers("Cache-Control: no-cache")
+    @GET("readinglists/v0/lists/pages/{project}/{title}")
+    fun getReadingListsContaining(
+        @Path("project") project: String?,
+        @Path("title") title: String?,
+        @Query("next") next: String?
+    ): Call<SyncedReadingLists>
+
+    @Headers("Cache-Control: no-cache")
+    @GET("readinglists/v0/lists/{id}/entries")
+    fun getReadingListEntries(
+        @Path("id") listId: Long,
+        @Query("next") next: String?
+    ): Call<SyncedReadingLists>
+
+    @POST("readinglists/v0/lists/{id}/entries")
+    fun addEntryToReadingList(
+        @Path("id") listId: Long,
+        @Query("csrf_token") token: String?,
+        @Body entry: SyncedReadingLists.RemoteReadingListEntry?
+    ): Call<SyncedReadingLists.RemoteIdResponse>
+
+    @POST("readinglists/v0/lists/{id}/entries/batch")
+    fun addEntriesToReadingList(
+        @Path("id") listId: Long,
+        @Query("csrf_token") token: String?,
+        @Body batch: SyncedReadingLists.RemoteReadingListEntryBatch?
+    ): Call<SyncedReadingLists.RemoteIdResponseBatch>
+
+    @DELETE("readinglists/v0/lists/{id}/entries/{entry_id}")
+    fun deleteEntryFromReadingList(
+        @Path("id") listId: Long,
+        @Path("entry_id") entryId: Long,
+        @Query("csrf_token") token: String?
+    ): Call<Unit>
 
     companion object {
         const val CORE_REST_API_PREFIX = "w/rest.php/"

--- a/app/src/main/java/org/wikipedia/dataclient/RestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.kt
@@ -11,24 +11,12 @@ import org.wikipedia.feed.announcement.AnnouncementList
 import org.wikipedia.feed.configure.FeedAvailability
 import org.wikipedia.feed.onthisday.OnThisDay
 import org.wikipedia.gallery.MediaList
-import org.wikipedia.readinglist.sync.SyncedReadingLists
-import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteIdResponse
-import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteIdResponseBatch
-import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingList
-import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingListEntry
-import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingListEntryBatch
 import org.wikipedia.suggestededits.provider.SuggestedEditItem
-import retrofit2.Call
 import retrofit2.Response
-import retrofit2.http.Body
-import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Headers
-import retrofit2.http.POST
-import retrofit2.http.PUT
 import retrofit2.http.Path
-import retrofit2.http.Query
 
 interface RestService {
 
@@ -121,80 +109,6 @@ interface RestService {
 
     @get:GET("feed/availability")
     val feedAvailability: Observable<FeedAvailability>
-
-    // ------- Reading lists -------
-    @POST("data/lists/setup")
-    fun setupReadingLists(@Query("csrf_token") token: String?): Call<Unit>
-
-    @POST("data/lists/teardown")
-    fun tearDownReadingLists(@Query("csrf_token") token: String?): Call<Unit>
-
-    @Headers("Cache-Control: no-cache")
-    @GET("data/lists/")
-    fun getReadingLists(@Query("next") next: String?): Call<SyncedReadingLists>
-
-    @POST("data/lists/")
-    fun createReadingList(
-        @Query("csrf_token") token: String?,
-        @Body list: RemoteReadingList?
-    ): Call<RemoteIdResponse>
-
-    @Headers("Cache-Control: no-cache")
-    @PUT("data/lists/{id}")
-    fun updateReadingList(
-        @Path("id") listId: Long, @Query("csrf_token") token: String?,
-        @Body list: RemoteReadingList?
-    ): Call<Unit>
-
-    @Headers("Cache-Control: no-cache")
-    @DELETE("data/lists/{id}")
-    fun deleteReadingList(
-        @Path("id") listId: Long,
-        @Query("csrf_token") token: String?
-    ): Call<Unit>
-
-    @Headers("Cache-Control: no-cache")
-    @GET("data/lists/changes/since/{date}")
-    fun getReadingListChangesSince(
-        @Path("date") iso8601Date: String?,
-        @Query("next") next: String?
-    ): Call<SyncedReadingLists>
-
-    @Headers("Cache-Control: no-cache")
-    @GET("data/lists/pages/{project}/{title}")
-    fun getReadingListsContaining(
-        @Path("project") project: String?,
-        @Path("title") title: String?,
-        @Query("next") next: String?
-    ): Call<SyncedReadingLists>
-
-    @Headers("Cache-Control: no-cache")
-    @GET("data/lists/{id}/entries/")
-    fun getReadingListEntries(
-        @Path("id") listId: Long,
-        @Query("next") next: String?
-    ): Call<SyncedReadingLists>
-
-    @POST("data/lists/{id}/entries/")
-    fun addEntryToReadingList(
-        @Path("id") listId: Long,
-        @Query("csrf_token") token: String?,
-        @Body entry: RemoteReadingListEntry?
-    ): Call<RemoteIdResponse>
-
-    @POST("data/lists/{id}/entries/batch")
-    fun addEntriesToReadingList(
-        @Path("id") listId: Long,
-        @Query("csrf_token") token: String?,
-        @Body batch: RemoteReadingListEntryBatch?
-    ): Call<RemoteIdResponseBatch>
-
-    @Headers("Cache-Control: no-cache")
-    @DELETE("data/lists/{id}/entries/{entry_id}")
-    fun deleteEntryFromReadingList(
-        @Path("id") listId: Long, @Path("entry_id") entryId: Long,
-        @Query("csrf_token") token: String?
-    ): Call<Unit>
 
     // ------- Recommendations -------
     @Headers("Cache-Control: no-cache")

--- a/app/src/main/java/org/wikipedia/dataclient/ServiceError.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/ServiceError.kt
@@ -1,6 +1,6 @@
 package org.wikipedia.dataclient
 
 interface ServiceError {
-    val title: String
-    val details: String
+    val key: String
+    val message: String
 }

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwException.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwException.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 class MwException(val error: MwServiceError) : RuntimeException() {
 
     val title: String
-        get() = error.title
+        get() = error.key
 
     override val message: String
-        get() = error.details
+        get() = error.message
 }

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwResponse.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwResponse.kt
@@ -13,7 +13,7 @@ abstract class MwResponse {
     init {
         if (errors?.isNotEmpty() == true) {
             // prioritize "blocked" or "abusefilter" errors over others.
-            throw MwException(errors.firstOrNull { it.title.contains("blocked") || it.title.startsWith("abusefilter-") } ?: errors.first())
+            throw MwException(errors.firstOrNull { it.key.contains("blocked") || it.key.startsWith("abusefilter-") } ?: errors.first())
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/MwServiceError.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/MwServiceError.kt
@@ -29,9 +29,9 @@ class MwServiceError(val code: String? = null,
         return data?.messages?.first { it.name == messageName }?.html
     }
 
-    override val title: String get() = code.orEmpty()
+    override val key get() = code.orEmpty()
 
-    override val details: String get() = StringUtil.removeStyleTags(html.orEmpty())
+    override val message get() = StringUtil.removeStyleTags(html.orEmpty())
 
     init {
         // Special case: if it's a Blocked error, parse the blockinfo structure ourselves.

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.kt
@@ -22,7 +22,7 @@ class UserInfo : BlockInfo() {
     @SerialName("cancreateerror") private val canCreateError: List<MwServiceError>? = null
     val options: Options? = null
 
-    val error get() = canCreateError?.get(0)?.title.orEmpty()
+    val error get() = canCreateError?.get(0)?.key.orEmpty()
     val hasBlockError get() = error.contains("block")
 
     fun groups(): Set<String> {

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/HttpStatusException.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/HttpStatusException.kt
@@ -18,7 +18,7 @@ class HttpStatusException : IOException {
             } else {
                 var str = "Code: $code, URL: $url"
                 serviceError?.run {
-                    str += ", title: $title, detail: $details"
+                    str += ", key: $key, message: $message"
                 }
                 str
             }

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/RbServiceError.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/RbServiceError.kt
@@ -4,20 +4,27 @@ import kotlinx.serialization.Serializable
 import org.wikipedia.dataclient.ServiceError
 import org.wikipedia.json.JsonUtil
 
+/**
+ * Model class that can represent either a RESTBase error or a MediaWiki REST API error.
+ * Since both types of errors have non-overlapping fields, we can use a single class to
+ * represent either of them, and then phase out the RESTBase-specific fields when RESTBase
+ * is fully decommissioned.
+ */
 @Serializable
 class RbServiceError : ServiceError {
 
-    private val type: String? = null
+    // These fields are given by RESTBase errors, and should be removed when RESTBase
+    // is fully decommissioned.
+    private val title: String? = null
     private val detail: String? = null
-    private val method: String? = null
-    private val uri: String? = null
 
+    // These fields are given by MediaWiki REST API errors, and should be preferred.
     private val errorKey: String? = null
     private val messageTranslations: Map<String, String>? = null
 
-    override val title: String = ""
+    override val key get() = title ?: errorKey.orEmpty()
 
-    override val details: String get() {
+    override val message: String get() {
         return if (messageTranslations != null) {
             messageTranslations.values.firstOrNull() ?: ""
         } else {

--- a/app/src/main/java/org/wikipedia/notifications/PollNotificationWorker.kt
+++ b/app/src/main/java/org/wikipedia/notifications/PollNotificationWorker.kt
@@ -25,7 +25,7 @@ class PollNotificationWorker(
             }
             Result.success()
         } catch (t: Throwable) {
-            if (t is MwException && t.error.title == "login-required") {
+            if (t is MwException && t.error.key == "login-required") {
                 assertLoggedIn()
             }
             L.e(t)

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListClient.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListClient.kt
@@ -176,7 +176,7 @@ class ReadingListClient(private val wiki: WikiSite) {
     }
 
     fun isErrorType(t: Throwable?, errorType: String): Boolean {
-        return t is HttpStatusException && t.serviceError?.title?.contains(errorType) == true
+        return t is HttpStatusException && t.serviceError?.key?.contains(errorType) == true
     }
 
     fun isServiceError(t: Throwable?): Boolean {

--- a/app/src/main/java/org/wikipedia/readinglist/sync/SyncedReadingLists.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/SyncedReadingLists.kt
@@ -3,8 +3,6 @@ package org.wikipedia.readinglist.sync
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.text.Normalizer
-import java.time.Instant
-import java.util.*
 
 @Serializable
 data class SyncedReadingLists(val lists: List<RemoteReadingList>? = null,
@@ -17,8 +15,6 @@ data class SyncedReadingLists(val lists: List<RemoteReadingList>? = null,
         @SerialName("default") val isDefault: Boolean = false,
         private val name: String,
         private val description: String? = null,
-        val created: String = Instant.now().toString(),
-        val updated: String = Instant.now().toString(),
         @SerialName("deleted") val isDeleted: Boolean = false
     ) {
         fun name(): String = Normalizer.normalize(name, Normalizer.Form.NFC)
@@ -31,8 +27,6 @@ data class SyncedReadingLists(val lists: List<RemoteReadingList>? = null,
         val listId: Long = -1,
         private val project: String,
         private val title: String,
-        val created: String = Instant.now().toString(),
-        val updated: String = Instant.now().toString(),
         @SerialName("deleted") val isDeleted: Boolean = false
     ) {
         fun project(): String = Normalizer.normalize(project, Normalizer.Form.NFC)
@@ -40,9 +34,7 @@ data class SyncedReadingLists(val lists: List<RemoteReadingList>? = null,
     }
 
     @Serializable
-    data class RemoteReadingListEntryBatch(val entries: List<RemoteReadingListEntry>) {
-        val batch: Array<RemoteReadingListEntry> = entries.toTypedArray()
-    }
+    data class RemoteReadingListEntryBatch(val batch: List<RemoteReadingListEntry>)
 
     @Serializable
     class RemoteIdResponse {


### PR DESCRIPTION
This switches to using the new MW REST endpoints for managing reading lists. The functionality shouldn't change, merely the URLs and the structure of some of the responses.

(For now, this is for testing purposes only, while we iron out any remaining issues with compatibility with the old RESTBase endpoints.)

https://phabricator.wikimedia.org/T357478
