### PR TITLE
Follow-up to zh variant fixes.

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -168,19 +168,12 @@ class WikipediaApp : Application() {
     /**
      * @return the value that should go in the Accept-Language header.
      */
-    fun getAcceptLanguage(wiki: WikiSite?, hasBcp47LangCode: Boolean = true): String {
+    fun getAcceptLanguage(wiki: WikiSite?): String {
         val wikiLang = if (wiki == null || "meta" == wiki.languageCode) "" else wiki.languageCode
-        if (hasBcp47LangCode) {
-            return AcceptLanguageUtil.getAcceptLanguage(
-                languageState.getBcp47LanguageCode(wikiLang),
-                languageState.getBcp47LanguageCode(languageState.appLanguageCode),
-                languageState.getBcp47LanguageCode(languageState.systemLanguageCode))
-        } else {
-            return AcceptLanguageUtil.getAcceptLanguage(
-                wikiLang,
-                languageState.getBcp47LanguageCode(wikiLang),
-                languageState.getBcp47LanguageCode(languageState.systemLanguageCode))
-        }
+        return AcceptLanguageUtil.getAcceptLanguage(
+            wikiLang,
+            languageState.appLanguageCode,
+            languageState.systemLanguageCode)
     }
 
     fun constrainFontSizeMultiplier(mult: Int): Int {

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/OkHttpWebViewClient.kt
@@ -112,7 +112,7 @@ abstract class OkHttpWebViewClient : WebViewClient() {
     private fun addHeaders(request: WebResourceRequest, builder: Request.Builder): Request.Builder {
         model.title?.let { title ->
             // TODO: Find a common way to set this header between here and RetrofitFactory.
-            builder.header("Accept-Language", WikipediaApp.instance.getAcceptLanguage(title.wikiSite, false))
+            builder.header("Accept-Language", WikipediaApp.instance.getAcceptLanguage(title.wikiSite))
             if (model.isInReadingList) {
                 builder.header(OfflineCacheInterceptor.SAVE_HEADER, OfflineCacheInterceptor.SAVE_HEADER_SAVE)
             }

--- a/app/src/main/java/org/wikipedia/language/AcceptLanguageUtil.kt
+++ b/app/src/main/java/org/wikipedia/language/AcceptLanguageUtil.kt
@@ -1,15 +1,34 @@
 package org.wikipedia.language
 
+import org.wikipedia.WikipediaApp
 import java.util.Locale
 
 object AcceptLanguageUtil {
-    private const val APP_LANGUAGE_QUALITY = .9f
-    private const val SYSTEM_LANGUAGE_QUALITY = .8f
 
     fun getAcceptLanguage(wikiLanguageCode: String, appLanguageCode: String, systemLanguageCode: String): String {
+        val languageState = WikipediaApp.instance.languageState
+        var quality = 1f
+
+        // Compose a list of accepted languages, with descending quality values.
+        // The first language is the most preferred, and has an implicit quality of 1.0.
         var acceptLanguage = wikiLanguageCode
-        acceptLanguage = appendToAcceptLanguage(acceptLanguage, appLanguageCode, APP_LANGUAGE_QUALITY)
-        acceptLanguage = appendToAcceptLanguage(acceptLanguage, systemLanguageCode, SYSTEM_LANGUAGE_QUALITY)
+        quality -= 0.1f
+
+        if (wikiLanguageCode.startsWith("zh")) {
+            // https://phabricator.wikimedia.org/T359822#10402218
+            // For the specific case of Chinese, we provide the old-style language variant code,
+            // in addition to the new-style BCP code. This seems to fix a tricky issue with the
+            // mobile-html endpoint, and potentially others that use old-style variant codes.
+            acceptLanguage = appendToAcceptLanguage(acceptLanguage, languageState.getBcp47LanguageCode(wikiLanguageCode), quality)
+            quality -= 0.1f
+        } else {
+            acceptLanguage = languageState.getBcp47LanguageCode(wikiLanguageCode)
+        }
+
+        acceptLanguage = appendToAcceptLanguage(acceptLanguage, languageState.getBcp47LanguageCode(appLanguageCode), quality)
+        quality -= 0.1f
+
+        acceptLanguage = appendToAcceptLanguage(acceptLanguage, languageState.getBcp47LanguageCode(systemLanguageCode), quality)
         return acceptLanguage
     }
 

--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.kt
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.kt
@@ -278,7 +278,7 @@ class SavedPageSyncService(context: Context, params: WorkerParameters) : Corouti
 
     private fun makeUrlRequest(wiki: WikiSite, url: String, pageTitle: PageTitle): Request.Builder {
         return Request.Builder().cacheControl(OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK).url(UriUtil.resolveProtocolRelativeUrl(wiki, url))
-                .addHeader("Accept-Language", WikipediaApp.instance.getAcceptLanguage(pageTitle.wikiSite, false))
+                .addHeader("Accept-Language", WikipediaApp.instance.getAcceptLanguage(pageTitle.wikiSite))
                 .addHeader(OfflineCacheInterceptor.SAVE_HEADER, OfflineCacheInterceptor.SAVE_HEADER_SAVE)
                 .addHeader(OfflineCacheInterceptor.LANG_HEADER, pageTitle.wikiSite.languageCode)
                 .addHeader(OfflineCacheInterceptor.TITLE_HEADER, UriUtil.encodeURL(pageTitle.prefixedText))

--- a/app/src/test/java/org/wikipedia/language/LanguageVariantTest.kt
+++ b/app/src/test/java/org/wikipedia/language/LanguageVariantTest.kt
@@ -26,15 +26,15 @@ class LanguageVariantTest {
         testDefaultLocaleAndAcceptLanguageAgree("test,zh-Hans-CN;q=0.8", "test", Locale.SIMPLIFIED_CHINESE)
         testDefaultLocaleAndAcceptLanguageAgree("es,zh-Hans;q=0.9,zh-Hant-TW;q=0.8", AppLanguageLookUpTable.SIMPLIFIED_CHINESE_LANGUAGE_CODE, Locale.TRADITIONAL_CHINESE, WikiSite.forLanguageCode("es"))
         testDefaultLocaleAndAcceptLanguageAgree("zh-Hant,zh-Hant-TW;q=0.8", AppLanguageLookUpTable.TRADITIONAL_CHINESE_LANGUAGE_CODE, Locale.TRADITIONAL_CHINESE)
-        testDefaultLocaleAndAcceptLanguageAgree("zh-tw,zh-Hant-TW;q=0.9,en;q=0.8", AppLanguageLookUpTable.TRADITIONAL_CHINESE_LANGUAGE_CODE, Locale.US, WikiSite.forLanguageCode("zh-tw"), false)
+        testDefaultLocaleAndAcceptLanguageAgree("zh-tw,zh-Hant-TW;q=0.9,en;q=0.7", AppLanguageLookUpTable.TRADITIONAL_CHINESE_LANGUAGE_CODE, Locale.US, WikiSite.forLanguageCode("zh-tw"))
 
         WikipediaApp.instance.languageState.setAppLanguageCodes(listOf(appLanguage))
         Locale.setDefault(defaultLocale)
     }
 
-    private fun testDefaultLocaleAndAcceptLanguageAgree(expected: String, appLanguage: String, systemLocale: Locale, wiki: WikiSite? = null, hasBcp47LangCode: Boolean = true) {
+    private fun testDefaultLocaleAndAcceptLanguageAgree(expected: String, appLanguage: String, systemLocale: Locale, wiki: WikiSite? = null) {
         WikipediaApp.instance.languageState.setAppLanguageCodes(listOf(appLanguage))
         Locale.setDefault(systemLocale)
-        MatcherAssert.assertThat(expected, Matchers.`is`(WikipediaApp.instance.getAcceptLanguage(wiki, hasBcp47LangCode)))
+        MatcherAssert.assertThat(expected, Matchers.`is`(WikipediaApp.instance.getAcceptLanguage(wiki)))
     }
 }


### PR DESCRIPTION
This further simplifies and solidifies the custom handling of `zh` variants when building the `Accept-Language` header, and also adds a few explanatory comments in the logic itself.
