### PR TITLE
Add a proper padding to the chip icon for smaller text for Donor badge

### DIFF
--- a/app/src/main/java/org/wikipedia/views/DonorBadgeView.kt
+++ b/app/src/main/java/org/wikipedia/views/DonorBadgeView.kt
@@ -13,9 +13,9 @@ import org.wikipedia.usercontrib.ContributionsDashboardHelper
 class DonorBadgeView(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
 
     interface Callback {
-        fun onDonorBadgeClick()
-        fun onBecomeDonorClick()
-        fun onUpdateDonorStatusClick()
+        fun onDonorBadgeClick() { }
+        fun onBecomeDonorClick() { }
+        fun onUpdateDonorStatusClick() { }
     }
     val binding = ViewDonorBadgeBinding.inflate(LayoutInflater.from(context), this)
 

--- a/app/src/main/res/layout/view_donor_badge.xml
+++ b/app/src/main/res/layout/view_donor_badge.xml
@@ -47,7 +47,7 @@
         android:layout_height="wrap_content"
         android:text="@string/contributions_dashboard_badge_update"
         android:textColor="?attr/progressive_color"
-        android:paddingVertical="16dp"
+        android:paddingVertical="8dp"
         android:visibility="gone"
         android:background="?selectableItemBackground"
         tools:text="Update donor status"

--- a/app/src/main/res/layout/view_donor_badge.xml
+++ b/app/src/main/res/layout/view_donor_badge.xml
@@ -25,7 +25,7 @@
 
     <com.google.android.material.chip.Chip
         android:id="@+id/becomeADonorChip"
-        style="@style/Small"
+        style="@style/Chip.Accessible.Icon.Small"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/contributions_dashboard_badge_become_a_donor"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -268,6 +268,11 @@
         <item name="iconGravity">start</item>
     </style>
 
+    <style name="Chip.Accessible.Icon.Small">
+        <item name="android:textSize">12sp</item>
+        <item name="lineHeight">18sp</item>
+    </style>
+
     <style name="List">
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">14sp</item>


### PR DESCRIPTION
### What does this do?
1. Added a default blank body for the `Callback` functions.
2. Added a small style for the chip to keep the icon's padding.

https://www.figma.com/design/qZvcD1IoEjPP13X5Ed3Fmv/Android-%E2%86%92-Contributions-Dashboard-%E2%86%92-T%3F?node-id=236-8261&node-type=frame&m=dev
