### PR TITLE
Fix: do not execute loadFromBackStack() twice when calling openInNewForegroundTab

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -963,7 +963,6 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     fun openInNewForegroundTab(title: PageTitle, entry: HistoryEntry) {
         openInNewTab(title, entry, foregroundTabPosition)
-        pageFragmentLoadState.loadFromBackStack()
     }
 
     fun openFromExistingTab(title: PageTitle, entry: HistoryEntry) {

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -518,7 +518,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
                 title == it.backStackPositionTitle }?.let { app.tabList.indexOf(it) } ?: -1
     }
 
-    private fun openInNewTab(title: PageTitle, entry: HistoryEntry, position: Int) {
+    private fun openInNewTab(title: PageTitle, entry: HistoryEntry, position: Int, loadFromBackstack: Boolean) {
         val selectedTabPosition = selectedTabPosition(title)
         if (selectedTabPosition >= 0) {
             setCurrentTabAndReset(selectedTabPosition)
@@ -552,6 +552,9 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         } else {
             pageFragmentLoadState.setTab(currentTab)
             currentTab.backStack.add(PageBackStackItem(title, entry))
+        }
+        if (loadFromBackstack) {
+            pageFragmentLoadState.loadFromBackStack()
         }
     }
 
@@ -953,16 +956,15 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     fun openInNewBackgroundTab(title: PageTitle, entry: HistoryEntry) {
         if (app.tabCount == 0) {
-            openInNewTab(title, entry, foregroundTabPosition)
-            pageFragmentLoadState.loadFromBackStack()
+            openInNewTab(title, entry, foregroundTabPosition, true)
         } else {
-            openInNewTab(title, entry, backgroundTabPosition)
+            openInNewTab(title, entry, backgroundTabPosition, false)
             (requireActivity() as PageActivity).animateTabsButton()
         }
     }
 
     fun openInNewForegroundTab(title: PageTitle, entry: HistoryEntry) {
-        openInNewTab(title, entry, foregroundTabPosition)
+        openInNewTab(title, entry, foregroundTabPosition, true)
     }
 
     fun openFromExistingTab(title: PageTitle, entry: HistoryEntry) {

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -38,6 +38,8 @@ class PageFragmentLoadState(private var model: PageViewModel,
                             private var leadImagesHandler: LeadImagesHandler,
                             private var currentTab: Tab) {
 
+    private var isLoading = false
+
     fun load(pushBackStack: Boolean) {
         if (pushBackStack && model.title != null && model.curEntry != null) {
             // update the topmost entry in the backstack, before we start overwriting things.
@@ -114,6 +116,10 @@ class PageFragmentLoadState(private var model: PageViewModel,
     }
 
     private fun pageLoad() {
+        if (isLoading) {
+            return
+        }
+        isLoading = true
         model.title?.let { title ->
             fragment.lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
                 L.e("Page details network error: ", throwable)
@@ -173,6 +179,7 @@ class PageFragmentLoadState(private var model: PageViewModel,
                 if (AnonymousNotificationHelper.shouldCheckAnonNotifications(watchedResponse)) {
                     checkAnonNotifications(title)
                 }
+                isLoading = false
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -38,8 +38,6 @@ class PageFragmentLoadState(private var model: PageViewModel,
                             private var leadImagesHandler: LeadImagesHandler,
                             private var currentTab: Tab) {
 
-    private var isLoading = false
-
     fun load(pushBackStack: Boolean) {
         if (pushBackStack && model.title != null && model.curEntry != null) {
             // update the topmost entry in the backstack, before we start overwriting things.
@@ -116,10 +114,6 @@ class PageFragmentLoadState(private var model: PageViewModel,
     }
 
     private fun pageLoad() {
-        if (isLoading) {
-            return
-        }
-        isLoading = true
         model.title?.let { title ->
             fragment.lifecycleScope.launch(CoroutineExceptionHandler { _, throwable ->
                 L.e("Page details network error: ", throwable)
@@ -179,7 +173,6 @@ class PageFragmentLoadState(private var model: PageViewModel,
                 if (AnonymousNotificationHelper.shouldCheckAnonNotifications(watchedResponse)) {
                     checkAnonNotifications(title)
                 }
-                isLoading = false
             }
         }
     }


### PR DESCRIPTION
### What does this do?
When we call `openInNewForegroundTab()`, it will call `loadFromBackStack()` two times in a certain case. This PR removes it and also adds a safe case in `PageFragmentLoadState` to set up the loading status.

**Phabricator:**
https://phabricator.wikimedia.org/T381534
