### PR TITLE
Use coroutine in EventPlatformClient

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -3,10 +3,10 @@ package org.wikipedia.analytics.eventplatform
 import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.core.os.postDelayed
-import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import org.wikipedia.BuildConfig
 import org.wikipedia.WikipediaApp
@@ -80,9 +80,12 @@ object EventPlatformClient {
 
     @SuppressLint("CheckResult")
     fun refreshStreamConfigs() {
-        ServiceFactory.get(WikiSite(BuildConfig.META_WIKI_BASE_URI)).streamConfigs
-                .subscribeOn(Schedulers.io())
-                .subscribe({ updateStreamConfigs(it.streamConfigs) }) { L.e(it) }
+        MainScope().launch(CoroutineExceptionHandler { _, t ->
+            L.e(t)
+        }) {
+            val response = ServiceFactory.get(WikiSite(BuildConfig.META_WIKI_BASE_URI)).getStreamConfigs()
+            updateStreamConfigs(response.streamConfigs)
+        }
     }
 
     private fun updateStreamConfigs(streamConfigs: Map<String, StreamConfig>) {

--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -215,8 +215,8 @@ interface Service {
         @Field("token") token: String
     ): MwPostResponse
 
-    @get:GET(MW_API_PREFIX + "action=streamconfigs&format=json&constraints=destination_event_service=eventgate-analytics-external")
-    val streamConfigs: Observable<MwStreamConfigsResponse>
+    @GET(MW_API_PREFIX + "action=streamconfigs&format=json&constraints=destination_event_service=eventgate-analytics-external")
+    suspend fun getStreamConfigs(): MwStreamConfigsResponse
 
     @GET(MW_API_PREFIX + "action=query&meta=allmessages&amenableparser=1")
     suspend fun getMessages(


### PR DESCRIPTION
This uses `MainScope()` to run the API call.