### PR TITLE
Display SVG files in correct language in Gallery.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -118,13 +118,13 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&meta=siteinfo&siprop=general|autocreatetempuser")
     suspend fun getPageIds(@Query("titles") titles: String): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&prop=imageinfo&iiprop=timestamp|user|url|mime|extmetadata&iiurlwidth=" + PREFERRED_THUMB_SIZE)
+    @GET(MW_API_PREFIX + "action=query&prop=imageinfo&iiprop=timestamp|user|url|mime|metadata|extmetadata&iiurlwidth=" + PREFERRED_THUMB_SIZE)
     suspend fun getImageInfo(
         @Query("titles") titles: String,
         @Query("iiextmetadatalanguage") lang: String
     ): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&prop=videoinfo&viprop=timestamp|user|url|mime|extmetadata|derivatives&viurlwidth=" + PREFERRED_THUMB_SIZE)
+    @GET(MW_API_PREFIX + "action=query&prop=videoinfo&viprop=timestamp|user|url|mime|metadata|extmetadata|derivatives&viurlwidth=" + PREFERRED_THUMB_SIZE)
     suspend fun getVideoInfo(
         @Query("titles") titles: String,
         @Query("viextmetadatalanguage") lang: String

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
@@ -44,7 +44,6 @@ import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 import org.wikipedia.views.ViewUtil
-import kotlin.getValue
 import kotlin.math.abs
 
 class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?> {
@@ -178,8 +177,8 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
         } else {
             var url = ImageUrlUtil.getUrlForPreferredSize(mediaInfo?.thumbUrl.orEmpty(), Constants.PREFERRED_GALLERY_IMAGE_SIZE)
             if (mediaInfo?.mime?.contains("svg") == true && mediaInfo?.getMetadataTranslations()?.contains(activityViewModel.wikiSite.languageCode) == true) {
-                // For SVG thumbnails, thumbnails can be rendered with language-specific translations.
-                // We just need to get the correct URL that points to the appropriate language.
+                // SVG thumbnails can be rendered with language-specific translations, so let's
+                // get the correct URL that points to the appropriate language.
                 url = ImageUrlUtil.insertLangIntoThumbUrl(url, activityViewModel.wikiSite.languageCode)
             }
             loadImage(url)

--- a/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryItemFragment.kt
@@ -20,6 +20,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -43,6 +44,7 @@ import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 import org.wikipedia.views.ViewUtil
+import kotlin.getValue
 import kotlin.math.abs
 
 class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?> {
@@ -56,6 +58,7 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
     private val binding get() = _binding!!
 
     private val viewModel: GalleryItemViewModel by viewModels()
+    private val activityViewModel: GalleryViewModel by activityViewModels()
 
     private var mediaController: MediaController? = null
 
@@ -173,7 +176,13 @@ class GalleryItemFragment : Fragment(), MenuProvider, RequestListener<Drawable?>
         if (isVideo) {
             loadVideo()
         } else {
-            loadImage(ImageUrlUtil.getUrlForPreferredSize(mediaInfo?.thumbUrl.orEmpty(), Constants.PREFERRED_GALLERY_IMAGE_SIZE))
+            var url = ImageUrlUtil.getUrlForPreferredSize(mediaInfo?.thumbUrl.orEmpty(), Constants.PREFERRED_GALLERY_IMAGE_SIZE)
+            if (mediaInfo?.mime?.contains("svg") == true && mediaInfo?.getMetadataTranslations()?.contains(activityViewModel.wikiSite.languageCode) == true) {
+                // For SVG thumbnails, thumbnails can be rendered with language-specific translations.
+                // We just need to get the correct URL that points to the appropriate language.
+                url = ImageUrlUtil.insertLangIntoThumbUrl(url, activityViewModel.wikiSite.languageCode)
+            }
+            loadImage(url)
         }
         onLoading(false)
         requireActivity().invalidateOptionsMenu()

--- a/app/src/main/java/org/wikipedia/gallery/ImageInfo.kt
+++ b/app/src/main/java/org/wikipedia/gallery/ImageInfo.kt
@@ -2,6 +2,10 @@ package org.wikipedia.gallery
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import org.wikipedia.json.JsonUtil
 
 @Suppress("unused")
 @Serializable
@@ -38,6 +42,9 @@ class ImageInfo {
 
     val mime = "*/*"
 
+    @SerialName("metadata")
+    val plainMetadata: List<MetadataItem> = emptyList()
+
     @SerialName("extmetadata")
     val metadata: ExtMetadata? = null
 
@@ -60,6 +67,16 @@ class ImageInfo {
         return derivative
     }
 
+    fun getMetadataTranslations(): List<String> {
+        plainMetadata.firstOrNull { it.name == "translations" }?.let { meta ->
+            if (meta.value is JsonArray) {
+                val translations = JsonUtil.json.decodeFromJsonElement<List<MetadataItem>>(meta.value)
+                return translations.map { it.name }
+            }
+        }
+        return emptyList()
+    }
+
     @Serializable
     class Derivative {
         val src = ""
@@ -69,5 +86,11 @@ class ImageInfo {
         val width = 0
         private val height = 0
         private val bandwidth: Long = 0
+    }
+
+    @Serializable
+    class MetadataItem {
+        val name = ""
+        val value: JsonElement? = null
     }
 }

--- a/app/src/main/java/org/wikipedia/util/ImageUrlUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ImageUrlUtil.kt
@@ -12,4 +12,13 @@ object ImageUrlUtil {
             original
         }
     }
+
+    fun insertLangIntoThumbUrl(original: String, lang: String): String {
+        val matcher = WIDTH_IN_IMAGE_URL_REGEX.matcher(original)
+        return if (matcher.find() && matcher.group(2)!!.toInt() > 0) {
+            matcher.replaceFirst("/${matcher.group(1).orEmpty()}lang$lang-${matcher.group(2).orEmpty()}$3")
+        } else {
+            original
+        }
+    }
 }


### PR DESCRIPTION
SVG files often have text in multiple languages, encoded into the same file.
Commons automatically generates thumbnails of such SVG files with a well-formed URL that encodes the language. Let's detect the translations that exist for a given SVG, and use the appropriate language (if available) for the thumbnail URL when drawing the SVG in the Gallery.

**Phabricator:**
https://phabricator.wikimedia.org/T374988
