### PR TITLE
Fix possible crash when searching for text in Syntax Highlighter.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.kt
+++ b/app/src/main/java/org/wikipedia/edit/richtext/SyntaxHighlighter.kt
@@ -210,7 +210,7 @@ class SyntaxHighlighter(
     private fun getSyntaxMatches(startOffset: Int, textLength: Int): List<SpanExtents> {
         val syntaxItem = SyntaxRule("", "", SyntaxRuleStyle.SEARCH_MATCHES)
 
-        return searchQueryPositions.orEmpty().asSequence()
+        return searchQueryPositions.orEmpty().toMutableList()
             .filter { it >= startOffset && it < startOffset + textLength }
             .mapIndexed { index, i ->
                 val newSpanInfoCreator = if (index == searchQueryPositionIndex) {
@@ -223,7 +223,6 @@ class SyntaxHighlighter(
                     end = i + searchQueryLength
                 }
             }
-            .toList()
     }
 
     fun setSearchQueryInfo(searchQueryPositions: List<Int>?, searchQueryLength: Int, searchQueryPositionIndex: Int) {


### PR DESCRIPTION
If you edit a large article, and go to "find text" in the editing window and start typing characters, it can potentially crash with a `ConcurrentModificationException` if the syntax highlight task doesn't finish before the new query positions are updated.

This is fixed by making a _copy_ of the list of query positions when highlighting them.