### PR TITLE
Follow-up to map markers.

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/ImagePipelineBitmapGetter.kt
+++ b/app/src/main/java/org/wikipedia/gallery/ImagePipelineBitmapGetter.kt
@@ -4,10 +4,11 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 
-class ImagePipelineBitmapGetter(context: Context, imageUrl: String?, callback: Callback) {
+class ImagePipelineBitmapGetter(context: Context, imageUrl: String?, transform: BitmapTransformation? = null, callback: Callback) {
     fun interface Callback {
         fun onSuccess(bitmap: Bitmap)
     }
@@ -15,6 +16,7 @@ class ImagePipelineBitmapGetter(context: Context, imageUrl: String?, callback: C
     init {
         Glide.with(context)
             .asBitmap()
+            .let { if (transform != null) it.transform(transform) else it }
             .load(imageUrl)
             .into(object : CustomTarget<Bitmap>() {
                 override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {

--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -93,6 +93,7 @@ import org.wikipedia.util.Resource
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.TabUtil
+import org.wikipedia.util.WhiteBackgroundTransformation
 import org.wikipedia.util.log.L
 import org.wikipedia.views.DrawableItemDecoration
 import org.wikipedia.views.ViewUtil
@@ -123,6 +124,8 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
     private lateinit var markerPaintSrcIn: Paint
     private lateinit var markerBorderPaint: Paint
     private val markerRect = Rect(0, 0, MARKER_SIZE, MARKER_SIZE)
+    private val whiteBackgroundTransformation = WhiteBackgroundTransformation()
+
     private val searchRadius
         get() = mapboxMap?.let {
             latitudeDiffToMeters(it.projection.visibleRegion.latLngBounds.latitudeSpan / 2)
@@ -676,7 +679,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
             return
         }
 
-        ImagePipelineBitmapGetter(requireContext(), url) { bitmap ->
+        ImagePipelineBitmapGetter(requireContext(), url, whiteBackgroundTransformation) { bitmap ->
             if (!isAdded) {
                 return@ImagePipelineBitmapGetter
             }


### PR DESCRIPTION
For map markers that have a thumbnail which is an SVG image with transparency, the marker must have a white background for the SVG to be properly visible.
Let's pass a `WhiteBackgroundTransformation` into the image pipeline getter, which also automatically respects the image dimming preference.