### PR TITLE
Show snackbar over BottomSheet only if allowed.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameArticleBottomSheet.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameArticleBottomSheet.kt
@@ -29,10 +29,11 @@ import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.ShareUtil
 import org.wikipedia.util.StringUtil
+import org.wikipedia.views.AllowSnackbarOverBottomSheet
 import org.wikipedia.views.ViewUtil
 import kotlin.getValue
 
-class OnThisDayGameArticleBottomSheet : ExtendedBottomSheetDialogFragment() {
+class OnThisDayGameArticleBottomSheet : ExtendedBottomSheetDialogFragment(), AllowSnackbarOverBottomSheet {
     fun interface Callback {
         fun onPageBookmarkChanged(page: PageSummary)
     }

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -35,6 +35,7 @@ import org.wikipedia.readinglist.ReadingListActivity
 import org.wikipedia.suggestededits.SuggestionsActivity
 import org.wikipedia.talk.TalkTopicsActivity
 import org.wikipedia.util.log.L
+import org.wikipedia.views.AllowSnackbarOverBottomSheet
 
 object FeedbackUtil {
     private const val LENGTH_SHORT = 3000
@@ -250,7 +251,8 @@ object FeedbackUtil {
     }
 
     private fun findBestView(activity: Activity): View {
-        // If the activity is currently displaying a bottom sheet, use that as the anchor view.
+        // If the activity is currently displaying a bottom sheet over which we allow a snackbar,
+        // use the bottom sheet's view as the anchor for the snackbar.
         getTopmostBottomSheetFragment(activity)?.let {
             return it.requireView()
         }
@@ -279,7 +281,7 @@ object FeedbackUtil {
     }
 
     private fun getTopmostBottomSheetFragment(fragment: Fragment): BottomSheetDialogFragment? {
-        if (fragment is BottomSheetDialogFragment && fragment.view != null) {
+        if (fragment is BottomSheetDialogFragment && fragment is AllowSnackbarOverBottomSheet && fragment.view != null) {
             return fragment
         }
         fragment.childFragmentManager.fragments.forEach {

--- a/app/src/main/java/org/wikipedia/views/AllowSnackbarOverBottomSheet.kt
+++ b/app/src/main/java/org/wikipedia/views/AllowSnackbarOverBottomSheet.kt
@@ -1,0 +1,3 @@
+package org.wikipedia.views
+
+interface AllowSnackbarOverBottomSheet


### PR DESCRIPTION
This introduces an `interface` to be used by BottomSheet components that want to allow Snackbars to be displayed over them.