### PR TITLE
Fix: do not load the gallery for file page in LinkPreviewDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewViewModel.kt
@@ -77,7 +77,7 @@ class LinkPreviewViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     }
 
     fun loadGallery(revision: Long) {
-        if (Prefs.isImageDownloadEnabled) {
+        if (Prefs.isImageDownloadEnabled && !pageTitle.isFilePage) {
             viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
                 L.w("Failed to fetch gallery collection.", throwable)
             }) {
@@ -87,8 +87,9 @@ class LinkPreviewViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
                 val items = mediaList.getItems("image", "video").asReversed()
                 val titleList =
                     items.filter { it.showInGallery }.map { it.title }.take(maxImages)
-                if (titleList.isEmpty()) _uiState.value = LinkPreviewViewState.Completed
-                else {
+                if (titleList.isEmpty()) {
+                    _uiState.value = LinkPreviewViewState.Completed
+                } else {
                     val response = ServiceFactory.get(
                         pageTitle.wikiSite
                     ).getImageInfo(


### PR DESCRIPTION
### What does this do?
When you insert an image in the editing mode or the new topic page, the progress bar stays in the loading status because the `loadGallery` has failed. 

This PR adds an additional condition to load the gallery if the page is not a file page.

