### PR TITLE
Simplify: remove old way of making circular images.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/places/PlacesCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/places/PlacesCardView.kt
@@ -49,7 +49,7 @@ class PlacesCardView(context: Context) : DefaultFeedCardView<PlacesCard>(context
             binding.placesCardDescription.text = StringUtil.fromHtml(it.pageTitle.description)
             binding.placesCardDescription.isVisible = !it.pageTitle.description.isNullOrEmpty()
             it.pageTitle.thumbUrl?.let { url ->
-                ViewUtil.loadImage(binding.placesCardThumbnail, url, circleShape = true)
+                ViewUtil.loadImage(binding.placesCardThumbnail, url)
             }
             Prefs.placesLastLocationAndZoomLevel?.first?.let { location ->
                 if (GeoUtil.isSamePlace(location.latitude, it.location.latitude, location.longitude, it.location.longitude)) {

--- a/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
+++ b/app/src/main/java/org/wikipedia/places/PlacesFragment.kt
@@ -817,7 +817,7 @@ class PlacesFragment : Fragment(), LinkPreviewDialog.LoadPageCallback, LinkPrevi
                 binding.listItemDistance.text = GeoUtil.getDistanceWithUnit(it, page.location, Locale.getDefault())
             }
             page.pageTitle.thumbUrl?.let {
-                ViewUtil.loadImage(binding.listItemThumbnail, it, circleShape = true)
+                ViewUtil.loadImage(binding.listItemThumbnail, it)
             }
         }
 

--- a/app/src/main/java/org/wikipedia/views/ViewUtil.kt
+++ b/app/src/main/java/org/wikipedia/views/ViewUtil.kt
@@ -34,13 +34,12 @@ import org.wikipedia.util.WhiteBackgroundTransformation
 
 object ViewUtil {
     private val CENTER_CROP_ROUNDED_CORNERS = MultiTransformation(CenterCrop(), WhiteBackgroundTransformation(), RoundedCorners(roundedDpToPx(2f)))
-    private val CENTER_CROP_CIRCLE = MultiTransformation(CenterCrop(), WhiteBackgroundTransformation(), RoundedCorners(roundedDpToPx(48f)))
 
     fun loadImageWithRoundedCorners(view: ImageView, url: String?) {
         loadImage(view, url, roundedCorners = true)
     }
 
-    fun loadImage(view: ImageView, url: String?, circleShape: Boolean = false, roundedCorners: Boolean = false, force: Boolean = false,
+    fun loadImage(view: ImageView, url: String?, roundedCorners: Boolean = false, force: Boolean = false,
                   listener: RequestListener<Drawable?>? = null) {
         val placeholder = getPlaceholderDrawable(view.context)
         var builder = Glide.with(view)
@@ -50,8 +49,6 @@ object ViewUtil {
                 .error(placeholder)
         builder = if (roundedCorners) {
             builder.transform(CENTER_CROP_ROUNDED_CORNERS)
-        } else if (circleShape) {
-            builder.transform(CENTER_CROP_CIRCLE)
         } else {
             builder.transform(WhiteBackgroundTransformation())
         }

--- a/app/src/main/res/layout/item_places_list.xml
+++ b/app/src/main/res/layout/item_places_list.xml
@@ -53,14 +53,14 @@
 
     </LinearLayout>
 
-    <ImageView
+    <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/listItemThumbnail"
+        app:shapeAppearanceOverlay="@style/CircularImageView"
         android:layout_width="72dp"
         android:layout_height="72dp"
         android:contentDescription="@null"
         android:src="@drawable/ic_w_logo_circle"
-        android:scaleType="centerInside"
-        android:adjustViewBounds="true"
+        android:scaleType="centerCrop"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent" />

--- a/app/src/main/res/layout/view_places_card.xml
+++ b/app/src/main/res/layout/view_places_card.xml
@@ -64,14 +64,14 @@
                 android:layout_height="wrap_content"
                 android:padding="20dp">
 
-                <ImageView
+                <com.google.android.material.imageview.ShapeableImageView
                     android:id="@+id/placesCardThumbnail"
+                    app:shapeAppearanceOverlay="@style/CircularImageView"
                     android:layout_width="90dp"
                     android:layout_height="90dp"
                     android:contentDescription="@null"
                     android:src="@drawable/ic_w_logo_circle"
-                    android:scaleType="centerInside"
-                    android:adjustViewBounds="true"
+                    android:scaleType="centerCrop"
                     android:layout_marginHorizontal="16dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
The Material library gives us a perfectly good `ShapeableImageView` to use, so we no longer need a fully custom Glide transformation to make circular images!