### PR TITLE
Add strings for Wikigame final screen

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1739,4 +1739,5 @@
   <string name="on_this_day_game_menu_notifications">Menu label for setting up the game notifications.</string>
   <string name="on_this_day_game_menu_info">Menu label for visiting the information page of the game.</string>
   <string name="on_this_day_game_menu_feedback">Menu label for providing feedback on the game.</string>
+  <string name="on_this_day_game_share_text">Message for the share function in the game result screen that shares the game. %s will be replaced by the store link of the app.</string>
 </resources>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1736,4 +1736,7 @@
   <string name="on_this_day_game_stats_average_score">Label for the statistics that indicates the average score from previous games.</string>
   <string name="on_this_day_game_stats_streak">Label for the statistics that indicates the current streak of the gameplay.</string>
   <string name="on_this_day_game_result_subtitle">Label shown over the list of articles mentioned in the game.</string>
+  <string name="on_this_day_game_menu_notifications">Menu label for setting up the game notifications.</string>
+  <string name="on_this_day_game_menu_info">Menu label for visiting the information page of the game.</string>
+  <string name="on_this_day_game_menu_feedback">Menu label for providing feedback on the game.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1821,4 +1821,5 @@
     <string name="on_this_day_game_menu_notifications">Notifications</string>
     <string name="on_this_day_game_menu_info">Info</string>
     <string name="on_this_day_game_menu_feedback">Feedback</string>
+    <string name="on_this_day_game_share_text">I\'m playing \"What came first?\" a daily trivia game on the Wikipedia Android app %s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1818,5 +1818,7 @@
     <string name="on_this_day_game_stats_average_score">Average score</string>
     <string name="on_this_day_game_stats_streak">Current streak</string>
     <string name="on_this_day_game_result_subtitle">Articles referenced in today\'s game</string>
-
+    <string name="on_this_day_game_menu_notifications">Notifications</string>
+    <string name="on_this_day_game_menu_info">Info</string>
+    <string name="on_this_day_game_menu_feedback">Feedback</string>
 </resources>


### PR DESCRIPTION
- For menu icons.
- For the text in the share function.