### PR TITLE
Fix crash no results

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -176,31 +176,32 @@ class SearchResultsFragment : Fragment() {
 
     private inner class NoSearchResultAdapter : RecyclerView.Adapter<NoSearchResultItemViewHolder>() {
         override fun onBindViewHolder(holder: NoSearchResultItemViewHolder, position: Int) {
-            holder.bindItem(position, viewModel.resultsCount[position])
+            holder.bindItem(viewModel.resultPairList[position])
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NoSearchResultItemViewHolder {
             return NoSearchResultItemViewHolder(ItemSearchNoResultsBinding.inflate(layoutInflater, parent, false))
         }
 
-        override fun getItemCount(): Int { return viewModel.resultsCount.size }
+        override fun getItemCount(): Int { return viewModel.resultPairList.size }
     }
 
     private inner class NoSearchResultItemViewHolder(val itemBinding: ItemSearchNoResultsBinding) : DefaultViewHolder<View>(itemBinding.root) {
         private val accentColorStateList = getThemedColorStateList(requireContext(), R.attr.progressive_color)
         private val secondaryColorStateList = getThemedColorStateList(requireContext(), R.attr.secondary_color)
-        fun bindItem(position: Int, resultsCount: Int) {
-            if (resultsCount == 0 && viewModel.invokeSource == Constants.InvokeSource.PLACES) {
+        fun bindItem(resultPair: Pair<String, Int>) {
+            val langCode = resultPair.first
+            val resultCount = resultPair.second
+            if (resultCount == 0 && viewModel.invokeSource == Constants.InvokeSource.PLACES) {
                 PlacesEvent.logAction("no_results_impression", "search_view")
             }
-            val langCode = WikipediaApp.instance.languageState.appLanguageCodes[position]
-            itemBinding.resultsText.text = if (resultsCount == 0) getString(R.string.search_results_count_zero) else resources.getQuantityString(R.plurals.search_results_count, resultsCount, resultsCount)
-            itemBinding.resultsText.setTextColor(if (resultsCount == 0) secondaryColorStateList else accentColorStateList)
-            itemBinding.languageCode.visibility = if (viewModel.resultsCount.size == 1) View.GONE else View.VISIBLE
+            itemBinding.resultsText.text = if (resultCount == 0) getString(R.string.search_results_count_zero) else resources.getQuantityString(R.plurals.search_results_count, resultCount, resultCount)
+            itemBinding.resultsText.setTextColor(if (resultCount == 0) secondaryColorStateList else accentColorStateList)
+            itemBinding.languageCode.visibility = if (viewModel.resultPairList.size == 1) View.GONE else View.VISIBLE
             itemBinding.languageCode.setLangCode(langCode)
-            itemBinding.languageCode.setTextColor(if (resultsCount == 0) secondaryColorStateList else accentColorStateList)
-            itemBinding.languageCode.setBackgroundTint(if (resultsCount == 0) secondaryColorStateList else accentColorStateList)
-            view.isEnabled = resultsCount > 0
+            itemBinding.languageCode.setTextColor(if (resultCount == 0) secondaryColorStateList else accentColorStateList)
+            itemBinding.languageCode.setBackgroundTint(if (resultCount == 0) secondaryColorStateList else accentColorStateList)
+            view.isEnabled = resultCount > 0
             view.setOnClickListener {
                 if (!isAdded) {
                     return@setOnClickListener

--- a/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
@@ -39,7 +39,7 @@ class SearchResultsViewModel : ViewModel() {
     class SearchResultsPagingSource(
         private val searchTerm: String?,
         private val languageCode: String?,
-        private var resultPairList: MutableList<Pair<String, Int>>?,
+        private var resultPairList: MutableList<Pair<String, Int>>,
         private var invokeSource: Constants.InvokeSource
     ) : PagingSource<Int, SearchResult>() {
 
@@ -93,7 +93,7 @@ class SearchResultsViewModel : ViewModel() {
                 }
 
                 if (resultList.isEmpty() && response?.continuation == null) {
-                    resultPairList?.clear()
+                    resultPairList.clear()
                     WikipediaApp.instance.languageState.appLanguageCodes.forEach { langCode ->
                         var countResultSize = 0
                         if (langCode != languageCode) {
@@ -108,7 +108,7 @@ class SearchResultsViewModel : ViewModel() {
                                 countResultSize = fullTextSearchResponse.query?.pages?.size ?: 0
                             }
                         }
-                        resultPairList?.add(langCode to countResultSize)
+                        resultPairList.add(langCode to countResultSize)
                     }
                 }
 


### PR DESCRIPTION
### What does this do?
Fix a possible crash when showing results for other languages in the `SearchResultsFragment`


### Why is this needed?
We get the language code by providing a position to the language list, which may cause a crash.
```
val langCode = WikipediaApp.instance.languageState.appLanguageCodes[position]
```
This PR changes the plain list to a `Pair<>` that contains the language code with its result counts.


### The error log in console
https://play.google.com/console/u/1/developers/6169333749249604352/app/4976363884102945010/vitals/crashes/0e0fb84f88cb64408c0412acfb8550ff/details?days=28&versionCode=50501&isUserPerceived=true

