### PR TITLE
Move description edit extras to a view model

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.kt
+++ b/app/src/main/java/org/wikipedia/Constants.kt
@@ -19,6 +19,10 @@ object Constants {
     const val ARG_WIKISITE = "wikiSite"
     const val ARG_TEXT = "text"
     const val ARG_BOOLEAN = "boolean"
+    const val ARG_HIGHLIGHT_TEXT = "highlightText"
+    const val ARG_SOURCE_SUMMARY = "sourceSummary"
+    const val ARG_TARGET_SUMMARY = "targetSummary"
+
     const val INTENT_APP_SHORTCUT_CONTINUE_READING = "appShortcutContinueReading"
     const val INTENT_APP_SHORTCUT_RANDOMIZER = "appShortcutRandomizer"
     const val INTENT_APP_SHORTCUT_SEARCH = "appShortcutSearch"

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditActivity.kt
@@ -61,8 +61,7 @@ class DescriptionEditActivity : SingleFragmentActivity<DescriptionEditFragment>(
         } else {
             ExclusiveBottomSheetPresenter.show(supportFragmentManager,
                     LinkPreviewDialog.newInstance(HistoryEntry(summary.pageTitle,
-                            if (intent.hasExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) && intent.getSerializableExtra
-                                    (Constants.INTENT_EXTRA_INVOKE_SOURCE) === InvokeSource.PAGE_ACTIVITY)
+                            if (viewModel.invokeSource == InvokeSource.PAGE_ACTIVITY)
                                 HistoryEntry.SOURCE_EDIT_DESCRIPTION else HistoryEntry.SOURCE_SUGGESTED_EDITS)))
         }
     }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -1,0 +1,16 @@
+package org.wikipedia.descriptions
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import org.wikipedia.Constants
+import org.wikipedia.page.PageTitle
+import org.wikipedia.suggestededits.PageSummaryForEdit
+
+class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
+    val pageTitle = savedStateHandle.get<PageTitle>(Constants.ARG_TITLE)!!
+    val highlightText = savedStateHandle.get<String>(Constants.ARG_HIGHLIGHT_TEXT)
+    val action = savedStateHandle.get<DescriptionEditActivity.Action>(Constants.INTENT_EXTRA_ACTION)!!
+    val invokeSource = savedStateHandle.get<Constants.InvokeSource>(Constants.INTENT_EXTRA_INVOKE_SOURCE)!!
+    val sourceSummary = savedStateHandle.get<PageSummaryForEdit>(Constants.ARG_SOURCE_SUMMARY)
+    val targetSummary = savedStateHandle.get<PageSummaryForEdit>(Constants.ARG_TARGET_SUMMARY)
+}


### PR DESCRIPTION
### What does this do?
This PR moves the description edit extras to a separate view model class, and has the description edit fragment load its activity's view model using the [`activityViewModels`](https://developer.android.com/reference/kotlin/androidx/fragment/app/package-summary#(androidx.fragment.app.Fragment).activityViewModels(kotlin.Function0,kotlin.Function0)) extension.

Note: The [`SavedStateHandle`](https://developer.android.com/reference/androidx/lifecycle/SavedStateHandle) class automatically loads the activity's intent extras and is passed to the view model when using the [default view model factory](https://github.com/androidx/androidx/blob/androidx-main/activity/activity/src/main/java/androidx/activity/ComponentActivity.kt#L547). More information on `SavedStateHandle` can be found [here](https://medium.com/androiddevelopers/viewmodels-persistence-onsaveinstancestate-restoring-ui-state-and-loaders-fc7cc4a6c090).

### Why is this needed?
This change allows both the description edit activity and fragment to access the extras passed to the activity without having to pass the extras from the activity to the fragment manually.
