### PR TITLE
Remove empty item from talk page list for incorrect header

### DIFF
--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsViewModel.kt
@@ -186,6 +186,9 @@ class TalkTopicsViewModel(var pageTitle: PageTitle, private val sidePanel: Boole
             threadItems.add(0, headerItem)
         }
 
+        // Remove empty items to prevent empty content from being displayed.
+        threadItems.removeIf { TalkTopicActivity.isHeaderTemplate(it) && it.replies.isEmpty() && it.othercontent.isEmpty() }
+
         sortedThreadItems = threadItems.filter { it.plainText.contains(currentSearchQuery.orEmpty(), true) ||
                 it.plainOtherContent.contains(currentSearchQuery.orEmpty(), true) ||
                 it.allReplies.any { reply -> reply.plainText.contains(currentSearchQuery.orEmpty(), true) ||


### PR DESCRIPTION
### What does this do?
For some reason, my [account's talk page](https://en.wikipedia.org/w/api.php?format=json&formatversion=2&errorformat=html&errorsuselocal=1&action=discussiontoolspageinfo&prop=threaditemshtml&page=User_talk%3ACFeng_%28WMF%29) does not have the correct header content. This PR adds an additional check to remove the empty item from the list.

<img src="https://github.com/user-attachments/assets/e2265b67-d653-4153-85f9-469a5147142e" width="400" />

