### PR TITLE
Fix: remove HTML tags from the Categories screen title

### DIFF
--- a/app/src/main/java/org/wikipedia/categories/CategoryActivity.kt
+++ b/app/src/main/java/org/wikipedia/categories/CategoryActivity.kt
@@ -62,7 +62,7 @@ class CategoryActivity : BaseActivity() {
         setStatusBarColor(ResourceUtil.getThemedColor(this, android.R.attr.windowBackground))
         setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        supportActionBar?.title = viewModel.pageTitle.displayText
+        supportActionBar?.title = StringUtil.removeHTMLTags(viewModel.pageTitle.displayText)
 
         binding.categoryRecycler.layoutManager = LinearLayoutManager(this)
         binding.categoryRecycler.addItemDecoration(DrawableItemDecoration(this, R.attr.list_divider, drawStart = false, drawEnd = false))


### PR DESCRIPTION
### What does this do?
Remove the HTML tags from the toolbar title.

Steps to reproduce:
1. Go to `James Madison` in `enwiki`.
2. Click on `Categories` and select `The Federalist Papers`