### PR TITLE
Wikigames: long-press to see the full text of the current card

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -63,7 +63,6 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
 
     private val cardAnimatorSetIn = AnimatorSet()
     private val cardAnimatorSetOut = AnimatorSet()
-    private var cardLongPressed = false
     private lateinit var mediaPlayer: MediaPlayer
 
     @SuppressLint("SourceLockedOrientationActivity", "ClickableViewAccessibility")
@@ -104,11 +103,11 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         // Add long-press listeners to the cards
         binding.questionCard1.setOnLongClickListener {
             showFullCardText(binding.questionText1, binding.questionThumbnail1, true)
-            cardLongPressed = true
+            binding.questionText1.tag = true
             true
         }
         binding.questionCard1.setOnTouchListener { v, event ->
-            if (event.action == MotionEvent.ACTION_UP && cardLongPressed) {
+            if (event.action == MotionEvent.ACTION_UP && (binding.questionText1.tag as? Boolean) == true) {
                 showFullCardText(binding.questionText1, binding.questionThumbnail1, false)
             }
             false
@@ -116,11 +115,11 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
 
         binding.questionCard2.setOnLongClickListener {
             showFullCardText(binding.questionText2, binding.questionThumbnail2, true)
-            cardLongPressed = true
+            binding.questionText2.tag = true
             true
         }
         binding.questionCard2.setOnTouchListener { v, event ->
-            if (event.action == MotionEvent.ACTION_UP && cardLongPressed) {
+            if (event.action == MotionEvent.ACTION_UP && (binding.questionText2.tag as? Boolean) == true) {
                 showFullCardText(binding.questionText2, binding.questionThumbnail2, false)
             }
             false
@@ -469,9 +468,8 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
     }
 
     private fun showFullCardText(textView: TextView, imageView: ImageView, showFullText: Boolean) {
-        imageView.isVisible = !showFullText && !(imageView.tag as Boolean)
+        imageView.isVisible = !showFullText && (imageView.tag as? Boolean) == false
         layoutTextViewForEllipsize(textView, !showFullText)
-        cardLongPressed = showFullText
     }
 
     private fun setCorrectIcon(view: ImageView) {

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -15,6 +15,7 @@ import android.os.Bundle
 import android.text.format.DateFormat
 import android.view.Menu
 import android.view.MenuItem
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateInterpolator
@@ -64,7 +65,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
     private val cardAnimatorSetOut = AnimatorSet()
     private lateinit var mediaPlayer: MediaPlayer
 
-    @SuppressLint("SourceLockedOrientationActivity")
+    @SuppressLint("SourceLockedOrientationActivity", "ClickableViewAccessibility")
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityOnThisDayGameBinding.inflate(layoutInflater)
@@ -97,6 +98,29 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
             if (viewModel.gameState.value is OnThisDayGameViewModel.CurrentQuestion || viewModel.gameState.value is OnThisDayGameViewModel.GameStarted) {
                 viewModel.submitCurrentResponse((it.tag as OnThisDay.Event).year)
             }
+        }
+
+        // Add long-press listeners to the cards
+        binding.questionCard1.setOnLongClickListener {
+            showFullCardText(binding.questionText1, binding.questionThumbnail1)
+            true
+        }
+        binding.questionCard1.setOnTouchListener { v, event ->
+            if (event.action == MotionEvent.ACTION_UP) {
+                hideFullCardText(binding.questionText1, binding.questionThumbnail1)
+            }
+            false
+        }
+
+        binding.questionCard2.setOnLongClickListener {
+            showFullCardText(binding.questionText2, binding.questionThumbnail2)
+            true
+        }
+        binding.questionCard2.setOnTouchListener { v, event ->
+            if (event.action == MotionEvent.ACTION_UP) {
+                hideFullCardText(binding.questionText2, binding.questionThumbnail2)
+            }
+            false
         }
 
         binding.nextQuestionText.setOnClickListener {
@@ -449,6 +473,17 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         view.setImageResource(R.drawable.ic_cancel_24px)
         view.imageTintList = ResourceUtil.getThemedColorStateList(this, R.attr.destructive_color)
         view.isVisible = true
+    }
+
+
+    private fun showFullCardText(textView: TextView, imageView: ImageView) {
+        imageView.isVisible = false
+        textView.maxLines = Int.MAX_VALUE
+    }
+
+    private fun hideFullCardText(textView: TextView, imageView: ImageView) {
+        imageView.isVisible = true
+        layoutTextViewForEllipsize(textView)
     }
 
     private fun enqueueGoNext(gameState: OnThisDayGameViewModel.GameState) {

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -63,6 +63,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
 
     private val cardAnimatorSetIn = AnimatorSet()
     private val cardAnimatorSetOut = AnimatorSet()
+    private var cardLongPressed = false
     private lateinit var mediaPlayer: MediaPlayer
 
     @SuppressLint("SourceLockedOrientationActivity", "ClickableViewAccessibility")
@@ -102,23 +103,25 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
 
         // Add long-press listeners to the cards
         binding.questionCard1.setOnLongClickListener {
-            showFullCardText(binding.questionText1, binding.questionThumbnail1)
+            showFullCardText(binding.questionText1, binding.questionThumbnail1, true)
+            cardLongPressed = true
             true
         }
         binding.questionCard1.setOnTouchListener { v, event ->
-            if (event.action == MotionEvent.ACTION_UP) {
-                hideFullCardText(binding.questionText1, binding.questionThumbnail1)
+            if (event.action == MotionEvent.ACTION_UP && cardLongPressed) {
+                showFullCardText(binding.questionText1, binding.questionThumbnail1, false)
             }
             false
         }
 
         binding.questionCard2.setOnLongClickListener {
-            showFullCardText(binding.questionText2, binding.questionThumbnail2)
+            showFullCardText(binding.questionText2, binding.questionThumbnail2, true)
+            cardLongPressed = true
             true
         }
         binding.questionCard2.setOnTouchListener { v, event ->
-            if (event.action == MotionEvent.ACTION_UP) {
-                hideFullCardText(binding.questionText2, binding.questionThumbnail2)
+            if (event.action == MotionEvent.ACTION_UP && cardLongPressed) {
+                showFullCardText(binding.questionText2, binding.questionThumbnail2, false)
             }
             false
         }
@@ -318,6 +321,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         layoutTextViewForEllipsize(binding.questionText1)
 
         val thumbnailUrl1 = viewModel.getThumbnailUrlForEvent(event1)
+        binding.questionThumbnail1.tag = thumbnailUrl1.isNullOrEmpty()
         if (thumbnailUrl1.isNullOrEmpty()) {
             binding.questionThumbnail1.isVisible = false
         } else {
@@ -331,6 +335,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         layoutTextViewForEllipsize(binding.questionText2)
 
         val thumbnailUrl2 = viewModel.getThumbnailUrlForEvent(event2)
+        binding.questionThumbnail2.tag = thumbnailUrl2.isNullOrEmpty()
         if (thumbnailUrl2.isNullOrEmpty()) {
             binding.questionThumbnail2.isVisible = false
         } else {
@@ -451,16 +456,22 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         }
     }
 
-    private fun layoutTextViewForEllipsize(textView: TextView) {
+    private fun layoutTextViewForEllipsize(textView: TextView, ellipsize: Boolean = true) {
         textView.maxLines = Int.MAX_VALUE
         textView.post {
-            if (!isDestroyed) {
+            if (!isDestroyed && ellipsize) {
                 // this seems to be the only way to properly ellipsize the text in its layout.
                 if (textView.lineHeight > 0) {
                     textView.maxLines = (textView.measuredHeight / textView.lineHeight)
                 }
             }
         }
+    }
+
+    private fun showFullCardText(textView: TextView, imageView: ImageView, showFullText: Boolean) {
+        imageView.isVisible = !showFullText && !(imageView.tag as Boolean)
+        layoutTextViewForEllipsize(textView, !showFullText)
+        cardLongPressed = showFullText
     }
 
     private fun setCorrectIcon(view: ImageView) {
@@ -473,17 +484,6 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         view.setImageResource(R.drawable.ic_cancel_24px)
         view.imageTintList = ResourceUtil.getThemedColorStateList(this, R.attr.destructive_color)
         view.isVisible = true
-    }
-
-
-    private fun showFullCardText(textView: TextView, imageView: ImageView) {
-        imageView.isVisible = false
-        textView.maxLines = Int.MAX_VALUE
-    }
-
-    private fun hideFullCardText(textView: TextView, imageView: ImageView) {
-        imageView.isVisible = true
-        layoutTextViewForEllipsize(textView)
     }
 
     private fun enqueueGoNext(gameState: OnThisDayGameViewModel.GameState) {


### PR DESCRIPTION
### What does this do?
We have a discussion on Slack about where to improve the readability of the game's question cards, this introduces a long-press action to show the full text of the card. 


https://phabricator.wikimedia.org/T387535
