### PR TITLE
Fix: apply start and end padding to the OverFlowMenuItem style

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -382,6 +382,8 @@
     <style name="OverflowMenuItem" parent="ListItem">
         <item name="android:paddingTop">13dp</item>
         <item name="android:paddingBottom">13dp</item>
+        <item name="android:paddingStart">16dp</item>
+        <item name="android:paddingEnd">16dp</item>
     </style>
 
     <style name="App.Button" parent="@style/Widget.Material3.Button">


### PR DESCRIPTION
### What does this do?
The start and end padding were removed while doing the style update.


### Why is this needed?
The padding is necessary for the menu items.

