### PR TITLE
Image recs on dewiki: restrict to CC-licensed images.

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/provider/EditingSuggestionsProvider.kt
@@ -324,7 +324,14 @@ object EditingSuggestionsProvider {
                         // TODO: make use of continuation parameter?
                         response.query?.pages?.forEach { page ->
                             if (page.thumbUrl().isNullOrEmpty() && page.growthimagesuggestiondata?.get(0)?.images?.get(0) != null) {
-                                articlesWithImageRecommendationsCache.addFirst(page)
+                                if (articlesWithImageRecommendationsCacheLang == "de") {
+                                    // In the case of dewiki, make sure the image is CC-licensed:
+                                    if (page.growthimagesuggestiondata[0].images[0].metadata?.license.orEmpty().lowercase().contains("cc")) {
+                                        articlesWithImageRecommendationsCache.addFirst(page)
+                                    }
+                                } else {
+                                    articlesWithImageRecommendationsCache.addFirst(page)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When using Image Recommendations with German Wikipedia, it occasionally recommends images that are "public domain" which is not always appropriate for German Wikipedia, because Germany has different definitions/durations for "public domain" than the US. Therefore let's restrict image recommendations (for dewiki) to only images that are Creative-Commons licensed.

**Phabricator:**
https://phabricator.wikimedia.org/T383765
