### PR TITLE
Prevent possible crash when exiting game during loading.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -202,7 +202,8 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
     }
 
     override fun onBackPressed() {
-        if (viewModel.gameState.value !is OnThisDayGameViewModel.GameEnded) {
+        if (viewModel.gameState.value !is Resource.Loading &&
+            viewModel.gameState.value !is OnThisDayGameViewModel.GameEnded) {
             showPauseDialog()
             return
         }

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameViewModel.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameViewModel.kt
@@ -198,6 +198,8 @@ class OnThisDayGameViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
             "game_end"
         } else if (_gameState.value is GameStarted) {
             "game_start"
+        } else if (_gameState.value is Resource.Loading) {
+            "game_loading"
         } else {
             "game_play_" + (currentState.currentQuestionIndex + 1)
         }


### PR DESCRIPTION
This can happen when entering the game and very quickly pressing Back (before the ViewModel finishes loading the content from the network).
This is because we attempt to show the Pause dialog and send an analytics event that depends on the game's `currentState` which is a `lateinit var` that hasn't been loaded yet.
This fix will:
* No longer show the Pause dialog if the game is still loading.
* Prevent analytics events from depending on an uninitialized `currentState`, by explicitly handing the case of the "loading" screen.
