### PR TITLE
Final, ultimate, definitely for real, design tweaks to the game.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -20,6 +20,7 @@ import android.view.ViewGroup
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.core.animation.doOnEnd
@@ -287,40 +288,28 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         binding.questionCard2.tag = event2
 
         binding.questionDate1.text = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).format(LocalDate.of(event1.year, viewModel.currentMonth, viewModel.currentDay))
-        binding.questionText1.maxLines = Integer.MAX_VALUE
+        binding.questionText1.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = 0 }
         binding.questionText1.text = event1.text
-        binding.questionText1.post {
-            if (!isDestroyed) {
-                // this seems to be the only way to properly ellipsize the text in its layout.
-                if (binding.questionText1.lineHeight > 0) {
-                    binding.questionText1.maxLines = (binding.questionText1.measuredHeight / binding.questionText1.lineHeight)
-                }
-            }
-        }
+        layoutTextViewForEllipsize(binding.questionText1)
 
         val thumbnailUrl1 = event1.pages.firstOrNull()?.thumbnailUrl
         if (thumbnailUrl1.isNullOrEmpty()) {
-            binding.questionThumbnail1.setImageResource(R.mipmap.launcher)
+            binding.questionThumbnail1.isVisible = false
         } else {
+            binding.questionThumbnail1.isVisible = true
             ViewUtil.loadImage(binding.questionThumbnail1, thumbnailUrl1, placeholderId = R.mipmap.launcher)
         }
 
         binding.questionDate2.text = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).format(LocalDate.of(event2.year, viewModel.currentMonth, viewModel.currentDay))
-        binding.questionText2.maxLines = Integer.MAX_VALUE
+        binding.questionText2.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = 0 }
         binding.questionText2.text = event2.text
-        binding.questionText2.post {
-            if (!isDestroyed) {
-                // this seems to be the only way to properly ellipsize the text in its layout.
-                if (binding.questionText2.lineHeight > 0) {
-                    binding.questionText2.maxLines = (binding.questionText2.measuredHeight / binding.questionText2.lineHeight)
-                }
-            }
-        }
+        layoutTextViewForEllipsize(binding.questionText2)
 
         val thumbnailUrl2 = event2.pages.firstOrNull()?.thumbnailUrl
         if (thumbnailUrl2.isNullOrEmpty()) {
-            binding.questionThumbnail2.setImageResource(R.mipmap.launcher)
+            binding.questionThumbnail2.isVisible = false
         } else {
+            binding.questionThumbnail2.isVisible = true
             ViewUtil.loadImage(binding.questionThumbnail2, thumbnailUrl2, placeholderId = R.mipmap.launcher)
         }
 
@@ -384,11 +373,9 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
     private fun onCurrentQuestionCorrect(gameState: OnThisDayGameViewModel.GameState) {
         updateGameState(gameState)
 
-        binding.whichCameFirstText.isVisible = false
+        updateQuestionEndLayout()
         binding.correctIncorrectText.setText(R.string.on_this_day_game_correct)
         binding.pointsText.isVisible = true
-        binding.nextQuestionText.isVisible = false
-        binding.centerContent.isVisible = true
 
         if (gameState.currentQuestionState.event1.year < gameState.currentQuestionState.event2.year) {
             binding.questionDate1.setBackgroundResource(R.drawable.game_date_background_correct)
@@ -406,10 +393,8 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
     private fun onCurrentQuestionIncorrect(gameState: OnThisDayGameViewModel.GameState) {
         updateGameState(gameState)
 
-        binding.whichCameFirstText.isVisible = false
+        updateQuestionEndLayout()
         binding.correctIncorrectText.setText(R.string.on_this_day_game_incorrect)
-        binding.nextQuestionText.isVisible = false
-        binding.centerContent.isVisible = true
 
         if (gameState.currentQuestionState.event1.year < gameState.currentQuestionState.event2.year) {
             binding.questionDate1.setBackgroundResource(R.drawable.game_date_background_correct)
@@ -427,6 +412,30 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
 
         playSound("sound_error")
         enqueueGoNext(gameState)
+    }
+
+    private fun updateQuestionEndLayout() {
+        binding.whichCameFirstText.isVisible = false
+        binding.nextQuestionText.isVisible = false
+        binding.centerContent.isVisible = true
+        if (!binding.questionThumbnail1.isVisible) {
+            binding.questionText1.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = binding.questionStatusIcon1.height + DimenUtil.roundedDpToPx(8f) }
+        }
+        if (!binding.questionThumbnail2.isVisible) {
+            binding.questionText2.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = binding.questionStatusIcon2.height + DimenUtil.roundedDpToPx(8f) }
+        }
+    }
+
+    private fun layoutTextViewForEllipsize(textView: TextView) {
+        textView.maxLines = Int.MAX_VALUE
+        textView.post {
+            if (!isDestroyed) {
+                // this seems to be the only way to properly ellipsize the text in its layout.
+                if (textView.lineHeight > 0) {
+                    textView.maxLines = (textView.measuredHeight / textView.lineHeight)
+                }
+            }
+        }
     }
 
     private fun setCorrectIcon(view: ImageView) {

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -292,7 +292,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         binding.questionText1.text = event1.text
         layoutTextViewForEllipsize(binding.questionText1)
 
-        val thumbnailUrl1 = event1.pages.firstOrNull()?.thumbnailUrl
+        val thumbnailUrl1 = viewModel.getThumbnailUrlForEvent(event1)
         if (thumbnailUrl1.isNullOrEmpty()) {
             binding.questionThumbnail1.isVisible = false
         } else {
@@ -305,7 +305,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         binding.questionText2.text = event2.text
         layoutTextViewForEllipsize(binding.questionText2)
 
-        val thumbnailUrl2 = event2.pages.firstOrNull()?.thumbnailUrl
+        val thumbnailUrl2 = viewModel.getThumbnailUrlForEvent(event2)
         if (thumbnailUrl2.isNullOrEmpty()) {
             binding.questionThumbnail2.isVisible = false
         } else {
@@ -419,10 +419,10 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         binding.nextQuestionText.isVisible = false
         binding.centerContent.isVisible = true
         if (!binding.questionThumbnail1.isVisible) {
-            binding.questionText1.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = binding.questionStatusIcon1.height + DimenUtil.roundedDpToPx(8f) }
+            binding.questionText1.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = DimenUtil.roundedDpToPx(40f) }
         }
         if (!binding.questionThumbnail2.isVisible) {
-            binding.questionText2.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = binding.questionStatusIcon2.height + DimenUtil.roundedDpToPx(8f) }
+            binding.questionText2.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = DimenUtil.roundedDpToPx(40f) }
         }
     }
 

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameViewModel.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameViewModel.kt
@@ -229,6 +229,10 @@ class OnThisDayGameViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
         return currentState.answerState[if (index >= 0) index / 2 else 0]
     }
 
