### PR TITLE
Update Donor Status logic for recurring donor option

### DIFF
--- a/app/src/main/java/org/wikipedia/donate/DonorHistoryActivity.kt
+++ b/app/src/main/java/org/wikipedia/donate/DonorHistoryActivity.kt
@@ -112,8 +112,6 @@ class DonorHistoryActivity : BaseActivity() {
                 DateUtils.DAY_IN_MILLIS
             )
         }
-        binding.recurringDonorCheckbox.isEnabled = viewModel.lastDonated != null
-        binding.recurringDonorContainer.isEnabled = viewModel.lastDonated != null
     }
 
     private fun showDonorStatusDialog() {

--- a/app/src/main/java/org/wikipedia/donate/DonorHistoryViewModel.kt
+++ b/app/src/main/java/org/wikipedia/donate/DonorHistoryViewModel.kt
@@ -11,7 +11,7 @@ class DonorHistoryViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
 
     var completedDonation = savedStateHandle.get<Boolean>(Constants.ARG_BOOLEAN) == true
     var currentDonorStatus = -1
-    var isDonor = completedDonation || (Prefs.hasDonorHistorySaved && Prefs.donationResults.isNotEmpty())
+    var isDonor = completedDonation || (Prefs.hasDonorHistorySaved && (Prefs.donationResults.isNotEmpty() || Prefs.isRecurringDonor))
     var lastDonated = Prefs.donationResults.lastOrNull()?.dateTime
     var isRecurringDonor = Prefs.isRecurringDonor
 

--- a/app/src/main/java/org/wikipedia/donate/DonorStatus.kt
+++ b/app/src/main/java/org/wikipedia/donate/DonorStatus.kt
@@ -9,10 +9,10 @@ enum class DonorStatus {
         fun donorStatus(): DonorStatus {
             return if (Prefs.hasDonorHistorySaved.not()) {
                 UNKNOWN
-            } else if (Prefs.donationResults.isEmpty()) {
-                NON_DONOR
-            } else {
+            } else if (Prefs.donationResults.isNotEmpty() || Prefs.isRecurringDonor) {
                 DONOR
+            } else {
+                NON_DONOR
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -36,6 +36,7 @@ import org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTI
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION
 import org.wikipedia.descriptions.DescriptionEditUtil
 import org.wikipedia.donate.DonorHistoryActivity
+import org.wikipedia.donate.DonorStatus
 import org.wikipedia.events.LoggedOutEvent
 import org.wikipedia.login.LoginActivity
 import org.wikipedia.main.MainActivity
@@ -358,17 +359,22 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     private fun setUpDonorHistoryStatus() {
-        Prefs.donationResults.lastOrNull()?.dateTime?.let {
-            val lastDonateMilli = LocalDateTime.parse(it).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-            binding.donorHistoryStatus.text = DateUtils.getRelativeTimeSpanString(
-                lastDonateMilli,
-                System.currentTimeMillis(),
-                DateUtils.DAY_IN_MILLIS
-            )
-            binding.lastDonatedChevron.isVisible = true
+        if (DonorStatus.donorStatus() == DonorStatus.DONOR) {
+            Prefs.donationResults.lastOrNull()?.dateTime?.let {
+                val lastDonateMilli = LocalDateTime.parse(it).atZone(ZoneId.systemDefault()).toInstant()
+                    .toEpochMilli()
+                binding.donorHistoryStatus.text = DateUtils.getRelativeTimeSpanString(
+                    lastDonateMilli,
+                    System.currentTimeMillis(),
+                    DateUtils.DAY_IN_MILLIS
+                )
+            } ?: run {
+                binding.donorHistoryStatus.text = getString(R.string.donor_history_recurring_donor)
+            }
             binding.donorHistoryStatus.isVisible = true
+            binding.lastDonatedChevron.isVisible = true
             binding.donorHistoryUpdateButton.isVisible = false
-        } ?: run {
+        } else {
             binding.donorHistoryUpdateButton.setOnClickListener {
                 requestUpdateDonorHistory.launch(DonorHistoryActivity.newIntent(requireContext()))
             }


### PR DESCRIPTION
### What does this do?

>Cooltey to update logic to not lock recurring based on if there is a date or not 


Based on the conversation in the Product Data meeting, we will need to enable the `recurring donor` checkbox, even if the last donated date is empty. This leads the logic of `Donor Status` some changes.