### PR TITLE
Fix: make sure to get a random page from a specific language code

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/random/RandomClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/random/RandomClient.kt
@@ -34,13 +34,13 @@ class RandomClient(
                 val randomSummary = try {
                     ServiceFactory.getRest(wikiSite).getRandomSummary()
                 } catch (e: Exception) {
-                    AppDatabase.instance.readingListPageDao().getRandomPage()?.let {
+                    AppDatabase.instance.readingListPageDao().getRandomPage(lang)?.let {
                         ReadingListPage.toPageSummary(it)
-                    } ?: run {
-                        throw e
                     }
                 }
-                list.add(RandomCard(randomSummary, age, wikiSite))
+                randomSummary?.let {
+                    list.add(RandomCard(it, age, wikiSite))
+                }
             }
             cb.success(list)
         }

--- a/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
@@ -65,8 +65,8 @@ interface ReadingListPageDao {
     @Query("UPDATE ReadingListPage SET status = :newStatus WHERE status = :oldStatus AND offline = :offline")
     fun updateStatus(oldStatus: Long, newStatus: Long, offline: Boolean)
 
-    @Query("SELECT * FROM ReadingListPage ORDER BY RANDOM() LIMIT 1")
-    fun getRandomPage(): ReadingListPage?
+    @Query("SELECT * FROM ReadingListPage WHERE lang = :lang ORDER BY RANDOM() LIMIT 1")
+    fun getRandomPage(lang: String): ReadingListPage?
 
     @Query("SELECT * FROM ReadingListPage WHERE UPPER(displayTitle) LIKE UPPER(:term) ESCAPE '\\'")
     fun findPageBySearchTerm(term: String): List<ReadingListPage>


### PR DESCRIPTION
### What does this do?
Updating `getRandomPage()` in the `ReadingListPageDao.kt` to make sure we are getting the correct random page for a specific wiki.

### Why is this needed?
If the app has multiple languages set, and once one of the `getRandomSummary()` is empty, it will fall back to search for the local pages without a specific language code, which will create content that does not align with the card language.

<img src="https://github.com/user-attachments/assets/6b715909-5af9-41e6-8c6c-7f78869f4937" width="450" />
