### PR TITLE
Fix: wrap findEntryForReadMore with withContext() for possible ANRs

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadClient.kt
@@ -3,8 +3,10 @@ package org.wikipedia.feed.becauseyouread
 import android.content.Context
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -29,7 +31,9 @@ class BecauseYouReadClient(
                 cb.success(emptyList())
             }
         ) {
-            val entries = AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(age, context.resources.getInteger(R.integer.article_engagement_threshold_sec))
+            val entries = withContext(Dispatchers.IO) {
+                AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(age, context.resources.getInteger(R.integer.article_engagement_threshold_sec))
+            }
             if (entries.size <= age) {
                 cb.success(emptyList())
             } else {


### PR DESCRIPTION
### What does this do?
We updated the query of `findEntriesBy()` for the YiR and this might fix the issue when running the query.

[ANR 1](https://play.google.com/console/u/1/developers/6169333749249604352/app/4972092403490495074/vitals/crashes/3cefad39c64043d0d5b482dd3c44454c/details?days=28&versionCode=50525&isUserPerceived=true)
[ANR 2](https://play.google.com/console/u/1/developers/6169333749249604352/app/4972092403490495074/vitals/crashes/657ff3b15436af6bcb2991a6d6b203e1/details?days=28&versionCode=50525&isUserPerceived=true)
[ANR 3](https://play.google.com/console/u/1/developers/6169333749249604352/app/4972092403490495074/vitals/crashes/48cf55566e2da98efd89e8b40dc9fc95/details?days=28&versionCode=50525&isUserPerceived=true)
