### PR TITLE
Fix: replace the %% symbol with the encoded symbol

### DIFF
--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -1675,7 +1675,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">Rəy yoxdur</string>
   <string name="contributions_dashboard_survey_dialog_ok">Rəy bildir</string>
   <string name="contributions_dashboard_donation_dialog_title">Azad biliyi dəstəklədiyiniz üçün təşəkkür edirik</string>
-  <string name="contributions_dashboard_donation_dialog_message">Siz milyonların etibar etdiyi resursu dəstəkləməyi seçən 2%%-in bir hissəsisiniz. Minnətdarlığımızı nümayiş etdirmək üçün töhfələr paneliniz donor statusunuzu göstərmək üçün yeniləndi. Yeniləməni görmək istəyirsiniz?</string>
+  <string name="contributions_dashboard_donation_dialog_message">Siz milyonların etibar etdiyi resursu dəstəkləməyi seçən 2&#37;-in bir hissəsisiniz. Minnətdarlığımızı nümayiş etdirmək üçün töhfələr paneliniz donor statusunuzu göstərmək üçün yeniləndi. Yeniləməni görmək istəyirsiniz?</string>
   <string name="contributions_dashboard_donation_dialog_cancel">Xeyr, təşəkkürlər</string>
   <string name="contributions_dashboard_donation_dialog_ok">Bəli, məni ora apar</string>
   <string name="contributions_dashboard_entry_dialog_title">Töhfələr panelinə edilən yeni əlavələri kəşf edin</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1442,7 +1442,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">Нямам мнение</string>
   <string name="contributions_dashboard_survey_dialog_ok">Оставете коментар</string>
   <string name="contributions_dashboard_donation_dialog_title">Благодарим Ви, че подкрепяте свободното знание</string>
-  <string name="contributions_dashboard_donation_dialog_message">Вие сте част от 2%%, които избраха да подкрепят ресурса, на който разчитат милиони. За да демонстрираме нашата благодарност, таблото за управление на вашите дарения е актуализирано, за да разпознае статуса Ви на дарител. Искате ли да видите актуализацията?</string>
+  <string name="contributions_dashboard_donation_dialog_message">Вие сте част от 2&#37;, които избраха да подкрепят ресурса, на който разчитат милиони. За да демонстрираме нашата благодарност, таблото за управление на вашите дарения е актуализирано, за да разпознае статуса Ви на дарител. Искате ли да видите актуализацията?</string>
   <string name="contributions_dashboard_donation_dialog_cancel">Не, благодаря</string>
   <string name="contributions_dashboard_donation_dialog_ok">Да, покажете ми</string>
   <string name="contributions_dashboard_entry_dialog_title" fuzzy="true">Таблото за управление на вашите приноси е актуализирано</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -1677,7 +1677,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">Necun opinion</string>
   <string name="contributions_dashboard_survey_dialog_ok">Dar tu opinion</string>
   <string name="contributions_dashboard_donation_dialog_title">Gratias pro appoiar le cognoscentia libere</string>
-  <string name="contributions_dashboard_donation_dialog_message">Tu face parte del 2%% que ha eligite a appoiar le ressource al qual milliones se fide. Pro demonstrar nostre gratitude, tu tabuliero de contributiones ha essite actualisate pro recognoscer tu stato de donator. Vole tu vider le actualisation?</string>
+  <string name="contributions_dashboard_donation_dialog_message">Tu face parte del 2&#37; que ha eligite a appoiar le ressource al qual milliones se fide. Pro demonstrar nostre gratitude, tu tabuliero de contributiones ha essite actualisate pro recognoscer tu stato de donator. Vole tu vider le actualisation?</string>
   <string name="contributions_dashboard_donation_dialog_cancel">No, gratias</string>
   <string name="contributions_dashboard_donation_dialog_ok">Si, porta me la</string>
   <string name="contributions_dashboard_entry_dialog_title" fuzzy="true">Tu tabuliero de contributiones ha essite actualisate</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1798,7 +1798,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">אין דעה</string>
   <string name="contributions_dashboard_survey_dialog_ok">שליחת משוב</string>
   <string name="contributions_dashboard_donation_dialog_title">תודה על תתמיכתך בידע חופשי</string>
