### PR TITLE
Fix: don't send empty string for morelike API in Recommended content

### DIFF
--- a/app/src/main/java/org/wikipedia/recommendedcontent/RecommendedContentFragment.kt
+++ b/app/src/main/java/org/wikipedia/recommendedcontent/RecommendedContentFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -111,9 +112,10 @@ class RecommendedContentFragment : Fragment() {
         if (list.isEmpty()) {
             parentSearchFragment.analyticsEvent = ExperimentalLinkPreviewInteraction(HistoryEntry.SOURCE_SEARCH, RecommendedContentAnalyticsHelper.abcTest.getGroupName(), false)
                 .also { it.logImpression() }
-            parentFragmentManager.popBackStack()
+            binding.nestedScrollView.isVisible = false
             return
         }
+        binding.nestedScrollView.isVisible = true
         parentSearchFragment.analyticsEvent = ExperimentalLinkPreviewInteraction(HistoryEntry.SOURCE_SEARCH, RecommendedContentAnalyticsHelper.abcTest.getGroupName(), true)
             .also { it.logImpression() }
         binding.recommendedContent.buildContent(viewModel.wikiSite, list, parentSearchFragment.analyticsEvent)

--- a/app/src/main/java/org/wikipedia/recommendedcontent/RecommendedContentViewModel.kt
+++ b/app/src/main/java/org/wikipedia/recommendedcontent/RecommendedContentViewModel.kt
@@ -82,34 +82,36 @@ class RecommendedContentViewModel(bundle: Bundle) : ViewModel() {
         }
     }
 
-    private suspend fun getMoreLikeSearchTerm(): String {
+    private suspend fun getMoreLikeSearchTerm(): String? {
         return withContext(Dispatchers.IO) {
             // Get term from last opened article
             var term = WikipediaApp.instance.tabList.lastOrNull {
                 it.backStackPositionTitle?.wikiSite == wikiSite
-            }?.backStackPositionTitle?.displayText ?: ""
+            }?.backStackPositionTitle?.displayText
 
             // Get term from last history entry if no article is opened
-            if (term.isEmpty()) {
+            if (term.isNullOrEmpty()) {
                 term = AppDatabase.instance.historyEntryWithImageDao().filterHistoryItemsWithoutTime().firstOrNull {
                     it.title.wikiSite == wikiSite
-                }?.apiTitle ?: ""
+                }?.apiTitle
             }
 
             // Ger term from Because you read if no history entry is found
-            if (term.isEmpty()) {
+            if (term.isNullOrEmpty()) {
                 term = AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(0, WikipediaApp.instance.resources.getInteger(
                     R.integer.article_engagement_threshold_sec)).lastOrNull {
                     it.title.wikiSite == wikiSite
-                }?.title?.displayText ?: ""
+                }?.title?.displayText
             }
 
             // Get term from last recent search if no because you read is found
-            if (term.isEmpty()) {
-                term = AppDatabase.instance.recentSearchDao().getRecentSearches().firstOrNull()?.text ?: ""
+            if (term.isNullOrEmpty()) {
+                term = AppDatabase.instance.recentSearchDao().getRecentSearches().firstOrNull()?.text
             }
 
-            StringUtil.addUnderscores(StringUtil.removeHTMLTags(term))
+            term?.let {
+                StringUtil.addUnderscores(StringUtil.removeHTMLTags(it))
+            }
         }
     }
 


### PR DESCRIPTION
### What does this do?
When you send an empty string to the `morelike` API, it returns an [unrelated result](https://en.wikipedia.org/w/api.php?format=json&formatversion=2&origin=*&action=query&prop=pageimages%7Cdescription&piprop=thumbnail&pithumbsize=160&pilimit=3&generator=search&gsrsearch=morelike:&gsrnamespace=0&gsrlimit=3&gsrqiprofile=classic_noboostlinks&uselang=content&smaxage=86400&maxage=86400).

