### PR TITLE
Final, ultimate fixes for db migration.

### DIFF
--- a/app/src/main/java/org/wikipedia/database/AppDatabase.kt
+++ b/app/src/main/java/org/wikipedia/database/AppDatabase.kt
@@ -259,7 +259,7 @@ abstract class AppDatabase : RoomDatabase() {
                 // a thumbnail), insert them and copy the other metadata.
                 database.execSQL("INSERT INTO PageImage (lang, namespace, apiTitle, description, timeSpentSec)" +
                         " SELECT lang, namespace, apiTitle, description, COALESCE(timeSpentSec, 0) as timeSpentSec FROM" +
-                        " (SELECT lang, namespace, apiTitle, description, COALESCE(timeSpentSec, 0) as timeSpentSec" +
+                        " (SELECT lang, namespace, apiTitle, description, MAX(COALESCE(timeSpentSec, 0)) as timeSpentSec" +
                         "     FROM HistoryEntry_old GROUP BY lang, namespace, apiTitle) AS HistoryUnique" +
                         " WHERE NOT EXISTS (SELECT 1 FROM PageImage" +
                         "     WHERE PageImage.lang = HistoryUnique.lang AND" +

--- a/app/src/main/java/org/wikipedia/database/AppDatabase.kt
+++ b/app/src/main/java/org/wikipedia/database/AppDatabase.kt
@@ -258,13 +258,13 @@ abstract class AppDatabase : RoomDatabase() {
                 // For PageImage rows that don't already exist (i.e. HistoryEntries that didn't have
                 // a thumbnail), insert them and copy the other metadata.
                 database.execSQL("INSERT INTO PageImage (lang, namespace, apiTitle, description, timeSpentSec)" +
-                        " SELECT HistoryEntry_old.lang, HistoryEntry_old.namespace, HistoryEntry_old.apiTitle," +
-                        " HistoryEntry_old.description, COALESCE(HistoryEntry_old.timeSpentSec, 0)" +
-                        " FROM HistoryEntry_old" +
+                        " SELECT lang, namespace, apiTitle, description, COALESCE(timeSpentSec, 0) as timeSpentSec FROM" +
+                        " (SELECT lang, namespace, apiTitle, description, COALESCE(timeSpentSec, 0) as timeSpentSec" +
+                        "     FROM HistoryEntry_old GROUP BY lang, namespace, apiTitle) AS HistoryUnique" +
                         " WHERE NOT EXISTS (SELECT 1 FROM PageImage" +
-                        "    WHERE PageImage.lang = HistoryEntry_old.lang AND" +
-                        "          PageImage.namespace = HistoryEntry_old.namespace AND" +
-                        "          PageImage.apiTitle = HistoryEntry_old.apiTitle)")
+                        "     WHERE PageImage.lang = HistoryUnique.lang AND" +
+                        "         PageImage.namespace = HistoryUnique.namespace AND" +
+                        "         PageImage.apiTitle = HistoryUnique.apiTitle)")
             }
         }
 

--- a/app/src/main/java/org/wikipedia/history/db/HistoryEntryWithImageDao.kt
+++ b/app/src/main/java/org/wikipedia/history/db/HistoryEntryWithImageDao.kt
@@ -20,7 +20,7 @@ interface HistoryEntryWithImageDao {
 
     // TODO: convert to PagingSource.
     // https://developer.android.com/topic/libraries/architecture/paging/v3-overview
-    @Query("SELECT HistoryEntry.*, PageImage.imageName, PageImage.description, PageImage.geoLat, PageImage.geoLon, PageImage.timeSpentSec FROM HistoryEntry LEFT OUTER JOIN PageImage ON (HistoryEntry.namespace = PageImage.namespace AND HistoryEntry.apiTitle = PageImage.apiTitle AND HistoryEntry.lang = PageImage.lang) INNER JOIN(SELECT displayTitle, MAX(timestamp) as max_timestamp FROM HistoryEntry GROUP BY displayTitle) LatestEntries ON HistoryEntry.displayTitle = LatestEntries.displayTitle AND HistoryEntry.timestamp = LatestEntries.max_timestamp WHERE UPPER(HistoryEntry.displayTitle) LIKE UPPER(:term) ESCAPE '\\' ORDER BY timestamp DESC")
+    @Query("SELECT HistoryEntry.*, PageImage.imageName, PageImage.description, PageImage.geoLat, PageImage.geoLon, PageImage.timeSpentSec FROM HistoryEntry LEFT OUTER JOIN PageImage ON (HistoryEntry.namespace = PageImage.namespace AND HistoryEntry.apiTitle = PageImage.apiTitle AND HistoryEntry.lang = PageImage.lang) INNER JOIN(SELECT lang, apiTitle, MAX(timestamp) as max_timestamp FROM HistoryEntry GROUP BY lang, apiTitle) LatestEntries ON HistoryEntry.apiTitle = LatestEntries.apiTitle AND HistoryEntry.timestamp = LatestEntries.max_timestamp WHERE UPPER(HistoryEntry.displayTitle) LIKE UPPER(:term) ESCAPE '\\' ORDER BY timestamp DESC")
     @RewriteQueriesToDropUnusedColumns
     suspend fun findEntriesBySearchTerm(term: String): List<HistoryEntryWithImage>
 


### PR DESCRIPTION
* There is just one more extreme edge case that the db migration logic was failing to catch (causing a tiny number of crashes in Beta): The old HistoryEntry could in fact contain entries that have the same combination of [lang, namespace, apiTitle], dating back to a time when we *didn't* upsert the "latest" entry for that combination. This kind of case would violate the primary-key constraint on the PageImage table. (This update does not increase the migration time at all.)
* When filtering the items in the History screen, they need to be unique by title *and* language, instead of just by title. Currently, if you navigate to different language versions of the same article (with the same title), it appears as a single entry in History.