### PR TITLE
Support URL sharing on recent screen for images

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -1,10 +1,12 @@
 package org.wikipedia.gallery
 
+import android.app.assist.AssistContent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.view.View
@@ -593,6 +595,15 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.LoadPageCallback, Gall
         // if we couldn't find a attribution string, then default to unknown
         binding.creditText.text = StringUtil.fromHtml(creditStr.ifBlank { getString(R.string.gallery_uploader_unknown) })
         binding.infoContainer.visibility = View.VISIBLE
+    }
+
+    override fun onProvideAssistContent(outContent: AssistContent) {
+        super.onProvideAssistContent(outContent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            currentItem?.mediaInfo?.commonsUrl?.let {
+                outContent.setWebUri(Uri.parse(it))
+            }
+        }
     }
 
     private inner class GalleryItemAdapter(activity: AppCompatActivity) : PositionAwareFragmentStateAdapter(activity) {


### PR DESCRIPTION
Similar to https://github.com/wikimedia/apps-android-wikipedia/pull/4816 but for pictures.

Unlike the name, .commonsUrl, it works for both images uploaded on Wikimedia Commons and locally uploaded images.

To test this open an article, open an image from it, hit the rectangle button above the emulator, click on the anchor icon on the recents screen.

This is the reason it's only enabled for API level 23
<img width="481" alt="image" src="https://github.com/user-attachments/assets/ac2620bd-147e-4441-893e-ae1ae0fe8386">
