### PR TITLE
Fix: remove timeSpentSec variable in the toHistoryEntry method

### DIFF
--- a/app/src/main/java/org/wikipedia/history/db/HistoryEntryWithImageDao.kt
+++ b/app/src/main/java/org/wikipedia/history/db/HistoryEntryWithImageDao.kt
@@ -86,9 +86,16 @@ interface HistoryEntryWithImageDao {
     }
 
     private fun toHistoryEntry(entryWithImage: HistoryEntryWithImage): HistoryEntry {
-        val entry = HistoryEntry(entryWithImage.authority, entryWithImage.lang, entryWithImage.apiTitle,
-            entryWithImage.displayTitle, 0, entryWithImage.namespace, entryWithImage.timestamp,
-            entryWithImage.source, entryWithImage.timeSpentSec)
+        val entry = HistoryEntry(
+            authority = entryWithImage.authority,
+            lang = entryWithImage.lang,
+            apiTitle = entryWithImage.apiTitle,
+            displayTitle = entryWithImage.displayTitle,
+            id = 0,
+            namespace = entryWithImage.namespace,
+            timestamp = entryWithImage.timestamp,
+            source = entryWithImage.source
+        )
         entry.title.thumbUrl = entryWithImage.imageName
         entry.title.description = entryWithImage.description
 


### PR DESCRIPTION
### What does this do?
The `entryWithImage.timeSpentSec` was added as a `prevId` in the `HistoryEntry` object incorrectly. This PR removes it from the method.