### PR TITLE
Possibly (?) resolve obscure lateinit UninitializedProperty crashes.

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -79,6 +79,11 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (DeviceUtil.assertAppContext(this, true)) {
+            finish()
+            return
+        }
+
         setTheme()
         removeSplashBackground()
 

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -79,7 +79,7 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (DeviceUtil.assertAppContext(this, true)) {
+        if (!DeviceUtil.assertAppContext(this, true)) {
             finish()
             return
         }

--- a/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/SingleFragmentActivity.kt
@@ -5,6 +5,7 @@ import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import org.wikipedia.R
+import org.wikipedia.util.DeviceUtil
 
 /**
  * Boilerplate for a FragmentActivity containing a single stack of Fragments.
@@ -14,6 +15,10 @@ abstract class SingleFragmentActivity<T : Fragment> : BaseActivity() {
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (!DeviceUtil.assertAppContext(this)) {
+            return
+        }
+
         inflateAndSetContentView()
 
         val currentFragment: T? = supportFragmentManager.findFragmentById(R.id.fragment_container) as T?

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -21,6 +21,7 @@ import org.wikipedia.navtab.NavTab
 import org.wikipedia.onboarding.InitialOnboardingActivity
 import org.wikipedia.page.PageActivity
 import org.wikipedia.settings.Prefs
+import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ResourceUtil
@@ -44,6 +45,9 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (!DeviceUtil.assertAppContext(this)) {
+            return
+        }
 
         setImageZoomHelper()
         if (Prefs.isInitialOnboardingEnabled && savedInstanceState == null &&

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
@@ -30,6 +30,7 @@ import org.wikipedia.page.PageTitle
 import org.wikipedia.push.WikipediaFirebaseMessagingService
 import org.wikipedia.settings.Prefs
 import org.wikipedia.talk.NotificationDirectReplyHelper
+import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.util.log.L
 import java.util.concurrent.TimeUnit
@@ -37,6 +38,10 @@ import java.util.concurrent.TimeUnit
 class NotificationPollBroadcastReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
+        if (!DeviceUtil.assertAppContext(context, true)) {
+            return
+        }
+
         when {
             Intent.ACTION_BOOT_COMPLETED == intent.action -> {
                 // To test the BOOT_COMPLETED intent:

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -95,10 +95,6 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
         CURRENT_TAB, CURRENT_TAB_SQUASH, NEW_TAB_BACKGROUND, NEW_TAB_FOREGROUND, EXISTING_TAB
     }
 
-    init {
-        L.d("yes")
-    }
-
     lateinit var binding: ActivityPageBinding
     private lateinit var toolbarHideHandler: ViewHideHandler
     private lateinit var pageFragment: PageFragment

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -95,10 +95,14 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
         CURRENT_TAB, CURRENT_TAB_SQUASH, NEW_TAB_BACKGROUND, NEW_TAB_FOREGROUND, EXISTING_TAB
     }
 
+    init {
+        L.d("yes")
+    }
+
     lateinit var binding: ActivityPageBinding
     private lateinit var toolbarHideHandler: ViewHideHandler
     private lateinit var pageFragment: PageFragment
-    private var app = WikipediaApp.instance
+    private lateinit var app: WikipediaApp
     private var hasTransitionAnimation = false
     private var wasTransitionShown = false
     private val currentActionModes = mutableSetOf<ActionMode>()
@@ -182,6 +186,11 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (!DeviceUtil.assertAppContext(this)) {
+            return
+        }
+
+        app = WikipediaApp.instance
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false)
         binding = ActivityPageBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/java/org/wikipedia/util/DeviceUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DeviceUtil.kt
@@ -7,6 +7,7 @@ import android.content.res.Resources
 import android.graphics.Color
 import android.net.ConnectivityManager
 import android.os.Build
+import android.os.Handler
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
 import android.view.View
@@ -21,6 +22,7 @@ import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.appbar.MaterialToolbar
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
+import kotlin.system.exitProcess
 
 object DeviceUtil {
     private inline val Window.insetsControllerCompat
@@ -72,6 +74,28 @@ object DeviceUtil {
                 it.setOnContextClickListener { obj -> obj.performLongClick() }
             }
         }
+    }
+
+    /**
+     * https://issuetracker.google.com/issues/160946170
+     * There's a platform-specific issue where the app gets launched in "Restricted" mode during a
+     * backup operation; And if the app crashes during that operation, it remains in Restricted
+     * mode in subsequent launches, including subsequent user-requested launches. While in this
+     * mode, the system doesn't actually launch our custom subclassed WikipediaApp object, but
+     * instead uses a vanilla Application object, which will cause issues when other classes try
+     * to access static data from the WikipediaApp object.
+     *
+     * This is a workaround that explicitly terminates the app process if it's running in Restricted
+     * mode, to be used sparingly from places where this crash is most likely to occur.
+     */
+    fun assertAppContext(context: Context, terminateOnFail: Boolean = false): Boolean {
+        if (context.applicationContext !is WikipediaApp) {
+            if (terminateOnFail) {
+                Handler(context.mainLooper).post { exitProcess(0) }
+            }
+            return false
+        }
+        return true
     }
 
     val isOnWiFi: Boolean


### PR DESCRIPTION
This might actually fix the elusive crashes we've seen relating to uninitialized `lateinit` instance variables coming from `WikipediaApp$Companion.getInstance`.
There is a platform-specific bug related to launching the app in "restricted" mode during device backup operations. I found a Google issue that provides a clue for why this may be happening:
https://issuetracker.google.com/u/0/issues/160946170

See comments in the code for more details.