### PR TITLE
Remove feature flag for machine-suggested descriptions.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
@@ -19,7 +19,6 @@ import org.wikipedia.page.linkpreview.LinkPreviewDialog
 import org.wikipedia.settings.Prefs
 import org.wikipedia.suggestededits.PageSummaryForEdit
 import org.wikipedia.util.DeviceUtil
-import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.views.SuggestedArticleDescriptionsDialog
 
 class DescriptionEditActivity : SingleFragmentActivity<DescriptionEditFragment>(), DescriptionEditFragment.Callback {
@@ -32,7 +31,7 @@ class DescriptionEditActivity : SingleFragmentActivity<DescriptionEditFragment>(
         val action = intent.getSerializableExtra(Constants.INTENT_EXTRA_ACTION) as Action
         val pageTitle = intent.parcelableExtra<PageTitle>(Constants.ARG_TITLE)!!
 
-        MachineGeneratedArticleDescriptionsAnalyticsHelper.isUserInExperiment = (ReleaseUtil.isPreBetaRelease && AccountUtil.isLoggedIn &&
+        MachineGeneratedArticleDescriptionsAnalyticsHelper.isUserInExperiment = (AccountUtil.isLoggedIn &&
                 action == Action.ADD_DESCRIPTION && pageTitle.description.isNullOrEmpty() &&
                 SuggestedArticleDescriptionsDialog.availableLanguages.contains(pageTitle.wikiSite.languageCode))
 

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -53,7 +53,6 @@ import org.wikipedia.suggestededits.SuggestedEditsSurvey
 import org.wikipedia.suggestededits.SuggestionsActivity
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 import java.io.IOException
@@ -231,7 +230,7 @@ class DescriptionEditFragment : Fragment() {
         binding.fragmentDescriptionEditView.updateInfoText()
 
         binding.fragmentDescriptionEditView.isSuggestionButtonEnabled =
-                ReleaseUtil.isPreBetaRelease && MachineGeneratedArticleDescriptionsAnalyticsHelper.isUserInExperiment &&
+                MachineGeneratedArticleDescriptionsAnalyticsHelper.isUserInExperiment &&
                 MachineGeneratedArticleDescriptionsAnalyticsHelper.abcTest.group != GROUP_1
 
         if (binding.fragmentDescriptionEditView.isSuggestionButtonEnabled) {
@@ -487,6 +486,7 @@ class DescriptionEditFragment : Fragment() {
             when (action) {
                 DescriptionEditActivity.Action.ADD_DESCRIPTION -> {
                     if (binding.fragmentDescriptionEditView.wasSuggestionChosen) {
+                        tags.add(EditTags.APP_DESCRIPTION_ADD)
                         if (binding.fragmentDescriptionEditView.wasSuggestionModified) {
                             // TODO
                         } else {


### PR DESCRIPTION
This opens machine-generated description suggestions back up for all users, instead of being feature-flagged for pre-beta only.
It also makes sure that the correct tag is added when a description is added through a machine suggested selection.

https://phabricator.wikimedia.org/T360581