### PR TITLE
Fix scroll area of edit window when obscured by wikitext buttons.

### DIFF
--- a/app/src/main/res/layout/activity_edit_section.xml
+++ b/app/src/main/res/layout/activity_edit_section.xml
@@ -20,7 +20,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@id/toolbar"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/edit_keyboard_overlay_formatting"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:scrollbars="vertical">


### PR DESCRIPTION
### What does this do?

Correctly align the scroll view in the EditSection activity, so that when the Wikitext buttons are visible, they do not obscure the last line of text in the editor.

### Why is this needed?

Resolves an annoying issue where the last line in the editor is not visible because it is overlapped by the wikitext buttons.

**Phabricator:**
https://phabricator.wikimedia.org/T372615
