### PR TITLE
Fix issues with Snackbar action after completing SE Feed items.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
@@ -84,15 +84,18 @@ class SuggestedEditsCardItemFragment : Fragment() {
             if (it.resultCode == RESULT_OK) {
                 if (isAdded) {
                     val openPageListener = SuggestedEditsSnackbars.OpenPageListener {
+                        // Note: at this point, the fragment may have already been replaced by a different one (because
+                        // we call showCardContent() down below), so we can't use requireActivity() here, and instead
+                        // should use the context from the snackbar view.
                         if (viewModel.cardActionType === ADD_IMAGE_TAGS) {
-                            startActivity(FilePageActivity.newIntent(requireActivity(), PageTitle(viewModel.imageTagPage?.title, WikiSite(WikipediaApp.instance.appOrSystemLanguageCode))))
+                            it.context.startActivity(FilePageActivity.newIntent(it.context, PageTitle(viewModel.imageTagPage?.title, WikiSite.forLanguageCode(WikipediaApp.instance.appOrSystemLanguageCode))))
                             return@OpenPageListener
                         }
                         val pageTitle = viewModel.sourceSummaryForEdit!!.pageTitle
                         if (viewModel.cardActionType === ADD_CAPTION || viewModel.cardActionType === TRANSLATE_CAPTION) {
-                            startActivity(GalleryActivity.newIntent(requireActivity(), pageTitle, pageTitle.prefixedText, pageTitle.wikiSite, 0))
+                            it.context.startActivity(GalleryActivity.newIntent(it.context, pageTitle, pageTitle.prefixedText, pageTitle.wikiSite, 0))
                         } else {
-                            startActivity(PageActivity.newIntentForNewTab(requireContext(), HistoryEntry(pageTitle, HistoryEntry.SOURCE_SUGGESTED_EDITS), pageTitle))
+                            it.context.startActivity(PageActivity.newIntentForNewTab(it.context, HistoryEntry(pageTitle, HistoryEntry.SOURCE_SUGGESTED_EDITS), pageTitle))
                         }
                     }
                     SuggestedEditsSnackbars.show(requireActivity(), viewModel.cardActionType, true, viewModel.targetSummaryForEdit?.lang, true, openPageListener)

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsSnackbars.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsSnackbars.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.suggestededits
 
 import android.app.Activity
+import android.view.View
 import com.google.android.material.snackbar.Snackbar
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -11,7 +12,7 @@ import org.wikipedia.util.FeedbackUtil
 object SuggestedEditsSnackbars {
 
     fun interface OpenPageListener {
-        fun open()
+        fun open(actionView: View)
     }
 
     private const val MAX_SHOW_PER_SESSION = 2
@@ -39,7 +40,7 @@ object SuggestedEditsSnackbars {
                                 })
                     })
             if (enableViewAction && listener != null) {
-                snackbar.setAction(R.string.suggested_edits_article_cta_snackbar_action) { listener.open() }
+                snackbar.setAction(R.string.suggested_edits_article_cta_snackbar_action) { listener.open(it) }
             }
 
             snackbar.addCallback(object : Snackbar.Callback() {


### PR DESCRIPTION
This fixes issues (and a potential crash) when tapping the View action in the snackbar after completing a Suggested Edit from the Feed card.

* The fragment from which the snackbar is launched is no longer attached (replaced by a new Suggestion), so we cannot use the same context for launching an activity.
* In the case of Image Tags, the `WikiSite` for launching the View action was being constructed incorrectly.

**Phabricator:**
https://phabricator.wikimedia.org/T383084
