### PR TITLE
Hugely improve performance of finding text in editor window.

### DIFF
--- a/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.kt
+++ b/app/src/main/java/org/wikipedia/edit/FindInEditorActionProvider.kt
@@ -7,7 +7,6 @@ import android.view.View
 import org.wikipedia.edit.richtext.SyntaxHighlighter
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.DimenUtil
-import org.wikipedia.util.StringUtil
 import org.wikipedia.views.FindInPageActionProvider
 import org.wikipedia.views.FindInPageActionProvider.FindInPageListener
 
@@ -62,10 +61,16 @@ class FindInEditorActionProvider(private val scrollView: View,
         searchQuery = text?.ifEmpty { null }
         currentResultIndex = 0
         resultPositions.clear()
-
         searchQuery?.let { query ->
-            resultPositions += query.toRegex(StringUtil.SEARCH_REGEX_OPTIONS).findAll(textView.text)
-                .map { it.range.first }
+            val textToSearch = textView.text
+            var index = 0
+            while (index >= 0 && index < textToSearch.length) {
+                index = textToSearch.indexOf(query, index, ignoreCase = true)
+                if (index >= 0) {
+                    resultPositions.add(index)
+                    index += query.length
+                }
+            }
         }
         scrollToCurrentResult()
     }


### PR DESCRIPTION
Regular expressions have _awful performance_ when looking for very many matches in a very long string.

This reverts #4386 by @Isira-Seneviratne, and demonstrates yet again that "beautiful code" is often terrible in other ways, and "simplifying" things often adds huge hidden complexity.

https://phabricator.wikimedia.org/T373028