### PR TITLE
Fix: replace popBackStack() with a general visibility update in Recommended Content

### DIFF
--- a/app/src/main/java/org/wikipedia/recommendedcontent/RecommendedContentFragment.kt
+++ b/app/src/main/java/org/wikipedia/recommendedcontent/RecommendedContentFragment.kt
@@ -50,7 +50,7 @@ class RecommendedContentFragment : Fragment() {
                             }
                             is Resource.Error -> {
                                 parentSearchFragment.onSearchProgressBar(false)
-                                parentFragmentManager.popBackStack()
+                                binding.nestedScrollView.isVisible = false
                                 L.d(it.throwable)
                             }
                         }
@@ -67,7 +67,7 @@ class RecommendedContentFragment : Fragment() {
                             }
                             is Resource.Error -> {
                                 parentSearchFragment.onSearchProgressBar(false)
-                                parentFragmentManager.popBackStack()
+                                binding.nestedScrollView.isVisible = false
                                 L.d(it.throwable)
                             }
                         }


### PR DESCRIPTION
### What does this do?
Replace the `popBackStack()` with a view visibility update to prevent a [possible crash](https://play.google.com/console/u/1/developers/6169333749249604352/app/4976363884102945010/vitals/crashes/40202a9f69c71b6772058d707e235375/details?days=28&versionCode=50501&isUserPerceived=true).

