### PR TITLE
Add autoTextSize support in add article description screen

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -26,11 +26,17 @@ import org.wikipedia.mlkit.MlKitLanguageDetector
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.suggestededits.PageSummaryForEdit
-import org.wikipedia.util.*
+import org.wikipedia.util.DeviceUtil
+import org.wikipedia.util.DimenUtil
+import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.L10nUtil
+import org.wikipedia.util.ResourceUtil
+import org.wikipedia.util.StringUtil
+import org.wikipedia.util.UriUtil
 import org.wikipedia.views.SuggestedArticleDescriptionsDialog
-import java.util.*
+import java.util.Locale
 
-class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
+class DescriptionEditView(context: Context, attrs: AttributeSet?) : LinearLayout(context, attrs), MlKitLanguageDetector.Callback {
     interface Callback {
         fun onSaveClick()
         fun onCancelClick()
@@ -38,10 +44,6 @@ class DescriptionEditView : LinearLayout, MlKitLanguageDetector.Callback {
         fun onVoiceInputClick()
         fun getAnalyticsHelper(): MachineGeneratedArticleDescriptionsAnalyticsHelper
     }
-
-    constructor(context: Context) : super(context)
-    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     private lateinit var pageTitle: PageTitle
     private lateinit var pageSummaryForEdit: PageSummaryForEdit

--- a/app/src/main/res/layout/view_description_edit.xml
+++ b/app/src/main/res/layout/view_description_edit.xml
@@ -45,7 +45,9 @@
                 android:textStyle="bold"
                 android:text="@string/description_edit_edit_description"
                 android:textColor="?attr/primary_color"
-                android:textSize="20sp" />
+                android:textSize="20sp"
+                app:autoSizeTextType="uniform"
+                app:autoSizeMaxTextSize="20sp" />
 
             <TextView
                 android:id="@+id/view_description_edit_save_button"


### PR DESCRIPTION
Users will not see the full text on the preview article screen toolbar for most devices. This PR adds the `app:autoSizeTextType` to adjust the text size so users can see all the text instead of `...` at the end.

<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/5b208853-7025-49c5-aa82-7b7f8d4d0416" width="400" >
<img src="https://github.com/wikimedia/apps-android-wikipedia/assets/2435576/005a716c-2f56-47c3-bc77-118d22da9b82" width="400" >
