### PR TITLE
compose base theme fix

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
+++ b/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
@@ -1,24 +1,24 @@
 package org.wikipedia.compose.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-
-enum class WikipediaThemeType {
-    SYSTEM, LIGHT, DARK, BLACK, SEPIA
-}
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import org.wikipedia.WikipediaApp
+import org.wikipedia.theme.Theme
 
 @Composable
 fun BaseTheme(
-    wikipediaThemeType: WikipediaThemeType = WikipediaThemeType.SYSTEM,
+    currentTheme: Theme = WikipediaApp.instance.currentTheme,
     content: @Composable () -> Unit
 ) {
-    val wikipediaColorSystem = when (wikipediaThemeType) {
-        WikipediaThemeType.LIGHT -> LightColors
-        WikipediaThemeType.DARK -> DarkColors
-        WikipediaThemeType.BLACK -> BlackColors
-        WikipediaThemeType.SEPIA -> SepiaColors
-        WikipediaThemeType.SYSTEM -> if (isSystemInDarkTheme()) DarkColors else LightColors
+    val appTheme by remember { mutableStateOf(currentTheme) }
+    val wikipediaColorSystem = when (appTheme) {
+        Theme.LIGHT -> LightColors
+        Theme.DARK -> DarkColors
+        Theme.BLACK -> BlackColors
+        Theme.SEPIA -> SepiaColors
     }
 
     CompositionLocalProvider(


### PR DESCRIPTION
### What does this do?
The theme was only switching between light and dark system theme. This update resolves the issue where the compose base theme wasn't properly updating when users switched between themes. 
