### PR TITLE
Update Edits sequential tooltips's target and orders

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -73,10 +73,10 @@ class SuggestedEditsTasksFragment : Fragment() {
             return@Runnable
         }
         val balloon = FeedbackUtil.getTooltip(requireContext(), binding.editsCountStatsView.tooltipText, autoDismiss = true, showDismissButton = true)
-        balloon.showAlignBottom(binding.editsCountStatsView.getTitleView())
-        balloon.relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editStreakStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editStreakStatsView.getTitleView())
-            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.pageViewStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.pageViewStatsView.getTitleView())
-            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editQualityStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editQualityStatsView.getTitleView())
+        balloon.showAlignBottom(binding.editsCountStatsView.getDescriptionView())
+        balloon.relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.pageViewStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.pageViewStatsView.getDescriptionView())
+            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editStreakStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editStreakStatsView.getDescriptionView())
+            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editQualityStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editQualityStatsView.getDescriptionView())
         Prefs.showOneTimeSequentialUserStatsTooltip = false
         BreadCrumbLogEvent.logTooltipShown(requireActivity(), binding.editsCountStatsView)
     }

--- a/app/src/main/java/org/wikipedia/views/SuggestedEditsStatsView.kt
+++ b/app/src/main/java/org/wikipedia/views/SuggestedEditsStatsView.kt
@@ -46,8 +46,8 @@ internal class SuggestedEditsStatsView(context: Context, attrs: AttributeSet? = 
         binding.image.setImageResource(imageDrawable)
     }
 
-    fun getTitleView(): View {
-        return binding.title
+    fun getDescriptionView(): View {
+        return binding.description
     }
 
     fun setGoodnessState(severity: Int) {


### PR DESCRIPTION
### What does this do?
Update the order of the Edits' tooltips to let them show from top to bottom and also set the correct target view from the `title` to the `description` view. 
