### PR TITLE
Show Wikigames entry dialog on Explore feed after the second visit

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameOnboardingFragment.kt
@@ -48,7 +48,7 @@ class OnThisDayGameOnboardingFragment : Fragment() {
     }
 
     companion object {
-        private const val SHOW_ON_EXPLORE_FEED_ON_COUNT = 2
+        private const val SHOW_ON_EXPLORE_FEED_COUNT = 2
 
         fun newInstance(invokeSource: InvokeSource): OnThisDayGameOnboardingFragment {
             return OnThisDayGameOnboardingFragment().apply {
@@ -62,7 +62,7 @@ class OnThisDayGameOnboardingFragment : Fragment() {
             if (!Prefs.otdEntryDialogShown &&
                 OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(wikiSite.languageCode) &&
                 OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(articleWikiSite.languageCode) &&
-                (invokeSource != InvokeSource.FEED || Prefs.exploreFeedVisitCount >= SHOW_ON_EXPLORE_FEED_ON_COUNT)) {
+                (invokeSource != InvokeSource.FEED || Prefs.exploreFeedVisitCount >= SHOW_ON_EXPLORE_FEED_COUNT)) {
                 Prefs.otdEntryDialogShown = true
                 WikiGamesEvent.submit("impression", "game_modal")
                 val dialogView = activity.layoutInflater.inflate(R.layout.dialog_on_this_day_game, null)

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameOnboardingFragment.kt
@@ -48,18 +48,21 @@ class OnThisDayGameOnboardingFragment : Fragment() {
     }
 
     companion object {
-        fun newInstance(invokeSource: Constants.InvokeSource): OnThisDayGameOnboardingFragment {
+        private const val SHOW_ON_EXPLORE_FEED_ON_COUNT = 2
+
+        fun newInstance(invokeSource: InvokeSource): OnThisDayGameOnboardingFragment {
             return OnThisDayGameOnboardingFragment().apply {
                 arguments = bundleOf(Constants.INTENT_EXTRA_INVOKE_SOURCE to invokeSource)
             }
         }
 
-        fun maybeShowOnThisDayGameDialog(activity: Activity, invokeSource: Constants.InvokeSource, articleWikiSite: WikiSite = WikipediaApp.instance.wikiSite) {
+        fun maybeShowOnThisDayGameDialog(activity: Activity, invokeSource: InvokeSource, articleWikiSite: WikiSite = WikipediaApp.instance.wikiSite) {
             val wikiSite = WikipediaApp.instance.wikiSite
             // Both of the primary language and the article language should be in the supported languages list.
             if (!Prefs.otdEntryDialogShown &&
                 OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(wikiSite.languageCode) &&
-                OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(articleWikiSite.languageCode)) {
+                OnThisDayGameViewModel.LANG_CODES_SUPPORTED.contains(articleWikiSite.languageCode) &&
+                (invokeSource != InvokeSource.FEED || Prefs.exploreFeedVisitCount >= SHOW_ON_EXPLORE_FEED_ON_COUNT)) {
                 Prefs.otdEntryDialogShown = true
                 WikiGamesEvent.submit("impression", "game_modal")
                 val dialogView = activity.layoutInflater.inflate(R.layout.dialog_on_this_day_game, null)

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -600,8 +600,8 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     }
 
     companion object {
-        // Actually shows on the 3rd time of using the app. The Pref.incrementExploreFeedVisitCount() gets call after MainFragment.onResume()
-        private const val SHOW_EDITS_SNACKBAR_COUNT = 2
+        // Actually shows on the 4th time of using the app. The Pref.incrementExploreFeedVisitCount() gets call after MainFragment.onResume()
+        private const val SHOW_EDITS_SNACKBAR_COUNT = 4
 
         fun newInstance(): MainFragment {
             return MainFragment().apply {

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -601,7 +601,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
 
     companion object {
         // Actually shows on the 4th time of using the app. The Pref.incrementExploreFeedVisitCount() gets call after MainFragment.onResume()
-        private const val SHOW_EDITS_SNACKBAR_COUNT = 4
+        private const val SHOW_EDITS_SNACKBAR_COUNT = 3
 
         fun newInstance(): MainFragment {
             return MainFragment().apply {


### PR DESCRIPTION
### What does this do?
- Show the Wikigames entry dialog after the second visit to the Explore feed.
- Show the Edits tooltip after the third visit to the Explore feed.

**Phabricator:**
https://phabricator.wikimedia.org/T388815
