### PR TITLE
Save additional donation info locally.

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
@@ -83,7 +83,11 @@ class GooglePayActivity : BaseActivity() {
                             }
                             is GooglePayViewModel.DonateSuccess -> {
                                 DonorExperienceEvent.logAction("impression", "gpay_processed", campaignId = intent.getStringExtra(DonateDialog.ARG_CAMPAIGN_ID).orEmpty())
-                                CampaignCollection.addDonationResult()
+                                CampaignCollection.addDonationResult(
+                                    amount = viewModel.finalAmount,
+                                    currency = viewModel.currencyCode,
+                                    recurring = binding.checkBoxRecurring.isChecked
+                                )
                                 setResult(RESULT_OK)
                                 finish()
                             }

--- a/app/src/main/java/org/wikipedia/dataclient/donate/CampaignCollection.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/donate/CampaignCollection.kt
@@ -48,8 +48,10 @@ object CampaignCollection {
         return "${WikipediaApp.instance.appOrSystemLanguageCode}${GeoUtil.geoIPCountry}_${campaignId}_Android"
     }
 
-    fun addDonationResult(fromWeb: Boolean = false) {
-        Prefs.donationResults = Prefs.donationResults.plus(DonationResult(dateTime = LocalDateTime.now().toString(), fromWeb = fromWeb))
+    fun addDonationResult(fromWeb: Boolean = false, amount: Float, currency: String, recurring: Boolean) {
+        Prefs.donationResults = Prefs.donationResults.plus(DonationResult(
+            LocalDateTime.now().toString(), fromWeb, amount, currency, recurring
+        ))
     }
 
     @Serializable

--- a/app/src/main/java/org/wikipedia/donate/DonationResult.kt
+++ b/app/src/main/java/org/wikipedia/donate/DonationResult.kt
@@ -5,5 +5,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 class DonationResult(
     val dateTime: String = "",
-    val fromWeb: Boolean = false
+    val fromWeb: Boolean = false,
+    val amount: Float = 0f,
+    val currency: String = "",
+    val recurring: Boolean = false
 )

--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -529,7 +529,10 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
                     // ...Except if the URL came as a result of a successful donation, in which case
                     // treat it differently:
                     if (language == "thankyou" && uri.getQueryParameter("order_id") != null) {
-                        CampaignCollection.addDonationResult(fromWeb = true)
+                        CampaignCollection.addDonationResult(fromWeb = true,
+                            amount = (uri.getQueryParameter("amount"))?.toFloat() ?: 0f,
+                            currency = uri.getQueryParameter("currency") ?: "",
+                            recurring = uri.getQueryParameter("recurring") == "1")
                         // Check if the donation started from the app, but completed via web, in which case
                         // show it in a SingleWebViewActivity.
                         val campaign = uri.getQueryParameter("wmf_campaign")


### PR DESCRIPTION
For future Year-in-review purposes, we would like to persist more data about the user's donation activity locally.
Whenever a donation is made, we will also persist the amount, currency, and whether the donation is recurring.
(the donation history can still be cleared by the user anytime, as before.)

https://phabricator.wikimedia.org/T388262
