### PR TITLE
Fix: do not show empty definitions in the WiktionaryDialog

### DIFF
--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
@@ -85,8 +85,11 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
     private fun layOutUsage(currentUsage: RbDefinition.Usage): View {
         val usageBinding = ItemWiktionaryDefinitionsListBinding.inflate(layoutInflater, binding.root, false)
         usageBinding.wiktionaryPartOfSpeech.text = currentUsage.partOfSpeech
-        for (i in currentUsage.definitions.indices) {
-            usageBinding.listWiktionaryDefinitionsWithExamples.addView(layOutDefinitionWithExamples(currentUsage.definitions[i], i + 1))
+        var index = 0
+        currentUsage.definitions.forEach {
+            if (it.definition.isNotEmpty()) {
+                usageBinding.listWiktionaryDefinitionsWithExamples.addView(layOutDefinitionWithExamples(it, ++index))
+            }
         }
         return usageBinding.root
     }


### PR DESCRIPTION
### What does this do?
https://en.wiktionary.org/api/rest_v1/page/definition/Australia
 The definition of `Australia` contains some empty definitions, this PR updates the logic to filter the empty ones.

<img src="https://github.com/user-attachments/assets/d25bd332-e60f-45a4-a77e-8d545b941ae9" width="300">
<img src="https://github.com/user-attachments/assets/bd45a469-4bdc-4648-b518-0933efc22f15" width="300">


