### PR TITLE
[Bug] watchlist state synchronization between talkPage and PageFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -19,6 +19,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.widget.LinearLayout
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.animation.doOnEnd
@@ -189,6 +190,16 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     val page get() = model.page
     val isLoading get() = bridge.isLoading
     val leadImageEditLang get() = leadImagesHandler.callToActionEditLang
+
+    private val requestTalkPageLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == TalkTopicsActivity.RESULT_WATCHLIST_CHANGE) {
+            result.data?.let { data ->
+                model.isWatched = data.getBooleanExtra(TalkTopicsActivity.EXTRA_WATCHLIST_STATUS, model.isWatched)
+                model.hasWatchlistExpiry = data.getBooleanExtra(TalkTopicsActivity.EXTRA_WATCHLIST_EXPIRY, model.hasWatchlistExpiry)
+                updateQuickActionsAndMenuOptions()
+            }
+        }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentPageBinding.inflate(inflater, container, false)
@@ -606,7 +617,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         if (stripUrlFragment) {
             talkTitle.fragment = null
         }
-        startActivity(TalkTopicsActivity.newIntent(requireActivity(), talkTitle, InvokeSource.PAGE_ACTIVITY))
+        requestTalkPageLauncher.launch(TalkTopicsActivity.newIntent(requireActivity(), talkTitle, InvokeSource.PAGE_ACTIVITY))
     }
 
     private fun startGalleryActivity(fileName: String) {

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -79,6 +79,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
     private var actionMode: ActionMode? = null
     private val searchActionModeCallback = SearchCallback()
     private var goToTopic = false
+    private var watchListModified = false
 
     private val requestLanguageChange = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         if (it.resultCode == RESULT_OK) {
@@ -290,6 +291,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
             }
             R.id.menu_watch -> {
                 if (AccountUtil.isLoggedIn) {
+                    watchListModified = true
                     viewModel.watchOrUnwatch(WatchlistExpiry.NEVER, viewModel.isWatched)
                 }
                 true
@@ -558,8 +560,21 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
         }
     }
 
+    override fun onBackPressed() {
+        if (watchListModified) {
+            val resultIntent = Intent()
+            resultIntent.putExtra(EXTRA_WATCHLIST_STATUS, viewModel.isWatched)
+            resultIntent.putExtra(EXTRA_WATCHLIST_EXPIRY, viewModel.hasWatchlistExpiry)
+            setResult(RESULT_WATCHLIST_CHANGE, resultIntent)
+        }
+        super.onBackPressed()
+    }
+
     companion object {
         private const val EXTRA_GO_TO_TOPIC = "goToTopic"
+        const val RESULT_WATCHLIST_CHANGE = 1001
+        const val EXTRA_WATCHLIST_STATUS = "watchListStatus"
+        const val EXTRA_WATCHLIST_EXPIRY = "watchListExpiry"
 
         fun newIntent(context: Context, pageTitle: PageTitle, invokeSource: Constants.InvokeSource): Intent {
             return Intent(context, TalkTopicsActivity::class.java)


### PR DESCRIPTION
### What does this do?
Synchronizes the watchlist status when a user modifies their watchlist state on the talk page and returns to the PageFragment.

[Bug Preview](https://github.com/user-attachments/assets/09348eb7-0ef5-4c5b-aded-50e06b0b1a31)
