### PR TITLE
Fix: make sure edits in Edit Patrol are sorted by date in descending order

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsRecentEditsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsRecentEditsViewModel.kt
@@ -135,7 +135,7 @@ class SuggestedEditsRecentEditsViewModel : ViewModel() {
             userInfoCache.addAll(usersInfoResponse)
 
             // Filtering User experiences and registration.
-            val finalRecentChanges = filterUserRegistration(filterUserExperience(recentChanges, userInfoCache))
+            val finalRecentChanges = filterUserRegistration(filterUserExperience(recentChanges, userInfoCache)).sortedByDescending { it.parsedDateTime }
 
             return Triple(finalRecentChanges, allRecentChanges, response.continuation?.rcContinuation)
         }


### PR DESCRIPTION
in `filterUserExperience()`, the `anon` items are added to the end of the filtered list, and we should sort the list again to prevent incorrect order in the list.