### PR TITLE
Math Images are now white (have full opacity) when image dimming is turned on.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -161,6 +161,14 @@ object JavaScriptActionHandler {
                 "})"
     }
 
+    fun handleMathImageDimming(): String {
+        return "(function() {" +
+                "let style = document.createElement('style');" +
+                "style.innerHTML = 'img.mwe-math-fallback-image-inline { opacity: 1; } ';" +
+                "document.head.appendChild(style);" +
+                "})();"
+    }
+
     fun appendReadMode(model: PageViewModel): String {
         if (model.page == null) {
             return ""

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -938,6 +938,9 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         // handler), since the page metadata might have altered the lead image display state.
         bridge.execute(JavaScriptActionHandler.setTopMargin(leadImagesHandler.topMargin))
         bridge.execute(JavaScriptActionHandler.setFooter(model))
+        if (Prefs.dimDarkModeImages) {
+            bridge.execute(JavaScriptActionHandler.handleMathImageDimming())
+        }
     }
 
     fun openInNewBackgroundTab(title: PageTitle, entry: HistoryEntry) {


### PR DESCRIPTION
Bug: T381210

### What does this do?
Math images inside of a wikipedia page are just the normal brightness instead of the dimmed amount when image dimming is selected.

### Why is this needed?
It was hard to see math images in dark mode with image dimming turned on because the math images weren't excluded from the dimming effect.

**Phabricator:**
https://phabricator.wikimedia.org/T381210
