### PR TITLE
Do not block the Edits screen if the primary language is `test`

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -290,6 +290,10 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     private fun maybeSetPausedOrDisabled(): Boolean {
+        if (WikipediaApp.instance.appOrSystemLanguageCode == "test") {
+            return false
+        }
+
         val pauseEndDate = UserContribStats.maybePauseAndGetEndDate()
 
         if (viewModel.totalContributions < MIN_CONTRIBUTIONS_FOR_SUGGESTED_EDITS && WikipediaApp.instance.appOrSystemLanguageCode == "en") {


### PR DESCRIPTION
### What does this do?
We should not disable the Edits screen if there are too many reverts in `testwiki`. This PR helps to skip the logic of checking revert counts in the Edits screen for `testwiki`.
