### PR TITLE
Fix: add Commons to dbName() logic for Constributions list

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
@@ -114,6 +114,8 @@ data class WikiSite(
     fun dbName(): String {
         return (if (uri.authority.orEmpty().contains("wikidata")) {
             "wikidata"
+        } else if (uri.authority.orEmpty().contains("commons")) {
+            "commons"
         } else {
             subdomain().replace("-".toRegex(), "_")
         }) + "wiki"


### PR DESCRIPTION
If you select "Wikimedia COmmons" in the contributions filter and go back to the list, you will find it shows "English Wikipedia" instead of Wikimedia Commons.