### PR TITLE
T387803 - Build Jetpack Compose NavHost and first YiR screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -275,6 +275,7 @@ dependencies {
     debugImplementation(libs.compose.ui.tooling)
     implementation(libs.compose.activity)
     implementation(libs.compose.view.model)
+    implementation(libs.androidx.navigation.compose)
 
     // Compose Test Library
     androidTestImplementation(libs.compose.test)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -375,6 +375,9 @@
         <activity
             android:name=".games.onthisday.OnThisDayGameActivity"/>
 
+        <activity
+            android:name=".yearinreview.YearInReviewActivity" android:exported="true"/>
+
         <provider
             android:name=".WikipediaFileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -376,7 +376,7 @@
             android:name=".games.onthisday.OnThisDayGameActivity"/>
 
         <activity
-            android:name=".yearinreview.YearInReviewActivity" android:exported="true"/>
+            android:name=".yearinreview.YearInReviewActivity"/>
 
         <provider
             android:name=".WikipediaFileProvider"

--- a/app/src/main/java/org/wikipedia/yearinreview/TestScreen.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/TestScreen.kt
@@ -11,15 +11,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 
 @Composable
-fun TestScreen(){
+fun TestScreen() {
+
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center
-    ){
+    ) {
         Text(
             text = "Hello World",
             fontSize = 30.sp,
-            modifier = Modifier.align(alignment=Alignment.CenterHorizontally)
+            modifier = Modifier.align(alignment = Alignment.CenterHorizontally)
         )
     }
 }

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import org.wikipedia.compose.theme.BaseTheme
 
 class YearInReviewActivity : ComponentActivity() {
 
@@ -19,7 +20,7 @@ class YearInReviewActivity : ComponentActivity() {
                 navController = navigationController, startDestination = "testscreen"
             ) {
                 composable("testscreen") {
-                    TestScreen()
+                    BaseTheme(content = { TestScreen() })
                 }
             }
         }

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
@@ -18,7 +18,7 @@ class YearInReviewActivity : ComponentActivity() {
             NavHost(
                 navController = navigationController, startDestination = "testscreen"
             ) {
-                composable("testscreen"){
+                composable("testscreen") {
                     TestScreen()
                 }
             }

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
@@ -1,0 +1,27 @@
+package org.wikipedia.yearinreview
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+class YearInReviewActivity: ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent{
+
+            val navigationController = rememberNavController()
+
+            NavHost(
+                navController = navigationController, startDestination = "testscreen"
+            ){
+                composable("testscreen"){
+                    TestScreen()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
@@ -7,17 +7,17 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 
-class YearInReviewActivity: ComponentActivity() {
+class YearInReviewActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent{
+        setContent {
 
             val navigationController = rememberNavController()
 
             NavHost(
                 navController = navigationController, startDestination = "testscreen"
-            ){
+            ) {
                 composable("testscreen"){
                     TestScreen()
                 }

--- a/app/src/main/java/org/wikipedia/yearinreview/testscreen.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/testscreen.kt
@@ -1,0 +1,31 @@
+package org.wikipedia.yearinreview
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun TestScreen(){
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center
+    ){
+        Text(
+            text = "Hello World",
+            fontSize = 30.sp,
+            modifier = Modifier.align(alignment=Alignment.CenterHorizontally)
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewTestScreen() {
+    TestScreen()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ material = "1.12.0"
 metricsVersion = "2.9"
 mlKitVersion = "17.0.6"
 mockitoVersion = "5.2.0"
+navigationCompose = "2.8.8"
 okHttpVersion = "4.12.0"
 orchestrator = "1.5.1"
 pagingRuntimeKtx = "3.3.6"
@@ -55,6 +56,7 @@ android-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "androidSd
 android-plugin-annotation-v9 = { module = "org.maplibre.gl:android-plugin-annotation-v9", version.ref = "androidPluginAnnotationV9" }
 androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espressoVersion" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-orchestrator = { module = "androidx.test:orchestrator", version.ref = "orchestrator" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomVersion" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomVersion" }


### PR DESCRIPTION
### What does this do?
This adds the YearInReviewActivity with Jetpack Compose navigation and a simple test screen. Dependencies and manifest are updated to preview the activity.

### Why is this needed?
Supports Year In Review EPIC T387034

**Phabricator:**
https://phabricator.wikimedia.org/T387803
https://phabricator.wikimedia.org/T387034
