### PR TITLE
Separates XML layout of SuggestedEditsTasksFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -72,17 +72,18 @@ class SuggestedEditsTasksFragment : Fragment() {
         if (!isAdded) {
             return@Runnable
         }
-        val balloon = FeedbackUtil.getTooltip(requireContext(), binding.editsCountStatsView.tooltipText, autoDismiss = true, showDismissButton = true)
-        balloon.showAlignBottom(binding.editsCountStatsView.getDescriptionView())
-        balloon.relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.pageViewStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.pageViewStatsView.getDescriptionView())
-            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editStreakStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editStreakStatsView.getDescriptionView())
-            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), binding.editQualityStatsView.tooltipText, autoDismiss = true, showDismissButton = true), binding.editQualityStatsView.getDescriptionView())
+        val contributionContainer = binding.layoutContributionsContainer
+        val balloon = FeedbackUtil.getTooltip(requireContext(), contributionContainer.editsCountStatsView.tooltipText, autoDismiss = true, showDismissButton = true)
+        balloon.showAlignBottom(contributionContainer.editsCountStatsView.getDescriptionView())
+        balloon.relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), contributionContainer.pageViewStatsView.tooltipText, autoDismiss = true, showDismissButton = true), contributionContainer.pageViewStatsView.getDescriptionView())
+            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), contributionContainer.editStreakStatsView.tooltipText, autoDismiss = true, showDismissButton = true), contributionContainer.editStreakStatsView.getDescriptionView())
+            .relayShowAlignBottom(FeedbackUtil.getTooltip(requireContext(), contributionContainer.editQualityStatsView.tooltipText, autoDismiss = true, showDismissButton = true), contributionContainer.editQualityStatsView.getDescriptionView())
         Prefs.showOneTimeSequentialUserStatsTooltip = false
-        BreadCrumbLogEvent.logTooltipShown(requireActivity(), binding.editsCountStatsView)
+        BreadCrumbLogEvent.logTooltipShown(requireActivity(), contributionContainer.editsCountStatsView)
     }
 
     private val requestAddLanguage = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        binding.tasksRecyclerView.adapter?.notifyDataSetChanged()
+        binding.layoutTasksContainer.tasksRecyclerView.adapter?.notifyDataSetChanged()
     }
 
     private val requestAddImageTags = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
