### PR TITLE
Add margins to the talk templates to avoid text reaches the edge

### DIFF
--- a/app/src/main/res/layout/fragment_talk_templates.xml
+++ b/app/src/main/res/layout/fragment_talk_templates.xml
@@ -123,7 +123,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_margin="12dp"
+            android:layout_margin="@dimen/activity_horizontal_margin"
             android:orientation="vertical"
             android:visibility="gone" />
 

--- a/app/src/main/res/layout/fragment_talk_templates.xml
+++ b/app/src/main/res/layout/fragment_talk_templates.xml
@@ -97,6 +97,7 @@
             android:gravity="center"
             android:orientation="vertical"
             android:visibility="gone"
+            android:layout_margin="12dp"
             tools:visibility="visible">
 
             <ImageView
@@ -122,6 +123,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
+            android:layout_margin="12dp"
             android:orientation="vertical"
             android:visibility="gone" />
 

--- a/app/src/main/res/layout/fragment_talk_templates.xml
+++ b/app/src/main/res/layout/fragment_talk_templates.xml
@@ -97,7 +97,7 @@
             android:gravity="center"
             android:orientation="vertical"
             android:visibility="gone"
-            android:layout_margin="12dp"
+            android:layout_margin="@dimen/activity_horizontal_margin"
             tools:visibility="visible">
 
             <ImageView


### PR DESCRIPTION
### What does this do?
A minor tweak for the empty container.
<img src="https://github.com/user-attachments/assets/7d9d5444-8206-41f1-8229-74fa35258c1a" width="400" />

