### PR TITLE
Streamline calls to PageSummary and MediaList.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/RestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.kt
@@ -32,6 +32,17 @@ interface RestService {
 
     @Headers("x-analytics: preview=1", "Accept: $ACCEPT_HEADER_SUMMARY")
     @GET("page/summary/{title}")
+    suspend fun getPageSummary(
+        @Path("title") title: String,
+        @Header("Referer") referrerUrl: String? = null,
+        @Header("Cache-Control") cacheControl: String? = null,
+        @Header(OfflineCacheInterceptor.SAVE_HEADER) saveHeader: String? = null,
+        @Header(OfflineCacheInterceptor.LANG_HEADER) langHeader: String? = null,
+        @Header(OfflineCacheInterceptor.TITLE_HEADER) titleHeader: String? = null
+    ): PageSummary
+
+    @Headers("x-analytics: preview=1", "Accept: $ACCEPT_HEADER_SUMMARY")
+    @GET("page/summary/{title}")
     suspend fun getSummaryResponse(
         @Path("title") title: String,
         @Header("Referer") referrerUrl: String? = null,
@@ -40,13 +51,6 @@ interface RestService {
         @Header(OfflineCacheInterceptor.LANG_HEADER) langHeader: String? = null,
         @Header(OfflineCacheInterceptor.TITLE_HEADER) titleHeader: String? = null
     ): Response<PageSummary>
-
-    @Headers("x-analytics: preview=1", "Accept: $ACCEPT_HEADER_SUMMARY")
-    @GET("page/summary/{title}")
-    suspend fun getPageSummary(
-        @Header("Referer") referrerUrl: String?,
-        @Path("title") title: String
-    ): PageSummary
 
     @Headers("Accept: $ACCEPT_HEADER_DEFINITION")
     @GET("page/definition/{title}")
@@ -58,7 +62,11 @@ interface RestService {
 
     @GET("page/media-list/{title}")
     suspend fun getMediaList(
-        @Path("title") title: String
+        @Path("title") title: String,
+        @Header("Cache-Control") cacheControl: String? = null,
+        @Header(OfflineCacheInterceptor.SAVE_HEADER) saveHeader: String? = null,
+        @Header(OfflineCacheInterceptor.LANG_HEADER) langHeader: String? = null,
+        @Header(OfflineCacheInterceptor.TITLE_HEADER) titleHeader: String? = null
     ): MediaList
 
     @GET("page/media-list/{title}/{revision}")
@@ -66,16 +74,6 @@ interface RestService {
         @Path("title") title: String,
         @Path("revision") revision: Long
     ): MediaList
-
-    @GET("page/media-list/{title}/{revision}")
-    suspend fun getMediaListResponse(
-        @Path("title") title: String?,
-        @Path("revision") revision: Long,
-        @Header("Cache-Control") cacheControl: String?,
-        @Header(OfflineCacheInterceptor.SAVE_HEADER) saveHeader: String?,
-        @Header(OfflineCacheInterceptor.LANG_HEADER) langHeader: String?,
-        @Header(OfflineCacheInterceptor.TITLE_HEADER) titleHeader: String?
-    ): Response<MediaList>
 
     @GET("feed/onthisday/events/{mm}/{dd}")
     suspend fun getOnThisDay(@Path("mm") month: Int,

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -61,7 +61,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
         }) {
             _loadPageSummaryState.value = Resource.Loading()
             editingAllowed = false
-            val summaryResponse = async { ServiceFactory.getRest(pageTitle.wikiSite).getPageSummary(null, pageTitle.prefixedText) }
+            val summaryResponse = async { ServiceFactory.getRest(pageTitle.wikiSite).getPageSummary(pageTitle.prefixedText) }
             val infoResponse = async { ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0) }
 
             val editError = infoResponse.await().query?.firstPage()?.getErrorForAction("edit")
@@ -145,8 +145,8 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
             var revision = -1L
             while (revision < newRevision && retry < 10) {
                 delay(2000)
-                val pageSummaryResponse = ServiceFactory.getRest(pageTitle.wikiSite).getSummaryResponse(pageTitle.prefixedText, cacheControl = OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString())
-                revision = pageSummaryResponse.body()?.revision ?: -1L
+                val pageSummary = ServiceFactory.getRest(pageTitle.wikiSite).getPageSummary(pageTitle.prefixedText, cacheControl = OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString())
+                revision = pageSummary.revision
                 retry++
             }
             _waitForRevisionState.value = Resource.Success(true)

--- a/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
@@ -135,8 +135,8 @@ class EditSectionViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
             while (revision < newRevision && retry < 10) {
                 delay(2000)
                 val pageSummaryResponse = ServiceFactory.getRest(pageTitle.wikiSite)
-                    .getSummaryResponse(pageTitle.prefixedText, cacheControl = OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString())
-                revision = pageSummaryResponse.body()?.revision ?: -1L
+                    .getPageSummary(pageTitle.prefixedText, cacheControl = OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString())
+                revision = pageSummaryResponse.revision
                 retry++
             }
             _waitForRevisionState.value = Resource.Success(revision)

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -155,8 +155,8 @@ class PageFragmentLoadState(private var model: PageViewModel,
 
                 val pageSummaryResponse = pageSummaryRequest.await()
                 val watchedResponse = watchedRequest.await()
-                val isWatched = watchedResponse.query?.firstPage()?.watched ?: false
-                val hasWatchlistExpiry = watchedResponse.query?.firstPage()?.hasWatchlistExpiry() ?: false
+                val isWatched = watchedResponse.query?.firstPage()?.watched == true
+                val hasWatchlistExpiry = watchedResponse.query?.firstPage()?.hasWatchlistExpiry() == true
                 if (pageSummaryResponse.body() == null) {
                     throw RuntimeException("Summary response was invalid.")
                 }

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -140,8 +140,9 @@ class PageFragmentLoadState(private var model: PageViewModel,
                 }
 
                 val pageSummaryRequest = async {
-                    ServiceFactory.getRest(title.wikiSite).getSummaryResponse(title.prefixedText, null, model.cacheControl.toString(),
-                        if (model.isInReadingList) OfflineCacheInterceptor.SAVE_HEADER_SAVE else null, title.wikiSite.languageCode, UriUtil.encodeURL(title.prefixedText))
+                    ServiceFactory.getRest(title.wikiSite).getSummaryResponse(title.prefixedText, cacheControl = model.cacheControl.toString(),
+                        saveHeader = if (model.isInReadingList) OfflineCacheInterceptor.SAVE_HEADER_SAVE else null,
+                        langHeader = title.wikiSite.languageCode, titleHeader = UriUtil.encodeURL(title.prefixedText))
                 }
                 val watchedRequest = async {
                     if (WikipediaApp.instance.isOnline && AccountUtil.isLoggedIn) {

--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.kt
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.kt
@@ -9,6 +9,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import okhttp3.Request
 import okio.Buffer
@@ -23,9 +24,7 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.okhttp.HttpStatusException
 import org.wikipedia.dataclient.okhttp.OfflineCacheInterceptor
 import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory
-import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.events.PageDownloadEvent
-import org.wikipedia.gallery.MediaList
 import org.wikipedia.page.PageTitle
 import org.wikipedia.pageimages.db.PageImage
 import org.wikipedia.readinglist.database.ReadingListPage
@@ -35,7 +34,6 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.util.*
 import org.wikipedia.util.log.L
 import org.wikipedia.views.CircularProgressBar
-import retrofit2.Response
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
@@ -158,11 +156,21 @@ class SavedPageSyncService(context: Context, params: WorkerParameters) : Corouti
         return withContext(Dispatchers.IO) {
             val pageTitle = ReadingListPage.toPageTitle(page)
 
-            // API calls
-            val summaryResponse = reqPageSummary(pageTitle)
-            val revision = summaryResponse.body()?.revision ?: 0
-            val mediaListResponse = reqMediaList(pageTitle, revision)
-            val mobileHTMLResponse = reqMobileHTML(pageTitle)
+            val summaryCall = async { ServiceFactory.getRest(pageTitle.wikiSite).getPageSummary(pageTitle.prefixedText,
+                cacheControl = OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString(),
+                saveHeader = OfflineCacheInterceptor.SAVE_HEADER_SAVE, langHeader = pageTitle.wikiSite.languageCode,
+                titleHeader = UriUtil.encodeURL(pageTitle.prefixedText)) }
+
+            val mediaListCall = async { ServiceFactory.getRest(pageTitle.wikiSite).getMediaList(pageTitle.prefixedText,
+                cacheControl = OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString(),
+                saveHeader = OfflineCacheInterceptor.SAVE_HEADER_SAVE, langHeader = pageTitle.wikiSite.languageCode,
+                titleHeader = UriUtil.encodeURL(pageTitle.prefixedText)) }
+
+            val mobileHTMLCall = async { reqMobileHTML(pageTitle) }
+
+            val summaryResponse = summaryCall.await()
+            val mediaListResponse = mediaListCall.await()
+            val mobileHTMLResponse = mobileHTMLCall.await()
 
             page.downloadProgress = MEDIA_LIST_PROGRESS
             FlowEventBus.post(PageDownloadEvent(page))
@@ -175,22 +183,22 @@ class SavedPageSyncService(context: Context, params: WorkerParameters) : Corouti
             }
             if (Prefs.isImageDownloadEnabled) {
                 // download thumbnail and lead image
-                if (!summaryResponse.body()?.thumbnailUrl.isNullOrEmpty()) {
-                    page.thumbUrl = UriUtil.resolveProtocolRelativeUrl(pageTitle.wikiSite, summaryResponse.body()?.thumbnailUrl.orEmpty())
+                if (!summaryResponse.thumbnailUrl.isNullOrEmpty()) {
+                    page.thumbUrl = UriUtil.resolveProtocolRelativeUrl(pageTitle.wikiSite, summaryResponse.thumbnailUrl.orEmpty())
                     AppDatabase.instance.pageImagesDao().insertPageImageSync(PageImage(pageTitle, page.thumbUrl.orEmpty()))
                     fileUrls.add(UriUtil.resolveProtocolRelativeUrl(
                         ImageUrlUtil.getUrlForPreferredSize(page.thumbUrl.orEmpty(), DimenUtil.calculateLeadImageWidth())))
                 }
 
                 // download article images
-                for (item in mediaListResponse.body()?.getItems("image").orEmpty()) {
+                for (item in mediaListResponse.getItems("image")) {
                     item.srcSets.let {
                         fileUrls.add(item.getImageUrl(DimenUtil.densityScalar))
                     }
                 }
             }
-            page.displayTitle = summaryResponse.body()?.displayTitle.orEmpty()
-            page.description = summaryResponse.body()?.description.orEmpty()
+            page.displayTitle = summaryResponse.displayTitle.orEmpty()
+            page.description = summaryResponse.description.orEmpty()
 
             reqSaveFiles(page, pageTitle, fileUrls)
 
@@ -199,24 +207,6 @@ class SavedPageSyncService(context: Context, params: WorkerParameters) : Corouti
             L.i("Saved page " + pageTitle.prefixedText + " (" + totalSize + ")")
 
             totalSize
-        }
-    }
-
-    private suspend fun reqPageSummary(pageTitle: PageTitle): Response<PageSummary> {
-        return withContext(Dispatchers.IO) {
-            ServiceFactory.getRest(pageTitle.wikiSite).getSummaryResponse(pageTitle.prefixedText,
-                null, OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString(),
-                OfflineCacheInterceptor.SAVE_HEADER_SAVE, pageTitle.wikiSite.languageCode,
-                UriUtil.encodeURL(pageTitle.prefixedText))
-        }
-    }
-
-    private suspend fun reqMediaList(pageTitle: PageTitle, revision: Long): Response<MediaList> {
-        return withContext(Dispatchers.IO) {
-            ServiceFactory.getRest(pageTitle.wikiSite).getMediaListResponse(pageTitle.prefixedText,
-                revision, OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString(),
-                OfflineCacheInterceptor.SAVE_HEADER_SAVE, pageTitle.wikiSite.languageCode,
-                UriUtil.encodeURL(pageTitle.prefixedText))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragmentViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragmentViewModel.kt
@@ -66,7 +66,7 @@ class SuggestedEditsImageRecsFragmentViewModel(savedStateHandle: SavedStateHandl
 
             recommendation = page?.growthimagesuggestiondata?.first()!!
             val wikiSite = WikiSite.forLanguageCode(langCode)
-            summary = ServiceFactory.getRest(wikiSite).getPageSummary(null, page.title)
+            summary = ServiceFactory.getRest(wikiSite).getPageSummary(page.title)
             pageTitle = summary.getPageTitle(wikiSite)
 
             val thumbUrl = UriUtil.resolveProtocolRelativeUrl(ImageUrlUtil.getUrlForPreferredSize(recommendation.images[0].metadata!!.thumbUrl, Constants.PREFERRED_CARD_THUMBNAIL_SIZE))

--- a/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
@@ -94,7 +94,7 @@ object EditingSuggestionsProvider {
                     }
                 }
 
-                pageSummary = ServiceFactory.getRest(wiki).getPageSummary(null, title)
+                pageSummary = ServiceFactory.getRest(wiki).getPageSummary(title)
             } finally {
                 mutex.release()
             }
@@ -154,14 +154,14 @@ object EditingSuggestionsProvider {
 
                 titles?.let {
                     val sourcePageSummary = async {
-                        ServiceFactory.getRest(it.first.wikiSite).getPageSummary(null, it.first.prefixedText).apply {
+                        ServiceFactory.getRest(it.first.wikiSite).getPageSummary(it.first.prefixedText).apply {
                             if (description.isNullOrEmpty()) {
                                 description = it.first.description
                             }
                         }
                     }
                     val targetPageSummary = async {
-                        ServiceFactory.getRest(it.second.wikiSite).getPageSummary(null, it.second.prefixedText)
+                        ServiceFactory.getRest(it.second.wikiSite).getPageSummary(it.second.prefixedText)
                     }
                     pair = sourcePageSummary.await() to targetPageSummary.await()
                 }

--- a/app/src/main/java/org/wikipedia/util/L10nUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/L10nUtil.kt
@@ -159,7 +159,7 @@ object L10nUtil {
             if (shouldUpdateExtracts) {
                 list.map { pageSummary ->
                     async {
-                        ServiceFactory.getRest(wikiSite).getPageSummary(null, pageSummary.apiTitle)
+                        ServiceFactory.getRest(wikiSite).getPageSummary(pageSummary.apiTitle)
                     }
                 }.awaitAll().forEachIndexed { index, pageSummary ->
                     list[index].extract = pageSummary.extract

--- a/app/src/main/java/org/wikipedia/widgets/WidgetFeaturedPageWorker.kt
+++ b/app/src/main/java/org/wikipedia/widgets/WidgetFeaturedPageWorker.kt
@@ -31,13 +31,13 @@ class WidgetFeaturedPageWorker(
             val summary = if (result.tfa != null) {
                 val hasParentLanguageCode = !WikipediaApp.instance.languageState.getDefaultLanguageCode(WikipediaApp.instance.wikiSite.languageCode).isNullOrEmpty()
                 if (hasParentLanguageCode) {
-                    ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getPageSummary(null, result.tfa.apiTitle)
+                    ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getPageSummary(result.tfa.apiTitle)
                 } else {
                     result.tfa
                 }
             } else {
                 val response = ServiceFactory.get(mainPageTitle.wikiSite).parseTextForMainPage(mainPageTitle.prefixedText)
-                ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getPageSummary(null, findFeaturedArticleTitle(response.text))
+                ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getPageSummary(findFeaturedArticleTitle(response.text))
             }
 
             val pageTitle = summary.getPageTitle(app.wikiSite)


### PR DESCRIPTION
(note that this is based on top of #5238)

* Previously we had a `getPageSummary()` call where the optional `Referer` parameter came _first_ for some reason, which required us to pass an explicit `null` everywhere this call was made. Let's make this parameter come second, along with all other optional parameters, so that any overloaded calls can be simplified.
* In the `SavedPageSyncService` where we were making the calls to retrieve the PageSummary, MediaList, and MobileHtml, those calls were being made serially, not in parallel. Let's use `async{}` to make these calls all at once, and speed up saving articles for offline usage.