### PR TITLE
Display custom splash screen on Android 12 and later

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -194,6 +194,7 @@ dependencies {
     implementation libs.swiperefreshlayout
     implementation libs.work.runtime.ktx
     implementation libs.metrics.platform
+    implementation libs.core.splashscreen
 
     implementation libs.glide
     implementation libs.okhttp3.integration

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.Toolbar
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.Fragment
 import org.wikipedia.Constants
 import org.wikipedia.R
@@ -43,6 +44,7 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         setImageZoomHelper()

--- a/app/src/main/java/org/wikipedia/search/SearchActivity.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchActivity.kt
@@ -2,12 +2,19 @@ package org.wikipedia.search
 
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.activity.SingleFragmentActivity
 import org.wikipedia.util.log.L
 
 class SearchActivity : SingleFragmentActivity<SearchFragment>() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
+        super.onCreate(savedInstanceState)
+    }
+
     public override fun createFragment(): SearchFragment {
         var source = intent.getSerializableExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE) as InvokeSource?
         if (source == null) {

--- a/app/src/main/res/drawable/splash_bg.xml
+++ b/app/src/main/res/drawable/splash_bg.xml
@@ -1,22 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- TODO: Move this to drawable folder when no longer supporting API levels < 21 -->
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:drawable="@color/gray700" />
-
-    <item android:bottom="128dp">
-        <shape android:shape="rectangle">
-            <gradient android:type="radial" android:gradientRadius="100dp"
-                android:startColor="@color/gray500" android:endColor="@color/gray700" />
-        </shape>
-    </item>
-
-    <item android:bottom="128dp">
-        <!-- Use a bitmap element with centered gravity to prevent scaling. -->
-        <bitmap
-            android:src="@drawable/w_nav_mark"
-            android:antialias="true"
-            android:gravity="center" />
-    </item>
-
-</layer-list>
+<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+    android:antialias="true"
+    android:gravity="center"
+    android:src="@drawable/w_nav_mark" />

--- a/app/src/main/res/values-night/splash.xml
+++ b/app/src/main/res/values-night/splash.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_bg</item>
+        <item name="postSplashScreenTheme">@style/AppTheme</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/splash.xml
+++ b/app/src/main/res/values/splash.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/white</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_bg</item>
+        <item name="postSplashScreenTheme">@style/AppTheme</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -89,11 +89,6 @@
 
     </style>
 
-    <style name="AppTheme.Splash">
-        <item name="android:windowBackground">@drawable/splash_bg</item>
-        <item name="android:navigationBarColor">@color/gray700</item>
-    </style>
-
     <style name="AppTheme.ActionBar">
         <item name="windowNoTitle">false</item>
         <item name="windowActionBar">true</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ swiperefreshlayout = "1.1.0"
 uiautomator = "2.3.0"
 viewpager2 = "1.1.0"
 workRuntimeKtx = "2.9.1"
+coreSplashScreen = "1.0.1"
 
 [libraries]
 android-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "androidSdk" }
@@ -108,6 +109,7 @@ room-testing = { module = "androidx.room:room-testing", version.ref = "roomVersi
 swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
 viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpager2" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
+core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashScreen" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle" }


### PR DESCRIPTION
### What does this do?
This PR implements the splash screen using the [Core Splashscreen](https://developer.android.com/reference/kotlin/androidx/core/splashscreen/SplashScreen) library. It also provides a night mode configuration for when the system-wide dark theme is enabled.

### Why is this needed?
On Android 12 and later, the launcher icon is displayed on the splash screen instead of the specified icon. This change allows for a consistent experience across all Android versions.

### Limitations
The icon is not displayed on API levels 21 and 22: https://developer.android.com/reference/kotlin/androidx/core/splashscreen/SplashScreen#themes

### Videos
* **Before changes**

  [Screen_recording_20241023_061728.webm](https://github.com/user-attachments/assets/87c9472a-399d-4067-a680-3f61242868a0)

  Android 5.0

  https://github.com/user-attachments/assets/15575b61-c451-411b-9962-8e53849bb70d

  Android 15

* **After changes**

  [Screen_recording_20241022_062100.webm](https://github.com/user-attachments/assets/a5336c86-3e4b-4931-b3fe-74f3603d3797)

  Android 5.0

  [Screen_recording_20241022_062144.webm](https://github.com/user-attachments/assets/5ca9316d-ff0f-4fd4-87eb-184e61940b07)

  Android 6.0

  https://github.com/user-attachments/assets/84b16831-7410-4f15-a4e3-bf55b22ac42b

  Android 15 (light mode)

  https://github.com/user-attachments/assets/59b7a8d5-4b3b-488a-a561-02dcb9e4b049

  Android 15 (dark mode)