### PR TITLE
Dismiss the bottomsheet onPaused to avoid possible crash

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameArticleBottomSheet.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameArticleBottomSheet.kt
@@ -31,7 +31,6 @@ import org.wikipedia.util.ShareUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.views.AllowSnackbarOverBottomSheet
 import org.wikipedia.views.ViewUtil
-import kotlin.getValue
 
 class OnThisDayGameArticleBottomSheet : ExtendedBottomSheetDialogFragment(), AllowSnackbarOverBottomSheet {
     fun interface Callback {
@@ -46,6 +45,11 @@ class OnThisDayGameArticleBottomSheet : ExtendedBottomSheetDialogFragment(), All
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         pageSummary = requireArguments().parcelable<PageSummary>(Constants.ARG_TITLE)!!
+    }
+
+    override fun onPause() {
+        super.onPause()
+        dismiss()
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
### What does this do?
A temporary solution for a crash when the "Don't keep activities" is on and the bottomsheet is opened, and a switch between the system app chooser will lead to a crash.
