### PR TITLE
Remove outdated mentions of `page/related` endpoint.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/ServiceFactory.kt
@@ -91,14 +91,9 @@ object ServiceFactory {
     private class LanguageVariantHeaderInterceptor(private val wiki: WikiSite?) : Interceptor {
         @Throws(IOException::class)
         override fun intercept(chain: Interceptor.Chain): Response {
-            var request = chain.request()
-
-            // TODO: remove when the https://phabricator.wikimedia.org/T271145 is resolved.
-            if (!request.url.encodedPath.contains("/page/related")) {
-                request = request.newBuilder()
-                    .header("Accept-Language", WikipediaApp.instance.getAcceptLanguage(wiki))
-                    .build()
-            }
+            var request = chain.request().newBuilder()
+                .header("Accept-Language", WikipediaApp.instance.getAcceptLanguage(wiki))
+                .build()
             return chain.proceed(request)
         }
     }

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadClient.kt
@@ -35,8 +35,6 @@ class BecauseYouReadClient(
             } else {
                 val entry = entries[age]
                 val langCode = entry.title.wikiSite.languageCode
-                // If the language code has a parent language code, it means set "Accept-Language" will slow down the loading time of /page/related
-                // TODO: remove when https://phabricator.wikimedia.org/T271145 is resolved.
                 val hasParentLanguageCode = !WikipediaApp.instance.languageState.getDefaultLanguageCode(langCode).isNullOrEmpty()
                 val searchTerm = StringUtil.removeUnderscores(entry.title.prefixedText)
 


### PR DESCRIPTION
The `page/related` endpoint has been removed some time ago, but we still have a couple of references to it in our code and comments.