### PR TITLE
Bug Fix: Snackbar not appearing after bottom sheet dismissal

### DIFF
--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -331,7 +331,8 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
                 FeedbackUtil.showMessage(this, getString(R.string.watchlist_page_removed_from_watchlist_snackbar, it.displayText))
             } else if (viewModel.isWatched) {
                 val snackbar = FeedbackUtil.makeSnackbar(requireActivity(),
-                getString(R.string.watchlist_page_add_to_watchlist_snackbar, it.displayText, getString(WatchlistExpiry.NEVER.stringId)))
+                getString(R.string.watchlist_page_add_to_watchlist_snackbar, it.displayText, getString(WatchlistExpiry.NEVER.stringId)),
+                    ignoreBottomSheet = true)
                 snackbar.setAction(R.string.watchlist_page_add_to_watchlist_snackbar_action) {
                         ExclusiveBottomSheetPresenter.show(activity.supportFragmentManager, WatchlistExpiryDialog.newInstance(pageTitle, WatchlistExpiry.NEVER))
                 }

--- a/app/src/main/java/org/wikipedia/readinglist/AddToReadingListDialog.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/AddToReadingListDialog.kt
@@ -105,7 +105,7 @@ open class AddToReadingListDialog : ExtendedBottomSheetDialogFragment() {
             if (readingLists.size >= Constants.MAX_READING_LISTS_LIMIT) {
                 val message = getString(R.string.reading_lists_limit_message)
                 dismiss()
-                makeSnackbar(requireActivity(), message).show()
+                makeSnackbar(requireActivity(), message, ignoreBottomSheet = true).show()
             } else {
                 showCreateListDialog()
             }
@@ -124,7 +124,7 @@ open class AddToReadingListDialog : ExtendedBottomSheetDialogFragment() {
     private fun addAndDismiss(readingList: ReadingList, titles: List<PageTitle>?) {
         if (readingList.pages.size + titles!!.size > Constants.MAX_READING_LIST_ARTICLE_LIMIT) {
             val message = getString(R.string.reading_list_article_limit_message, readingList.title, Constants.MAX_READING_LIST_ARTICLE_LIMIT)
-            makeSnackbar(requireActivity(), message).show()
+            makeSnackbar(requireActivity(), message, ignoreBottomSheet = true).show()
             dismiss()
             return
         }
@@ -143,13 +143,13 @@ open class AddToReadingListDialog : ExtendedBottomSheetDialogFragment() {
             } else {
                 if (addedTitlesList.size == 1) getString(R.string.reading_list_article_added_to_named, addedTitlesList[0], readingList.title) else getString(R.string.reading_list_articles_added_to_named, addedTitlesList.size, readingList.title)
             }
-            showViewListSnackBar(readingList, message)
+            showViewListSnackBar(readingList, message, true)
             dismiss()
         }
     }
 
-    fun showViewListSnackBar(list: ReadingList, message: String) {
-        makeSnackbar(requireActivity(), message)
+    fun showViewListSnackBar(list: ReadingList, message: String, ignoreBottomSheet: Boolean) {
+        makeSnackbar(requireActivity(), message, ignoreBottomSheet = ignoreBottomSheet)
                 .setAction(R.string.reading_list_added_view_button) { v -> v.context.startActivity(ReadingListActivity.newIntent(v.context, list)) }.show()
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/MoveToReadingListDialog.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/MoveToReadingListDialog.kt
@@ -49,7 +49,7 @@ class MoveToReadingListDialog : AddToReadingListDialog() {
                 val movedTitlesList = withContext(Dispatchers.IO) {
                     AppDatabase.instance.readingListPageDao().movePagesToListAndDeleteSourcePages(it, readingList, titles)
                 }
-                showViewListSnackBar(readingList, if (movedTitlesList.size == 1) getString(R.string.reading_list_article_moved_to_named, movedTitlesList[0], readingList.title) else getString(R.string.reading_list_articles_moved_to_named, movedTitlesList.size, readingList.title))
+                showViewListSnackBar(readingList, if (movedTitlesList.size == 1) getString(R.string.reading_list_article_moved_to_named, movedTitlesList[0], readingList.title) else getString(R.string.reading_list_articles_moved_to_named, movedTitlesList.size, readingList.title), true)
                 dismiss()
             }
         }

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -142,8 +142,8 @@ object FeedbackUtil {
         return snackbar
     }
 
-    fun makeSnackbar(activity: Activity, text: CharSequence, duration: Int = LENGTH_DEFAULT, wikiSite: WikiSite = WikipediaApp.instance.wikiSite): Snackbar {
-        return makeSnackbar(findBestView(activity), text, duration, wikiSite)
+    fun makeSnackbar(activity: Activity, text: CharSequence, duration: Int = LENGTH_DEFAULT, wikiSite: WikiSite = WikipediaApp.instance.wikiSite, ignoreBottomSheet: Boolean = false): Snackbar {
+        return makeSnackbar(findBestView(activity, ignoreBottomSheet), text, duration, wikiSite)
     }
 
     fun showToastOverView(view: View, text: CharSequence?, duration: Int): Toast {
@@ -249,10 +249,12 @@ object FeedbackUtil {
         }
     }
 
-    private fun findBestView(activity: Activity): View {
+    private fun findBestView(activity: Activity, ignoreBottomSheet: Boolean = false): View {
         // If the activity is currently displaying a bottom sheet, use that as the anchor view.
-        getTopmostBottomSheetFragment(activity)?.let {
-            return it.requireView()
+        if (!ignoreBottomSheet) {
+            getTopmostBottomSheetFragment(activity)?.let {
+                return it.requireView()
+            }
         }
 
         // Otherwise, use the appropriate view for the activity.

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistExpiryDialog.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistExpiryDialog.kt
@@ -67,7 +67,7 @@ class WatchlistExpiryDialog : ExtendedBottomSheetDialogFragment() {
                     when (it) {
                         is Resource.Success -> {
                             FeedbackUtil.makeSnackbar(requireActivity(), getString(R.string.watchlist_page_add_to_watchlist_snackbar,
-                                viewModel.pageTitle.displayText, getString(it.data.stringId))).show()
+                                viewModel.pageTitle.displayText, getString(it.data.stringId)), ignoreBottomSheet = true).show()
                             callback()?.onExpiryChanged(it.data)
                             dismiss()
                         }


### PR DESCRIPTION
### What does this do?
This resolves the issue of the Snackbar not appearing after the bottom sheet is dismissed. When a user adds an article to a new list, the Snackbar doesn't show because findBestView detects the bottom sheet as the anchor view, causing it to attach there and not display properly. This occurs on other similar cases as well. 

Added a boolean **ignoreBottomSheet** in the **findBestView** function to ignore finding the bottomSheet when not required.

[Bug Preview](https://github.com/user-attachments/assets/91c1f782-c0db-4fa7-84e0-64e21ac25fb1)


[Fix](https://github.com/user-attachments/assets/c8b0e8ad-d052-4a7f-a023-a15f0b56a354)

