### PR TITLE
Follow-up 2: Keep Game dialog language logic a bit more self-contained.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
@@ -135,7 +135,7 @@ class FeedFragment : Fragment(), BackPressedHandler {
     override fun onResume() {
         super.onResume()
         maybeShowRegionalLanguageVariantDialog()
-        OnThisDayGameOnboardingFragment.maybeShowOnThisDayGameDialog(requireActivity())
+        OnThisDayGameOnboardingFragment.maybeShowOnThisDayGameDialog(requireActivity(), InvokeSource.FEED)
 
         // Explicitly invalidate the feed adapter, since it occasionally crashes the StaggeredGridLayout
         // on certain devices.

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameOnboardingFragment.kt
@@ -17,6 +17,7 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.WikiGamesEvent
 import org.wikipedia.databinding.FragmentOnThisDayGameOnboardingBinding
+import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DateUtil
 import org.wikipedia.util.FeedbackUtil
@@ -53,9 +54,12 @@ class OnThisDayGameOnboardingFragment : Fragment() {
             }
         }
 
-        fun maybeShowOnThisDayGameDialog(activity: Activity) {
+        fun maybeShowOnThisDayGameDialog(activity: Activity, invokeSource: Constants.InvokeSource, articleWikiSite: WikiSite = WikipediaApp.instance.wikiSite) {
             val wikiSite = WikipediaApp.instance.wikiSite
-            if (!Prefs.otdEntryDialogShown && OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(wikiSite.languageCode)) {
+            // Both of the primary language and the article language should be in the supported languages list.
+            if (!Prefs.otdEntryDialogShown &&
+                OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(wikiSite.languageCode) &&
+                OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(articleWikiSite.languageCode)) {
                 Prefs.otdEntryDialogShown = true
                 WikiGamesEvent.submit("impression", "game_modal")
                 val dialogView = activity.layoutInflater.inflate(R.layout.dialog_on_this_day_game, null)
@@ -65,7 +69,7 @@ class OnThisDayGameOnboardingFragment : Fragment() {
                     .show()
                 dialogView.findViewById<Button>(R.id.playGameButton).setOnClickListener {
                     WikiGamesEvent.submit("enter_click", "game_modal")
-                    activity.startActivityForResult(OnThisDayGameActivity.newIntent(activity, InvokeSource.PAGE_ACTIVITY, wikiSite), 0)
+                    activity.startActivityForResult(OnThisDayGameActivity.newIntent(activity, invokeSource, wikiSite), 0)
                     dialog.dismiss()
                 }
                 dialogView.findViewById<ImageView>(R.id.closeButton).setOnClickListener {

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -74,7 +74,6 @@ import org.wikipedia.diff.ArticleEditDetailsActivity
 import org.wikipedia.edit.EditHandler
 import org.wikipedia.gallery.GalleryActivity
 import org.wikipedia.games.onthisday.OnThisDayGameOnboardingFragment
-import org.wikipedia.games.onthisday.OnThisDayGameViewModel
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.login.LoginActivity
@@ -693,13 +692,6 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         }
     }
 
-    private fun maybeShowOnThisDayGameDialog() {
-        // Both of the primary language and the article language should be in the supported languages list.
-        if (OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(model.title?.wikiSite?.languageCode)) {
-            OnThisDayGameOnboardingFragment.maybeShowOnThisDayGameDialog(requireActivity())
-        }
-    }
-
     private fun showFindReferenceInPage(referenceAnchor: String,
                                         backLinksList: List<String?>,
                                         referenceText: String) {
@@ -938,7 +930,8 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
             webView.visibility = View.VISIBLE
         }
         maybeShowAnnouncement()
-        maybeShowOnThisDayGameDialog()
+        OnThisDayGameOnboardingFragment.maybeShowOnThisDayGameDialog(requireActivity(),
+            InvokeSource.PAGE_ACTIVITY, model.title?.wikiSite ?: WikipediaApp.instance.wikiSite)
 
         bridge.onMetadataReady()
         // Explicitly set the top margin (even though it might have already been set in the setup


### PR DESCRIPTION
* This moves the logic of checking whether to show the Game dialog entirely into the Game class, instead of exposing it in PageFragment.
* This also adds an InvokeSource parameter into the `maybeShowOnThisDayGameDialog()` function, since it can be called from PageActivity or from the Feed, but it was hard-coding InvokeSource.PageActivity when actually launching the game.