### PR TITLE
Roll back targeting of SDK 35 to 34.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ static def computeVersionName(versionCode, label) {
 final JavaVersion JAVA_VERSION = JavaVersion.VERSION_17
 
 android {
-    compileSdk 35
+    compileSdk 34
 
     compileOptions {
         coreLibraryDesugaringEnabled true
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         applicationId 'org.wikipedia'
         minSdk 21
-        targetSdk 35
+        targetSdk 34
         versionCode 50509
         testApplicationId 'org.wikipedia.test'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ balloon = "1.6.11"
 browser = "1.8.0"
 commonsLang3 = "3.17.0"
 constraintlayout = "2.2.0"
-coreKtx = "1.15.0"
+coreKtx = "1.13.1"
 desugar_jdk_libs = "2.1.3"
 drawerlayout = "1.2.0"
 espressoVersion = "3.6.1"
@@ -44,7 +44,7 @@ roomVersion = "2.6.1"
 swiperefreshlayout = "1.1.0"
 uiautomator = "2.3.0"
 viewpager2 = "1.1.0"
-workRuntimeKtx = "2.10.0"
+workRuntimeKtx = "2.9.1"
 
 [libraries]
 android-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "androidSdk" }


### PR DESCRIPTION
Targeting API 35 introduces some unforeseen visual regressions (in most of our Activities) because we're no longer properly accounting for Android 15's new guidelines for edge-to-edge support:

https://developer.android.com/about/versions/15/behavior-changes-15#ux

Let's roll this back for now, and build proper edge-to-edge support (which will probably take a bit more time) before targeting API 35.

**Phabricator:**
https://phabricator.wikimedia.org/T380145
