### PR TITLE
Respect the current language when providing the local results

### DIFF
--- a/app/src/main/java/org/wikipedia/history/db/HistoryEntryWithImageDao.kt
+++ b/app/src/main/java/org/wikipedia/history/db/HistoryEntryWithImageDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.RewriteQueriesToDropUnusedColumns
 import org.apache.commons.lang3.StringUtils
+import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.search.SearchResult
 import org.wikipedia.search.SearchResults
@@ -26,7 +27,7 @@ interface HistoryEntryWithImageDao {
     @RewriteQueriesToDropUnusedColumns
     fun findEntriesBy(excludeSource1: Int, excludeSource2: Int, excludeSource3: Int, minTimeSpent: Int, limit: Int): List<HistoryEntryWithImage>
 
-    fun findHistoryItem(searchQuery: String): SearchResults {
+    fun findHistoryItem(wikiSite: WikiSite, searchQuery: String): SearchResults {
         var normalizedQuery = StringUtils.stripAccents(searchQuery)
         if (normalizedQuery.isEmpty()) {
             return SearchResults()
@@ -35,7 +36,7 @@ interface HistoryEntryWithImageDao {
             .replace("%", "\\%").replace("_", "\\_")
 
         val entries = findEntriesBySearchTerm("%$normalizedQuery%")
-                .filter { StringUtil.fromHtml(it.displayTitle).contains(normalizedQuery, true) }
+                .filter { wikiSite.languageCode == it.lang && StringUtil.fromHtml(it.displayTitle).contains(normalizedQuery, true) }
 
         return if (entries.isEmpty()) SearchResults()
         else SearchResults(entries.take(3).map { SearchResult(toHistoryEntry(it).title, SearchResult.SearchResultType.HISTORY) }.toMutableList())

--- a/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
@@ -143,7 +143,7 @@ interface ReadingListPageDao {
         )
     }
 
-    fun findPageForSearchQueryInAnyList(searchQuery: String): SearchResults {
+    fun findPageForSearchQueryInAnyList(wikiSite: WikiSite, searchQuery: String): SearchResults {
         var normalizedQuery = StringUtils.stripAccents(searchQuery)
         if (normalizedQuery.isEmpty()) {
             return SearchResults()
@@ -152,7 +152,7 @@ interface ReadingListPageDao {
             .replace("%", "\\%").replace("_", "\\_")
 
         val pages = findPageBySearchTerm("%$normalizedQuery%")
-                .filter { StringUtil.fromHtml(it.accentInvariantTitle).contains(normalizedQuery, true) }
+                .filter { wikiSite.languageCode == it.lang && StringUtil.fromHtml(it.accentInvariantTitle).contains(normalizedQuery, true) }
 
         return if (pages.isEmpty()) SearchResults()
         else SearchResults(pages.take(2).map {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
@@ -59,11 +59,11 @@ class SearchResultsViewModel : ViewModel() {
                     if (searchTerm.length >= 2 && invokeSource != Constants.InvokeSource.PLACES) {
                         withContext(Dispatchers.IO) {
                             listOf(async {
-                                getSearchResultsFromTabs(searchTerm)
+                                getSearchResultsFromTabs(wikiSite, searchTerm)
                             }, async {
-                                AppDatabase.instance.historyEntryWithImageDao().findHistoryItem(searchTerm)
+                                AppDatabase.instance.historyEntryWithImageDao().findHistoryItem(wikiSite, searchTerm)
                             }, async {
-                                AppDatabase.instance.readingListPageDao().findPageForSearchQueryInAnyList(searchTerm)
+                                AppDatabase.instance.readingListPageDao().findPageForSearchQueryInAnyList(wikiSite, searchTerm)
                             }).awaitAll().forEach {
                                 resultList.addAll(it.results.take(1))
                             }
@@ -125,10 +125,10 @@ class SearchResultsViewModel : ViewModel() {
             return null
         }
 
-        private fun getSearchResultsFromTabs(searchTerm: String): SearchResults {
+        private fun getSearchResultsFromTabs(wikiSite: WikiSite, searchTerm: String): SearchResults {
             WikipediaApp.instance.tabList.forEach { tab ->
                 tab.backStackPositionTitle?.let {
-                    if (StringUtil.fromHtml(it.displayText).contains(searchTerm, true)) {
+                    if (wikiSite == it.wikiSite && StringUtil.fromHtml(it.displayText).contains(searchTerm, true)) {
                         return SearchResults(mutableListOf(SearchResult(it, SearchResult.SearchResultType.TAB_LIST)))
                     }
                 }


### PR DESCRIPTION
### What does this do?
This PR checks the language code from the current tab and searches for the local results.


**Phabricator:**
https://phabricator.wikimedia.org/T379777