### PR TITLE
Update EditAttemptStep event to include wiki parameter.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EditAttemptStepEvent.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EditAttemptStepEvent.kt
@@ -46,7 +46,7 @@ class EditAttemptStepEvent(private val event: EditAttemptStepInteractionEvent) :
                 WikipediaApp.instance.appInstallID, "", editorInterface,
                 INTEGRATION_ID, "", WikipediaApp.instance.getString(R.string.device_type).lowercase(), 0, getUserIdForWikiSite(pageTitle.wikiSite),
                 !AccountUtil.isLoggedIn, AccountUtil.isTemporaryAccount, 1, pageTitle.prefixedText,
-                pageTitle.namespace().code())))
+                pageTitle.namespace().code(), pageTitle.wikiSite.dbName())))
         }
 
         private fun getUserIdForWikiSite(wikiSite: WikiSite): Int {
@@ -70,4 +70,5 @@ class EditAttemptStepInteractionEvent(private val action: String,
                                       private val user_is_temp: Boolean,
                                       private val version: Int,
                                       private val page_title: String,
-                                      private val page_ns: Int)
+                                      private val page_ns: Int,
+                                      private val wiki: String)


### PR DESCRIPTION
This whole time we weren't sending the `wiki` parameter of the `EditAttemptStep` events, which is often important for analytics purposes.

https://phabricator.wikimedia.org/T388082
