### PR TITLE
Update campaign ID format sent with GPay transaction.

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
@@ -154,7 +154,7 @@ class GooglePayViewModel : ViewModel() {
                 .submitPayment(
                     decimalFormatCanonical.format(finalAmount),
                     BuildConfig.VERSION_NAME,
-                    campaignId,
+                    WikipediaApp.instance.appOrSystemLanguageCode + campaignId + "_Android",
                     billingObj.optString("locality", ""),
                     currentCountryCode,
                     currencyCode,


### PR DESCRIPTION
The campaign ID that is sent to the fundraising API needs to be updated to match the format used by iOS, which is: `language`+`campaignID`+`_`+`platform`.  (note no underscore between language and ID, and underscore between ID and platform)
This will enhance and simplify analytics.

**Phabricator:**
https://phabricator.wikimedia.org/T367360
