### PR TITLE
Instrument donation results.

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
@@ -28,6 +28,7 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.DonorExperienceEvent
 import org.wikipedia.databinding.ActivityDonateBinding
+import org.wikipedia.dataclient.donate.CampaignCollection
 import org.wikipedia.dataclient.donate.DonationConfig
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.Resource
@@ -82,6 +83,7 @@ class GooglePayActivity : BaseActivity() {
                             }
                             is GooglePayViewModel.DonateSuccess -> {
                                 DonorExperienceEvent.logAction("impression", "gpay_processed", campaignId = intent.getStringExtra(DonateDialog.ARG_CAMPAIGN_ID).orEmpty())
+                                CampaignCollection.addDonationResult()
                                 setResult(RESULT_OK)
                                 finish()
                             }

--- a/app/src/main/java/org/wikipedia/dataclient/donate/CampaignCollection.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/donate/CampaignCollection.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import okhttp3.Request
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory
+import org.wikipedia.donate.DonationResult
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.GeoUtil
@@ -45,6 +46,10 @@ object CampaignCollection {
 
     fun getFormattedCampaignId(campaignId: String): String {
         return "${WikipediaApp.instance.appOrSystemLanguageCode}${GeoUtil.geoIPCountry}_${campaignId}_Android"
+    }
+
+    fun addDonationResult(fromWeb: Boolean = false) {
+        Prefs.donationResults = Prefs.donationResults.plus(DonationResult(dateTime = LocalDateTime.now().toString(), fromWeb = fromWeb))
     }
 
     @Serializable

--- a/app/src/main/java/org/wikipedia/donate/DonationResult.kt
+++ b/app/src/main/java/org/wikipedia/donate/DonationResult.kt
@@ -1,0 +1,9 @@
+package org.wikipedia.donate
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class DonationResult(
+    val dateTime: String = "",
+    val fromWeb: Boolean = false
+)

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -45,6 +45,7 @@ import org.wikipedia.commons.FilePageActivity
 import org.wikipedia.concurrency.FlowEventBus
 import org.wikipedia.databinding.ActivityPageBinding
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.donate.CampaignCollection
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.descriptions.DescriptionEditActivity
 import org.wikipedia.descriptions.DescriptionEditRevertHelpView
@@ -506,15 +507,19 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
                 val language = wiki.languageCode.lowercase(Locale.getDefault())
                 if (Constants.NON_LANGUAGE_SUBDOMAINS.contains(language) || (title.isSpecial && !title.isContributions)) {
                     // ...Except if the URL came as a result of a successful donation, in which case
-                    // open it in a Custom Tab.
-                    val utmCampaign = uri.getQueryParameter("wmf_campaign")
-                    if (utmCampaign != null && utmCampaign == "Android") {
-                        // TODO: need to verify if the page can be displayed and logged properly.
-                        DonorExperienceEvent.logAction("impression", "webpay_processed", wiki.languageCode)
-                        startActivity(SingleWebViewActivity.newIntent(this@PageActivity, uri.toString(),
-                            true, pageFragment.title, SingleWebViewActivity.PAGE_CONTENT_SOURCE_DONOR_EXPERIENCE))
-                        finish()
-                        return
+                    // treat it differently:
+                    if (language == "thankyou" && uri.getQueryParameter("order_id") != null) {
+                        CampaignCollection.addDonationResult(fromWeb = true)
+                        // Check if the donation started from the app, but completed via web, in which case
+                        // show it in a SingleWebViewActivity.
+                        val campaign = uri.getQueryParameter("wmf_campaign")
+                        if (campaign != null && campaign == "Android") {
+                            DonorExperienceEvent.logAction("impression", "webpay_processed", wiki.languageCode)
+                            startActivity(SingleWebViewActivity.newIntent(this@PageActivity, uri.toString(),
+                                true, pageFragment.title, SingleWebViewActivity.PAGE_CONTENT_SOURCE_DONOR_EXPERIENCE))
+                            finish()
+                            return
+                        }
                     }
                     UriUtil.visitInExternalBrowser(this, it)
                     finish()

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -11,6 +11,7 @@ import org.wikipedia.analytics.SessionData
 import org.wikipedia.analytics.eventplatform.AppSessionEvent
 import org.wikipedia.analytics.eventplatform.StreamConfig
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.donate.DonationResult
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.page.PageTitle
 import org.wikipedia.page.action.PageActionItem
@@ -725,6 +726,10 @@ object Prefs {
     var isDonationTestEnvironment
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_donation_test_env, false)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_donation_test_env, value)
+
+    var donationResults
+        get() = JsonUtil.decodeFromString<List<DonationResult>>(PrefsIoUtil.getString(R.string.preference_key_donation_results, null)).orEmpty()
+        set(value) = PrefsIoUtil.setString(R.string.preference_key_donation_results, JsonUtil.encodeToString(value))
 
     var recommendedContentSurveyShown
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_recommended_content_survey_shown, false)

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -162,6 +162,7 @@
     <string name="preference_key_places_last_location_and_zoom_level">placesLastLocationAndZoomLevel</string>
     <string name="preference_key_recent_used_templates">recentUsedTemplates</string>
     <string name="preference_key_donation_test_env">donationTestEnv</string>
+    <string name="preference_key_donation_results">donationResults</string>
     <string name="preference_key_payment_methods_last_query_time">paymentMethodsLastQueryTime</string>
     <string name="preference_key_payment_methods_merchant_id">paymentMethodsMerchantId</string>
     <string name="preference_key_payment_methods_gateway_id">paymentMethodsGatewayId</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -429,6 +429,11 @@
             android:key="@string/preference_key_donation_test_env"
             android:title="Donation test environment" />
 
+        <org.wikipedia.settings.EditTextAutoSummarizePreference
+            style="@style/DataStringPreference"
+            android:key="@string/preference_key_donation_results"
+            android:title="Donation results" />
+
         <org.wikipedia.settings.IntPreference
             style="@style/IntPreference"
             android:key="ab_test_recommendedContent"


### PR DESCRIPTION
This creates a `DonationResult` object for successful donations, and persists a list of such objects in Prefs.

https://phabricator.wikimedia.org/T376082