### PR TITLE
Fix potential crash in Search paging, and simplify.

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -128,7 +128,6 @@ class SearchResultsFragment : Fragment() {
         binding.searchResultsList.visibility = View.GONE
         binding.searchErrorView.visibility = View.GONE
         binding.searchErrorView.visibility = View.GONE
-        viewModel.clearResults()
     }
 
     private inner class SearchResultsFragmentLongPressHandler(private val lastPositionRequested: Int) : LongPressMenu.Callback {


### PR DESCRIPTION
Along with using a PagingSource (which is good), we are also _manually_ keeping track of `totalResults` (which is bad).
The `totalResults` seems to be for checking duplicate results, but we're already checking for duplicate results in the PagingSource itself. I don't believe we need this.