### PR TITLE
Fix crash when leaving NewsFragment.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/news/NewsFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsFragment.kt
@@ -84,8 +84,8 @@ class NewsFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        _binding = null
         binding.appBarLayout.removeOnOffsetChangedListener(offsetChangedListener)
+        _binding = null
         super.onDestroyView()
     }
 


### PR DESCRIPTION
Accessing `binding` right after setting it to `null` 😅 Somehow slipped past review.