### PR TITLE
Reduce ANRs: make all HistoryEntry DAO functions suspend.

### DIFF
--- a/app/src/main/java/org/wikipedia/pageimages/db/PageImageDao.kt
+++ b/app/src/main/java/org/wikipedia/pageimages/db/PageImageDao.kt
@@ -10,13 +10,10 @@ import org.wikipedia.history.HistoryEntry
 @Dao
 interface PageImageDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertPageImageSync(pageImage: PageImage)
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPageImage(pageImage: PageImage)
 
     @Query("SELECT * FROM PageImage")
-    fun getAllPageImages(): List<PageImage>
+    suspend fun getAllPageImages(): List<PageImage>
 
     @Query("SELECT * FROM PageImage WHERE lang = :lang AND namespace = :namespace AND apiTitle = :apiTitle")
     suspend fun findItemsBy(lang: String, namespace: String, apiTitle: String): List<PageImage>

--- a/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.kt
+++ b/app/src/main/java/org/wikipedia/savedpages/SavedPageSyncService.kt
@@ -185,7 +185,7 @@ class SavedPageSyncService(context: Context, params: WorkerParameters) : Corouti
                 // download thumbnail and lead image
                 if (!summaryResponse.thumbnailUrl.isNullOrEmpty()) {
                     page.thumbUrl = UriUtil.resolveProtocolRelativeUrl(pageTitle.wikiSite, summaryResponse.thumbnailUrl.orEmpty())
-                    AppDatabase.instance.pageImagesDao().insertPageImageSync(PageImage(
+                    AppDatabase.instance.pageImagesDao().insertPageImage(PageImage(
                         pageTitle,
                         page.thumbUrl.orEmpty(),
                         summaryResponse.description,


### PR DESCRIPTION
The proper solution is to make the Room DAO functions `suspend`, which causes Room to _automatically_ put those functions into an IO dispatcher.

