### PR TITLE
API underpinnings for integrating with Growth Impact module.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/CoreRestService.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.dataclient
 
 import org.wikipedia.dataclient.growthtasks.GrowthImageSuggestion
+import org.wikipedia.dataclient.growthtasks.GrowthUserImpact
 import org.wikipedia.dataclient.restbase.DiffResponse
 import org.wikipedia.dataclient.restbase.EditCount
 import org.wikipedia.dataclient.restbase.Revision
@@ -33,6 +34,11 @@ interface CoreRestService {
         @Path("title") title: String,
         @Body body: GrowthImageSuggestion.AddImageFeedbackBody
     )
+
+    @GET("growthexperiments/v0/user-impact/%23{userId}")
+    suspend fun getUserImpact(
+        @Path("userId") userId: Int
+    ): GrowthUserImpact
 
     companion object {
         const val CORE_REST_API_PREFIX = "w/rest.php/"

--- a/app/src/main/java/org/wikipedia/dataclient/growthtasks/GrowthUserImpact.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/growthtasks/GrowthUserImpact.kt
@@ -1,0 +1,60 @@
+package org.wikipedia.dataclient.growthtasks
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import org.wikipedia.json.JsonUtil
+
+@Suppress("unused")
+@Serializable
+class GrowthUserImpact(
+    @SerialName("@version") val version: Int = 0,
+    val userId: Int = 0,
+    val userName: String = "",
+    val receivedThanksCount: Int = 0,
+    @SerialName("editCountByNamespace") private val mEditCountByNamespace: JsonElement? = null,
+    @SerialName("editCountByDay") private val mEditCountByDay: JsonElement? = null,
+    @SerialName("editCountByTaskType") private val mEditCountByTaskType: JsonElement? = null,
+    val totalUserEditCount: Int = 0,
+    val totalEditsCount: Int = 0,
+    val newcomerTaskEditCount: Int = 0,
+    val revertedEditCount: Int = 0,
+    val lastEditTimestamp: Long = 0,
+    @SerialName("longestEditingStreak") private val mLongestEditingStreak: JsonElement? = null,
+    @SerialName("dailyTotalViews") private val mDailyTotalViews: JsonElement? = null,
+    val totalPageviewsCount: Long = 0,
+    @SerialName("topViewedArticles") private val mTopViewedArticles: JsonElement? = null,
+) {
+    val editCountByNamespace: Map<Int, Int> by lazy { if (mEditCountByNamespace is JsonObject) { JsonUtil.json.decodeFromJsonElement(mEditCountByNamespace) } else { emptyMap() } }
+    val editCountByDay: Map<String, Int> by lazy { if (mEditCountByDay is JsonObject) { JsonUtil.json.decodeFromJsonElement(mEditCountByDay) } else { emptyMap() } }
+    val editCountByTaskType: Map<String, Int> by lazy { if (mEditCountByTaskType is JsonObject) { JsonUtil.json.decodeFromJsonElement(mEditCountByTaskType) } else { emptyMap() } }
+    val dailyTotalViews: Map<String, Int> by lazy { if (mDailyTotalViews is JsonObject) { JsonUtil.json.decodeFromJsonElement(mDailyTotalViews) } else { emptyMap() } }
+    val topViewedArticles: Map<String, ArticleViews> by lazy { if (mTopViewedArticles is JsonObject) { JsonUtil.json.decodeFromJsonElement(mTopViewedArticles) } else { emptyMap() } }
+    val longestEditingStreak: EditStreak? by lazy { if (mLongestEditingStreak is JsonObject) { JsonUtil.json.decodeFromJsonElement(mLongestEditingStreak) } else { null } }
+
+    @Serializable
+    class ArticleViews(
+        val firstEditDate: String = "",
+        val newestEdit: String = "",
+        val imageUrl: String = "",
+        val viewsCount: Long = 0,
+        private val views: JsonElement? = null
+    ) {
+        val viewsByDay: Map<String, Int> by lazy { if (views is JsonObject) { JsonUtil.json.decodeFromJsonElement(views) } else { emptyMap() } }
+    }
+
+    @Serializable
+    class EditStreak(
+        val datePeriod: EditDateRange? = null,
+        val totalEditCountForPeriod: Int = 0
+    )
+
+    @Serializable
+    class EditDateRange(
+        val start: String = "",
+        val end: String = "",
+        val days: Int = 0,
+    )
+}


### PR DESCRIPTION
This adds support for retrieving the data from the Impact module of the Growth Experiments extension.
This module provides all kinds of useful statistics about the user's editing history, which will eventually replace the statistics we show in our Edits tab.

https://phabricator.wikimedia.org/T377235