-  <string name="contributions_dashboard_donation_dialog_message">אני מודים לך על היותך ב־2%% מהאנשים שבחרו לתמוך במשאב שמיליונים מסתמכים עליו. כדי להראות את הכרת התודה שלנו, לוח הבקרה של התרומות שלך עודכן כדי להכיר בסטטוס שלך כתורם. מעניין אותך לראות את העדכון?</string>
+  <string name="contributions_dashboard_donation_dialog_message">אני מודים לך על היותך ב־2&#37; מהאנשים שבחרו לתמוך במשאב שמיליונים מסתמכים עליו. כדי להראות את הכרת התודה שלנו, לוח הבקרה של התרומות שלך עודכן כדי להכיר בסטטוס שלך כתורם. מעניין אותך לראות את העדכון?</string>
   <string name="contributions_dashboard_donation_dialog_cancel">לא, תודה</string>
   <string name="contributions_dashboard_donation_dialog_ok">כן, קחו אותי לשם</string>
   <string name="contributions_dashboard_entry_dialog_title">היכרות עם התוספות החדשות ללוח הבקרה של התרומות</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -1684,7 +1684,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">Немам мислење</string>
   <string name="contributions_dashboard_survey_dialog_ok">Дајте мислење</string>
   <string name="contributions_dashboard_donation_dialog_title">Ви благодариме што го поддржувате слободното знаење</string>
-  <string name="contributions_dashboard_donation_dialog_message">Вие сте дел од 2 ‰ кои избраа да го поддржат ресурсот на кој се потпираат милиони. За да ја искажеме нашата благодарност, вашата управувачница на дарувања е подновена како признание на вашиот статус на дарител. Дали би сакале да ја видите подновата?</string>
+  <string name="contributions_dashboard_donation_dialog_message">Вие сте дел од 2&#37; кои избраа да го поддржат ресурсот на кој се потпираат милиони. За да ја искажеме нашата благодарност, вашата управувачница на дарувања е подновена како признание на вашиот статус на дарител. Дали би сакале да ја видите подновата?</string>
   <string name="contributions_dashboard_donation_dialog_cancel">Не, благодарам</string>
   <string name="contributions_dashboard_donation_dialog_ok">Да, покажи ми</string>
   <string name="contributions_dashboard_entry_dialog_title">Истражете ги новите додатоци во управувачницата со придонеси</string>

--- a/app/src/main/res/values-nqo/strings.xml
+++ b/app/src/main/res/values-nqo/strings.xml
@@ -1398,7 +1398,7 @@
   <string name="donor_history_updated_message_snackbar">ߣߌ߬ߟߌߟߊ ߟߊ߫ ߘߐ߬ߝߐ ߓߘߊ߫ ߟߊߞߎߘߦߊ߫</string>
   <string name="contributions_dashboard_survey_dialog_title">ߘߍ߬ߡߍ߲߬ߠߌ߲ ߞߍ߫ ߞߊ߬ ߓߟߏߡߊߜߍ߲ߠߊ ߟߎ߬ ߟߊ߫ ߦߌ߬ߘߊ߬ߥߟߊ ߟߊߦߙߌߥߊ߫</string>
   <string name="contributions_dashboard_donation_dialog_title">ߌ ߣߌ߫ ߗߋ߫ ߟߐ߲ߕߊ߫ ߛߙߊ߬ߓߊߟߌ ߞߐߡߊߓߌ߲ߓߌ߲ ߠߊ߫</string>
