### PR TITLE
(Truly) fix possible crash in recommended content.

### DIFF
--- a/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/RecentSearchesFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.view.isInvisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -106,10 +108,7 @@ class RecentSearchesFragment : Fragment() {
         val isGeneralized = RecommendedContentAnalyticsHelper.abcTest.group == ABTest.GROUP_2
         val langeCode = callback?.getLangCode() ?: WikipediaApp.instance.appOrSystemLanguageCode
         recommendedContentFragment = RecommendedContentFragment.newInstance(wikiSite = WikiSite.forLanguageCode(langeCode), isGeneralized)
-        childFragmentManager.beginTransaction()
-            .add(R.id.fragmentOverlayContainer, recommendedContentFragment!!, null)
-            .addToBackStack(null)
-            .commit()
+        childFragmentManager.commit { replace(R.id.fragmentOverlayContainer, recommendedContentFragment!!) }
     }
 
     private fun updateSearchEmptyView(searchesEmpty: Boolean) {


### PR DESCRIPTION
The (minor) crash was being caused by using the `childFragmentManager` to add the RecommendedContent child fragment _to the backstack_, which is not exactly correct. This causes the fragment manager to **recreate** the fragment automatically (outside of our control) in certain situations, which will cause a second instance of that fragment to exist, and lead to unexpected/undefined behavior.