### PR TITLE
Hygiene: remove unused API calls and rename the getClaims() function

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
+++ b/app/src/main/java/org/wikipedia/commons/ImageTagsProvider.kt
@@ -8,7 +8,7 @@ import org.wikipedia.language.LanguageUtil
 object ImageTagsProvider {
     suspend fun getImageTags(pageId: Int, langCode: String): Map<String, List<String>> {
         try {
-            val claims = ServiceFactory.get(Constants.commonsWikiSite).getClaimsSuspend("M$pageId", "P180")
+            val claims = ServiceFactory.get(Constants.commonsWikiSite).getClaims("M$pageId", "P180")
             val ids = getDepictsClaims(claims.claims)
             return if (ids.isEmpty()) {
                 emptyMap()

--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -500,13 +500,7 @@ interface Service {
     ): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=wbgetclaims")
-    fun getClaims(
-        @Query("entity") entity: String,
-        @Query("property") property: String?
-    ): Observable<Claims>
-
-    @GET(MW_API_PREFIX + "action=wbgetclaims")
-    suspend fun getClaimsSuspend(
+    suspend fun getClaims(
         @Query("entity") entity: String,
         @Query("property") property: String?
     ): Claims
@@ -522,15 +516,6 @@ interface Service {
     suspend fun getWikidataDescription(@Query("titles") titles: String,
                                        @Query("sites") sites: String,
                                        @Query("languages") langCode: String): Entities
-
-    @POST(MW_API_PREFIX + "action=wbsetclaim&errorlang=uselang")
-    @FormUrlEncoded
-    fun postSetClaim(
-        @Field("claim") claim: String,
-        @Field("token") token: String,
-        @Field("summary") summary: String?,
-        @Field("tags") tags: String?
-    ): Observable<MwPostResponse>
 
     @POST(MW_API_PREFIX + "action=wbsetdescription&errorlang=uselang")
     @FormUrlEncoded


### PR DESCRIPTION
### What does this do?
Clean up unused API calls and rename the `getClaims()`.