### PR TITLE
Fix donor badge disable click state

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -99,6 +99,7 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
                     } else {
                         getString(R.string.contributions_dashboard_logged_out_user)
                     }
+                    binding.donorBadge.disableClickForDonor()
                     binding.donorBadge.setup(object : DonorBadgeView.Callback {
                         override fun onBecomeDonorClick() {
                             launchDonateDialog()

--- a/app/src/main/java/org/wikipedia/views/DonorBadgeView.kt
+++ b/app/src/main/java/org/wikipedia/views/DonorBadgeView.kt
@@ -23,6 +23,10 @@ class DonorBadgeView(context: Context, attrs: AttributeSet? = null) : FrameLayou
         layoutParams = ViewGroup.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
     }
 
+    fun disableClickForDonor() {
+        binding.donorChip.isEnabled = false
+    }
+
     fun setup(callback: Callback) {
         if (!ContributionsDashboardHelper.contributionsDashboardEnabled) {
             isVisible = false


### PR DESCRIPTION
### What does this do?
Removes the clicking ability of donor badge shown on the SuggestedEditsTaskFragment

### Why is this needed?
This is just for design reason. 
