### PR TITLE
Update build-tools version in Actions workflows.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,7 +22,7 @@ jobs:
       run: ./gradlew clean checkstyle ktlint assembleAlphaRelease lintAlphaRelease testAlphaRelease
     - name: List
       run: ls -alR ./app/build/outputs/apk/
-    - uses: r0adkll/sign-android-release@v1
+    - uses: kevin-david/zipalign-sign-android-release@v2
       name: Sign APK
       id: build_signed
       with:
@@ -32,8 +32,8 @@ jobs:
         keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
         keyPassword: ${{ secrets.KEY_PASSWORD }}
       env:
-        # override default build-tools version (29.0.3) -- optional
-        BUILD_TOOLS_VERSION: "34.0.0"
+        # override default build-tools (optional)
+        BUILD_TOOLS_VERSION: "35.0.1"
     - name: Create hash
       run: git rev-parse HEAD > app/build/outputs/apk/alpha/release/rev-hash.txt
     - name: Rename APK to universal

--- a/.github/workflows/android_branch.yml
+++ b/.github/workflows/android_branch.yml
@@ -32,7 +32,7 @@ jobs:
         keyPassword: ${{ secrets.KEY_PASSWORD }}
       env:
         # override default build-tools version (33.0.0) -- optional
-        BUILD_TOOLS_VERSION: "34.0.0"
+        BUILD_TOOLS_VERSION: "35.0.1"
     - uses: actions/upload-artifact@v4
       name: Upload APK artifact
       with:


### PR DESCRIPTION
One of the GitHub Actions that we depend on uses an explicit version of Android build-tools, so we need to periodically keep it up-to-date.
Also the name of the action used in `android.yml` is out of date, and should be the same as the one used in `android_branch.yml`.