### PR TITLE
Use selectableItemBackground in SearchBarView in Places

### DIFF
--- a/app/src/main/res/layout/fragment_places.xml
+++ b/app/src/main/res/layout/fragment_places.xml
@@ -52,7 +52,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:gravity="center_vertical"
-                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:background="?attr/selectableItemBackground"
                     android:maxLines="1"
                     android:ellipsize="end"
                     android:text="@string/places_search_hint"


### PR DESCRIPTION
If you switch to List in the Places, and click on the search bar, you will notice the ripple animation overflows the entire search bar view. Change the background to use `selectableItemBackground` will resolve the issue.