-  <string name="contributions_dashboard_donation_dialog_message">ߌ ߦߋ߫ 2%% ߟߎ߫ ߘߏ߫ ߟߋ߬ ߘߌ߫߸ ߡߍ߲ ߠߎ߬ ߣߵߊ߬ ߞߊ߬ߣߌ߲߬ ߠߊ߫ ߞߊ߬ ߛߐ߬ߘߐ߲߬ߘߊ߫ ߞߋ߲߬ߥߟߎ ߟߎ߬ ߞߐߡߊߓߌ߲ߓߌ߲߫ ߡߍ߲ ߠߎ߬ ߛߍߥߊߣߍ߲ ߦߴߊ߬ ߟߊ߫. ߊ߲ ߧߴߊ߲ ߠߊ߫ ߞߏߢߌߡߊߟߐ߲ ߦߌ߬ߘߊ߬ ߟߴߌ ߟߊ߫، ߌ ߟߊ߫ ߦߌ߬ߘߊ߬ߥߟߊ ߓߘߊ߫ ߞߵߌ ߟߌ߬ߤߟߊ ߡߊߦߟߍ߬ߡߊ߲߫ ߞߵߊ߬ ߞߍ߫ ߣߌ߬ߟߌߟߊ ߘߌ߫. ߌ ߦߴߊ߬ ߝߍ߬ ߞߊ߬ ߟߊ߬ߞߎ߬ߘߦߊ߬ߟߌ ߟߊ߬ߞߎ߬ߘߦߊ߬ߟߌ ߦߋ߫؟</string>
+  <string name="contributions_dashboard_donation_dialog_message">ߌ ߦߋ߫ 2&#37; ߟߎ߫ ߘߏ߫ ߟߋ߬ ߘߌ߫߸ ߡߍ߲ ߠߎ߬ ߣߵߊ߬ ߞߊ߬ߣߌ߲߬ ߠߊ߫ ߞߊ߬ ߛߐ߬ߘߐ߲߬ߘߊ߫ ߞߋ߲߬ߥߟߎ ߟߎ߬ ߞߐߡߊߓߌ߲ߓߌ߲߫ ߡߍ߲ ߠߎ߬ ߛߍߥߊߣߍ߲ ߦߴߊ߬ ߟߊ߫. ߊ߲ ߧߴߊ߲ ߠߊ߫ ߞߏߢߌߡߊߟߐ߲ ߦߌ߬ߘߊ߬ ߟߴߌ ߟߊ߫، ߌ ߟߊ߫ ߦߌ߬ߘߊ߬ߥߟߊ ߓߘߊ߫ ߞߵߌ ߟߌ߬ߤߟߊ ߡߊߦߟߍ߬ߡߊ߲߫ ߞߵߊ߬ ߞߍ߫ ߣߌ߬ߟߌߟߊ ߘߌ߫. ߌ ߦߴߊ߬ ߝߍ߬ ߞߊ߬ ߟߊ߬ߞߎ߬ߘߦߊ߬ߟߌ ߟߊ߬ߞߎ߬ߘߦߊ߬ߟߌ ߦߋ߫؟</string>
   <string name="contributions_dashboard_donation_dialog_cancel">ߊ߬ߦߌ߫߸ ߌ ߣߌ߫ ߗߋ߫</string>
   <string name="contributions_dashboard_donation_dialog_ok">ߊ߬ߥߐ߫، ߒ ߠߊߛߋ߫ ߦߋ߲߬</string>
   <string name="survey_dialog_option_very_satisfied">ߒ ߠߊߥߛߊ߬ߣߍ߲߫ ߞߏߛߓߍ߫</string>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1714,7 +1714,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">Negative action button text for the contributions dashboard survey dialog.</string>
   <string name="contributions_dashboard_survey_dialog_ok">Positive action button text for the contributions dashboard survey dialog.</string>
   <string name="contributions_dashboard_donation_dialog_title">Title for the donation success dialog that shows after the user completed the donation flow.</string>
-  <string name="contributions_dashboard_donation_dialog_message">Message for the donation success dialog that shows after the user completed the donation flow. Please preserve the double-percent (2%%) escaping.</string>
+  <string name="contributions_dashboard_donation_dialog_message">Message for the donation success dialog that shows after the user completed the donation flow. Please preserve the &#37; as the encoded percent symbol.</string>
   <string name="contributions_dashboard_donation_dialog_cancel">Negative action button text for the donation success dialog that shows after the user completed the donation flow.</string>
   <string name="contributions_dashboard_donation_dialog_ok">Positive action button text for the donation success dialog that shows after the user completed the donation flow.</string>
   <string name="contributions_dashboard_entry_dialog_title">Title for the contributions dashboard entry dialog.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1696,7 +1696,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">Ingen åsikt</string>
   <string name="contributions_dashboard_survey_dialog_ok">Ge återkoppling</string>
   <string name="contributions_dashboard_donation_dialog_title">Tack för att du stödjer fri kunskap</string>
-  <string name="contributions_dashboard_donation_dialog_message">Du är en del av de 2%% som väljer att stödja resursen som miljontals använder. För att demonstrera vår tacksamhet har din instrumentbräda uppdaterats för att erkänna sin status som donator. Vill du se uppdateringen?</string>
+  <string name="contributions_dashboard_donation_dialog_message">Du är en del av de 2&#37; som väljer att stödja resursen som miljontals använder. För att demonstrera vår tacksamhet har din instrumentbräda uppdaterats för att erkänna sin status som donator. Vill du se uppdateringen?</string>
   <string name="contributions_dashboard_donation_dialog_cancel">Nej tack</string>
   <string name="contributions_dashboard_donation_dialog_ok">Ja, ta mig dit</string>
   <string name="contributions_dashboard_entry_dialog_title" fuzzy="true">Din bidragsinstrumentbräda har uppdaterats</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1799,7 +1799,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">Немає думки</string>
   <string name="contributions_dashboard_survey_dialog_ok">Залишити відгук</string>
   <string name="contributions_dashboard_donation_dialog_title">Дякуємо за підтримку вільних знань</string>
