### PR TITLE
Fix: clear notifications from the db after logging out

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -19,6 +19,7 @@ import org.wikipedia.appshortcuts.AppShortcuts
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.concurrency.FlowEventBus
 import org.wikipedia.connectivity.ConnectionStateMonitor
+import org.wikipedia.database.AppDatabase
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.SharedPreferenceCookieManager
 import org.wikipedia.dataclient.WikiSite
@@ -251,6 +252,7 @@ class WikipediaApp : Application() {
             ServiceFactory.get(wikiSite).postLogout(token)
         }.invokeOnCompletion {
             SharedPreferenceCookieManager.instance.clearAllCookies()
+            AppDatabase.instance.notificationDao().deleteAll()
             L.d("Logout complete.")
         }
     }

--- a/app/src/main/java/org/wikipedia/notifications/db/NotificationDao.kt
+++ b/app/src/main/java/org/wikipedia/notifications/db/NotificationDao.kt
@@ -1,6 +1,11 @@
 package org.wikipedia.notifications.db
 
-import androidx.room.*
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -13,6 +18,9 @@ interface NotificationDao {
 
     @Delete
     suspend fun deleteNotification(notification: Notification)
+
+    @Query("DELETE FROM Notification")
+    fun deleteAll()
 
     @Query("SELECT * FROM Notification")
     fun getAllNotifications(): List<Notification>


### PR DESCRIPTION
### What does this do?
The notifications are kept in the database even if you log out and switch to another account, which does not make sense if the user sees the notifications that do not associate with the currently logged-in account.

### Why is this needed?
Clear the notification after the user logs out to prevent showing incorrect content for the user. 