### PR TITLE
Remove installreferrer from refactored dependencies.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -190,7 +190,6 @@ dependencies {
     implementation libs.recyclerview
     implementation libs.viewpager2
     implementation libs.flexbox
-    implementation libs.installreferrer
     implementation libs.drawerlayout
     implementation libs.work.runtime.ktx
     implementation libs.metrics.platform


### PR DESCRIPTION
The version-catalog refactor accidentally left behind the installreferrer dependency for the default flavor.