### PR TITLE
Remove ChromeLikeTabSwitcher license

### DIFF
--- a/app/src/main/assets/licenses/ChromeLikeTabSwitcher
+++ b/app/src/main/assets/licenses/ChromeLikeTabSwitcher
@@ -1,1 +1,0 @@
-This project is distributed under the Apache License version 2.0. For further information about this license agreement's content please refer to its full version, which is available at http://www.apache.org/licenses/LICENSE-2.0.txt.

--- a/app/src/main/res/values/credits.xml
+++ b/app/src/main/res/values/credits.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="libraries_list"><![CDATA[<a href="https://github.com/skydoves/Balloon">Balloon</a>
+    <string name="libraries_list" tools:ignore="TypographyDashes"><![CDATA[<a href="https://github.com/skydoves/Balloon">Balloon</a>
         <!-- https://github.com/skydoves/Balloon/blob/main/LICENSE -->
         (<a href="content:///android_asset/licenses/Balloon">license</a>),
-
-        <a href="https://github.com/michael-rapp/ChromeLikeTabSwitcher">ChromeLikeTabSwitcher</a>
-        <!-- https://github.com/michael-rapp/ChromeLikeTabSwitcher/blob/master/LICENSE.txt -->
-        (<a href="content:///android_asset/licenses/ChromeLikeTabSwitcher">license</a>),
 
         <a href="https://commons.apache.org/proper/commons-lang/">Commons Lang</a>
         <!-- https://www.apache.org/licenses/ -->


### PR DESCRIPTION
### What does this do?
Remove the `ChromeLikeTabSwitcher` license and credit from the app.