@@ -107,14 +108,14 @@ class SuggestedEditsTasksFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupTestingButtons()
-        binding.contributionsContainer.setOnClickListener {
+        binding.layoutContributionsContainer.contributionsContainer.setOnClickListener {
             startActivity(UserContribListActivity.newIntent(requireActivity(), AccountUtil.userName))
         }
-
-        binding.learnMoreCard.setOnClickListener {
+        val tasksContainer = binding.layoutTasksContainer
+        tasksContainer.learnMoreCard.setOnClickListener {
             FeedbackUtil.showAndroidAppEditingFAQ(requireContext())
         }
-        binding.learnMoreButton.setOnClickListener {
+        tasksContainer.learnMoreButton.setOnClickListener {
             FeedbackUtil.showAndroidAppEditingFAQ(requireContext())
         }
 
@@ -128,9 +129,9 @@ class SuggestedEditsTasksFragment : Fragment() {
         binding.suggestedEditsScrollView.setOnScrollChangeListener(NestedScrollView.OnScrollChangeListener { _, _, scrollY, _, _ ->
             (requireActivity() as MainActivity).updateToolbarElevation(scrollY > 0)
         })
-        binding.tasksRecyclerView.layoutManager = LinearLayoutManager(context)
-        binding.tasksRecyclerView.adapter = RecyclerAdapter(displayedTasks)
-        binding.tasksContainer.isVisible = false
+        tasksContainer.tasksRecyclerView.layoutManager = LinearLayoutManager(context)
+        tasksContainer.tasksRecyclerView.adapter = RecyclerAdapter(displayedTasks)
+        tasksContainer.tasksContainer.isVisible = false
 
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
@@ -169,7 +170,7 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        binding.tasksRecyclerView.adapter = null
+        binding.layoutTasksContainer.tasksRecyclerView.adapter = null
         binding.suggestedEditsScrollView.removeCallbacks(sequentialTooltipRunnable)
         _binding = null
         super.onDestroyView()
@@ -186,19 +187,19 @@ class SuggestedEditsTasksFragment : Fragment() {
             requestLogin.launch(LoginActivity.newIntent(requireContext(), LoginActivity.SOURCE_SUGGESTED_EDITS))
         }
         binding.messageCard.isVisible = true
-        binding.contributionsContainer.isVisible = false
-        binding.statsDivider.isVisible = false
+        binding.layoutContributionsContainer.contributionsContainer.isVisible = false
+        binding.layoutContributionsContainer.statsDivider.isVisible = false
     }
 
     private fun clearContents(shouldScrollToTop: Boolean = true) {
         binding.suggestedEditsScrollView.isVisible = true
         binding.swipeRefreshLayout.isRefreshing = false
         binding.progressBar.isVisible = false
-        binding.tasksContainer.isVisible = false
+        binding.layoutTasksContainer.tasksContainer.isVisible = false
         binding.errorView.isVisible = false
         binding.messageCard.isVisible = false
-        binding.contributionsContainer.isVisible = false
-        binding.statsDivider.isVisible = false
+        binding.layoutContributionsContainer.contributionsContainer.isVisible = false
+        binding.layoutContributionsContainer.statsDivider.isVisible = false
         if (shouldScrollToTop) {
             binding.suggestedEditsScrollView.scrollTo(0, 0)
         }
@@ -226,54 +227,55 @@ class SuggestedEditsTasksFragment : Fragment() {
             return
         }
 
-        binding.tasksRecyclerView.adapter!!.notifyDataSetChanged()
+        binding.layoutTasksContainer.tasksRecyclerView.adapter!!.notifyDataSetChanged()
         setUserStatsViewsAndTooltips()
-
-        binding.pageViewStatsView.setDescription(viewModel.totalPageviews.toString())
+        val contributionContainer = binding.layoutContributionsContainer
+        contributionContainer.pageViewStatsView.setDescription(viewModel.totalPageviews.toString())
 
         if (viewModel.latestEditStreak < 2) {
-            binding.editStreakStatsView.setTitle(resources.getString(R.string.suggested_edits_last_edited))
-            binding.editStreakStatsView.setDescription(if (viewModel.latestEditDate.time > 0) DateUtil.getMDYDateString(viewModel.latestEditDate) else resources.getString(R.string.suggested_edits_last_edited_never))
+            contributionContainer.editStreakStatsView.setTitle(resources.getString(R.string.suggested_edits_last_edited))
+            contributionContainer.editStreakStatsView.setDescription(if (viewModel.latestEditDate.time > 0) DateUtil.getMDYDateString(viewModel.latestEditDate) else resources.getString(R.string.suggested_edits_last_edited_never))
         } else {
-            binding.editStreakStatsView.setTitle(resources.getString(R.string.suggested_edits_edit_streak_label_text))
-            binding.editStreakStatsView.setDescription(resources.getQuantityString(R.plurals.suggested_edits_edit_streak_detail_text,
+            contributionContainer.editStreakStatsView.setTitle(resources.getString(R.string.suggested_edits_edit_streak_label_text))
+            contributionContainer.editStreakStatsView.setDescription(resources.getQuantityString(R.plurals.suggested_edits_edit_streak_detail_text,
                 viewModel.latestEditStreak, viewModel.latestEditStreak))
         }
 
         if (viewModel.totalContributions == 0) {
-            binding.contributionsContainer.isVisible = false
-            binding.statsDivider.isVisible = false
+            contributionContainer.contributionsContainer.isVisible = false
+            contributionContainer.statsDivider.isVisible = false
             binding.messageCard.isVisible = true
             binding.messageCard.setOnboarding(getString(R.string.suggested_edits_onboarding_message, AccountUtil.userName))
         } else {
-            binding.contributionsContainer.isVisible = true
-            binding.statsDivider.isVisible = true
-            binding.editsCountStatsView.setTitle(resources.getQuantityString(R.plurals.suggested_edits_contribution, viewModel.totalContributions))
-            binding.editsCountStatsView.setDescription(viewModel.totalContributions.toString())
+            contributionContainer.contributionsContainer.isVisible = true
+            contributionContainer.statsDivider.isVisible = true
+            contributionContainer.editsCountStatsView.setTitle(resources.getQuantityString(R.plurals.suggested_edits_contribution, viewModel.totalContributions))
+            contributionContainer.editsCountStatsView.setDescription(viewModel.totalContributions.toString())
             if (Prefs.showOneTimeSequentialUserStatsTooltip) {
                  showOneTimeSequentialUserStatsTooltips()
             }
         }
 
         binding.swipeRefreshLayout.setBackgroundColor(ResourceUtil.getThemedColor(requireContext(), R.attr.paper_color))
-        binding.tasksContainer.isVisible = true
+        binding.layoutTasksContainer.tasksContainer.isVisible = true
     }
 
     private fun setUserStatsViewsAndTooltips() {
-        binding.editsCountStatsView.setImageDrawable(R.drawable.ic_mode_edit_white_24dp)
-        binding.editsCountStatsView.tooltipText = getString(R.string.suggested_edits_contributions_stat_tooltip)
+        val contributionContainer = binding.layoutContributionsContainer
+        contributionContainer.editsCountStatsView.setImageDrawable(R.drawable.ic_mode_edit_white_24dp)
+        contributionContainer.editsCountStatsView.tooltipText = getString(R.string.suggested_edits_contributions_stat_tooltip)
 
-        binding.editStreakStatsView.setTitle(resources.getString(R.string.suggested_edits_edit_streak_label_text))
-        binding.editStreakStatsView.setImageDrawable(R.drawable.ic_icon_revision_history_apps)
-        binding.editStreakStatsView.tooltipText = getString(R.string.suggested_edits_edit_streak_stat_tooltip)
+        contributionContainer.editStreakStatsView.setTitle(resources.getString(R.string.suggested_edits_edit_streak_label_text))
+        contributionContainer.editStreakStatsView.setImageDrawable(R.drawable.ic_icon_revision_history_apps)
+        contributionContainer.editStreakStatsView.tooltipText = getString(R.string.suggested_edits_edit_streak_stat_tooltip)
 
-        binding.pageViewStatsView.setTitle(getString(R.string.suggested_edits_views_label_text))
-        binding.pageViewStatsView.setImageDrawable(R.drawable.ic_trending_up_black_24dp)
-        binding.pageViewStatsView.tooltipText = getString(R.string.suggested_edits_page_views_stat_tooltip)
+        contributionContainer.pageViewStatsView.setTitle(getString(R.string.suggested_edits_views_label_text))
+        contributionContainer.pageViewStatsView.setImageDrawable(R.drawable.ic_trending_up_black_24dp)
+        contributionContainer.pageViewStatsView.tooltipText = getString(R.string.suggested_edits_page_views_stat_tooltip)
 
-       binding.editQualityStatsView.setGoodnessState(viewModel.revertSeverity)
-       binding.editQualityStatsView.setTitle(getString(R.string.suggested_edits_quality_label_text))
-       binding.editQualityStatsView.tooltipText = getString(R.string.suggested_edits_edit_quality_stat_tooltip, UserContribStats.totalReverts)
+       contributionContainer.editQualityStatsView.setGoodnessState(viewModel.revertSeverity)
+       contributionContainer.editQualityStatsView.setTitle(getString(R.string.suggested_edits_quality_label_text))
+       contributionContainer.editQualityStatsView.tooltipText = getString(R.string.suggested_edits_edit_quality_stat_tooltip, UserContribStats.totalReverts)
     }
 
     private fun showOneTimeSequentialUserStatsTooltips() {
@@ -321,12 +323,13 @@ class SuggestedEditsTasksFragment : Fragment() {
     }
 
     private fun setupTestingButtons() {
+        val tasksContainer = binding.layoutTasksContainer
         if (!ReleaseUtil.isPreBetaRelease) {
-            binding.showIPBlockedMessage.isVisible = false
-            binding.showOnboardingMessage.isVisible = false
+            tasksContainer.showIPBlockedMessage.isVisible = false
+            tasksContainer.showOnboardingMessage.isVisible = false
         }
-        binding.showIPBlockedMessage.setOnClickListener { setIPBlockedStatus() }
-        binding.showOnboardingMessage.setOnClickListener { viewModel.totalContributions = 0; setFinalUIState() }
+        tasksContainer.showIPBlockedMessage.setOnClickListener { setIPBlockedStatus() }
+        tasksContainer.showOnboardingMessage.setOnClickListener { viewModel.totalContributions = 0; setFinalUIState() }
     }
 
     private fun setUpTasks() {

--- a/app/src/main/res/layout/fragment_suggested_edits_tasks.xml
+++ b/app/src/main/res/layout/fragment_suggested_edits_tasks.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.wikipedia.views.WikiSwipeRefreshLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<org.wikipedia.views.WikiSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/swipeRefreshLayout"
@@ -25,189 +24,33 @@
                     android:id="@+id/errorView"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_margin="32dp"
                     android:layout_gravity="center"
+                    android:layout_margin="32dp"
                     android:visibility="gone"
-                    tools:visibility="visible"/>
+                    tools:visibility="visible" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                    <org.wikipedia.views.WikiCardView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginHorizontal="@dimen/activity_horizontal_margin"
-                        android:layout_marginTop="8dp">
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical">
-
-                            <LinearLayout
-                                android:id="@+id/contributionsContainer"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:background="?attr/selectableItemBackground"
-                                android:clickable="true"
-                                android:focusable="true"
-                                android:paddingStart="16dp"
-                                android:paddingTop="12dp"
-                                android:paddingEnd="16dp"
-                                android:paddingBottom="12dp"
-                                android:orientation="vertical"
-                                android:visibility="gone">
-
-                                <org.wikipedia.views.SuggestedEditsStatsView
-                                    android:id="@+id/editsCountStatsView"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:minHeight="48dp" />
-
-                                <org.wikipedia.views.SuggestedEditsStatsView
-                                    android:id="@+id/pageViewStatsView"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:minHeight="48dp" />
-
-                                <org.wikipedia.views.SuggestedEditsStatsView
-                                    android:id="@+id/editStreakStatsView"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:minHeight="48dp" />
-
-                                <org.wikipedia.views.SuggestedEditsStatsView
-                                    android:id="@+id/editQualityStatsView"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:minHeight="48dp" />
-
-                            </LinearLayout>
-
-                            <View
-                                android:id="@+id/statsDivider"
-                                android:layout_width="match_parent"
-                                android:layout_height="1dp"
-                                android:layout_marginHorizontal="16dp"
-                                android:background="?attr/list_divider"
-                                android:visibility="gone"/>
-
-                        </LinearLayout>
-
-                    </org.wikipedia.views.WikiCardView>
+                    <include
+                        android:id="@+id/layoutContributionsContainer"
+                        layout="@layout/suggested_edits_tasks_contribution_container" />
 
                     <org.wikipedia.views.MessageCardView
                         android:id="@+id/messageCard"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginVertical="16dp"
                         android:layout_marginStart="@dimen/activity_horizontal_margin"
                         android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                        android:layout_marginVertical="16dp"
                         android:visibility="gone" />
 
-                    <LinearLayout
-                        android:id="@+id/tasksContainer"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/contributeSubtitleView"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="32dp"
-                            android:layout_marginBottom="8dp"
-                            android:layout_marginStart="@dimen/activity_horizontal_margin"
-                            android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                            android:text="@string/suggested_edits_label"
-                            android:textColor="?attr/primary_color"
-                            android:textSize="20sp"
-                            android:textStyle="bold"/>
-
-                        <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/tasksRecyclerView"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content" />
-
-                        <org.wikipedia.views.WikiCardView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/activity_horizontal_margin"
-                            android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                            android:layout_marginTop="24dp"
-                            android:layout_marginBottom="24dp">
-
-                            <LinearLayout
-                                android:id="@+id/learnMoreCard"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:paddingStart="16dp"
-                                android:paddingEnd="16dp"
-                                android:paddingTop="16dp"
-                                android:paddingBottom="8dp"
-                                android:orientation="vertical"
-                                android:clickable="true"
-                                android:focusable="true"
-                                android:background="?attr/selectableItemBackground">
-
-                                <TextView
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:textSize="20sp"
-                                    android:textStyle="bold"
-                                    android:textColor="?attr/primary_color"
-                                    android:text="@string/suggested_edits_what_is_title"/>
-
-                                <TextView
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginTop="8dp"
-                                    android:textSize="16sp"
-                                    android:lineSpacingExtra="8sp"
-                                    android:textColor="?attr/secondary_color"
-                                    android:text="@string/suggested_edits_what_is_text"/>
-
-                                <com.google.android.material.button.MaterialButton
-                                    android:id="@+id/learnMoreButton"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    style="@style/App.Button.Secondary"
-                                    android:text="@string/suggested_edits_learn_more"
-                                    android:layout_marginTop="6dp"
-                                    app:icon="@drawable/ic_open_in_new_black_24px"/>
-
-                            </LinearLayout>
-
-                        </org.wikipedia.views.WikiCardView>
-
-                        <!-- TODO: remove. -->
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:padding="8dp">
-
-                            <TextView
-                                android:id="@+id/showIPBlockedMessage"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="8dp"
-                                android:textColor="?attr/progressive_color"
-                                android:textSize="@dimen/bottom_nav_label_text_size"
-                                android:text="IPBlocked" />
-
-                            <TextView
-                                android:id="@+id/showOnboardingMessage"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="8dp"
-                                android:textColor="?attr/progressive_color"
-                                android:textSize="@dimen/bottom_nav_label_text_size"
-                                android:text="Onboarding" />
-                        </LinearLayout>
-
-                    </LinearLayout>
+                    <include
+                        android:id="@+id/layoutTasksContainer"
+                        layout="@layout/suggested_edits_tasks_container"
+                        />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/suggested_edits_tasks_container.xml
+++ b/app/src/main/res/layout/suggested_edits_tasks_container.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/tasksContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/contributeSubtitleView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginBottom="8dp"
+        android:text="@string/suggested_edits_label"
+        android:textColor="?attr/primary_color"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/tasksRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <org.wikipedia.views.WikiCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginBottom="24dp">
+
+        <LinearLayout
+            android:id="@+id/learnMoreCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            android:orientation="vertical"
+            android:paddingStart="16dp"
+            android:paddingTop="16dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/suggested_edits_what_is_title"
+                android:textColor="?attr/primary_color"
+                android:textSize="20sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:lineSpacingExtra="8sp"
+                android:text="@string/suggested_edits_what_is_text"
+                android:textColor="?attr/secondary_color"
+                android:textSize="16sp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/learnMoreButton"
+                style="@style/App.Button.Secondary"
+                app:icon="@drawable/ic_open_in_new_black_24px"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/suggested_edits_learn_more" />
+
+        </LinearLayout>
+
+    </org.wikipedia.views.WikiCardView>
+
+    <!-- TODO: remove. -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp">
+
+        <TextView
+            android:id="@+id/showIPBlockedMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="IPBlocked"
+            android:textColor="?attr/progressive_color"
+            android:textSize="@dimen/bottom_nav_label_text_size" />
+
+        <TextView
+            android:id="@+id/showOnboardingMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="Onboarding"
+            android:textColor="?attr/progressive_color"
+            android:textSize="@dimen/bottom_nav_label_text_size" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/suggested_edits_tasks_contribution_container.xml
+++ b/app/src/main/res/layout/suggested_edits_tasks_contribution_container.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.wikipedia.views.WikiCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/activity_horizontal_margin"
+    android:layout_marginTop="8dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/contributionsContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingStart="16dp"
+                android:paddingTop="12dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="12dp"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <org.wikipedia.views.SuggestedEditsStatsView
+                    android:id="@+id/editsCountStatsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+
+                <org.wikipedia.views.SuggestedEditsStatsView
+                    android:id="@+id/pageViewStatsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+
+                <org.wikipedia.views.SuggestedEditsStatsView
+                    android:id="@+id/editStreakStatsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+
+                <org.wikipedia.views.SuggestedEditsStatsView
+                    android:id="@+id/editQualityStatsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+
+            </LinearLayout>
+
+            <View
+                android:id="@+id/statsDivider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginHorizontal="16dp"
+                android:background="?attr/list_divider"
+                android:visibility="gone"/>
+
+        </LinearLayout>
+
+</org.wikipedia.views.WikiCardView>


### PR DESCRIPTION
### What does this do?
Separates XML layout into different XML layouts for easier handling and maintenance

### Why is this needed?
In layouts like fragment_suggested_edits_tasks we can organize the code across multiple layouts and include them as needed. This approach will simplify the process of adding new views to the UI and help maintain the design. 
