### PR TITLE
Use displayMetrics.density instead of deprecated methods

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -37,7 +37,7 @@ import org.wikipedia.theme.Theme
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.util.log.L
-import java.util.*
+import java.util.UUID
 
 class WikipediaApp : Application() {
     init {
@@ -230,8 +230,8 @@ class WikipediaApp : Application() {
      * @return Actual current size of the font.
      */
     fun getFontSize(window: Window, editing: Boolean = false): Float {
-        return DimenUtil.getFontSizeFromSp(window,
-                resources.getDimension(R.dimen.textSize)) * (1.0f + (if (editing) Prefs.editingTextSizeMultiplier else Prefs.textSizeMultiplier) *
+        return DimenUtil.getFontSizeFromSp(window, resources.getDimension(R.dimen.textSize)) *
+                (1.0f + (if (editing) Prefs.editingTextSizeMultiplier else Prefs.textSizeMultiplier) *
                 DimenUtil.getFloat(R.dimen.textSizeMultiplierFactor))
     }
 

--- a/app/src/main/java/org/wikipedia/util/DimenUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DimenUtil.kt
@@ -42,7 +42,7 @@ object DimenUtil {
     }
 
     fun getFontSizeFromSp(window: Window, fontSp: Float): Float {
-        return fontSp / window.context.resources.displayMetrics.density
+        return fontSp / window.context.resources.displayMetrics.scaledDensity
     }
 
     // TODO: use getResources().getDimensionPixelSize()?  Define leadImageWidth with px, not dp?

--- a/app/src/main/java/org/wikipedia/util/DimenUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DimenUtil.kt
@@ -42,9 +42,7 @@ object DimenUtil {
     }
 
     fun getFontSizeFromSp(window: Window, fontSp: Float): Float {
-        val metrics = DisplayMetrics()
-        window.windowManager.defaultDisplay.getMetrics(metrics)
-        return fontSp / metrics.scaledDensity
+        return fontSp / window.context.resources.displayMetrics.density
     }
 
     // TODO: use getResources().getDimensionPixelSize()?  Define leadImageWidth with px, not dp?


### PR DESCRIPTION
`defaultDisplay.getMetrics(metrics)` is deprecated. But we still need to use `scaledDensity` for converting from `sp` to `dp`.