### PR TITLE
Minor: update the order of enabled countries list for Recommended Content

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/metricsplatform/RecommendedContentAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/analytics/metricsplatform/RecommendedContentAnalyticsHelper.kt
@@ -12,10 +12,11 @@ class RecommendedContentAnalyticsHelper {
         private val enabledCountries = listOf(
             // sub-saharan africa
             "AO", "BJ", "BW", "IO", "BF", "BI", "CV", "CM", "CF", "TD", "KM", "CG", "IC", "CD", "DJ", "GQ", "ER",
-            "SZ", "ET", "GA", "GM", "GH", "GN", "GW", "KE", "LS", "LR", "MG", "MW", "ML", "MR", "YT", "MZ", "NA",
-            "NE", "NG", "RE", "RW", "SH", "ST", "SN", "SC", "SL", "SO", "ZA", "SS", "TG", "UG", "TZ", "ZM", "ZW",
+            "SZ", "ET", "GA", "GM", "GH", "GN", "GW", "KE", "LS", "LR", "MG", "MW", "ML", "MR", "MU", "YT", "MZ",
+            "NA", "NE", "NG", "RE", "RW", "SH", "ST", "SN", "SC", "SL", "SO", "ZA", "SS", "TG", "UG", "TZ", "ZM",
+            "ZW",
             // south asia
-            "IN", "PK", "BD", "LK", "MU", "MV", "NP", "BT", "AF"
+            "IN", "PK", "BD", "LK", "MV", "NP", "BT", "AF"
         )
 
         val recommendedContentEnabled get() = ReleaseUtil.isPreBetaRelease ||


### PR DESCRIPTION
### What does this do?
Moves `MU` country code from South Asia to sub-Saharan Africa.


### Why is this needed?
To avoid confusion. No impact on the current release. 
