### PR TITLE
Fix another potential crash when deleting items from reading list.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
@@ -318,10 +318,6 @@ class ReadingListsFragment : Fragment(), SortReadingListsDialog.Callback, Readin
                             (displayedLists[oldItemPosition] as ReadingList).compareTo(lists[newItemPosition]))
                 }
             })
-            // If the number of lists has changed, just invalidate everything, as a
-            // simple way to get the bottom item margin to apply to the correct item.
-            val invalidateAll = (importMode || forcedRefresh || displayedLists.size != lists.size ||
-                    (!currentSearchQuery.isNullOrEmpty() && !searchQuery.isNullOrEmpty() && currentSearchQuery != searchQuery))
 
             // if the default list is empty, then removes it.
             if (lists.size == 1 && lists[0] is ReadingList &&
@@ -329,6 +325,11 @@ class ReadingListsFragment : Fragment(), SortReadingListsDialog.Callback, Readin
                     (lists[0] as ReadingList).pages.isEmpty()) {
                 lists.removeAt(0)
             }
+
+            // If the number of lists has changed, just invalidate everything, as a
+            // simple way to get the bottom item margin to apply to the correct item.
+            val invalidateAll = (importMode || forcedRefresh || displayedLists.size != lists.size ||
+                    (!currentSearchQuery.isNullOrEmpty() && !searchQuery.isNullOrEmpty() && currentSearchQuery != searchQuery))
 
             lifecycleScope.launch {
                 suggestedReadingList = null


### PR DESCRIPTION
This one can happen when you:
* Have no reading lists except the default Saved list.
* Add a single page to the default list.
* Go to the Saved tab and tap on the Saved list to see its contents.
* Delete your single page from that list, so that it's empty.
* Go Back to the Saved tab.

This one is very minor, but we are still seeing a few of them in the Play Store console.

It's because the logic that determines full invalidation happens in an incorrect place (before the state of the displayed lists is finished updating).