### PR TITLE
Fix bottom scroll position in Diff view.

### DIFF
--- a/app/src/main/res/layout/fragment_article_edit_details.xml
+++ b/app/src/main/res/layout/fragment_article_edit_details.xml
@@ -321,6 +321,7 @@
         android:id="@+id/diffRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingBottom="72dp"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         android:scrollbars="vertical"/>
 


### PR DESCRIPTION
Because of how the diff views are arranged, the last item in the list is sometimes obscured by the bottom button container. For now let's just give the RecyclerView an explicit bottom padding.

https://phabricator.wikimedia.org/T371893