### PR TITLE
Fix: add non-BCP47 code to the Accept-Language for mobile-html

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -171,8 +171,8 @@ class WikipediaApp : Application() {
     fun getAcceptLanguage(wiki: WikiSite?): String {
         val wikiLang = if (wiki == null || "meta" == wiki.languageCode) "" else wiki.languageCode
         return AcceptLanguageUtil.getAcceptLanguage(
+            wikiLang,
             languageState.getBcp47LanguageCode(wikiLang),
-            languageState.getBcp47LanguageCode(languageState.appLanguageCode),
                 languageState.getBcp47LanguageCode(languageState.systemLanguageCode))
     }
 


### PR DESCRIPTION
### What does this do?
This is a temporary fix for https://phabricator.wikimedia.org/T359822#10402218

