### PR TITLE
Fix: scroll to the selected language tab when back from the language list

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -95,6 +95,7 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
                 }
             }
             Prefs.selectedLanguagePositionInSearch = position
+            setUpLanguageScroll(Prefs.selectedLanguagePositionInSearch)
         }
     }
 


### PR DESCRIPTION
### Steps to reproduce the issue
1. Go to the search screen and make sure you have multiple app languages.
2. Select the second or the last app language to go back to the search screen.
3. We should see the language tab is selected when going back to the Search screen.

