### PR TITLE
Fix: do not make an API call for an empty list in getPagesForLanguageVariant()

### DIFF
--- a/app/src/main/java/org/wikipedia/util/L10nUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/L10nUtil.kt
@@ -167,16 +167,19 @@ object L10nUtil {
                 }
             }
 
+            val mwQueryResult = mwQueryResponse.await()
+            val wikiDataResult = wikiDataResponse.await()
+
             list.forEach { pageSummary ->
                 // Find the correct display title from the varianttitles map, and insert the new page summary to the list.
-                val displayTitle = mwQueryResponse.await().query?.pages?.find { StringUtil.addUnderscores(it.title) == pageSummary.apiTitle }?.varianttitles?.get(wikiSite.languageCode)
+                val displayTitle = mwQueryResult.query?.pages?.find { StringUtil.addUnderscores(it.title) == pageSummary.apiTitle }?.varianttitles?.get(wikiSite.languageCode)
                 val newPageSummary = pageSummary.apply {
                     val newDisplayTitle = displayTitle ?: pageSummary.displayTitle
                     this.titles = PageSummary.Titles(
                         canonical = pageSummary.apiTitle,
                         display = newDisplayTitle
                     )
-                    this.description = wikiDataResponse.await().entities.values.firstOrNull {
+                    this.description = wikiDataResult.entities.values.firstOrNull {
                         it.getLabels()[wikiSite.languageCode]?.value == newDisplayTitle
                     }?.getDescriptions()?.get(wikiSite.languageCode)?.value ?: pageSummary.description
                 }

--- a/app/src/main/java/org/wikipedia/util/L10nUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/L10nUtil.kt
@@ -140,6 +140,9 @@ object L10nUtil {
 
     suspend fun getPagesForLanguageVariant(list: List<PageSummary>, wikiSite: WikiSite, shouldUpdateExtracts: Boolean = false): List<PageSummary> {
         return withContext(Dispatchers.IO) {
+            if (list.isEmpty()) {
+                return@withContext emptyList()
+            }
             val newList = mutableListOf<PageSummary>()
             val titles = list.joinToString(separator = "|") { it.apiTitle }
             // First, get the correct description from Wikidata directly.


### PR DESCRIPTION
### What does this do?
If the `list` is empty, it will still return an empty string from the `joinToString()` method, which will cause an error when requesting the wikidata API call in `L10nUtil.getPagesForLanguageVariant()`.


### Why is this needed?
If the `morelike:` API returns an empty result, it is not necessary to go through the `getPagesForLanguageVariant` process.
