### PR TITLE
Update migration query to also insert missing PageImage rows.

### DIFF
--- a/app/src/main/java/org/wikipedia/database/AppDatabase.kt
+++ b/app/src/main/java/org/wikipedia/database/AppDatabase.kt
@@ -258,12 +258,14 @@ abstract class AppDatabase : RoomDatabase() {
                 // For PageImage rows that don't already exist (i.e. HistoryEntries that didn't have
                 // a thumbnail), insert them and copy the other metadata.
                 database.execSQL("INSERT INTO PageImage (lang, namespace, apiTitle, description, timeSpentSec)" +
-                        " SELECT he.lang, he.namespace, he.apiTitle, he.description, COALESCE(he.timeSpentSec, 0)" +
-                        " FROM HistoryEntry_old he" +
-                        " WHERE NOT EXISTS (SELECT 1 FROM PageImage pi" +
-                        "    WHERE pi.lang = he.lang AND" +
-                        "          pi.namespace = he.namespace AND" +
-                        "          pi.apiTitle = he.apiTitle)")
+                        " SELECT HistoryEntry_old.lang, HistoryEntry_old.namespace, HistoryEntry_old.apiTitle," +
+                        " HistoryEntry_old.description, COALESCE(HistoryEntry_old.timeSpentSec, 0)" +
+                        " FROM HistoryEntry_old" +
+                        " WHERE NOT EXISTS (SELECT 1 FROM PageImage" +
+                        "    WHERE PageImage.lang = HistoryEntry_old.lang AND" +
+                        "          PageImage.namespace = HistoryEntry_old.namespace AND" +
+                        "          PageImage.apiTitle = HistoryEntry_old.apiTitle)")
+
             }
         }
 

--- a/app/src/main/java/org/wikipedia/database/AppDatabase.kt
+++ b/app/src/main/java/org/wikipedia/database/AppDatabase.kt
@@ -29,7 +29,6 @@ import org.wikipedia.talk.db.TalkPageSeen
 import org.wikipedia.talk.db.TalkPageSeenDao
 import org.wikipedia.talk.db.TalkTemplate
 import org.wikipedia.talk.db.TalkTemplateDao
-import org.wikipedia.util.log.L
 
 const val DATABASE_NAME = "wikipedia.db"
 const val DATABASE_VERSION = 28
@@ -218,7 +217,6 @@ abstract class AppDatabase : RoomDatabase() {
         }
         val MIGRATION_26_28 = object : Migration(26, 28) {
             override fun migrate(database: SupportSQLiteDatabase) {
-                L.d(">>> migration start")
                 // Rename the existing HistoryEntry table, which we're preserving for now (in case
                 // things go wrong with migrations in the field).
                 database.execSQL("ALTER TABLE HistoryEntry RENAME TO HistoryEntry_old")
@@ -266,8 +264,6 @@ abstract class AppDatabase : RoomDatabase() {
                         "    WHERE pi.lang = he.lang AND" +
                         "          pi.namespace = he.namespace AND" +
                         "          pi.apiTitle = he.apiTitle)")
-
-                L.d(">>> migration end")
             }
         }
 

--- a/app/src/main/java/org/wikipedia/database/AppDatabase.kt
+++ b/app/src/main/java/org/wikipedia/database/AppDatabase.kt
@@ -265,7 +265,6 @@ abstract class AppDatabase : RoomDatabase() {
                         "    WHERE PageImage.lang = HistoryEntry_old.lang AND" +
                         "          PageImage.namespace = HistoryEntry_old.namespace AND" +
                         "          PageImage.apiTitle = HistoryEntry_old.apiTitle)")
-
             }
         }
 


### PR DESCRIPTION
This updates the v28 migration step to _also_ insert rows into the `PageImage` table that didn't yet exist, instead of only updating existing rows.

This catches cases where the user visited an article that doesn't have a lead image, but the user spent time reading the article, and/or the article has a description. We still want to capture this metadata in the updated `PageImage` table.

For 10000 entries, this adds another ~50ms to the migration step.