### PR TITLE
Fix: load the contribution items from saved language code

### DIFF
--- a/app/src/main/java/org/wikipedia/usercontrib/UserContribFilterActivity.kt
+++ b/app/src/main/java/org/wikipedia/usercontrib/UserContribFilterActivity.kt
@@ -27,7 +27,9 @@ class UserContribFilterActivity : BaseActivity() {
     private lateinit var binding: ActivityUserContribWikiSelectBinding
 
     private val langUpdateLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        if (!WikipediaApp.instance.languageState.appLanguageCodes.contains(Prefs.userContribFilterLangCode)) {
+        if (!WikipediaApp.instance.languageState.appLanguageCodes.contains(Prefs.userContribFilterLangCode) &&
+            Prefs.userContribFilterLangCode != Constants.WIKI_CODE_COMMONS &&
+            Prefs.userContribFilterLangCode != Constants.WIKI_CODE_WIKIDATA) {
             Prefs.userContribFilterLangCode = WikipediaApp.instance.appOrSystemLanguageCode
         }
         binding.recyclerView.adapter = ItemAdapter(this)
@@ -44,14 +46,14 @@ class UserContribFilterActivity : BaseActivity() {
         setResult(RESULT_OK)
     }
 
-    inner class ItemViewHolder constructor(itemView: UserContribFilterItemView) :
+    inner class ItemViewHolder(itemView: UserContribFilterItemView) :
         DefaultViewHolder<UserContribFilterItemView>(itemView) {
         fun bindItem(item: Item) {
             view.setContents(item)
         }
     }
 
-    private inner class FilterHeaderViewHolder constructor(itemView: View) :
+    private inner class FilterHeaderViewHolder(itemView: View) :
         DefaultViewHolder<View>(itemView) {
         val headerText = itemView.findViewById<TextView>(R.id.filter_header_title)!!
 
@@ -60,7 +62,7 @@ class UserContribFilterActivity : BaseActivity() {
         }
     }
 
-    private inner class AddLanguageViewHolder constructor(private val filterItemView: UserContribFilterItemView) :
+    private inner class AddLanguageViewHolder(private val filterItemView: UserContribFilterItemView) :
             DefaultViewHolder<UserContribFilterItemView>(filterItemView), UserContribFilterItemView.Callback {
         fun bindItem(text: String) {
             filterItemView.callback = this

--- a/app/src/main/java/org/wikipedia/usercontrib/UserContribListActivity.kt
+++ b/app/src/main/java/org/wikipedia/usercontrib/UserContribListActivity.kt
@@ -264,7 +264,7 @@ class UserContribListActivity : BaseActivity() {
         }
     }
 
-    private inner class LoadingViewHolder constructor(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    private inner class LoadingViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         fun bindItem(loadState: LoadState, retry: () -> Unit) {
             val errorView = itemView.findViewById<WikiErrorView>(R.id.errorView)
             val progressBar = itemView.findViewById<View>(R.id.progressBar)
@@ -277,7 +277,7 @@ class UserContribListActivity : BaseActivity() {
         }
     }
 
-    private inner class StatsViewHolder constructor(private val view: UserContribStatsView) : RecyclerView.ViewHolder(view) {
+    private inner class StatsViewHolder(private val view: UserContribStatsView) : RecyclerView.ViewHolder(view) {
         fun bindItem() {
             val statsFlowValue = viewModel.userContribStatsData.value
             if (statsFlowValue is Resource.Success) {
@@ -286,14 +286,14 @@ class UserContribListActivity : BaseActivity() {
         }
     }
 
-    private inner class SeparatorViewHolder constructor(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    private inner class SeparatorViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         fun bindItem(listItem: String) {
             val dateText = itemView.findViewById<TextView>(R.id.date_text)
             dateText.text = listItem
         }
     }
 
-    private inner class SearchBarViewHolder constructor(val binding: ViewEditHistorySearchBarBinding) : RecyclerView.ViewHolder(binding.root) {
+    private inner class SearchBarViewHolder(val binding: ViewEditHistorySearchBarBinding) : RecyclerView.ViewHolder(binding.root) {
 
         init {
             binding.root.isVisible = false

--- a/app/src/main/java/org/wikipedia/usercontrib/UserContribListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/usercontrib/UserContribListViewModel.kt
@@ -5,12 +5,18 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import androidx.paging.*
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import androidx.paging.cachedIn
+import androidx.paging.filter
+import androidx.paging.insertSeparators
+import androidx.paging.map
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.wikipedia.Constants
-import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
@@ -21,14 +27,14 @@ import org.wikipedia.util.Resource
 import org.wikipedia.util.log.L
 import retrofit2.HttpException
 import java.io.IOException
-import java.util.*
+import java.util.Date
 
 class UserContribListViewModel(bundle: Bundle) : ViewModel() {
 
     val userContribStatsData = MutableLiveData<Resource<UserContribStats>>()
 
     var userName: String = bundle.getString(UserContribListActivity.INTENT_EXTRA_USER_NAME)!!
-    var langCode: String = WikipediaApp.instance.appOrSystemLanguageCode
+    var langCode: String = Prefs.userContribFilterLangCode
 
     val wikiSite get(): WikiSite {
         return when (langCode) {


### PR DESCRIPTION
This fixes the following issues:
1. The `langCode` in the viewModel should be from `Prefs.userContribFilterLangCode` instead of the appOrSystemLanguageCode
2. If you go to "Filter contributions" and click on "Update app languages" and then go back, the selected item will be changed to the top wiki in the list.

This PR also removes the unnecessary `constructor`s