### PR TITLE
Send user_is_temp parameter in EditAttemptStep.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EditAttemptStepEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EditAttemptStepEvent.kt
@@ -45,7 +45,7 @@ class EditAttemptStepEvent(private val event: EditAttemptStepInteractionEvent) :
             EventPlatformClient.submit(EditAttemptStepEvent(EditAttemptStepInteractionEvent(action,
                 WikipediaApp.instance.appInstallID, "", editorInterface,
                 INTEGRATION_ID, "", WikipediaApp.instance.getString(R.string.device_type).lowercase(), 0, getUserIdForWikiSite(pageTitle.wikiSite),
-                1, pageTitle.prefixedText, pageTitle.namespace().code())))
+                AccountUtil.isTemporaryAccount, 1, pageTitle.prefixedText, pageTitle.namespace().code())))
         }
 
         private fun getUserIdForWikiSite(wikiSite: WikiSite): Int {
@@ -65,6 +65,7 @@ class EditAttemptStepInteractionEvent(private val action: String,
                                       private val platform: String,
                                       private val user_editcount: Int,
                                       private val user_id: Int,
+                                      private val user_is_temp: Boolean,
                                       private val version: Int,
                                       private val page_title: String,
                                       private val page_ns: Int)


### PR DESCRIPTION
Apparently the `EditAttemptStep` schema has an (optional) `user_is_temp` parameter that we can use, for free, without any additional work.