### PR TITLE
Use style instead of deprecated method for resizing dialog window.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -690,7 +690,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     private fun maybeShowRecommendedContentSurvey() {
         if (Prefs.recommendedContentSurveyShown) {
-             return
+             //return
         }
         historyEntry?.let {
             val duration = if (ReleaseUtil.isPreBetaRelease) 1L else 10L

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -690,7 +690,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     private fun maybeShowRecommendedContentSurvey() {
         if (Prefs.recommendedContentSurveyShown) {
-             //return
+             return
         }
         historyEntry?.let {
             val duration = if (ReleaseUtil.isPreBetaRelease) 1L else 10L

--- a/app/src/main/java/org/wikipedia/views/SurveyDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/SurveyDialog.kt
@@ -65,7 +65,7 @@ object SurveyDialog {
                 .logImpression(feedbackShown = true)
         }
 
-        val dialogBuilder = MaterialAlertDialogBuilder(activity)
+        val dialogBuilder = MaterialAlertDialogBuilder(activity, R.style.AlertDialogTheme_AdjustResize)
             .setCancelable(false)
             .setView(binding.root)
 

--- a/app/src/main/java/org/wikipedia/views/SurveyDialog.kt
+++ b/app/src/main/java/org/wikipedia/views/SurveyDialog.kt
@@ -2,7 +2,6 @@ package org.wikipedia.views
 
 import android.app.Activity
 import android.view.View
-import android.view.WindowManager
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
@@ -93,9 +92,6 @@ object SurveyDialog {
         }
 
         dialog = dialogBuilder.show()
-
-        // TODO: not to use the deprecated method
-        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
     }
 
     private fun showFeedbackInputDialog(activity: Activity, messageId: Int, source: Constants.InvokeSource) {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -537,6 +537,7 @@
         <item name="elevationOverlayEnabled">false</item>
         <item name="materialAlertDialogTitleTextStyle">@style/H2.DialogTitle</item>
         <item name="materialAlertDialogBodyTextStyle">@style/P.DialogBody</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
 
     <style name="DialogIconWithTint" parent="MaterialAlertDialog.Material3.Title.Icon.CenterStacked">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -539,7 +539,7 @@
         <item name="materialAlertDialogBodyTextStyle">@style/P.DialogBody</item>
     </style>
 
-    <style name="AlertDialogTheme.AdjustResize" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+    <style name="AlertDialogTheme.AdjustResize">
         <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -537,6 +537,9 @@
         <item name="elevationOverlayEnabled">false</item>
         <item name="materialAlertDialogTitleTextStyle">@style/H2.DialogTitle</item>
         <item name="materialAlertDialogBodyTextStyle">@style/P.DialogBody</item>
+    </style>
+
+    <style name="AlertDialogTheme.AdjustResize" parent="ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
 


### PR DESCRIPTION
Technically this still uses `adjustResize` for the window, but this doesn't seem to be deprecated, and is simpler, and applies to all dialogs automatically.
