### PR TITLE
Fix: make sure scheduling wikigame notification works correctly for API < 33

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -628,23 +628,20 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
 
     fun requestPermissionAndScheduleGameNotification() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val permission = android.Manifest.permission.POST_NOTIFICATIONS
             when {
-                ContextCompat.checkSelfPermission(
-                    this,
-                    android.Manifest.permission.POST_NOTIFICATIONS
-                ) == PackageManager.PERMISSION_GRANTED -> {
+                ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED -> {
                     OnThisDayGameNotificationManager.scheduleDailyGameNotification(this)
                 }
-
-                else -> {
-                    requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
-                }
+                else -> requestPermissionLauncher.launch(permission)
             }
+        } else {
+            OnThisDayGameNotificationManager.scheduleDailyGameNotification(this)
         }
     }
 
     companion object {
-        fun newIntent(context: Context, invokeSource: Constants.InvokeSource, wikiSite: WikiSite): Intent {
+        fun newIntent(context: Context, invokeSource: InvokeSource, wikiSite: WikiSite): Intent {
             val intent = Intent(context, OnThisDayGameActivity::class.java)
                 .putExtra(Constants.ARG_WIKISITE, wikiSite)
                 .putExtra(Constants.INTENT_EXTRA_INVOKE_SOURCE, invokeSource)


### PR DESCRIPTION
### What does this do?
The logic of scheduling wikigame notification only works for API > 32. 

The older API does not require the permission check, but we still need to run the function to schedule the notification.

