### PR TITLE
Compose XML Color states

### DIFF
--- a/app/src/androidTest/java/org/wikipedia/tests/articles/ArticleNewTabTest.kt
+++ b/app/src/androidTest/java/org/wikipedia/tests/articles/ArticleNewTabTest.kt
@@ -18,7 +18,7 @@ import org.wikipedia.theme.Theme
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
-class ArticleTabTest : BaseTest<MainActivity>(
+class ArticleNewTabTest : BaseTest<MainActivity>(
  activityClass = MainActivity::class.java
 ) {
 

--- a/app/src/androidTest/java/org/wikipedia/testsuites/ArticlesTestSuite.kt
+++ b/app/src/androidTest/java/org/wikipedia/testsuites/ArticlesTestSuite.kt
@@ -4,9 +4,9 @@ import OverflowMenuTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 import org.junit.runners.Suite.SuiteClasses
+import org.wikipedia.tests.articles.ArticleNewTabTest
 import org.wikipedia.tests.articles.ArticlePageActionItemTest
 import org.wikipedia.tests.articles.ArticleSectionsTest
-import org.wikipedia.tests.articles.ArticleTabTest
 import org.wikipedia.tests.articles.EditIconTest
 import org.wikipedia.tests.articles.LeadNonLeadImageAndPreviewLinkTest
 import org.wikipedia.tests.articles.MediaTest
@@ -19,7 +19,7 @@ import org.wikipedia.tests.articles.TableOfContentsTest
 @SuiteClasses(
     ArticlePageActionItemTest::class,
     ArticleSectionsTest::class,
-    ArticleTabTest::class,
+    ArticleNewTabTest::class,
     LeadNonLeadImageAndPreviewLinkTest::class,
     EditIconTest::class,
     MediaTest::class,

--- a/app/src/main/java/org/wikipedia/compose/components/CircularButton.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/CircularButton.kt
@@ -1,0 +1,60 @@
+package org.wikipedia.compose.components
+
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.wikipedia.compose.theme.BaseTheme
+import org.wikipedia.compose.theme.WikipediaTheme
+
+@Composable
+fun CircularButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+    defaultBgColor: Color = WikipediaTheme.colors.backgroundColor,
+    selectedBgColor: Color = WikipediaTheme.colors.progressiveColor,
+    size: Dp = 40.dp,
+    interactionSource: MutableInteractionSource? = null,
+    indication: Indication? = null,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(if (isSelected) selectedBgColor else defaultBgColor)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = indication,
+                onClick = {
+                    onClick()
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        content()
+    }
+}
+
+@Preview
+@Composable
+private fun CircularButtonPreview() {
+    BaseTheme {
+        CircularButton(
+            onClick = {},
+            content = {}
+        )
+    }
+}

--- a/app/src/main/java/org/wikipedia/compose/components/NavigationBar.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/NavigationBar.kt
@@ -1,0 +1,96 @@
+package org.wikipedia.compose.components
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import org.wikipedia.R
+import org.wikipedia.compose.theme.WikipediaTheme
+
+data class NewTab(
+    @StringRes val text: Int,
+    val id: Int,
+    @DrawableRes var selectedIcon: Int,
+    @DrawableRes var unSelectedIcon: Int,
+)
+
+val newNavTabsList = listOf(
+    NewTab(
+        text = R.string.feed,
+        id = R.id.nav_tab_explore,
+        selectedIcon = R.drawable.explore_bold,
+        unSelectedIcon = R.drawable.explore_bold,
+    ),
+    NewTab(
+        text = R.string.nav_item_saved,
+        id = R.id.nav_tab_reading_lists,
+        selectedIcon = R.drawable.ic_bookmark_white_24dp,
+        unSelectedIcon = R.drawable.ic_bookmark_border_white_24dp,
+    ),
+    NewTab(
+        text = R.string.nav_item_search,
+        id = R.id.nav_tab_search,
+        selectedIcon = R.drawable.search_bold,
+        unSelectedIcon = R.drawable.ic_search_white_24dp,
+    ),
+    NewTab(
+        text = R.string.nav_item_suggested_edits,
+        id = R.id.nav_tab_edits,
+        selectedIcon = R.drawable.ic_mode_edit_white_24dp,
+        unSelectedIcon = R.drawable.outline_edit_24,
+    ),
+    NewTab(
+        text = R.string.nav_item_more,
+        id = R.id.nav_tab_more,
+        selectedIcon = R.drawable.ic_menu_white_24dp,
+        unSelectedIcon = R.drawable.ic_menu_white_24dp,
+    ),
+)
+
+@Composable
+fun CustomNavigationBar(
+    modifier: Modifier = Modifier,
+    newTabs: List<NewTab>
+) {
+    var selectedItem by remember { mutableIntStateOf(0) }
+    NavigationBar(
+        containerColor = WikipediaTheme.colors.paperColor,
+        content = {
+            newTabs.forEachIndexed { index, item ->
+                NavigationBarItem(
+                    icon = {
+                       Icon(painter = painterResource(
+                           if (selectedItem == index) item.selectedIcon else item.unSelectedIcon
+                       ), contentDescription = null)
+                    },
+                    label = {
+                        Text(
+                            text = stringResource(item.text)
+                        )
+                    },
+                    colors = NavigationBarItemDefaults.colors(
+                        selectedIconColor = WikipediaTheme.colors.destructiveColor,
+                        unselectedIconColor = WikipediaTheme.colors.placeholderColor,
+                        selectedTextColor = WikipediaTheme.colors.destructiveColor,
+                        unselectedTextColor = WikipediaTheme.colors.placeholderColor,
+                    ),
+                    selected = selectedItem == index,
+                    onClick = {
+                        selectedItem = index
+                    },
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/java/org/wikipedia/compose/components/OutlinedCircularButton.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/OutlinedCircularButton.kt
@@ -1,0 +1,64 @@
+package org.wikipedia.compose.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.wikipedia.compose.theme.BaseTheme
+import org.wikipedia.compose.theme.WikipediaTheme
+
+@Composable
+fun OutlinedCircularButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    size: Dp = 40.dp,
+    isSelected: Boolean = false,
+    defaultBgColor: Color = WikipediaTheme.colors.secondaryColor,
+    selectedBgColor: Color = WikipediaTheme.colors.paperColor,
+    outlineColor: Color = WikipediaTheme.colors.progressiveColor,
+    pressedColor: Color = Color.Transparent,
+    content: @Composable () -> Unit
+) {
+    CircularButton(
+        modifier = modifier
+            .size(size)
+            .border(
+                border = BorderStroke(
+                    width = 2.dp,
+                    color = if (isSelected) outlineColor else Color.Transparent
+                ),
+                shape = CircleShape
+            ),
+        defaultBgColor = defaultBgColor,
+        selectedBgColor = selectedBgColor,
+        interactionSource = remember { MutableInteractionSource() },
+        indication = ripple(color = pressedColor),
+        onClick = onClick,
+        content = { content() }
+    )
+}
+
+@Preview
+@Composable
+private fun OutlinedCircularButtonPreview() {
+    BaseTheme {
+        OutlinedCircularButton(
+            size = 45.dp,
+            onClick = {},
+            isSelected = true,
+            content = {
+                Text("Aa")
+            },
+        )
+    }
+}

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -40,6 +40,9 @@ import org.wikipedia.activity.FragmentUtil.getCallback
 import org.wikipedia.analytics.eventplatform.ReadingListsAnalyticsHelper
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.commons.FilePageActivity
+import org.wikipedia.compose.components.CustomNavigationBar
+import org.wikipedia.compose.components.newNavTabsList
+import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.concurrency.FlowEventBus
 import org.wikipedia.databinding.FragmentMainBinding
 import org.wikipedia.dataclient.WikiSite
@@ -125,7 +128,6 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
         super.onCreateView(inflater, container, savedInstanceState)
         _binding = FragmentMainBinding.inflate(inflater, container, false)
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
-
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 FlowEventBus.events.collectLatest { event ->
@@ -174,6 +176,17 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
             handleIntent(requireActivity().intent)
         }
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.navTabCompose.setContent {
+            BaseTheme {
+                CustomNavigationBar(
+                    newTabs = newNavTabsList
+                )
+            }
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/org/wikipedia/theme/ThemeChooserButtons.kt
+++ b/app/src/main/java/org/wikipedia/theme/ThemeChooserButtons.kt
@@ -1,0 +1,97 @@
+package org.wikipedia.theme
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.wikipedia.WikipediaApp
+import org.wikipedia.compose.ComposeColors
+import org.wikipedia.compose.components.OutlinedCircularButton
+
+data class ThemeChooser(
+    val name: String,
+    val theme: Theme,
+    val defaultBackgroundColor: Color,
+    val selectedBackgroundColor: Color,
+    val pressedColor: Color,
+    val textColor: Color
+)
+
+@Composable
+fun ThemeChooserButtons(
+    modifier: Modifier = Modifier,
+    currentTheme: Theme = WikipediaApp.instance.currentTheme,
+    onThemeClick: (selectedTheme: ThemeChooser) -> Unit
+) {
+    val buttons = remember {
+        mutableStateListOf(
+            ThemeChooser(
+                name = "Aa",
+                theme = Theme.LIGHT,
+                defaultBackgroundColor = ComposeColors.White,
+                selectedBackgroundColor = ComposeColors.White,
+                pressedColor = ComposeColors.Gray300,
+                textColor = ComposeColors.Gray700
+            ),
+            ThemeChooser(
+                name = "Aa",
+                theme = Theme.SEPIA,
+                defaultBackgroundColor = ComposeColors.Beige300,
+                selectedBackgroundColor = ComposeColors.Beige300,
+                pressedColor = ComposeColors.Beige300,
+                textColor = ComposeColors.Gray700
+            ),
+            ThemeChooser(
+                name = "Aa",
+                theme = Theme.DARK,
+                defaultBackgroundColor = ComposeColors.Gray700,
+                selectedBackgroundColor = ComposeColors.Gray700,
+                pressedColor = ComposeColors.Gray600,
+                textColor = ComposeColors.Gray100
+            ),
+            ThemeChooser(
+                name = "Aa",
+                theme = Theme.BLACK,
+                defaultBackgroundColor = ComposeColors.Black,
+                selectedBackgroundColor = ComposeColors.Black,
+                pressedColor = ComposeColors.Gray700,
+                textColor = ComposeColors.Gray100
+            )
+        )
+    }
+    var currentSelectedTheme by remember { mutableStateOf(buttons.find { it.theme == currentTheme }) }
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+    ) {
+        buttons.forEach { themeChooser ->
+            OutlinedCircularButton(
+                onClick = {
+                    currentSelectedTheme = themeChooser
+                    onThemeClick(themeChooser)
+                },
+                defaultBgColor = themeChooser.defaultBackgroundColor,
+                selectedBgColor = themeChooser.selectedBackgroundColor,
+                isSelected = currentSelectedTheme?.theme == themeChooser.theme,
+                pressedColor = themeChooser.pressedColor,
+                content = {
+                    Text(
+                        text = themeChooser.name,
+                        color = themeChooser.textColor,
+                        fontSize = 16.sp
+                    )
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.kt
+++ b/app/src/main/java/org/wikipedia/theme/ThemeChooserDialog.kt
@@ -10,6 +10,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
@@ -25,6 +27,7 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.FragmentUtil
 import org.wikipedia.analytics.eventplatform.AppearanceSettingInteractionEvent
+import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.concurrency.FlowEventBus
 import org.wikipedia.databinding.DialogThemeChooserBinding
 import org.wikipedia.events.WebViewInvalidateEvent
@@ -143,6 +146,31 @@ class ThemeChooserDialog : ExtendedBottomSheetDialogFragment() {
         super.onCreate(savedInstanceState)
         invokeSource = requireArguments().getSerializable(Constants.INTENT_EXTRA_INVOKE_SOURCE) as InvokeSource
         appearanceSettingInteractionEvent = AppearanceSettingInteractionEvent(invokeSource)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        if (invokeSource == Constants.InvokeSource.SETTINGS) {
+            binding.themeChooserCompose.isVisible = true
+            binding.themeChooserXML.isVisible = false
+            binding.themeChooserCompose.setContent {
+                BaseTheme {
+                    ThemeChooserButtons(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        onThemeClick = { selectedTheme ->
+                            if (app.currentTheme !== selectedTheme.theme) {
+                                appearanceSettingInteractionEvent.logThemeChange(app.currentTheme, selectedTheme.theme)
+                                app.currentTheme = selectedTheme.theme
+                            }
+                        }
+                    )
+                }
+            }
+        } else {
+            binding.themeChooserXML.isVisible = true
+            binding.themeChooserCompose.isVisible = false
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomFragment.kt
+++ b/app/src/main/java/org/wikipedia/theme/ThemeFittingRoomFragment.kt
@@ -41,7 +41,6 @@ class ThemeFittingRoomFragment : Fragment() {
                 }
             }
         }
-
         return binding.root
     }
 

--- a/app/src/main/res/color/color_state_nav_tab.xml
+++ b/app/src/main/res/color/color_state_nav_tab.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="true" android:color="?attr/progressive_color" />
+    <item android:state_checked="true" android:color="?attr/destructive_color" />
     <item android:color="?attr/placeholder_color" />
 </selector>

--- a/app/src/main/res/layout/dialog_theme_chooser.xml
+++ b/app/src/main/res/layout/dialog_theme_chooser.xml
@@ -227,7 +227,13 @@
                 android:textColor="?attr/primary_color"
                 android:textStyle="bold"/>
 
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/themeChooserCompose"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
             <LinearLayout
+                android:id="@+id/themeChooserXML"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -47,4 +47,12 @@
         app:itemPaddingTop="8dp"
         app:elevation="0dp"/>
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/navTabCompose"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/main_nav_tab_layout"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### What does this do?
This implements custom buttons in Compose that can dynamically change their state without needing a separate function for XML selectors. In XML, we define colors for different states using selectors, but in Compose this can be handled directly within the button function itself. I also converted the theme buttons in the **ThemeChooserDialog** to Compose and limited the access to the **AppTheme** in settings for testing purpose. 

**Phabricator:**
https://phabricator.wikimedia.org/T381832