### PR TITLE
Enforce end-date for Recommended Content experiment.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/RecommendedContentAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/RecommendedContentAnalyticsHelper.kt
@@ -2,13 +2,14 @@ package org.wikipedia.analytics.metricsplatform
 
 import org.wikipedia.util.GeoUtil
 import org.wikipedia.util.ReleaseUtil
+import java.time.LocalDate
 
 class RecommendedContentAnalyticsHelper {
 
     companion object {
         val abcTest = RecommendedContentABCTest()
 
-        private val enableCountries = listOf(
+        private val enabledCountries = listOf(
             // sub-saharan africa
             "AO", "BJ", "BW", "IO", "BF", "BI", "CV", "CM", "CF", "TD", "KM", "CG", "IC", "CD", "DJ", "GQ", "ER",
             "SZ", "ET", "GA", "GM", "GH", "GN", "GW", "KE", "LS", "LR", "MG", "MW", "ML", "MR", "YT", "MZ", "NA",
@@ -17,8 +18,8 @@ class RecommendedContentAnalyticsHelper {
             "IN", "PK", "BD", "LK", "MU", "MV", "NP", "BT", "AF"
         )
 
-        fun recommendedContentEnabled(): Boolean {
-            return ReleaseUtil.isPreProdRelease || enableCountries.contains(GeoUtil.geoIPCountry.orEmpty())
-        }
+        val recommendedContentEnabled get() = ReleaseUtil.isPreProdRelease &&
+                enabledCountries.contains(GeoUtil.geoIPCountry.orEmpty()) &&
+                LocalDate.now() <= LocalDate.of(2024, 10, 1)
     }
 }

--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/RecommendedContentAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/RecommendedContentAnalyticsHelper.kt
@@ -18,8 +18,8 @@ class RecommendedContentAnalyticsHelper {
             "IN", "PK", "BD", "LK", "MU", "MV", "NP", "BT", "AF"
         )
 
-        val recommendedContentEnabled get() = ReleaseUtil.isPreProdRelease &&
-                enabledCountries.contains(GeoUtil.geoIPCountry.orEmpty()) &&
-                LocalDate.now() <= LocalDate.of(2024, 10, 1)
+        val recommendedContentEnabled get() = ReleaseUtil.isPreBetaRelease ||
+                (enabledCountries.contains(GeoUtil.geoIPCountry.orEmpty()) &&
+                LocalDate.now() <= LocalDate.of(2024, 10, 1))
     }
 }

--- a/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.kt
@@ -97,7 +97,7 @@ class RecentSearchesFragment : Fragment() {
     }
 
     private fun loadRecommendedContent() {
-        if (!RecommendedContentAnalyticsHelper.recommendedContentEnabled() ||
+        if (!RecommendedContentAnalyticsHelper.recommendedContentEnabled ||
             RecommendedContentAnalyticsHelper.abcTest.group == ABTest.GROUP_1) {
             // Construct and send an impression event now, since there will be no loading of recommended content.
             (requireParentFragment() as SearchFragment).analyticsEvent = ExperimentalLinkPreviewInteraction(HistoryEntry.SOURCE_SEARCH, RecommendedContentAnalyticsHelper.abcTest.getGroupName(), false)


### PR DESCRIPTION
This will make sure that Recommended Content will not be shown after a specified hard-coded date.