### PR TITLE
Fix potential crash when zooming images with ImageZoomHelper.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/ImageZoomHelper.kt
+++ b/app/src/main/java/org/wikipedia/views/ImageZoomHelper.kt
@@ -290,7 +290,7 @@ class ImageZoomHelper(activity: Activity) {
             private set
 
         private fun getIntTag(view: View): Int {
-            return if (view.tag == null) 0 else view.tag as Int
+            return if (view.tag == null || view.tag !is Int) 0 else view.tag as Int
         }
 
         fun setViewZoomable(view: View) {


### PR DESCRIPTION
(not related to the game)
This is a minor-ish [crash](https://play.google.com/console/u/0/developers/6169333749249604352/app/4976363884102945010/vitals/crashes/f82733c921a2df2983a1988d3a2f627d/details?days=28&versionCode=50519&isUserPerceived=true) that seems to have started happening in production (and beta) since our last release.
Even though I can't reproduce it myself yet, this additional check should take care of it.
It would be great to merge this into our current release.