### PR TITLE
Use local language names instead of canonical names where appropriate.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
@@ -183,7 +183,7 @@ class SuggestedEditsCardItemFragment : Fragment() {
     private fun showTranslateDescriptionUI() {
         showAddDescriptionUI()
         binding.callToActionButton.text = context?.getString(R.string.suggested_edits_feed_card_add_translation_in_language_button,
-                WikipediaApp.instance.languageState.getAppLanguageCanonicalName(viewModel.targetSummaryForEdit?.lang))
+                WikipediaApp.instance.languageState.getAppLanguageLocalizedName(viewModel.targetSummaryForEdit?.lang))
         binding.viewArticleSubtitle.visibility = VISIBLE
         binding.viewArticleSubtitle.text = viewModel.sourceSummaryForEdit?.description
     }
@@ -199,7 +199,7 @@ class SuggestedEditsCardItemFragment : Fragment() {
     private fun showTranslateImageCaptionUI() {
         showAddImageCaptionUI()
         binding.callToActionButton.text = context?.getString(R.string.suggested_edits_feed_card_translate_image_caption,
-                WikipediaApp.instance.languageState.getAppLanguageCanonicalName(viewModel.targetSummaryForEdit?.lang))
+                WikipediaApp.instance.languageState.getAppLanguageLocalizedName(viewModel.targetSummaryForEdit?.lang))
         binding.viewArticleSubtitle.visibility = VISIBLE
         binding.viewArticleSubtitle.text = viewModel.sourceSummaryForEdit?.description
     }

--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
@@ -210,7 +210,7 @@ class LangLinksActivity : BaseActivity() {
             languageEntries.clear()
             for (entry in originalLanguageEntries) {
                 val languageCode = entry.wikiSite.languageCode
-                val canonicalName = app.languageState.getAppLanguageCanonicalName(languageCode).orEmpty()
+                val canonicalName = viewModel.getCanonicalName(languageCode) ?: app.languageState.getAppLanguageCanonicalName(languageCode).orEmpty()
                 val localizedName = app.languageState.getAppLanguageLocalizedName(languageCode).orEmpty()
                 if (canonicalName.contains(filterText, true) || localizedName.contains(filterText, true)) {
                     languageEntries.add(entry)

--- a/app/src/main/java/org/wikipedia/notifications/NotificationFilterItemView.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationFilterItemView.kt
@@ -89,7 +89,7 @@ class NotificationFilterItemView constructor(context: Context, attrs: AttributeS
             Constants.WIKI_CODE_WIKIDATA -> context.getString(R.string.wikidata)
             context.getString(R.string.notifications_all_wikis_text) -> filterCode
             context.getString(R.string.notifications_all_types_text) -> filterCode
-            else -> WikipediaApp.instance.languageState.getAppLanguageCanonicalName(filterCode).orEmpty()
+            else -> WikipediaApp.instance.languageState.getAppLanguageLocalizedName(filterCode).orEmpty()
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/places/PlacesFilterActivity.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFilterActivity.kt
@@ -126,7 +126,7 @@ class PlacesFilterActivity : BaseActivity() {
         }
 
         fun bindItem(languageCode: String) {
-            itemViewBinding.placesFilterTitle.text = WikipediaApp.instance.languageState.getAppLanguageCanonicalName(languageCode)
+            itemViewBinding.placesFilterTitle.text = WikipediaApp.instance.languageState.getAppLanguageLocalizedName(languageCode)
             itemViewBinding.placesFilterLangCode.setLangCode(languageCode)
             itemViewBinding.placesFilterRadio.isVisible = languageCode == Prefs.placesWikiCode
             itemViewBinding.root.setOnClickListener {

--- a/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.kt
+++ b/app/src/main/java/org/wikipedia/settings/languages/WikipediaLanguagesFragment.kt
@@ -257,7 +257,7 @@ class WikipediaLanguagesFragment : Fragment(), MenuProvider, WikipediaLanguagesI
 
     private inner class WikipediaLanguageItemHolder(itemView: WikipediaLanguagesItemView) : DefaultViewHolder<WikipediaLanguagesItemView>(itemView) {
         fun bindItem(languageCode: String, position: Int) {
-            view.setContents(languageCode, app.languageState.getAppLanguageCanonicalName(languageCode), position)
+            view.setContents(languageCode, app.languageState.getAppLanguageLocalizedName(languageCode), position)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsRecentEditsFilterItemView.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsRecentEditsFilterItemView.kt
@@ -53,7 +53,7 @@ class SuggestedEditsRecentEditsFilterItemView constructor(context: Context, attr
         } else {
             titleText = when (filter.filterCode) {
                 context.getString(R.string.notifications_all_wikis_text) -> filter.filterCode
-                else -> WikipediaApp.instance.languageState.getAppLanguageCanonicalName(filter.filterCode).orEmpty()
+                else -> WikipediaApp.instance.languageState.getAppLanguageLocalizedName(filter.filterCode).orEmpty()
             }
         }
 

--- a/app/src/main/java/org/wikipedia/views/LanguageScrollView.kt
+++ b/app/src/main/java/org/wikipedia/views/LanguageScrollView.kt
@@ -99,7 +99,7 @@ class LanguageScrollView(context: Context, attrs: AttributeSet? = null) : Constr
     private fun updateTabLanguageLabel(customView: View, languageCode: String? = null, @ColorInt textColor: Int? = null) {
         val languageLabelTextView = customView.findViewById<TextView>(R.id.language_label)
         if (!languageCode.isNullOrEmpty()) {
-            languageLabelTextView.text = WikipediaApp.instance.languageState.getAppLanguageCanonicalName(languageCode)
+            languageLabelTextView.text = WikipediaApp.instance.languageState.getAppLanguageLocalizedName(languageCode)
         }
         textColor?.let {
             languageLabelTextView.setTextColor(textColor)

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistFilterItemView.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistFilterItemView.kt
@@ -79,7 +79,7 @@ class WatchlistFilterItemView constructor(context: Context, attrs: AttributeSet?
         }
         return when (filter.filterCode) {
             context.getString(R.string.notifications_all_wikis_text) -> filter.filterCode
-            else -> WikipediaApp.instance.languageState.getAppLanguageCanonicalName(filter.filterCode).orEmpty()
+            else -> WikipediaApp.instance.languageState.getAppLanguageLocalizedName(filter.filterCode).orEmpty()
         }
     }
 }


### PR DESCRIPTION
Wherever we show a selection of languages, the names of the languages should be in the name of that language itself, instead of English.

**Phabricator:**
https://phabricator.wikimedia.org/T383150
