### PR TITLE
Fix app icon missing from the app info screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
         android:fullBackupContent="@xml/full_backup_rules"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
+        android:icon="@mipmap/launcher"
         android:label="@string/app_name"
         android:name=".WikipediaApp"
         android:theme="@style/AppTheme">


### PR DESCRIPTION
### What does this do?
Fixes the app icon missing from the app info screen 

**Phabricator:**
https://phabricator.wikimedia.org/T380374