### PR TITLE
Fix potential crash when filtering reading list pages.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListBehaviorsUtil.kt
@@ -377,7 +377,8 @@ object ReadingListBehaviorsUtil {
 
     fun searchListsAndPages(coroutineScope: CoroutineScope, searchQuery: String?, callback: SearchCallback) {
         coroutineScope.launch(exceptionHandler) {
-            val list = withContext(Dispatchers.IO) { applySearchQuery(searchQuery, AppDatabase.instance.readingListDao().getAllLists()) }
+            allReadingLists = withContext(Dispatchers.IO) { AppDatabase.instance.readingListDao().getAllLists() }
+            val list = withContext(Dispatchers.IO) { applySearchQuery(searchQuery, allReadingLists) }
             if (searchQuery.isNullOrEmpty()) {
                 ReadingList.sortGenericList(list, Prefs.getReadingListSortMode(ReadingList.SORT_BY_NAME_ASC))
             }


### PR DESCRIPTION
This fixes a crash that can happen when:
* Go to your reading lists (Saved) tab.
* Tap the filter button in the toolbar, and type a search term, so that the filtered results include pages from your lists, not just the lists themselves.
* Long-press one of the pages.

It looks like this has been broken due to an earlier refactor (#4701), and simply not noticed until now.