### PR TITLE
Send a LoggedOutEvent to the FlowEventBus for refreshing screen purpose

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -22,6 +22,7 @@ import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.SharedPreferenceCookieManager
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.events.ChangeTextSizeEvent
+import org.wikipedia.events.LoggedOutEvent
 import org.wikipedia.events.ThemeFontChangeEvent
 import org.wikipedia.installreferrer.InstallReferrerListener
 import org.wikipedia.language.AcceptLanguageUtil
@@ -248,6 +249,7 @@ class WikipediaApp : Application() {
         }.invokeOnCompletion {
             SharedPreferenceCookieManager.instance.clearAllCookies()
             AppDatabase.instance.notificationDao().deleteAll()
+            FlowEventBus.post(LoggedOutEvent())
             L.d("Logout complete.")
         }
     }

--- a/app/src/main/java/org/wikipedia/events/LoggedOutEvent.kt
+++ b/app/src/main/java/org/wikipedia/events/LoggedOutEvent.kt
@@ -1,0 +1,3 @@
+package org.wikipedia.events
+
+class LoggedOutEvent


### PR DESCRIPTION
### What does this do?
To send a `LoggedOutEvent` event after the log-out process is completed. 

### Why is this needed?
To make sure the #5048 is updated properly.


**Phabricator:**
https://phabricator.wikimedia.org/T377779