### PR TITLE
Add `pilicense=any` for prop=pageimages API calls

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -92,7 +92,7 @@ interface Service {
 
     @GET(
         MW_API_PREFIX + "action=query&generator=search&gsrnamespace=0&gsrqiprofile=classic_noboostlinks" +
-                "&origin=*&piprop=thumbnail&prop=pageimages|description|info|pageprops" +
+                "&origin=*&piprop=thumbnail&pilicense=any&prop=pageimages|description|info|pageprops" +
                 "&inprop=varianttitles&smaxage=86400&maxage=86400&pithumbsize=" + PREFERRED_THUMB_SIZE
     )
     suspend fun searchMoreLike(
@@ -112,7 +112,7 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=description&redirects=1")
     suspend fun getDescription(@Query("titles") titles: String): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&prop=info|description|pageimages&inprop=varianttitles|displaytitle&redirects=1&pithumbsize=" + PREFERRED_THUMB_SIZE)
+    @GET(MW_API_PREFIX + "action=query&prop=info|description|pageimages&pilicense=any&inprop=varianttitles|displaytitle&redirects=1&pithumbsize=" + PREFERRED_THUMB_SIZE)
     suspend fun getInfoByPageIdsOrTitles(@Query("pageids") pageIds: String? = null, @Query("titles") titles: String? = null): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query&meta=siteinfo&siprop=general|autocreatetempuser")
@@ -172,7 +172,7 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=info&generator=categories&inprop=varianttitles|displaytitle&gclshow=!hidden&gcllimit=500")
     suspend fun getCategories(@Query("titles") titles: String): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&prop=description|pageimages|info&generator=categorymembers&inprop=varianttitles|displaytitle&gcmprop=ids|title")
+    @GET(MW_API_PREFIX + "action=query&prop=description|pageimages|info&pilicense=any&generator=categorymembers&inprop=varianttitles|displaytitle&gcmprop=ids|title")
     suspend fun getCategoryMembers(
         @Query("gcmtitle") title: String,
         @Query("gcmtype") type: String,


### PR DESCRIPTION
### What does this do?
Some of our API requests have the `prop=pageimages` but do not add the `pilicense=any`. This PR adds the license parameter to align with other API calls.

For example, `morelike: 四大自由 (油畫)` in `zhwiki`, the `結婚執照 (油畫)` will not show the thumbnails if we do not specify the license.

<img src="https://github.com/user-attachments/assets/552db658-6eb7-4185-b360-ec7de20105cf" width="400" />
