### PR TITLE
Hygiene: remove unnecessary string function.

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -157,7 +157,7 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
         if (!detail.isNullOrEmpty()) {
             val view = ImageDetailView(context)
             view.binding.titleText.text = titleString
-            view.binding.contentText.text = StringUtil.strip(StringUtil.fromHtml(detail))
+            view.binding.contentText.text = StringUtil.fromHtml(detail).trim()
             if (!externalLink.isNullOrEmpty()) {
                 view.binding.contentText.setTextColor(ResourceUtil.getThemedColor(context, R.attr.progressive_color))
                 view.binding.contentText.setTextIsSelectable(false)

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -229,7 +229,7 @@ class DescriptionEditView(context: Context, attrs: AttributeSet?) : LinearLayout
         pageSummaryForEdit = if (isTranslationEdit) targetSummary!! else sourceSummary
         binding.viewDescriptionEditPageSummaryContainer.visibility = VISIBLE
         binding.viewDescriptionEditPageSummaryLabel.text = getLabelText(sourceSummary.lang)
-        binding.viewDescriptionEditPageSummary.text = StringUtil.strip(StringUtil.removeHTMLTags(if (isTranslationEdit || action == DescriptionEditActivity.Action.ADD_CAPTION) sourceSummary.description else sourceSummary.extractHtml))
+        binding.viewDescriptionEditPageSummary.text = StringUtil.removeHTMLTags(if (isTranslationEdit || action == DescriptionEditActivity.Action.ADD_CAPTION) sourceSummary.description else sourceSummary.extractHtml).trim()
         if (binding.viewDescriptionEditPageSummary.text.toString().isEmpty() || action == DescriptionEditActivity.Action.ADD_CAPTION &&
             !sourceSummary.pageTitle.description.isNullOrEmpty()) {
             binding.viewDescriptionEditPageSummaryContainer.visibility = GONE

--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -558,7 +558,7 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.LoadPageCallback, Gall
 
         if (!descriptionStr.isNullOrEmpty()) {
             binding.descriptionContainer.visibility = View.VISIBLE
-            binding.descriptionText.text = StringUtil.strip(descriptionStr)
+            binding.descriptionText.text = descriptionStr.trim()
         } else {
             binding.descriptionContainer.visibility = View.GONE
         }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -154,7 +154,7 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
             sourceSummaryForEdit!!.description!!.ifEmpty { getString(R.string.suggested_edits_no_description) }
         }
 
-        binding.viewArticleSubtitle.text = StringUtil.strip(StringUtil.removeHTMLTags(descriptionText))
+        binding.viewArticleSubtitle.text = StringUtil.removeHTMLTags(descriptionText).trim()
         binding.viewImageFileName.setDetailText(StringUtil.removeNamespace(sourceSummaryForEdit?.displayTitle.orEmpty()))
 
         if (!sourceSummaryForEdit?.user.isNullOrEmpty()) {

--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -50,11 +50,6 @@ object StringUtil {
         return s.encodeUtf8().md5().hex()
     }
 
-    fun strip(str: CharSequence?): CharSequence {
-        // TODO: remove this function once Kotlin conversion of consumers is complete.
-        return if (str.isNullOrEmpty()) "" else str.trim()
-    }
-
     fun intToHexStr(i: Int): String {
         return String.format("x%08x", i)
     }

--- a/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
+++ b/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
@@ -55,12 +55,6 @@ class StringUtilTest {
     }
 
     @Test
-    fun testStrip() {
-        MatcherAssert.assertThat(StringUtil.strip("test"), Matchers.`is`("test"))
-        MatcherAssert.assertThat(StringUtil.strip(" test  "), Matchers.`is`("test"))
-    }
-
-    @Test
     fun testIntToHexStr() {
         MatcherAssert.assertThat(StringUtil.intToHexStr(1), Matchers.`is`("x00000001"))
     }


### PR DESCRIPTION
The `strip()` function is no longer needed. (there's even a `TODO` to remove it.)