### PR TITLE
Correctly strip html styling from Talk activity titles.

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkThreadHeaderView.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkThreadHeaderView.kt
@@ -36,7 +36,7 @@ class TalkThreadHeaderView constructor(context: Context, attrs: AttributeSet? = 
         binding.pageTitleText.movementMethod = movementMethod
         val baseTitle = TalkTopicsActivity.getNonTalkPageTitle(pageTitle)
         val pageTitleText = StringUtil.fromHtml(pageTitle.namespace.ifEmpty { TalkAliasData.valueFor(pageTitle.wikiSite.languageCode) } +
-                ": " + "<a href='" + baseTitle.uri + "'>${StringUtil.removeNamespace(pageTitle.displayText)}</a>")
+                ": " + "<a href='" + baseTitle.uri + "'>${StringUtil.removeNamespace(StringUtil.removeHTMLTags(pageTitle.displayText))}</a>")
         StringUtil.setHighlightedAndBoldenedText(binding.pageTitleText, pageTitleText, searchQuery)
 
         binding.threadTitleText.isVisible = !TalkTopicActivity.isHeaderTemplate(item)

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -408,7 +408,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
     }
 
     private fun setToolbarTitle(pageTitle: PageTitle) {
-        val title = StringUtil.fromHtml(pageTitle.namespace.ifEmpty { TalkAliasData.valueFor(pageTitle.wikiSite.languageCode) } + ": " + "<a href='#'>${StringUtil.removeNamespace(pageTitle.displayText)}</a>")
+        val title = StringUtil.fromHtml(pageTitle.namespace.ifEmpty { TalkAliasData.valueFor(pageTitle.wikiSite.languageCode) } + ": " + "<a href='#'>${StringUtil.removeNamespace(StringUtil.removeHTMLTags(pageTitle.displayText))}</a>")
         ViewUtil.getTitleViewFromToolbar(binding.toolbar)?.let {
             it.contentDescription = title
             it.isVisible = !goToTopic


### PR DESCRIPTION
We were not stripping HTML tags from the PageTitle that is displayed as the title of the Talk activity, which can lead to unintended HTML spills.

**Phabricator:**
https://phabricator.wikimedia.org/T374393