### PR TITLE
Fix/remove unnecessary parameter during page->gallery transition.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -215,5 +215,5 @@ object JavaScriptActionHandler {
 
     @Serializable
     class ImageHitInfo(val left: Float = 0f, val top: Float = 0f, val width: Float = 0f, val height: Float = 0f,
-                       val src: String = "", val centerCrop: Boolean = false)
+                       val src: String = "")
 }

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -154,8 +154,7 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.LoadPageCallback, Gall
             params.gravity = Gravity.CENTER
             binding.transitionReceiver.layoutParams = params
             binding.transitionReceiver.visibility = View.VISIBLE
-            ViewUtil.loadImage(binding.transitionReceiver, TRANSITION_INFO!!.src, TRANSITION_INFO!!.centerCrop,
-                force = false, listener = null)
+            ViewUtil.loadImage(binding.transitionReceiver, TRANSITION_INFO!!.src)
             val transitionMillis = 500
             binding.transitionReceiver.postDelayed({
                 if (isDestroyed) {

--- a/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/leadimages/LeadImagesHandler.kt
@@ -226,7 +226,7 @@ class LeadImagesHandler(private val parentFragment: PageFragment,
                     val wiki = language?.run { WikiSite.forLanguageCode(this) } ?: it.wikiSite
                     val hitInfo = JavaScriptActionHandler.ImageHitInfo(pageHeaderView.imageView.left.toFloat(),
                         pageHeaderView.imageView.top.toFloat(), leadImageWidth.toFloat(), leadImageHeight.toFloat(),
-                        leadImageUrl!!, true)
+                        leadImageUrl!!)
                     GalleryActivity.setTransitionInfo(hitInfo)
                     val options = ActivityOptionsCompat.makeSceneTransitionAnimation(activity, pageHeaderView.imageView, activity.getString(R.string.transition_page_gallery))
                     callback?.onPageRequestGallery(it, filename, wiki, parentFragment.revision, true, options)

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -136,7 +136,7 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
     private val galleryViewListener = GalleryViewListener { view, thumbUrl, imageName ->
         var options: ActivityOptionsCompat? = null
         view.drawable?.let {
-            val hitInfo = JavaScriptActionHandler.ImageHitInfo(0f, 0f, it.intrinsicWidth.toFloat(), it.intrinsicHeight.toFloat(), thumbUrl, false)
+            val hitInfo = JavaScriptActionHandler.ImageHitInfo(0f, 0f, it.intrinsicWidth.toFloat(), it.intrinsicHeight.toFloat(), thumbUrl)
             GalleryActivity.setTransitionInfo(hitInfo)
             view.transitionName = requireActivity().getString(R.string.transition_page_gallery)
             options = ActivityOptionsCompat.makeSceneTransitionAnimation(requireActivity(), view, requireActivity().getString(R.string.transition_page_gallery))


### PR DESCRIPTION
When tapping the lead image of an article to go to the Gallery, the transition image has weird rounded corners that appear momentarily, then change back to regular square corners.
This is because of mismatched parameters that are being passed from the `ImageHitInfo` class. This class has a `centerCrop` parameter, which is unused, but it's being interpreted as the `cricleShape` parameter (because they're both boolean) by the `loadImage()` function.

This removes the unused `centerCrop` parameter, which fixes the rounded-corners issue. Note that the lead-image transition is still not "perfect" -- the shape and cropping of the image is still not the same between the transition and the gallery, but his is a much harder problem, to be fixed in a larger refactor.

https://github.com/user-attachments/assets/0d81123c-0b56-43d7-b08f-b05d427f24b0

