### PR TITLE
Fix: license links do not match the libraries

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/LicenseLinkText.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/LicenseLinkText.kt
@@ -25,8 +25,8 @@ data class LinkTextData(
 @Composable
 fun LicenseLinkText(
     links: List<LinkTextData>,
-    textStyle: TextStyle = WikipediaTheme.typography.small,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = WikipediaTheme.typography.small
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
@@ -51,6 +51,7 @@ fun LicenseLinkText(
             ) {
                 append(linkTextData.text)
             }
+            append(" ")
         }
     }
 

--- a/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
@@ -54,39 +54,39 @@ import org.wikipedia.theme.Theme
 class AboutActivity : BaseActivity() {
     private val credits = listOf(
         LinkTextData(
-            text = "Balloon ",
+            text = "Balloon",
             url = "https://github.com/skydoves/Balloon/blob/main/LICENSE/"
         ),
         LinkTextData(
-            text = "(license), ",
+            text = "(license),",
             asset = "licenses/Balloon"
         ),
         LinkTextData(
-            text = "Commons Lang ",
+            text = "Commons Lang",
             url = "https://www.apache.org/licenses/"
         ),
         LinkTextData(
-            text = "(license), ",
+            text = "(license),",
             asset = "licenses/CommonsLang3"
         ),
         LinkTextData(
-            text = "jsoup ",
+            text = "jsoup",
             url = "https://github.com/jhy/jsoup"
         ),
         LinkTextData(
-            text = "(license), ",
+            text = "(license),",
             asset = "licenses/jsoup"
         ),
         LinkTextData(
-            text = "OkHttp ",
+            text = "OkHttp",
             url = "https://square.github.io/okhttp/"
         ),
         LinkTextData(
-            text = "(license), ",
+            text = "(license),",
             asset = "licenses/OkHttp"
         ),
         LinkTextData(
-            text = "Retrofit ",
+            text = "Retrofit",
             url = "https://square.github.io/retrofit/"
         ),
         LinkTextData(


### PR DESCRIPTION
### What does this do?
Remove space from the `text` and append a space in the `buildAnnotatedString` but outside the `withLink` block since the space should not be a part of a clickable target.


**Phabricator:**
https://phabricator.wikimedia.org/T384362#10654307
