### PR TITLE
Prevent possible crash due to post-ing on a View.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/announcement/AnnouncementCardView.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.feed.announcement
 
+import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.view.LayoutInflater
@@ -65,6 +66,9 @@ class AnnouncementCardView(context: Context) : DefaultFeedCardView<AnnouncementC
                     if (it.aspectRatio() != 0.0) {
                         binding.viewAnnouncementHeaderImage.scaleType = ImageView.ScaleType.FIT_CENTER
                         binding.viewAnnouncementHeaderImage.post {
+                            if ((context as? Activity)?.isDestroyed == true) {
+                                return@post
+                            }
                             binding.viewAnnouncementHeaderImage.updateLayoutParams {
                                 height = (binding.viewAnnouncementHeaderImage.width / it.aspectRatio()).toInt()
                             }


### PR DESCRIPTION
Rookie mistake -- doing a `.post { ... }` but forgetting to check if the activity is still active.
(this is causing a couple of crashes in production, but I do believe this crash is silent, so this is ok to wait until next release.)