### PR TITLE
Temp accounts: explicitly set expiry to 90 days.

### DIFF
--- a/app/src/main/java/org/wikipedia/auth/AccountUtil.kt
+++ b/app/src/main/java/org/wikipedia/auth/AccountUtil.kt
@@ -16,11 +16,13 @@ import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.UriUtil
 import org.wikipedia.util.log.L.d
 import org.wikipedia.util.log.L.logRemoteErrorIfProd
-import java.util.*
-import java.util.concurrent.TimeUnit
+import java.time.LocalDate
+import java.util.Collections
+import kotlin.math.max
 
 object AccountUtil {
     private const val CENTRALAUTH_USER_COOKIE_NAME = "centralauth_User"
+    private const val TEMP_ACCOUNT_EXPIRY_DAYS = 90
 
     fun updateAccount(response: AccountAuthenticatorResponse?, result: LoginResult) {
         if (createAccount(result.userName!!, result.password!!)) {
@@ -102,19 +104,20 @@ object AccountUtil {
         return UriUtil.decodeURL(SharedPreferenceCookieManager.instance.getCookieValueByName(CENTRALAUTH_USER_COOKIE_NAME).orEmpty().trim())
     }
 
-    fun getUserNameExpiryFromCookie(): Long {
-        return SharedPreferenceCookieManager.instance.getCookieExpiryByName(CENTRALAUTH_USER_COOKIE_NAME)
-    }
-
     fun maybeShowTempAccountWelcome(activity: Activity) {
         if (!Prefs.tempAccountWelcomeShown && isTemporaryAccount) {
             Prefs.tempAccountWelcomeShown = true
             Prefs.tempAccountDialogShown = false
+            Prefs.tempAccountCreateDay = LocalDate.now().toEpochDay()
 
-            val expiryDays = TimeUnit.MILLISECONDS.toDays(getUserNameExpiryFromCookie() - System.currentTimeMillis()).toInt()
+            val expiryDays = tempAccountDaysLeft()
             FeedbackUtil.showMessage(activity, activity.resources.getQuantityString(R.plurals.temp_account_created,
                 expiryDays, userName, expiryDays))
         }
+    }
+
+    fun tempAccountDaysLeft(): Int {
+        return max(TEMP_ACCOUNT_EXPIRY_DAYS - (LocalDate.now().toEpochDay() - Prefs.tempAccountCreateDay), 0).toInt()
     }
 
     fun isUserNameTemporary(userName: String): Boolean {

--- a/app/src/main/java/org/wikipedia/dataclient/SharedPreferenceCookieManager.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/SharedPreferenceCookieManager.kt
@@ -33,18 +33,6 @@ class SharedPreferenceCookieManager(
     }
 
     @Synchronized
-    fun getCookieExpiryByName(name: String): Long {
-        for (domainSpec in cookieJar.keys) {
-            for (cookie in cookieJar[domainSpec]!!) {
-                if (cookie.name == name) {
-                    return cookie.expiresAt
-                }
-            }
-        }
-        return 0
-    }
-
-    @Synchronized
     fun getCookieByName(name: String, domainSpec: String, matchExactName: Boolean = true): String? {
         cookieJar[domainSpec]?.let { cookies ->
             for (cookie in cookies) {

--- a/app/src/main/java/org/wikipedia/settings/LogoutPreference.kt
+++ b/app/src/main/java/org/wikipedia/settings/LogoutPreference.kt
@@ -16,7 +16,6 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.SingleWebViewActivity
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.util.StringUtil
-import java.util.concurrent.TimeUnit
 
 @Suppress("unused")
 class LogoutPreference : Preference {
@@ -40,7 +39,7 @@ class LogoutPreference : Preference {
 
         holder.itemView.findViewById<TextView>(R.id.accountExpiry).apply {
             isVisible = AccountUtil.isTemporaryAccount
-            val expiryDays = TimeUnit.MILLISECONDS.toDays(AccountUtil.getUserNameExpiryFromCookie() - System.currentTimeMillis()).toInt()
+            val expiryDays = AccountUtil.tempAccountDaysLeft()
             text = context.resources.getQuantityString(R.plurals.temp_account_expiry, expiryDays, expiryDays)
         }
 

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -618,6 +618,10 @@ object Prefs {
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_temp_account_dialog_shown, false)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_temp_account_dialog_shown, value)
 
+    var tempAccountCreateDay
+        get() = PrefsIoUtil.getLong(R.string.preference_key_temp_account_create_day, 0)
+        set(value) = PrefsIoUtil.setLong(R.string.preference_key_temp_account_create_day, value)
+
     var readingListShareTooltipShown
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_reading_lists_share_tooltip_shown, false)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_reading_lists_share_tooltip_shown, value)

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -131,6 +131,7 @@
     <string name="preference_key_show_edit_talk_page_source_prompt">showEditTalkPageSourcePrompt</string>
     <string name="preference_key_temp_account_welcome_shown">tempAccountWelcomeShown</string>
     <string name="preference_key_temp_account_dialog_shown">tempAccountDialogShown</string>
+    <string name="preference_key_temp_account_create_day">tempAccountCreateDay</string>
     <string name="preference_key_talk_topics_sort_mode">talkTopicsSortMode</string>
     <string name="preference_key_reading_focus_mode">readingFocusMode</string>
     <string name="preference_key_edit_history_filter_type">editHistoryFilterType</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -314,6 +314,10 @@
             android:key="@string/preference_key_temp_account_dialog_shown"
             android:title="@string/preference_key_temp_account_dialog_shown" />
 
+        <org.wikipedia.settings.LongPreference
+            android:key="@string/preference_key_temp_account_create_day"
+            android:title="@string/preference_key_temp_account_create_day" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/preferences_developer_reading_list_category">


### PR DESCRIPTION
According to updated guidance, we _cannot_ use the expiry of the CentralAuth cookie as the expiration date of the user's temp account. We must therefore hardcode a value of 90 days for the expiry, and record ourselves the date on which the temp account was created.

https://phabricator.wikimedia.org/T388849
