### PR TITLE
Revert "Fix: a possible crash about lateinit WikipediaApp instance has not en initialized"

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -135,9 +135,6 @@ class WikipediaApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        // Set the instance after the Application is fully initialized.
-        instance = this
-
         WikiSite.setDefaultBaseUrl(Prefs.mediaWikiBaseUrl)
 
         connectionStateMonitor.enable()


### PR DESCRIPTION
Reverts wikimedia/apps-android-wikipedia#4984

This did not reduce the number of instances of this crash. In the interest of keeping unnecessary code to a minimum, and to reduce confusion for investigating the real cause of this crash, let's keep a single assignment of the `instance` variable.