### PR TITLE
Show game notification only if current language is supported.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameNotificationManager.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameNotificationManager.kt
@@ -113,7 +113,8 @@ object OnThisDayGameNotificationManager {
     }
 
     fun showNotification(context: Context) {
-        if ((WikipediaApp.instance.currentResumedActivity is OnThisDayGameActivity).not()) {
+        if (WikipediaApp.instance.currentResumedActivity !is OnThisDayGameActivity &&
+            OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(WikipediaApp.instance.wikiSite.languageCode)) {
             NotificationPresenter.showNotification(
                 context = context,
                 builder = NotificationPresenter.getDefaultBuilder(context, 1, NOTIFICATION_TYPE_LOCAL),


### PR DESCRIPTION
If the user sets their language to German (available for playing the game), then plays the game, then enables the notification, then **changes their language** to something else, then the resulting notification will allow them to play the game _in that new language_, which we don't want.

This will ensure that the game (when invoked from the notification) is only playable for the current list of allowed languages.