+    fun getThumbnailUrlForEvent(event: OnThisDay.Event): String? {
+        return event.pages.firstOrNull { !it.thumbnailUrl.isNullOrEmpty() }?.thumbnailUrl
+    }
+
     private fun composeQuestionState(index: Int): QuestionState {
         return QuestionState(events[index * 2], events[index * 2 + 1], currentMonth, currentDay)
     }

--- a/app/src/main/res/layout/activity_on_this_day_game.xml
+++ b/app/src/main/res/layout/activity_on_this_day_game.xml
@@ -98,25 +98,31 @@
                 android:layout_gravity="bottom|end"
                 android:contentDescription="@null" />
 
-            <TextView
-                android:id="@+id/questionText1"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginEnd="132dp"
-                android:ellipsize="end"
-                style="@style/P"
-                android:textColor="?attr/primary_color"
-                tools:text="Lorem ipsum"/>
+                android:orientation="horizontal">
+                <TextView
+                    android:id="@+id/questionText1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:ellipsize="end"
+                    style="@style/P"
+                    android:textColor="?attr/primary_color"
+                    tools:text="Lorem ipsum"/>
 
-            <org.wikipedia.views.FaceAndColorDetectImageView
-                android:id="@+id/questionThumbnail1"
-                app:shapeAppearanceOverlay="@style/RoundedCornerOverlay.All"
-                android:layout_width="110dp"
-                android:layout_height="110dp"
-                android:layout_gravity="end"
-                android:contentDescription="@null"
-                android:scaleType="centerCrop"
-                android:src="@mipmap/launcher"/>
+                <org.wikipedia.views.FaceAndColorDetectImageView
+                    android:id="@+id/questionThumbnail1"
+                    app:shapeAppearanceOverlay="@style/RoundedCornerOverlay.All"
+                    android:layout_width="110dp"
+                    android:layout_height="110dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_gravity="end"
+                    android:contentDescription="@null"
+                    android:scaleType="centerCrop"
+                    android:src="@mipmap/launcher"/>
+            </LinearLayout>
 
         </org.wikipedia.views.WikiCardView>
 
@@ -200,25 +206,31 @@
                 android:layout_gravity="bottom|end"
                 android:contentDescription="@null" />
 
-            <TextView
-                android:id="@+id/questionText2"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginEnd="132dp"
-                android:ellipsize="end"
-                style="@style/P"
-                android:textColor="?attr/primary_color"
-                tools:text="Lorem ipsum"/>
+                android:orientation="horizontal">
+                <TextView
+                    android:id="@+id/questionText2"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:ellipsize="end"
+                    style="@style/P"
+                    android:textColor="?attr/primary_color"
+                    tools:text="Lorem ipsum"/>
 
-            <org.wikipedia.views.FaceAndColorDetectImageView
-                android:id="@+id/questionThumbnail2"
-                app:shapeAppearanceOverlay="@style/RoundedCornerOverlay.All"
-                android:layout_width="110dp"
-                android:layout_height="110dp"
-                android:layout_gravity="end"
-                android:contentDescription="@null"
-                android:scaleType="centerCrop"
-                android:src="@mipmap/launcher"/>
+                <org.wikipedia.views.FaceAndColorDetectImageView
+                    android:id="@+id/questionThumbnail2"
+                    app:shapeAppearanceOverlay="@style/RoundedCornerOverlay.All"
+                    android:layout_width="110dp"
+                    android:layout_height="110dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_gravity="end"
+                    android:contentDescription="@null"
+                    android:scaleType="centerCrop"
+                    android:src="@mipmap/launcher"/>
+            </LinearLayout>
 
         </org.wikipedia.views.WikiCardView>
 


### PR DESCRIPTION
* This updates the question-card layout for the case where the question has no image thumbnail. This will no longer use a "placeholder" image, and will instead make the text flow to the full width of the card, and above the "correct/incorrect" icon.
* This also updates the logic for getting the thumbnail for the current Event. Instead of trying to get the thumbnail from the "first" article in the event, this will now get any thumbnail from _any_ article in the event.

The changes look a bit more major / intimidating than they are; this is a minor-ish tweak.