### PR TITLE
Facepalm: correctly get campaign id from Activity's intent.

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
@@ -271,8 +271,8 @@ class GooglePayActivity : BaseActivity() {
         if (requestCode == LOAD_PAYMENT_DATA_REQUEST_CODE) {
             when (resultCode) {
                 Activity.RESULT_OK -> {
-                    data?.let { intent ->
-                        PaymentData.getFromIntent(intent)?.let { paymentData ->
+                    data?.let { dataIntent ->
+                        PaymentData.getFromIntent(dataIntent)?.let { paymentData ->
                             viewModel.submit(paymentData,
                                 binding.checkBoxTransactionFee.isChecked,
                                 binding.checkBoxRecurring.isChecked,


### PR DESCRIPTION
In one of the most unfortunate cases of name shadowing, there were two variables called `intent`, and we were using the wrong one to get the campaign ID, resulting in a fallback to the default id.

https://phabricator.wikimedia.org/T375124