### PR TITLE
Wikigames: remove unused and duplicated strings

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1729,8 +1729,6 @@
   <string name="on_this_day_game_point">Indication of points earned with a correct response. (always 1 point, not plural)</string>
   <string name="on_this_day_game_next">Button label for navigating to the next question.</string>
   <string name="on_this_day_game_finish">Button label for finishing the game.</string>
-  <string name="on_this_day_game_experiment_chip_text">Chip label for the game menu item in the more menu.</string>
-  <string name="on_this_day_game_nav_title">Menu label for accessing the Games feature.</string>
   <string name="on_this_day_game_share">Button label for sharing game results.</string>
   <string name="on_this_day_game_pause_title">Title of a dialog box that pops up when the game is about to be paused.</string>
   <string name="on_this_day_game_pause_body">Body text of a dialog box that pops up when the game is about to be paused.</string>
@@ -1753,7 +1751,6 @@
   <string name="on_this_day_game_menu_notifications">Menu label for setting up the game notifications.</string>
   <string name="on_this_day_game_menu_info">Menu label for visiting the information page of the game.</string>
   <string name="on_this_day_game_menu_feedback">Menu label for providing feedback on the game.</string>
-  <string name="on_this_day_game_share_text">Message for the share function in the game result screen that shares the game. %s will be replaced by the store link of the app. The title \"What came first?\" is {{msg-wm|Wikipedia-android-strings-on this day game feed entry card title}}</string>
   <string name="on_this_day_game_article_read_button">Button label for the article bottom sheet from the game result screen that can open the article.</string>
   <string name="on_this_day_game_article_related_event_title">Title of the related event to the article in the bottom sheet from the game result screen.</string>
   <string name="on_this_day_game_article_answer_correct_stats_message">Message of the related event to the article in the bottom sheet from the game result screen that indicates the answer was correct.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1811,8 +1811,6 @@
     <string name="on_this_day_game_point">+1 point</string>
     <string name="on_this_day_game_next">Next question</string>
     <string name="on_this_day_game_finish">Final results</string>
-    <string name="on_this_day_game_experiment_chip_text">Experiment</string>
-    <string name="on_this_day_game_nav_title">Games</string>
     <string name="on_this_day_game_share">Share with friends</string>
     <string name="on_this_day_game_pause_title">Pause the game?</string>
     <string name="on_this_day_game_pause_body">Your progress will be saved for the day. You can find the game on your Explore feed.</string>
@@ -1835,7 +1833,6 @@
     <string name="on_this_day_game_menu_notifications">Game notifications</string>
     <string name="on_this_day_game_menu_info">Learn more</string>
     <string name="on_this_day_game_menu_feedback">Problem with feature</string>
-    <string name="on_this_day_game_share_text">I\'m playing \"What came first?\" a daily trivia game on the Wikipedia Android app %s</string>
     <string name="on_this_day_game_article_read_button">Read article</string>
     <string name="on_this_day_game_article_related_event_title">Event related to this article</string>
     <string name="on_this_day_game_article_answer_correct_stats_message">You got this question right</string>


### PR DESCRIPTION
### What does this do?
`on_this_day_game_experiment_chip_text` and `on_this_day_game_nav_title` are unused strings.
`on_this_day_game_share_text` is a duplicated string.