### PR TITLE
Fix certain markers in Places missing a thumbnail image.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -231,7 +231,7 @@ interface Service {
             @Field("url") url: String,
     ): ShortenUrlResponse
 
-    @GET(MW_API_PREFIX + "action=query&generator=geosearch&prop=coordinates|description|pageimages|info&inprop=varianttitles|displaytitle")
+    @GET(MW_API_PREFIX + "action=query&generator=geosearch&prop=coordinates|description|pageimages|info&inprop=varianttitles|displaytitle&pilicense=any")
     suspend fun getGeoSearch(
         @Query("ggscoord", encoded = true) coordinates: String,
         @Query("ggsradius") radius: Int,


### PR DESCRIPTION
When requesting `pageimages` for getting the thumbnail of an article, we must specify `pilicense=any` to get any kind of image, including ones that might not be freely licensed, e.g. fair-use, in the case of logos etc.

https://phabricator.wikimedia.org/T368784
