### PR TITLE
Fix: design signoff updates for Contribute Tab and Donor history

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -56,6 +56,7 @@ import org.wikipedia.views.DefaultRecyclerAdapter
 import org.wikipedia.views.DefaultViewHolder
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.util.Date
 import java.util.concurrent.TimeUnit
 
 class SuggestedEditsTasksFragment : Fragment() {
@@ -190,6 +191,7 @@ class SuggestedEditsTasksFragment : Fragment() {
 
     private fun onLoading() {
         binding.progressBar.isVisible = true
+        binding.suggestedEditsScrollView.isVisible = false
     }
 
     private fun onRequireLogin() {
@@ -203,6 +205,7 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     private fun clearContents(shouldScrollToTop: Boolean = true) {
+        binding.suggestedEditsScrollView.isVisible = true
         binding.swipeRefreshLayout.isRefreshing = false
         binding.progressBar.isVisible = false
         binding.tasksContainer.isVisible = false
@@ -356,11 +359,17 @@ class SuggestedEditsTasksFragment : Fragment() {
             Prefs.donationResults.lastOrNull()?.dateTime?.let {
                 val lastDonateMilli = LocalDateTime.parse(it).atZone(ZoneId.systemDefault()).toInstant()
                     .toEpochMilli()
-                binding.donorHistoryStatus.text = DateUtils.getRelativeTimeSpanString(
+                var relativeTimeSpan = DateUtils.getRelativeTimeSpanString(
                     lastDonateMilli,
                     System.currentTimeMillis(),
-                    DateUtils.DAY_IN_MILLIS
+                    DateUtils.DAY_IN_MILLIS,
+                    DateUtils.FORMAT_NUMERIC_DATE
                 )
+                // Replace with the original dateTime string
+                if (relativeTimeSpan.contains("/")) {
+                    relativeTimeSpan = DateUtil.getMDYDateString(Date(lastDonateMilli))
+                }
+                binding.donorHistoryStatus.text = relativeTimeSpan
             } ?: run {
                 binding.donorHistoryStatus.text = getString(R.string.donor_history_recurring_donor)
             }

--- a/app/src/main/res/layout/activity_donor_history.xml
+++ b/app/src/main/res/layout/activity_donor_history.xml
@@ -148,6 +148,7 @@
                 android:layout_marginHorizontal="16dp"
                 android:layout_marginVertical="6dp"
                 android:text="@string/donor_history_donate_button"
+                android:fontFamily="sans-serif"
                 app:icon="@drawable/ic_heart_24"/>
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_suggested_edits_tasks.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_tasks.xml
@@ -92,6 +92,7 @@
                                 android:id="@+id/statsDivider"
                                 android:layout_width="match_parent"
                                 android:layout_height="1dp"
+                                android:layout_marginHorizontal="16dp"
                                 android:background="?attr/list_divider"/>
 
                             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -510,7 +510,7 @@
     </style>
 
     <style name="TextInputLayoutErrorTextAppearance">
-        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:fontFamily">sans-serif</item>
     </style>
 
     <style name="TextInputLayoutStyle" parent="Widget.Material3.TextInputLayout.FilledBox">


### PR DESCRIPTION
### What does this do?
- Add `marginHorizontal` to the divider.
- Hide the entire `suggestedEditsScrollView` when loading.
- Show the original date in the format desired for the donor history.
- Update the logged-out vs logged-in status properly in the Contribute tab only ([done in the feature branch](https://github.com/wikimedia/apps-android-wikipedia/pull/5013/commits/6620f2d55168e62e8adc0a273ecedd493159cbde)).
- Update the donation button font family to use regular font weight.
- Update error text font family to use regular font weight.

**Phabricator:**
https://phabricator.wikimedia.org/T376435#10291284
https://phabricator.wikimedia.org/T376431#10291306
