### PR TITLE
Add optional `formattedId` dynamic parameter to campaign URLs.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/donate/Campaign.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/donate/Campaign.kt
@@ -37,10 +37,8 @@ class Campaign(
     @Serializable
     class Action(
         val title: String = "",
-        @SerialName("url") val rawUrl: String? = null
-    ) {
-        val url get() = rawUrl?.replace("\$platform;", "Android")
-    }
+        val url: String? = null
+    )
 
     @Serializable
     class PlatformParams

--- a/app/src/main/java/org/wikipedia/page/campaign/CampaignDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/campaign/CampaignDialog.kt
@@ -22,11 +22,10 @@ class CampaignDialog internal constructor(private val context: Context, val camp
 
     init {
         val campaignView = CampaignDialogView(context)
-        campaignView.campaignAssets = campaign.assets[WikipediaApp.instance.appOrSystemLanguageCode]
         campaignView.callback = this
         val dateDiff = Duration.between(Instant.ofEpochMilli(Prefs.announcementPauseTime), Instant.now())
         campaignView.showNeutralButton = dateDiff.toDays() >= 1 && campaign.endDateTime?.isAfter(LocalDateTime.now().plusDays(1)) == true
-        campaignView.setupViews()
+        campaignView.setupViews(campaign.id, campaign.assets[WikipediaApp.instance.appOrSystemLanguageCode])
         setView(campaignView)
     }
 

--- a/app/src/main/java/org/wikipedia/page/campaign/CampaignDialogView.kt
+++ b/app/src/main/java/org/wikipedia/page/campaign/CampaignDialogView.kt
@@ -9,6 +9,7 @@ import androidx.core.view.isVisible
 import org.wikipedia.analytics.eventplatform.DonorExperienceEvent
 import org.wikipedia.databinding.DialogCampaignBinding
 import org.wikipedia.dataclient.donate.Campaign
+import org.wikipedia.dataclient.donate.CampaignCollection
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.StringUtil
@@ -24,10 +25,9 @@ class CampaignDialogView(context: Context) : FrameLayout(context) {
 
     private val binding = DialogCampaignBinding.inflate(LayoutInflater.from(context), this, true)
     var showNeutralButton = true
-    var campaignAssets: Campaign.Assets? = null
     var callback: Callback? = null
 
-    fun setupViews() {
+    fun setupViews(campaignId: String, campaignAssets: Campaign.Assets?) {
         campaignAssets?.let {
             if (!it.text.isNullOrEmpty()) {
                 binding.contentText.movementMethod = LinkMovementMethodCompat.getInstance()
@@ -58,7 +58,8 @@ class CampaignDialogView(context: Context) : FrameLayout(context) {
                     binding.positiveButton.text = positiveButton.title
                     positiveButton.url?.let { url ->
                         binding.positiveButton.setOnClickListener {
-                            callback?.onPositiveAction(url)
+                            val formattedUrl = url.replace("\$platform;", "Android").replace("\$formattedId;", CampaignCollection.getFormattedCampaignId(campaignId))
+                            callback?.onPositiveAction(formattedUrl)
                         }
                     }
 


### PR DESCRIPTION
(This refers to the campaign URLs provided to us in the campaign configuration structures from FR-tech.)
Right now we have a dynamic parameter called `$platform;` that is automatically replaced by the `iOS` or `Android` platforms. We are adding another dynamic parameter (to be used in future campaigns by FR-tech) called `$formattedId;` which will be replaced by the decorated campaign ID that we pass to analytics.

**Phabricator:**
https://phabricator.wikimedia.org/T376083