### PR TITLE
Show the pause game dialog for the onBackPressed action

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -173,15 +173,7 @@ class OnThisDayGameActivity : BaseActivity() {
         return when (item.itemId) {
             android.R.id.home -> {
                 if (viewModel.gameState.value !is OnThisDayGameViewModel.GameEnded) {
-                    MaterialAlertDialogBuilder(this, R.style.AlertDialogTheme_Icon)
-                        .setIcon(R.drawable.ic_pause_filled_24)
-                        .setTitle(R.string.on_this_day_game_pause_title)
-                        .setMessage(R.string.on_this_day_game_pause_body)
-                        .setPositiveButton(R.string.on_this_day_game_pause_positive) { _, _ ->
-                            finish()
-                        }
-                        .setNegativeButton(R.string.on_this_day_game_pause_negative, null)
-                        .show()
+                    showPauseDialog()
                     true
                 } else {
                     super.onOptionsItemSelected(item)
@@ -210,8 +202,24 @@ class OnThisDayGameActivity : BaseActivity() {
             bottomSheetBehavior?.state = BottomSheetBehavior.STATE_COLLAPSED
             return
         }
+        if (viewModel.gameState.value !is OnThisDayGameViewModel.GameEnded) {
+            showPauseDialog()
+            return
+        }
         super.onBackPressed()
         finish()
+    }
+
+    private fun showPauseDialog() {
+        MaterialAlertDialogBuilder(this, R.style.AlertDialogTheme_Icon)
+            .setIcon(R.drawable.ic_pause_filled_24)
+            .setTitle(R.string.on_this_day_game_pause_title)
+            .setMessage(R.string.on_this_day_game_pause_body)
+            .setPositiveButton(R.string.on_this_day_game_pause_positive) { _, _ ->
+                finish()
+            }
+            .setNegativeButton(R.string.on_this_day_game_pause_negative, null)
+            .show()
     }
 
     @SuppressLint("RestrictedApi")


### PR DESCRIPTION
### What does this do?
Show the wiki game pause dialog for the `onBackPressed` action.

### Why is this needed?
The dialog only pops up when clicking on the close button. It will be better if we add the dialog for the back button action.