### PR TITLE
Follow-up to recurring tasks.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.analytics.eventplatform
 
-import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.core.os.postDelayed
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -78,14 +77,9 @@ object EventPlatformClient {
         OutputBuffer.sendAllScheduled()
     }
 
-    @SuppressLint("CheckResult")
-    fun refreshStreamConfigs() {
-        MainScope().launch(CoroutineExceptionHandler { _, t ->
-            L.e(t)
-        }) {
-            val response = ServiceFactory.get(WikiSite(BuildConfig.META_WIKI_BASE_URI)).getStreamConfigs()
-            updateStreamConfigs(response.streamConfigs)
-        }
+    suspend fun refreshStreamConfigs() {
+        val response = ServiceFactory.get(WikiSite(BuildConfig.META_WIKI_BASE_URI)).getStreamConfigs()
+        updateStreamConfigs(response.streamConfigs)
     }
 
     private fun updateStreamConfigs(streamConfigs: Map<String, StreamConfig>) {
@@ -97,7 +91,11 @@ object EventPlatformClient {
     fun setUpStreamConfigs() {
         STREAM_CONFIGS.clear()
         STREAM_CONFIGS.putAll(Prefs.streamConfigs)
-        refreshStreamConfigs()
+        MainScope().launch(CoroutineExceptionHandler { _, t ->
+            L.e(t)
+        }) {
+            refreshStreamConfigs()
+        }
     }
 
     /**

--- a/app/src/main/java/org/wikipedia/recurring/RecurringTasksExecutor.kt
+++ b/app/src/main/java/org/wikipedia/recurring/RecurringTasksExecutor.kt
@@ -1,10 +1,8 @@
 package org.wikipedia.recurring
 
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.WikipediaApp
 import org.wikipedia.alphaupdater.AlphaUpdateChecker
 import org.wikipedia.settings.RemoteConfigRefreshTask
@@ -17,14 +15,11 @@ class RecurringTasksExecutor() {
         MainScope().launch(CoroutineExceptionHandler { _, throwable ->
             L.e(throwable)
         }) {
-            withContext(Dispatchers.IO) {
-                RemoteConfigRefreshTask().runIfNecessary()
-                DailyEventTask(app).runIfNecessary()
-                TalkOfflineCleanupTask(app).runIfNecessary()
-                TalkOfflineCleanupTask(app)
-                if (ReleaseUtil.isAlphaRelease) {
-                    AlphaUpdateChecker(app).runIfNecessary()
-                }
+            RemoteConfigRefreshTask().runIfNecessary()
+            DailyEventTask(app).runIfNecessary()
+            TalkOfflineCleanupTask(app).runIfNecessary()
+            if (ReleaseUtil.isAlphaRelease) {
+                AlphaUpdateChecker(app).runIfNecessary()
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/recurring/TalkOfflineCleanupTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/TalkOfflineCleanupTask.kt
@@ -1,6 +1,8 @@
 package org.wikipedia.recurring
 
 import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.wikipedia.R
 import org.wikipedia.database.AppDatabase
 import java.io.File
@@ -15,14 +17,16 @@ class TalkOfflineCleanupTask(context: Context) : RecurringTask() {
     }
 
     override suspend fun run(lastRun: Date) {
-        AppDatabase.instance.offlineObjectDao()
-            .searchForOfflineObjects(CLEANUP_URL_SEARCH_KEY)
-            .filter {
-                (absoluteTime - File(it.path + ".0").lastModified()) > TimeUnit.DAYS.toMillis(CLEANUP_MAX_AGE_DAYS)
-            }.forEach {
-                AppDatabase.instance.offlineObjectDao().deleteOfflineObject(it)
-                AppDatabase.instance.offlineObjectDao().deleteFilesForObject(it)
-            }
+        withContext(Dispatchers.IO) {
+            AppDatabase.instance.offlineObjectDao()
+                .searchForOfflineObjects(CLEANUP_URL_SEARCH_KEY)
+                .filter {
+                    (absoluteTime - File(it.path + ".0").lastModified()) > TimeUnit.DAYS.toMillis(CLEANUP_MAX_AGE_DAYS)
+                }.forEach {
+                    AppDatabase.instance.offlineObjectDao().deleteOfflineObject(it)
+                    AppDatabase.instance.offlineObjectDao().deleteFilesForObject(it)
+                }
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
@@ -1,5 +1,7 @@
 package org.wikipedia.settings
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.internal.closeQuietly
@@ -17,17 +19,19 @@ class RemoteConfigRefreshTask : RecurringTask() {
     }
 
     override suspend fun run(lastRun: Date) {
-        var response: Response? = null
-        try {
-            val request = Request.Builder().url(REMOTE_CONFIG_URL).build()
-            response = client.newCall(request).execute()
-            val configStr = response.body!!.string()
-            RemoteConfig.updateConfig(configStr)
-            L.d(configStr)
-        } catch (e: Exception) {
-            L.e(e)
-        } finally {
-            response?.closeQuietly()
+        withContext(Dispatchers.IO) {
+            var response: Response? = null
+            try {
+                val request = Request.Builder().url(REMOTE_CONFIG_URL).build()
+                response = client.newCall(request).execute()
+                val configStr = response.body!!.string()
+                RemoteConfig.updateConfig(configStr)
+                L.d(configStr)
+            } catch (e: Exception) {
+                L.e(e)
+            } finally {
+                response?.closeQuietly()
+            }
         }
     }
 


### PR DESCRIPTION
According to the [best practices](https://developer.android.com/kotlin/coroutines/coroutines-best-practices#main-safe) relating to coroutines, all `suspend` functions must be "main-safe", i.e. must be callable from the main thread.

This means that each `suspend` function must be responsible for its own `withContext{}` block, instead of the calling function putting them into a context.