### PR TITLE
Add test for incorrectly encoded percent symbol.

### DIFF
--- a/app/src/test/java/org/wikipedia/language/TranslationTests.kt
+++ b/app/src/test/java/org/wikipedia/language/TranslationTests.kt
@@ -111,7 +111,7 @@ class TranslationTests {
                 targetMap.forEach { (targetKey, targetList) ->
                     val baseList = baseMap[targetKey]
                     if (baseList != null && baseList != targetList) {
-                        mismatches.append("Unsupported Wikitext/Markdown in ")
+                        mismatches.append("Unsupported Wikitext, Markdown, Encoding in ")
                             .append(lang)
                             .append("/")
                             .append(STRINGS_XML_NAME).append(": ")
@@ -252,7 +252,8 @@ class TranslationTests {
             "\\{\\{.*?\\}\\}",
             "\\[\\[.*?\\]\\]",
             "\\*\\*.*?\\*\\*",
-            "''.*?''"
+            "''.*?''",
+            "[^%]% "
         )
         private val BAD_NAMES = listOf("ldrtl", "sw360dp", "sw600dp", "sw720dp", "v19", "v21", "v23", "land", "night")
 


### PR DESCRIPTION
This might not catch all possible malformations of percent symbol `%%` encoding, but it would have caught the case that was causing the crash of #5096.