### PR TITLE
Follow up: remove unused usage from RecurringTasksExecutor

### DIFF
--- a/app/src/main/java/org/wikipedia/recurring/RecurringTasksExecutor.kt
+++ b/app/src/main/java/org/wikipedia/recurring/RecurringTasksExecutor.kt
@@ -21,7 +21,6 @@ class RecurringTasksExecutor() {
                 RemoteConfigRefreshTask().runIfNecessary()
                 DailyEventTask(app).runIfNecessary()
                 TalkOfflineCleanupTask(app).runIfNecessary()
-                TalkOfflineCleanupTask(app)
                 if (ReleaseUtil.isAlphaRelease) {
                     AlphaUpdateChecker(app).runIfNecessary()
                 }


### PR DESCRIPTION
😓 didn't notice this redundant `TalkOfflineCleanupTask`.