### PR TITLE
Fix: issue of showing the User_Talk metrics in Edit History

### DIFF
--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -4,15 +4,25 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.*
-import kotlinx.coroutines.*
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import androidx.paging.cachedIn
+import androidx.paging.filter
+import androidx.paging.insertSeparators
+import androidx.paging.map
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import org.wikipedia.Constants
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.dataclient.restbase.EditCount
 import org.wikipedia.dataclient.restbase.Metrics
+import org.wikipedia.page.Namespace
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DateUtil
@@ -93,9 +103,9 @@ class EditHistoryListViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
             val editCountsAnonResponse = async { ServiceFactory.getCoreRest(pageTitle.wikiSite).getEditCount(pageTitle.prefixedText, EditCount.EDIT_TYPE_ANONYMOUS) }
             val editCountsBotResponse = async { ServiceFactory.getCoreRest(pageTitle.wikiSite).getEditCount(pageTitle.prefixedText, EditCount.EDIT_TYPE_BOT) }
             val articleMetricsResponse = async {
-                try {
+                if (pageTitle.namespace() == Namespace.MAIN) {
                     ServiceFactory.getRest(WikiSite("wikimedia.org")).getArticleMetrics(pageTitle.wikiSite.authority(), pageTitle.prefixedText, lastYear, today)
-                } catch (_: Exception) {
+                } else {
                     null
                 }
             }


### PR DESCRIPTION
### What does this do?
This PR fixes the issue when requesting the `https://wikimedia.org/api/rest_v1/metrics` endpoint for a user talk page. It looks like an unsupported namespace, and we can check if the namespace is `Main` to avoid breaking the layout in the Edit History list.


### Steps to reproduce
1. Go to a user talk page.
2. Click on the Edit history

The following screenshots show the invisible icon was caused by the incompleted request in the view model.
<img src="https://github.com/user-attachments/assets/92e6a1e0-bd81-481c-82ea-c0fd174cb92c" width="400" />
<img src="https://github.com/user-attachments/assets/7a39c7fa-9800-4bb6-b19b-cfa94d33e2e3" width="400" />

