### PR TITLE
Use article language for summary when adding/changing a description.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -26,6 +26,7 @@ import org.wikipedia.edit.Edit
 import org.wikipedia.language.AppLanguageLookUpTable
 import org.wikipedia.page.PageTitle
 import org.wikipedia.suggestededits.PageSummaryForEdit
+import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
@@ -169,10 +170,9 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
         var text = firstRevision?.contentMain.orEmpty()
         val baseRevId = firstRevision?.revId ?: 0
         text = updateDescriptionInArticle(text, currentDescription)
-        val automaticallyAddedEditSummary = WikipediaApp.instance.getString(
+        val automaticallyAddedEditSummary = L10nUtil.getStringForArticleLanguage(pageTitle,
             if (pageTitle.description.isNullOrEmpty()) R.string.edit_summary_added_short_description
-            else R.string.edit_summary_updated_short_description
-        )
+            else R.string.edit_summary_updated_short_description)
         var editSummary = automaticallyAddedEditSummary
         editComment?.let {
             editSummary += ", $it"


### PR DESCRIPTION
### What does this do?
When submitting an article description, the comment that goes along with the edit is currently in the language of the device, not the language of the article.

### Why is this needed?
The language of the comment must be the article language, regardless of the device language.

**Phabricator:**
https://phabricator.wikimedia.org/T379586
