### PR TITLE
Switch to official Retrofit kotlinx.serialization converter

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.kt
@@ -1,7 +1,6 @@
 package org.wikipedia.dataclient
 
 import androidx.collection.lruCache
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Response
@@ -15,6 +14,7 @@ import org.wikipedia.json.JsonUtil
 import org.wikipedia.settings.Prefs
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.create
 import java.io.IOException
 

--- a/app/src/test/java/org/wikipedia/test/MockRetrofitTest.kt
+++ b/app/src/test/java/org/wikipedia/test/MockRetrofitTest.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.test
 
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import okhttp3.MediaType.Companion.toMediaType
 import org.junit.Before
 import org.wikipedia.dataclient.RestService
@@ -9,6 +8,7 @@ import org.wikipedia.dataclient.WikiSite.Companion.forLanguageCode
 import org.wikipedia.json.JsonUtil
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 abstract class MockRetrofitTest : MockWebServerTest() {
     protected lateinit var apiService: Service

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ paletteKtx = "1.0.0"
 photoview = "2.3.0"
 preferenceKtx = "1.2.1"
 recyclerview = "1.3.2"
-retrofit2KotlinxSerializationConverter = "1.0.0"
 retrofitVersion = "2.11.0"
 robolectric = "4.13"
 roomVersion = "2.6.1"
@@ -108,7 +107,7 @@ preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = 
 recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofitVersion" }
 retrofit2-adapter-rxjava3 = { module = "com.squareup.retrofit2:adapter-rxjava3", version.ref = "retrofitVersion" }
-retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
+retrofit2-kotlinx-serialization-converter = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofitVersion" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 room-testing = { module = "androidx.room:room-testing", version.ref = "roomVersion" }
 rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "rxandroid" }


### PR DESCRIPTION
### What does this do?
This PR updates the kotlinx.serialization converter for Retrofit to [the official first-party converter](https://github.com/square/retrofit/tree/trunk/retrofit-converters/kotlinx-serialization).

### Why is this needed?
The [original converter](https://github.com/JakeWharton/retrofit2-kotlinx-serialization-converter) is no longer being maintained.