### PR TITLE
Update .gitignore to ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ scripts/backup.ab
 # miscellaneous
 all-apks.sh
 device*.png
+
+# Log Files
+*.log


### PR DESCRIPTION
Some log files exist in the `.kotlin` folder, and we should avoid pushing them to the branch.