### PR TITLE
Correctly format Campaign ID for native payments and analytics.

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayViewModel.kt
@@ -15,6 +15,7 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.donate.CampaignCollection
 import org.wikipedia.dataclient.donate.DonationConfig
 import org.wikipedia.dataclient.donate.DonationConfigHelper
 import org.wikipedia.settings.Prefs
@@ -154,7 +155,7 @@ class GooglePayViewModel : ViewModel() {
                 .submitPayment(
                     decimalFormatCanonical.format(finalAmount),
                     BuildConfig.VERSION_NAME,
-                    WikipediaApp.instance.appOrSystemLanguageCode + campaignId + "_Android",
+                    CampaignCollection.getFormattedCampaignId(campaignId),
                     billingObj.optString("locality", ""),
                     currentCountryCode,
                     currencyCode,

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/DonorExperienceEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/DonorExperienceEvent.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.analytics.eventplatform
 
 import org.wikipedia.WikipediaApp
+import org.wikipedia.dataclient.donate.CampaignCollection
 import org.wikipedia.settings.Prefs
 
 class DonorExperienceEvent {
@@ -16,7 +17,7 @@ class DonorExperienceEvent {
             submit(
                 action,
                 activeInterface,
-                campaignId?.let { "campaign_id: $it, " }.orEmpty() + "banner_opt_in: ${Prefs.donationBannerOptIn}",
+                campaignId?.let { "campaign_id: ${CampaignCollection.getFormattedCampaignId(it)}, " }.orEmpty() + "banner_opt_in: ${Prefs.donationBannerOptIn}",
                 wikiId
             )
         }

--- a/app/src/main/java/org/wikipedia/dataclient/donate/CampaignCollection.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/donate/CampaignCollection.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 import okhttp3.Request
+import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.settings.Prefs
@@ -40,6 +41,10 @@ object CampaignCollection {
             })
         }
         return campaignList
+    }
+
+    fun getFormattedCampaignId(campaignId: String): String {
+        return "${WikipediaApp.instance.appOrSystemLanguageCode}${GeoUtil.geoIPCountry}_${campaignId}_Android"
     }
 
     @Serializable


### PR DESCRIPTION
This breaks out the formatting of the campaignId into a function, and the function is now called from the Google Pay submission workflow, as well as DonorExperience events that make use of the campaignId.

https://phabricator.wikimedia.org/T375124