### PR TITLE
Wikigames: Hide next question button after clicking on it

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -101,6 +101,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
 
         binding.nextQuestionText.setOnClickListener {
             viewModel.submitCurrentResponse(0)
+            binding.nextQuestionText.isVisible = false
         }
 
         binding.root.setOnApplyWindowInsetsListener { view, windowInsets ->


### PR DESCRIPTION
### What does this do?
This fixes the issue when you click on the "Next question" button rapidly, the content and the behavior of the game go wrong.

https://github.com/user-attachments/assets/edfdb768-1710-43fc-a018-9321a8be5407