-  <string name="contributions_dashboard_donation_dialog_message">Ви є частиною тих 2%%, які вирішили підтримати ресурс, на який покладаються мільйони. Щоб продемонструвати нашу вдячність, ми оновили панель вашого внеску, щоб відзначити на ній ваш статус жертводавця. Бажаєте побачити оновлення?</string>
+  <string name="contributions_dashboard_donation_dialog_message">Ви є частиною тих 2&#37;, які вирішили підтримати ресурс, на який покладаються мільйони. Щоб продемонструвати нашу вдячність, ми оновили панель вашого внеску, щоб відзначити на ній ваш статус жертводавця. Бажаєте побачити оновлення?</string>
   <string name="contributions_dashboard_donation_dialog_cancel">Ні, дякую</string>
   <string name="contributions_dashboard_donation_dialog_ok">Так, покажіть мені</string>
   <string name="contributions_dashboard_entry_dialog_title" fuzzy="true">Панель вашого внеску оновлено</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1522,7 +1522,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">Không có ý kiến</string>
   <string name="contributions_dashboard_survey_dialog_ok">Để lại phản hồi</string>
   <string name="contributions_dashboard_donation_dialog_title">Cảm ơn bạn đã ủng hộ kho tri thức mở</string>
-  <string name="contributions_dashboard_donation_dialog_message">Bạn là một phần của 2%% đã chọn hỗ trợ nguồn tài nguyên mà hàng triệu người đang dựa vào. Để thể hiện lòng biết ơn của chúng tôi, bảng điều khiển đóng góp của bạn đã được cập nhật để ghi nhận trạng thái của bạn là người quyên góp. Bạn có muốn xem bản cập nhật không?</string>
+  <string name="contributions_dashboard_donation_dialog_message">Bạn là một phần của 2&#37; đã chọn hỗ trợ nguồn tài nguyên mà hàng triệu người đang dựa vào. Để thể hiện lòng biết ơn của chúng tôi, bảng điều khiển đóng góp của bạn đã được cập nhật để ghi nhận trạng thái của bạn là người quyên góp. Bạn có muốn xem bản cập nhật không?</string>
   <string name="contributions_dashboard_donation_dialog_cancel">Thôi</string>
   <string name="contributions_dashboard_donation_dialog_ok">Có, đưa tôi qua đó</string>
   <string name="contributions_dashboard_entry_dialog_title" fuzzy="true">Bảng điều khiển đóng góp của bạn đã được cập nhật</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1713,7 +1713,7 @@
   <string name="contributions_dashboard_survey_dialog_cancel">無意見</string>
   <string name="contributions_dashboard_survey_dialog_ok">分享意見回饋</string>
   <string name="contributions_dashboard_donation_dialog_title">感謝您對自由知識的支持</string>
-  <string name="contributions_dashboard_donation_dialog_message">您選擇作為支持數百萬人所依賴資源的 2%% 的一分子。為了表達我們的謝意，已更新您的貢獻面板來表揚出您的身份為捐款者。您想查看更新嗎？</string>
+  <string name="contributions_dashboard_donation_dialog_message">您選擇作為支持數百萬人所依賴資源的 2&#37; 的一分子。為了表達我們的謝意，已更新您的貢獻面板來表揚出您的身份為捐款者。您想查看更新嗎？</string>
   <string name="contributions_dashboard_donation_dialog_cancel">不用了，謝謝</string>
   <string name="contributions_dashboard_donation_dialog_ok">是的，讓我查看</string>
   <string name="contributions_dashboard_entry_dialog_title">探索貢獻面板的新增內容</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1794,7 +1794,7 @@
     <string name="contributions_dashboard_survey_dialog_cancel">No opinion</string>
     <string name="contributions_dashboard_survey_dialog_ok">Share feedback</string>
     <string name="contributions_dashboard_donation_dialog_title">Thank you for supporting free knowledge</string>
-    <string name="contributions_dashboard_donation_dialog_message">You are a part of the 2%% that chose to support the resource millions rely on. To demonstrate our gratitude, your contributions dashboard has been updated to recognize your status as a donor. Would you like to see the update?</string>
+    <string name="contributions_dashboard_donation_dialog_message">You are a part of the 2&#37; that chose to support the resource millions rely on. To demonstrate our gratitude, your contributions dashboard has been updated to recognize your status as a donor. Would you like to see the update?</string>
     <string name="contributions_dashboard_donation_dialog_cancel">No, thanks</string>
     <string name="contributions_dashboard_donation_dialog_ok">Yes, take me there</string>
     <string name="contributions_dashboard_entry_dialog_title">Explore the new additions to the contributions dashboard</string>


### PR DESCRIPTION
### What does this do?
This replaces the double percent symbol, which was intended to show the `%` by adding another `%` to escape the symbol, which does not work in an `AlertDialog` and shows two `%` symbols in the dialog.

### Why is this needed?
To show the percent symbol in the dialog, we can use the encoded symbol.

