### PR TITLE
Ignore UnsafeOptInUsageError warning

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -25,4 +25,5 @@
     <issue id="MissingQuantity" severity="warning" />
     <issue id="ImpliedQuantity" severity="warning" />
     <issue id="AppLinkUrlError" severity="warning" />
+    <issue id="UnsafeOptInUsageError" severity="ignore" />
 </lint>


### PR DESCRIPTION
### What does this do?
The IDE now warns the files that use `@Serializable` annotation, and it has the warning info below:
```
This declaration is opt-in and its usage should be marked with @kotlinx. serialization. InternalSerializationApi or @OptIn(markerClass = kotlinx. serialization. InternalSerializationApi. class) More... (Ctrl+F1) 
Inspection info: This API has been flagged as opt-in with error-level severity.  Any declaration annotated with this marker is considered part of an unstable or otherwise non-standard API surface and its call sites should accept the opt-in aspect of it by using the @OptIn annotation, using the marker annotation -- effectively causing further propagation of the opt-in aspect -- or configuring the UnsafeOptInUsageError check's options for project-wide opt-in.  To configure project-wide opt-in, specify the opt-in option value in lint. xml as a comma-delimited list of opted-in annotations: 
 <lint>     <issue id="UnsafeOptInUsageError">         <option name="opt-in" value="com. foo. ExperimentalBarAnnotation" />     </ issue> </ lint> 
  Issue id: UnsafeOptInUsageError Vendor: Android Open Source Project Identifier: androidx. annotation. experimental Feedback: https:// issuetracker. google. com/ issues/ new?component=459778
```

### Why is this needed?
To fix it temporarily, we can add `<issue id="UnsafeOptInUsageError" severity="ignore" />` in the `lint.xml` 


