### PR TITLE
Apply getPagesForLanguageVariant function for the BecauseYouReadClient

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadClient.kt
@@ -13,6 +13,7 @@ import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.feed.dataclient.FeedClient
+import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 
@@ -47,13 +48,12 @@ class BecauseYouReadClient(
                     entry.title.extract, entry.title.thumbUrl, langCode)
 
                 moreLikeResponse.query?.pages?.forEach {
+                    val pageSummary = PageSummary(it.displayTitle(langCode), it.title, it.description, it.extract, it.thumbUrl(), langCode)
                     if (it.title != searchTerm) {
                         if (hasParentLanguageCode) {
-                            val pageSummary = ServiceFactory.getRest(entry.title.wikiSite).getPageSummary(entry.referrer, it.title)
-                            relatedPages.add(pageSummary)
+                            relatedPages.add(L10nUtil.getPagesForLanguageVariant(listOf(pageSummary), entry.title.wikiSite).first())
                         } else {
-                            relatedPages.add(PageSummary(it.displayTitle(langCode), it.title, it.description,
-                                it.extract, it.thumbUrl(), langCode))
+                            relatedPages.add(pageSummary)
                         }
                     }
                 }


### PR DESCRIPTION
### What does this do?
Apply the `L10nUtil.getPagesForLanguageVariant` to get the correct article title AND the correct article description.


### Why is this needed?
This originally used `getPageSummary`, but the description is often incorrect for different language variants. 
