### PR TITLE
Fix: do not show CSS styles file page description

### DIFF
--- a/app/src/main/java/org/wikipedia/commons/FilePageView.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageView.kt
@@ -157,7 +157,7 @@ class FilePageView constructor(context: Context, attrs: AttributeSet? = null) : 
         if (!detail.isNullOrEmpty()) {
             val view = ImageDetailView(context)
             view.binding.titleText.text = titleString
-            view.binding.contentText.text = StringUtil.fromHtml(detail).trim()
+            view.binding.contentText.text = StringUtil.fromHtml(StringUtil.removeStyleTags(detail)).trim()
             if (!externalLink.isNullOrEmpty()) {
                 view.binding.contentText.setTextColor(ResourceUtil.getThemedColor(context, R.attr.progressive_color))
                 view.binding.contentText.setTextIsSelectable(false)


### PR DESCRIPTION
### What does this do?
This PR adds the function that removes the `<style>` tags from the source in the `FilePageFragment`.

Steps to reproduce:
1. Go to the "Picture of the day" on March 4, 2025 (`Senador Tancredo Neves.jpg`)
2. Scroll down to see the `Author` section.
