### PR TITLE
Update and refine tests for percent symbol encoding in strings.

### DIFF
--- a/app/src/test/java/org/wikipedia/language/TranslationTests.kt
+++ b/app/src/test/java/org/wikipedia/language/TranslationTests.kt
@@ -16,6 +16,12 @@ class TranslationTests {
 
         // Step 1: collect counts of parameters in en/strings.xml
         val baseMap = findMatchedParamsInXML(baseFile, POSSIBLE_PARAMS, true)
+        val baseSinglePercentMap = findMatchedParamsInXML(baseFile, SINGLE_PERCENT_REGEX, false)
+        val baseDoublePercentMap = findMatchedParamsInXML(baseFile, DOUBLE_PERCENT_REGEX, false)
+
+        baseMap.forEach { (key, list) ->
+            checkPercentSymbolEncoding(list, baseSinglePercentMap[key]!!, baseDoublePercentMap[key]!!, mismatches, "en", key)
+        }
 
         // Step 2: finding parameters in other languages
         for (dir in allFiles) {
@@ -23,10 +29,14 @@ class TranslationTests {
                 if (dir.name.contains("-")) dir.name.substring(dir.name.indexOf("-") + 1) else "en"
             val targetStringsXml = File(dir, STRINGS_XML_NAME)
             val targetMap = findMatchedParamsInXML(targetStringsXml, POSSIBLE_PARAMS, true)
+            val targetSinglePercentMap = findMatchedParamsInXML(targetStringsXml, SINGLE_PERCENT_REGEX, false)
+            val targetDoublePercentMap = findMatchedParamsInXML(targetStringsXml, DOUBLE_PERCENT_REGEX, false)
 
             // compare the counts inside the maps
             targetMap.forEach { (targetKey, targetList) ->
                 val baseList = baseMap[targetKey]
+                checkPercentSymbolEncoding(targetList, targetSinglePercentMap[targetKey]!!, targetDoublePercentMap[targetKey]!!, mismatches, lang, targetKey)
+
                 if (baseList != null && baseList != targetList) {
                     mismatches.append("Parameters mismatched in ")
                         .append(lang)
@@ -110,6 +120,7 @@ class TranslationTests {
                 // compare the counts inside the maps
                 targetMap.forEach { (targetKey, targetList) ->
                     val baseList = baseMap[targetKey]
+
                     if (baseList != null && baseList != targetList) {
                         mismatches.append("Unsupported Wikitext, Markdown, Encoding in ")
                             .append(lang)
@@ -123,6 +134,24 @@ class TranslationTests {
 
         // Step 3: check the result
         MatcherAssert.assertThat("\n" + mismatches.toString(), mismatches.length, Matchers.`is`(0))
+    }
+
+    private fun checkPercentSymbolEncoding(argList: List<Int>, singlePercentList: List<Int>,
+                                           doublePercentList: List<Int>, mismatches: StringBuilder, lang: String, key: String) {
+        val totalArgs = argList.sum()
+        if (totalArgs > 0 && singlePercentList[0] > 0) {
+            mismatches.append("Incorrect single percent encoding in ")
+                .append(lang)
+                .append("/")
+                .append(STRINGS_XML_NAME).append(": ")
+                .append(key).append(" \n")
+        } else if (totalArgs == 0 && doublePercentList[0] > 0) {
+            mismatches.append("Incorrect double percent encoding in ")
+                .append(lang)
+                .append("/")
+                .append(STRINGS_XML_NAME).append(": ")
+                .append(key).append(" \n")
+        }
     }
 
     private val baseFile: File
@@ -252,8 +281,13 @@ class TranslationTests {
             "\\{\\{.*?\\}\\}",
             "\\[\\[.*?\\]\\]",
             "\\*\\*.*?\\*\\*",
-            "''.*?''",
+            "''.*?''"
+        )
+        private val SINGLE_PERCENT_REGEX = listOf(
             "[^%]% "
+        )
+        private val DOUBLE_PERCENT_REGEX = listOf(
+            "%+%"
         )
         private val BAD_NAMES = listOf("ldrtl", "sw360dp", "sw600dp", "sw720dp", "v19", "v21", "v23", "land", "night")
 


### PR DESCRIPTION
This updates our TranslationTests to properly check (for real) the encoding of percent symbols, according to the true rules:
* If a string has other formatting parameters (`%s`, `%1$d`, etc), then a literal percent must be encoded as `%%`.
* If a string _does not_ have any formatting parameters, then a literal percent must not be encoded (`%`).