### PR TITLE
Remove AggregatedLanguages variable in FeedContentType

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedContentType.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedContentType.kt
@@ -85,18 +85,6 @@ enum class FeedContentType(private val code: Int,
     }
 
     companion object {
-        val aggregatedLanguages: List<String>
-            get() {
-                val appLangCodes = WikipediaApp.instance.languageState.appLanguageCodes
-                val list = mutableListOf<String>()
-                entries.filter { it.isEnabled }.forEach { type ->
-                    list.addAll(appLangCodes.filter {
-                        (type.langCodesSupported.isEmpty() || type.langCodesSupported.contains(it)) &&
-                                !type.langCodesDisabled.contains(it) && !list.contains(it)
-                    })
-                }
-                return list
-            }
 
         fun saveState() {
             val enabledList = mutableListOf<Boolean>()

--- a/app/src/main/java/org/wikipedia/feed/aggregated/AggregatedFeedContentClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/aggregated/AggregatedFeedContentClient.kt
@@ -150,7 +150,7 @@ class AggregatedFeedContentClient {
                 }
             ) {
                 val cards = mutableListOf<Card>()
-                FeedContentType.aggregatedLanguages.forEach { langCode ->
+                WikipediaApp.instance.languageState.appLanguageCodes.forEach { langCode ->
                     val wikiSite = WikiSite.forLanguageCode(langCode)
                     val hasParentLanguageCode = !WikipediaApp.instance.languageState.getDefaultLanguageCode(langCode).isNullOrEmpty()
                     var feedContentResponse = ServiceFactory.getRest(wikiSite).getFeedFeatured(date.year, date.month, date.day)

--- a/app/src/main/java/org/wikipedia/feed/random/RandomClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/random/RandomClient.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import org.wikipedia.WikipediaApp
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
@@ -28,7 +29,7 @@ class RandomClient(
             }
         ) {
             val list = mutableListOf<RandomCard>()
-            FeedContentType.aggregatedLanguages.forEach { lang ->
+            WikipediaApp.instance.languageState.appLanguageCodes.filter { !FeedContentType.RANDOM.langCodesDisabled.contains(it) }.forEach { lang ->
                 val wikiSite = WikiSite.forLanguageCode(lang)
                 val randomSummary = try {
                     ServiceFactory.getRest(wikiSite).getRandomSummary()


### PR DESCRIPTION
The "edit card languages" option for Randomizer does not work properly. After digging into the issue, I have noticed the `aggregatedLanguages` will always return the app languages, which seems unnecessary. 

This PR removes the `aggregatedLanguages` from `FeedContentType` since we do not specify which type we are currently using when calling `aggregatedLanguages`, and it always return the full list of languages, it is safe to delete from the code and uses regular `WikipediaApp.instance.languageState.appLanguageCodes`.