### PR TITLE
Fix: Remove namespace from message displayed when watching a Talk page.

### DIFF
--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistViewModel.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistViewModel.kt
@@ -221,7 +221,13 @@ class WatchlistViewModel : ViewModel() {
             if (watchObj == null) {
                 throw IOException("Watch response is null.")
             }
-            val message = StringUtil.fromHtml(messageCall.await().text).toString().trim()
+
+            val parsedMessage = StringUtil.fromHtml(messageCall.await().text).toString().trim()
+            val message = if (isTalkPage == true && pageTitle.namespace.isNotEmpty()) {
+                parsedMessage.replaceFirst("${pageTitle.namespace}:", "")
+            } else {
+                parsedMessage
+            }
 
             if (unwatch) {
                 WatchlistAnalyticsHelper.logRemovedFromWatchlistSuccess(pageTitle)


### PR DESCRIPTION
### What does this do?
Removes the redundant "Talk:" namespace prefix from the confirmation message displayed when a user adds a Talk page to their watchlist.


**Phabricator:**
https://phabricator.wikimedia.org/T376362

<details>
  <summary>Before and After screenshots</summary>

**Before**

![Before](https://github.com/user-attachments/assets/2008635b-1872-4342-882a-e080bada9a14)

**After**

![After](https://github.com/user-attachments/assets/8cd201d7-5f39-4d8e-9f5a-87677b7ea276)

</details>