### PR TITLE
Refine game-related analytics.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -489,6 +489,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
 
         binding.questionCard1.isEnabled = false
         binding.questionCard2.isEnabled = false
+        cardAnimatorSetIn.removeAllListeners()
         cardAnimatorSetIn.cancel()
         cardAnimatorSetIn.playTogether(textA1, translationX1, translationA1, translationX2, translationA2)
         cardAnimatorSetIn.doOnEnd {

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -162,15 +162,8 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             android.R.id.home -> {
-                WikiGamesEvent.submit("exit_click", "game_play", slideName = viewModel.getCurrentScreenName())
-                if (viewModel.gameState.value !is OnThisDayGameViewModel.GameStarted &&
-                    viewModel.gameState.value !is OnThisDayGameViewModel.GameEnded) {
-                    showPauseDialog()
-                    true
-                } else {
-                    onFinish()
-                    true
-                }
+                onBackPressed()
+                true
             }
             R.id.menu_learn_more -> {
                 WikiGamesEvent.submit("about_click", "game_play", slideName = viewModel.getCurrentScreenName())
@@ -202,13 +195,19 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
     }
 
     override fun onBackPressed() {
+        WikiGamesEvent.submit("exit_click", "game_play", slideName = viewModel.getCurrentScreenName())
         if (viewModel.gameState.value !is Resource.Loading &&
+            !isOnboardingFragmentVisible() &&
             viewModel.gameState.value !is OnThisDayGameViewModel.GameEnded) {
             showPauseDialog()
             return
         }
         super.onBackPressed()
         onFinish()
+    }
+
+    private fun isOnboardingFragmentVisible(): Boolean {
+        return supportFragmentManager.findFragmentById(R.id.fragmentContainer) is OnThisDayGameOnboardingFragment
     }
 
     private fun onFinish() {
@@ -524,6 +523,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         translationA2.startDelay = duration
         translationA2.interpolator = interpolator
 
+        cardAnimatorSetOut.removeAllListeners()
         cardAnimatorSetOut.cancel()
         cardAnimatorSetOut.playTogether(translationX1, translationA1, translationX2, translationA2)
         cardAnimatorSetOut.doOnEnd {

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameOnboardingFragment.kt
@@ -31,7 +31,7 @@ class OnThisDayGameOnboardingFragment : Fragment() {
         super.onCreateView(inflater, container, savedInstanceState)
         _binding = FragmentOnThisDayGameOnboardingBinding.inflate(inflater, container, false)
 
-        WikiGamesEvent.submit("impression", "game_play", slideName = viewModel.getCurrentScreenName())
+        WikiGamesEvent.submit("impression", "game_play", slideName = "game_start")
         return binding.root
     }
 
@@ -39,7 +39,7 @@ class OnThisDayGameOnboardingFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.playGameButton.setOnClickListener {
-            WikiGamesEvent.submit("play_click", "game_play", slideName = viewModel.getCurrentScreenName())
+            WikiGamesEvent.submit("play_click", "game_play", slideName = "game_start")
             requireActivity().supportFragmentManager.popBackStack()
             (requireActivity() as? OnThisDayGameActivity)?.animateQuestionsIn()
         }

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameViewModel.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameViewModel.kt
@@ -196,8 +196,6 @@ class OnThisDayGameViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     fun getCurrentScreenName(): String {
         return if (_gameState.value is GameEnded) {
             "game_end"
-        } else if (_gameState.value is GameStarted) {
-            "game_start"
         } else if (_gameState.value is Resource.Loading) {
             "game_loading"
         } else {


### PR DESCRIPTION
This makes a few small refinements to analytics events coming from the game:

* Deduplicate code for the "X" button and the system Back button, which do the same thing, and should send the same event.
* The ViewModel doesn't differentiate very nicely between a "GameStart" state and a "first question" state, which was confusing the analytics a bit:
   * This was causing events to be sent with a `slideName` of "game_start" when it should have been "game_play_1". This is now fixed by giving an explicit `slideName` in the onboarding fragment, and return "game_play_1" from the ViewModel even if the current state is GameStart.
* The `cardAnimatorSet` Animators are given a `doOnEnd {}` callback every time the cards are animated, and this actually _adds_ a `doOnEnd` call every time, which will cause those callbacks to be called multiple times. Therefore we must call `removeAllListeners()` before adding `doOnEnd`.