### PR TITLE
No longer ignore maplibre for dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
       interval: "daily"
     registries: "*"
     labels: [ "dependencies" ]
-    ignore:
-      # Ignore automatic MapLibre updates, since it uses nonstandard version suffixes, e.g. "-pre0"
-      - dependency-name: "org.maplibre.gl"
     groups:
       kotlin-ksp:
         patterns:


### PR DESCRIPTION
My upstream PR was accepted (https://github.com/dependabot/dependabot-core/pull/10207), so the issue with `-pre` releases should now be fixed.