### PR TITLE
Fix possible duplicate action in notifications.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
@@ -130,6 +130,7 @@ object NotificationPresenter {
         if (UriUtil.isDiffUrl(link.url)) {
             try {
                 addActionForDiffLink(context, builder, link, n)
+                return
             } catch (e: Exception) {
                 L.e(e)
             }


### PR DESCRIPTION
### What does this do?
De-duplicate action buttons in certain notifications that are shown to the user.

### Why is this needed?
There was a missing `return` statement when processing a notification of a certain kind, which was causing a duplicate action to be added.

**Phabricator:**
https://phabricator.wikimedia.org/T351425
