### PR TITLE
Follow-up: More proper handling of Dialog insets.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/ExtendedBottomSheetDialogFragment.kt
@@ -5,9 +5,6 @@ import android.content.Context
 import android.os.Bundle
 import android.view.MotionEvent
 import androidx.annotation.StyleRes
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.wikipedia.R
@@ -31,11 +28,6 @@ open class ExtendedBottomSheetDialogFragment : BottomSheetDialogFragment() {
         super.onStart()
         dialog?.window?.let {
             DeviceUtil.setNavigationBarColor(it, ResourceUtil.getThemedColor(requireContext(), R.attr.paper_color))
-            ViewCompat.setOnApplyWindowInsetsListener(it.decorView) { view, insets ->
-                val insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-                view.updatePadding(bottom = insets.bottom)
-                WindowInsetsCompat.CONSUMED
-            }
         }
     }
 

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -12,7 +12,10 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.os.bundleOf
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -257,7 +260,8 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
 
     override fun onResume() {
         super.onResume()
-        val containerView = requireDialog().findViewById<ViewGroup>(R.id.container)
+
+        val containerView = requireDialog().findViewById<ViewGroup>(android.R.id.content)
         if (overlayView == null && containerView != null) {
             LinkPreviewOverlayView(requireContext()).let {
                 overlayView = it
@@ -285,6 +289,12 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
                     it.showTertiaryButton(false)
                 }
                 containerView.addView(it)
+
+                ViewCompat.setOnApplyWindowInsetsListener(it) { view, insets ->
+                    val systemWindowInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+                    view.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = systemWindowInsets.bottom }
+                    insets
+                }
             }
         }
     }


### PR DESCRIPTION
This removes the custom inset handling from the base ExtendedBottomSheetDialog class, because the system appears to be handling bottom-sheet insets for us automatically. (Look at the ThemeChooser dialog, or the ReferenceDialog)

In the case of LinkPreviewDialog, we have a "custom" situation with our overlay buttons that sit on top of the dialog. These buttons (and _only_ these buttons) should be handled with a custom inset handler.