### PR TITLE
Revert "Do not reload the feed content onResume in FeedFragment"

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
@@ -151,7 +151,8 @@ class FeedFragment : Fragment(), BackPressedHandler {
         showRemoveChineseVariantPrompt()
 
         // Explicitly invalidate the feed adapter, since it occasionally crashes the StaggeredGridLayout
-        // on certain devices. (TODO: investigate further)
+        // on certain devices.
+        // https://issuetracker.google.com/issues/188096921
         feedAdapter.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
@@ -149,6 +149,10 @@ class FeedFragment : Fragment(), BackPressedHandler {
     override fun onResume() {
         super.onResume()
         showRemoveChineseVariantPrompt()
+
+        // Explicitly invalidate the feed adapter, since it occasionally crashes the StaggeredGridLayout
+        // on certain devices. (TODO: investigate further)
+        feedAdapter.notifyDataSetChanged()
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
Unfortunately this crash is definitely still happening, as seen in the current Beta, so we still need this fix.
