### PR TITLE
Update the item width for the customize toolbar overflow menu

### DIFF
--- a/app/src/main/java/org/wikipedia/views/PageActionOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/PageActionOverflowView.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import android.widget.PopupWindow
 import androidx.core.view.doOnDetach
 import androidx.core.widget.PopupWindowCompat
@@ -22,6 +23,7 @@ import org.wikipedia.page.action.PageActionItem
 import org.wikipedia.page.customize.CustomizeToolbarActivity
 import org.wikipedia.page.tabs.Tab
 import org.wikipedia.settings.Prefs
+import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
 
 class PageActionOverflowView(context: Context) : FrameLayout(context) {
@@ -47,10 +49,23 @@ class PageActionOverflowView(context: Context) : FrameLayout(context) {
             }
             binding.overflowList.addView(view)
         }
-        binding.customizeToolbar.setOnClickListener {
+        addCustomizeToolbarItem()
+    }
+
+    private fun addCustomizeToolbarItem() {
+        val view = ItemCustomizeToolbarMenuBinding.inflate(LayoutInflater.from(context)).root
+        view.text = context.getString(R.string.customize_toolbar_title)
+        view.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_settings_black_24dp, 0, 0, 0)
+        view.setOnClickListener {
             dismissPopupWindowHost()
             context.startActivity(CustomizeToolbarActivity.newIntent(context))
         }
+        val border = View(context)
+        border.layoutParams = LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, DimenUtil.roundedDpToPx(1f))
+        border.setBackgroundColor(ResourceUtil.getThemedColor(context, R.attr.border_color))
+        view.tag = false
+//        binding.overflowList.addView(border)
+        binding.overflowList.addView(view)
     }
 
     fun show(anchorView: View, callback: PageActionItem.Callback, currentTab: Tab, model: PageViewModel) {
@@ -65,6 +80,9 @@ class PageActionOverflowView(context: Context) : FrameLayout(context) {
         binding.overflowForward.visibility = if (currentTab.canGoForward()) VISIBLE else GONE
 
         for (i in 1 until binding.overflowList.childCount) {
+            if (binding.overflowList.getChildAt(i).tag == false) {
+                continue
+            }
             val view = binding.overflowList.getChildAt(i) as MaterialTextView
             val pageActionItem = PageActionItem.find(view.id)
             val enabled = model.page != null && (!model.shouldLoadAsMobileWeb || (model.shouldLoadAsMobileWeb && pageActionItem.isAvailableOnMobileWeb))

--- a/app/src/main/res/layout/view_page_action_overflow.xml
+++ b/app/src/main/res/layout/view_page_action_overflow.xml
@@ -19,7 +19,7 @@
 
             <LinearLayout
                 android:id="@+id/overflowList"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/paper_color"
                 android:orientation="vertical">

--- a/app/src/main/res/layout/view_page_action_overflow.xml
+++ b/app/src/main/res/layout/view_page_action_overflow.xml
@@ -13,43 +13,20 @@
         android:layout_height="wrap_content">
 
         <LinearLayout
+            android:id="@+id/overflowList"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="?attr/paper_color"
             android:orientation="vertical">
 
-            <LinearLayout
-                android:id="@+id/overflowList"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="?attr/paper_color"
-                android:orientation="vertical">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/overflow_forward"
-                    style="@style/OverflowMenuItem"
-                    android:drawablePadding="16dp"
-                    android:text="@string/nav_item_forward"
-                    android:layoutDirection="locale"
-                    android:textDirection="locale"
-                    app:drawableStartCompat="@drawable/ic_arrow_forward_black_24dp"
-                    app:drawableTint="?attr/primary_color" />
-
-            </LinearLayout>
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="?attr/border_color" />
-
             <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/customize_toolbar"
+                android:id="@+id/overflow_forward"
                 style="@style/OverflowMenuItem"
-                android:layout_width="wrap_content"
                 android:drawablePadding="16dp"
-                android:text="@string/customize_toolbar_title"
+                android:text="@string/nav_item_forward"
                 android:layoutDirection="locale"
                 android:textDirection="locale"
-                app:drawableStartCompat="@drawable/ic_settings_black_24dp"
+                app:drawableStartCompat="@drawable/ic_arrow_forward_black_24dp"
                 app:drawableTint="?attr/primary_color" />
 
         </LinearLayout>


### PR DESCRIPTION
### What does this do?
Make sure the width of the menu items have the proper width.

Before vs After
<img src="https://github.com/user-attachments/assets/1fc1f125-475f-4117-a155-df6048c0e680" width="300" />
<img src="https://github.com/user-attachments/assets/8cf1ea06-7b3f-49bd-97f3-669dcd899982" width="300" />

