### PR TITLE
Correctly calculate size of initial revision of an article.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/page/edithistory/EditHistoryListViewModel.kt
@@ -57,7 +57,11 @@ class EditHistoryListViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
         val userEditsOnly = Prefs.editHistoryFilterType == EditCount.EDIT_TYPE_EDITORS
 
         pagingData.insertSeparators { before, after ->
-            if (before != null && after != null) { before.diffSize = before.size - after.size }
+            if (before != null && after != null) {
+                before.diffSize = before.size - after.size
+            } else if (before != null) {
+                before.diffSize = before.size
+            }
             null
         }.filter {
             when {


### PR DESCRIPTION
Because of the way we were postprocessing the PagingData of the edit history, the initial revision of an article was getting a `diffSize` of zero, because the `diffSize` was simply never set.

https://phabricator.wikimedia.org/T388926
