### PR TITLE
Make View.setLayoutDirection into an extension function.

### DIFF
--- a/app/src/main/java/org/wikipedia/categories/CategoryDialog.kt
+++ b/app/src/main/java/org/wikipedia/categories/CategoryDialog.kt
@@ -13,10 +13,10 @@ import androidx.recyclerview.widget.RecyclerView
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.databinding.DialogCategoriesBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.page.PageTitle
 import org.wikipedia.readinglist.database.ReadingList
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
@@ -35,7 +35,7 @@ class CategoryDialog : ExtendedBottomSheetDialogFragment() {
         binding.categoriesRecycler.layoutManager = LinearLayoutManager(requireActivity())
         binding.categoriesRecycler.addItemDecoration(DrawableItemDecoration(requireContext(), R.attr.list_divider, drawStart = false, drawEnd = false))
         binding.categoriesDialogPageTitle.text = StringUtil.fromHtml(viewModel.pageTitle.displayText)
-        L10nUtil.setConditionalLayoutDirection(binding.root, viewModel.pageTitle.wikiSite.languageCode)
+        binding.root.setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
 
         binding.categoriesError.isVisible = false
         binding.categoriesNoneFound.isVisible = false

--- a/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
+++ b/app/src/main/java/org/wikipedia/commons/FilePageFragment.kt
@@ -29,6 +29,7 @@ import org.wikipedia.databinding.FragmentFilePageBinding
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.descriptions.DescriptionEditActivity
 import org.wikipedia.descriptions.DescriptionEditActivity.Action
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.gallery.ImagePipelineBitmapGetter
 import org.wikipedia.gallery.MediaDownloadReceiver
 import org.wikipedia.page.PageTitle
@@ -37,7 +38,6 @@ import org.wikipedia.suggestededits.SuggestedEditsImageTagEditActivity
 import org.wikipedia.suggestededits.SuggestedEditsSnackbars
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ShareUtil.shareImage
 import java.io.File
@@ -78,7 +78,7 @@ class FilePageFragment : Fragment(), FilePageView.Callback, MenuProvider {
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         (requireActivity() as AppCompatActivity).setSupportActionBar(binding.toolbar)
 
-        L10nUtil.setConditionalLayoutDirection(binding.root, viewModel.pageTitle.wikiSite.languageCode)
+        binding.root.setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
         return binding.root
     }
 

--- a/app/src/main/java/org/wikipedia/commons/ImagePreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/commons/ImagePreviewDialog.kt
@@ -15,10 +15,10 @@ import kotlinx.coroutines.launch
 import org.wikipedia.R
 import org.wikipedia.databinding.DialogImagePreviewBinding
 import org.wikipedia.descriptions.DescriptionEditActivity.Action
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.suggestededits.PageSummaryForEdit
 import org.wikipedia.util.DimenUtil
-import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
 import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 
@@ -30,7 +30,7 @@ class ImagePreviewDialog : ExtendedBottomSheetDialogFragment(), DialogInterface.
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = DialogImagePreviewBinding.inflate(inflater, container, false)
-        setConditionalLayoutDirection(binding.root, viewModel.pageSummaryForEdit.lang)
+        binding.root.setLayoutDirectionByLang(viewModel.pageSummaryForEdit.lang)
         return binding.root
     }
 

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditBottomBarView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditBottomBarView.kt
@@ -5,8 +5,8 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import org.wikipedia.databinding.ViewDescriptionEditReadArticleBarBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.suggestededits.PageSummaryForEdit
-import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
 import org.wikipedia.util.StringUtil
 import org.wikipedia.views.ViewUtil
 
@@ -26,7 +26,7 @@ class DescriptionEditBottomBarView constructor(context: Context, attrs: Attribut
     }
 
     fun setSummary(summaryForEdit: PageSummaryForEdit) {
-        setConditionalLayoutDirection(this, summaryForEdit.lang)
+        setLayoutDirectionByLang(summaryForEdit.lang)
         binding.viewArticleTitle.text = StringUtil.fromHtml(StringUtil.removeNamespace(summaryForEdit.displayTitle))
         if (summaryForEdit.thumbnailUrl.isNullOrEmpty()) {
             binding.viewImageThumbnail.visibility = GONE

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditReviewView.kt
@@ -9,12 +9,12 @@ import org.wikipedia.databinding.ViewDescriptionEditReviewBinding
 import org.wikipedia.descriptions.DescriptionEditLicenseView.Companion.ARG_NOTICE_ARTICLE_DESCRIPTION
 import org.wikipedia.descriptions.DescriptionEditLicenseView.Companion.ARG_NOTICE_DEFAULT
 import org.wikipedia.descriptions.DescriptionEditLicenseView.Companion.ARG_NOTICE_IMAGE_CAPTION
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.suggestededits.PageSummaryForEdit
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.views.ViewUtil
 
-class DescriptionEditReviewView constructor(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
+class DescriptionEditReviewView(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
     private val binding = ViewDescriptionEditReviewBinding.inflate(LayoutInflater.from(context), this)
 
     val isShowing: Boolean
@@ -33,7 +33,7 @@ class DescriptionEditReviewView constructor(context: Context, attrs: AttributeSe
     }
 
     fun setSummary(summaryForEdit: PageSummaryForEdit, description: String, captionReview: Boolean) {
-        L10nUtil.setConditionalLayoutDirection(this, summaryForEdit.lang)
+        setLayoutDirectionByLang(summaryForEdit.lang)
         if (captionReview) {
             setGalleryReviewView(summaryForEdit, description)
             binding.licenseView.buildLicenseNotice(ARG_NOTICE_IMAGE_CAPTION)

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -21,6 +21,7 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.MachineGeneratedArticleDescriptionsAnalyticsHelper
 import org.wikipedia.databinding.GroupCaptchaBinding
 import org.wikipedia.databinding.ViewDescriptionEditBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.language.LanguageUtil
 import org.wikipedia.mlkit.MlKitLanguageDetector
 import org.wikipedia.page.PageTitle
@@ -29,7 +30,6 @@ import org.wikipedia.suggestededits.PageSummaryForEdit
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.UriUtil
@@ -235,7 +235,7 @@ class DescriptionEditView(context: Context, attrs: AttributeSet?) : LinearLayout
             !sourceSummary.pageTitle.description.isNullOrEmpty()) {
             binding.viewDescriptionEditPageSummaryContainer.visibility = GONE
         }
-        L10nUtil.setConditionalLayoutDirection(this, if (isTranslationEdit) sourceSummary.lang else pageTitle.wikiSite.languageCode)
+        setLayoutDirectionByLang(if (isTranslationEdit) sourceSummary.lang else pageTitle.wikiSite.languageCode)
 
         binding.viewDescriptionEditReadArticleBarContainer.setSummary(pageSummaryForEdit)
         binding.viewDescriptionEditReadArticleBarContainer.setOnClickListener { performReadArticleClick() }

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -40,6 +40,7 @@ import org.wikipedia.databinding.FragmentArticleEditDetailsBinding
 import org.wikipedia.dataclient.mwapi.MwQueryPage.Revision
 import org.wikipedia.dataclient.okhttp.HttpStatusException
 import org.wikipedia.extensions.parcelableExtra
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.Namespace
@@ -58,7 +59,6 @@ import org.wikipedia.util.ClipboardUtil
 import org.wikipedia.util.CustomTabsUtil
 import org.wikipedia.util.DateUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.ShareUtil
@@ -260,7 +260,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
             }
         }
 
-        L10nUtil.setConditionalLayoutDirection(requireView(), viewModel.pageTitle.wikiSite.languageCode)
+        requireView().setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
 
         binding.appBarLayout.addOnOffsetChangedListener(actionBarOffsetChangedListener)
     }

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -51,6 +51,7 @@ import org.wikipedia.edit.preview.EditPreviewFragment
 import org.wikipedia.edit.richtext.SyntaxHighlighter
 import org.wikipedia.edit.summaries.EditSummaryFragment
 import org.wikipedia.extensions.parcelableExtra
+import org.wikipedia.extensions.setTextDirectionByLang
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.login.LoginActivity
 import org.wikipedia.notifications.AnonymousNotificationHelper
@@ -65,7 +66,6 @@ import org.wikipedia.theme.ThemeChooserDialog
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
@@ -175,7 +175,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
             viewModel.editingAllowed = savedInstanceState.getBoolean(EXTRA_KEY_EDITING_ALLOWED, false)
             sectionTextModified = savedInstanceState.getBoolean(EXTRA_KEY_SECTION_TEXT_MODIFIED, false)
         }
-        L10nUtil.setConditionalTextDirection(binding.editSectionText, viewModel.pageTitle.wikiSite.languageCode)
+        binding.editSectionText.setTextDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
 
         fetchSectionText()
 

--- a/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryHandler.kt
+++ b/app/src/main/java/org/wikipedia/edit/summaries/EditSummaryHandler.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.edit.db.EditSummary
+import org.wikipedia.extensions.setTextDirectionByLang
 import org.wikipedia.page.PageTitle
-import org.wikipedia.util.L10nUtil.setConditionalTextDirection
 
 class EditSummaryHandler(private val coroutineScope: CoroutineScope,
                          private val container: View,
@@ -17,7 +17,7 @@ class EditSummaryHandler(private val coroutineScope: CoroutineScope,
 
     init {
         container.setOnClickListener { summaryEdit.requestFocus() }
-        setConditionalTextDirection(summaryEdit, title.wikiSite.languageCode)
+        summaryEdit.setTextDirectionByLang(title.wikiSite.languageCode)
 
         coroutineScope.launch {
             val summaries = AppDatabase.instance.editSummaryDao().getEditSummaries()

--- a/app/src/main/java/org/wikipedia/extensions/View.kt
+++ b/app/src/main/java/org/wikipedia/extensions/View.kt
@@ -1,12 +1,23 @@
 package org.wikipedia.extensions
 
+import android.text.TextUtils
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import org.wikipedia.util.L10nUtil
+import java.util.Locale
 import kotlin.coroutines.CoroutineContext
 
 fun View.coroutineScope(coroutineContext: CoroutineContext = Dispatchers.Main): CoroutineScope {
     return (context as? AppCompatActivity)?.lifecycleScope ?: CoroutineScope(coroutineContext)
+}
+
+fun View.setTextDirectionByLang(lang: String) {
+    textDirection = if (L10nUtil.isLangRTL(lang)) View.TEXT_DIRECTION_RTL else View.TEXT_DIRECTION_LTR
+}
+
+fun View.setLayoutDirectionByLang(lang: String) {
+    layoutDirection = TextUtils.getLayoutDirectionFromLocale(Locale(lang))
 }

--- a/app/src/main/java/org/wikipedia/feed/news/NewsFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsFragment.kt
@@ -19,6 +19,7 @@ import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.databinding.FragmentNewsBinding
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.feed.model.Card
 import org.wikipedia.feed.view.ListCardItemView
 import org.wikipedia.history.HistoryEntry
@@ -29,7 +30,6 @@ import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.GradientUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.TabUtil
 import org.wikipedia.views.DefaultRecyclerAdapter
@@ -59,7 +59,7 @@ class NewsFragment : Fragment() {
         appCompatActivity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
         appCompatActivity.supportActionBar?.title = ""
 
-        L10nUtil.setConditionalLayoutDirection(binding.root, viewModel.wiki.languageCode)
+        binding.root.setLayoutDirectionByLang(viewModel.wiki.languageCode)
 
         binding.gradientView.background = GradientUtil.getPowerGradient(ResourceUtil.getThemedColor(requireContext(), R.attr.overlay_color), Gravity.TOP)
         val imageUri = viewModel.item.thumb()

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardItemFragment.kt
@@ -32,13 +32,13 @@ import org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_CAPTI
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION
 import org.wikipedia.descriptions.DescriptionEditReviewView.Companion.ARTICLE_EXTRACT_MAX_LINE_WITHOUT_IMAGE
 import org.wikipedia.descriptions.DescriptionEditReviewView.Companion.ARTICLE_EXTRACT_MAX_LINE_WITH_IMAGE
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
 import org.wikipedia.suggestededits.SuggestedEditsImageTagEditActivity
 import org.wikipedia.suggestededits.SuggestedEditsSnackbars
 import org.wikipedia.util.ImageUrlUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 
@@ -144,7 +144,7 @@ class SuggestedEditsCardItemFragment : Fragment() {
         binding.callToActionButton.visibility = VISIBLE
         viewModel.sourceSummaryForEdit?.let {
             val langCode = viewModel.targetSummaryForEdit?.lang ?: it.lang
-            L10nUtil.setConditionalLayoutDirection(binding.cardView, langCode)
+            binding.cardView.setLayoutDirectionByLang(langCode)
         }
 
         when (viewModel.cardActionType) {

--- a/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/suggestededits/SuggestedEditsCardView.kt
@@ -7,10 +7,10 @@ import androidx.fragment.app.Fragment
 import com.google.android.material.tabs.TabLayoutMediator
 import org.wikipedia.WikipediaApp
 import org.wikipedia.databinding.ViewSuggestedEditsCardBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.feed.view.CardFooterView
 import org.wikipedia.feed.view.DefaultFeedCardView
 import org.wikipedia.feed.view.FeedAdapter
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.views.PositionAwareFragmentStateAdapter
 
 class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEditsCard>(context), CardFooterView.Callback {
@@ -43,8 +43,8 @@ class SuggestedEditsCardView(context: Context) : DefaultFeedCardView<SuggestedEd
         binding.seCardsPager.adapter = SECardsPagerAdapter(card)
         binding.seCardsPager.offscreenPageLimit = 3
         binding.cardFooter.callback = this
-        L10nUtil.setConditionalLayoutDirection(binding.seCardsPager, WikipediaApp.instance.wikiSite.languageCode)
-        L10nUtil.setConditionalLayoutDirection(binding.seCardsIndicatorLayout, WikipediaApp.instance.wikiSite.languageCode)
+        binding.seCardsPager.setLayoutDirectionByLang(WikipediaApp.instance.wikiSite.languageCode)
+        binding.seCardsIndicatorLayout.setLayoutDirectionByLang(WikipediaApp.instance.wikiSite.languageCode)
         TabLayoutMediator(binding.seCardsIndicatorLayout, binding.seCardsPager) { _, _ -> }.attach()
         binding.cardFooter.setFooterActionText(card.footerActionText(), null)
     }

--- a/app/src/main/java/org/wikipedia/feed/topread/TopReadFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/topread/TopReadFragment.kt
@@ -15,6 +15,7 @@ import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.databinding.FragmentMostReadBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.feed.model.Card
 import org.wikipedia.feed.view.ListCardItemView
 import org.wikipedia.history.HistoryEntry
@@ -22,7 +23,6 @@ import org.wikipedia.page.PageActivity
 import org.wikipedia.readinglist.ReadingListBehaviorsUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.TabUtil
 import org.wikipedia.views.DefaultRecyclerAdapter
 import org.wikipedia.views.DefaultViewHolder
@@ -45,7 +45,7 @@ class TopReadFragment : Fragment() {
             supportActionBar?.title = getString(R.string.top_read_activity_title, card.subtitle())
         }
 
-        L10nUtil.setConditionalLayoutDirection(binding.root, card.wikiSite().languageCode)
+        binding.root.setLayoutDirectionByLang(card.wikiSite().languageCode)
 
         binding.mostReadRecyclerView.layoutManager = LinearLayoutManager(context)
         binding.mostReadRecyclerView.addItemDecoration(DrawableItemDecoration(requireContext(), R.attr.list_divider))

--- a/app/src/main/java/org/wikipedia/feed/view/CardHeaderView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/CardHeaderView.kt
@@ -14,10 +14,10 @@ import androidx.core.view.isVisible
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.databinding.ViewCardHeaderBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.feed.model.Card
-import org.wikipedia.util.L10nUtil
 
-class CardHeaderView constructor(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
+class CardHeaderView(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
 
     interface Callback {
         fun onRequestDismissCard(card: Card): Boolean
@@ -71,11 +71,11 @@ class CardHeaderView constructor(context: Context, attrs: AttributeSet? = null) 
         binding.viewListCardHeaderSecondaryIcon.isVisible = false
         if (langCode.isNullOrEmpty() || WikipediaApp.instance.languageState.appLanguageCodes.size < 2) {
             binding.viewListCardHeaderLangCode.isVisible = false
-            L10nUtil.setConditionalLayoutDirection(this, WikipediaApp.instance.languageState.systemLanguageCode)
+            setLayoutDirectionByLang(WikipediaApp.instance.languageState.systemLanguageCode)
         } else {
             binding.viewListCardHeaderLangCode.isVisible = true
             binding.viewListCardHeaderLangCode.setLangCode(langCode)
-            L10nUtil.setConditionalLayoutDirection(this, langCode)
+            setLayoutDirectionByLang(langCode)
         }
         return this
     }

--- a/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/CardLargeHeaderView.kt
@@ -12,8 +12,8 @@ import androidx.palette.graphics.Palette
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.databinding.ViewCardHeaderLargeBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.util.DimenUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.TransitionUtil
@@ -35,7 +35,7 @@ class CardLargeHeaderView : ConstraintLayout {
     val sharedElements get() = TransitionUtil.getSharedElements(context, binding.viewCardHeaderLargeImage)
 
     fun setLanguageCode(langCode: String): CardLargeHeaderView {
-        L10nUtil.setConditionalLayoutDirection(this, langCode)
+        setLayoutDirectionByLang(langCode)
         return this
     }
 

--- a/app/src/main/java/org/wikipedia/feed/view/DefaultFeedCardView.kt
+++ b/app/src/main/java/org/wikipedia/feed/view/DefaultFeedCardView.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import android.view.View
 import android.widget.LinearLayout
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.feed.model.Card
-import org.wikipedia.util.L10nUtil
 
 abstract class DefaultFeedCardView<T : Card?>(context: Context?) : LinearLayout(context), FeedCardView<T> {
     override var card: T? = null
     override var callback: FeedAdapter.Callback? = null
 
     protected fun setLayoutDirectionByWikiSite(wiki: WikiSite, rootView: View) {
-        L10nUtil.setConditionalLayoutDirection(rootView, wiki.languageCode)
+        rootView.setLayoutDirectionByLang(wiki.languageCode)
     }
 }

--- a/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationActivity.kt
@@ -45,6 +45,7 @@ import org.wikipedia.analytics.eventplatform.NotificationInteractionEvent
 import org.wikipedia.databinding.ActivityNotificationsBinding
 import org.wikipedia.databinding.ItemNotificationBinding
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.history.SearchActionModeCallback
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.richtext.RichTextUtil
@@ -53,7 +54,6 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
@@ -400,7 +400,7 @@ class NotificationActivity : BaseActivity() {
             binding.notificationSubtitle.typeface = if (n.isUnread) typefaceSansSerifBold else Typeface.DEFAULT
 
             val langCode = StringUtil.dbNameToLangCode(n.wiki)
-            L10nUtil.setConditionalLayoutDirection(itemView, langCode)
+            itemView.setLayoutDirectionByLang(langCode)
 
             n.title?.let { title ->
                 StringUtil.setHighlightedAndBoldenedText(binding.notificationSource, title.full,

--- a/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/SidePanelHandler.kt
@@ -23,6 +23,7 @@ import org.wikipedia.analytics.eventplatform.ArticleTocInteractionEvent
 import org.wikipedia.analytics.metricsplatform.ArticleTocInteraction
 import org.wikipedia.bridge.CommunicationBridge
 import org.wikipedia.bridge.JavaScriptActionHandler
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
@@ -97,7 +98,7 @@ class SidePanelHandler internal constructor(private val fragment: PageFragment,
         tocAdapter.setPage(page)
         rtl = L10nUtil.isLangRTL(page.title.wikiSite.languageCode)
         binding.tocList.rtl = rtl
-        L10nUtil.setConditionalLayoutDirection(binding.sidePanelContainer, page.title.wikiSite.languageCode)
+        binding.sidePanelContainer.setLayoutDirectionByLang(page.title.wikiSite.languageCode)
         binding.sidePanelContainer.updateLayoutParams<DrawerLayout.LayoutParams> {
             gravity = if (rtl) Gravity.LEFT else Gravity.RIGHT
         }

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -33,6 +33,7 @@ import org.wikipedia.databinding.DialogLinkPreviewBinding
 import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.edit.EditHandler
 import org.wikipedia.edit.EditSectionActivity
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.gallery.GalleryActivity
 import org.wikipedia.gallery.GalleryThumbnailScrollView.GalleryViewListener
 import org.wikipedia.history.HistoryEntry
@@ -167,7 +168,7 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
                 requestStubArticleEditLauncher.launch(EditSectionActivity.newIntent(requireContext(), -1, null, this, Constants.InvokeSource.LINK_PREVIEW_MENU, null))
             }
         }
-        L10nUtil.setConditionalLayoutDirection(binding.root, viewModel.pageTitle.wikiSite.languageCode)
+        binding.root.setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {

--- a/app/src/main/java/org/wikipedia/page/references/ReferenceDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/references/ReferenceDialog.kt
@@ -15,11 +15,11 @@ import org.wikipedia.R
 import org.wikipedia.activity.FragmentUtil.getCallback
 import org.wikipedia.databinding.FragmentReferencesPagerBinding
 import org.wikipedia.databinding.ViewReferencePagerItemBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.page.LinkHandler
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.util.DimenUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.StringUtil
 import java.util.Locale
 
@@ -42,7 +42,7 @@ class ReferenceDialog : ExtendedBottomSheetDialogFragment() {
                 binding.referencePager.adapter = ReferencesAdapter(this)
                 TabLayoutMediator(binding.pageIndicatorView, binding.referencePager) { _, _ -> }.attach()
                 binding.referencePager.setCurrentItem(it.selectedReferenceIndex, true)
-                L10nUtil.setConditionalLayoutDirection(binding.root, it.linkHandler.wikiSite.languageCode)
+                binding.root.setLayoutDirectionByLang(it.linkHandler.wikiSite.languageCode)
             } ?: return@let null
         } ?: run {
             dismiss()

--- a/app/src/main/java/org/wikipedia/random/RandomItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/random/RandomItemFragment.kt
@@ -17,9 +17,9 @@ import org.wikipedia.Constants
 import org.wikipedia.databinding.FragmentRandomItemBinding
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.page.PageSummary
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.page.PageTitle
 import org.wikipedia.util.ImageUrlUtil.getUrlForPreferredSize
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.log.L
 
@@ -52,7 +52,7 @@ class RandomItemFragment : Fragment() {
             viewModel.getRandomPage()
         }
 
-        L10nUtil.setConditionalLayoutDirection(binding.root, viewModel.wikiSite.languageCode)
+        binding.root.setLayoutDirectionByLang(viewModel.wikiSite.languageCode)
 
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -27,11 +27,11 @@ import org.wikipedia.analytics.eventplatform.PlacesEvent
 import org.wikipedia.databinding.FragmentSearchResultsBinding
 import org.wikipedia.databinding.ItemSearchNoResultsBinding
 import org.wikipedia.databinding.ItemSearchResultBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.PageTitle
 import org.wikipedia.readinglist.LongPressMenu
 import org.wikipedia.readinglist.database.ReadingListPage
-import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
 import org.wikipedia.util.ResourceUtil.getThemedColorStateList
 import org.wikipedia.util.StringUtil
 import org.wikipedia.views.DefaultViewHolder
@@ -104,7 +104,7 @@ class SearchResultsFragment : Fragment() {
     val isShowing get() = binding.searchResultsDisplay.visibility == View.VISIBLE
 
     fun setLayoutDirection(langCode: String) {
-        setConditionalLayoutDirection(binding.searchResultsList, langCode)
+        binding.searchResultsList.setLayoutDirectionByLang(langCode)
     }
 
     fun startSearch(term: String?, force: Boolean) {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsItemFragment.kt
@@ -16,10 +16,10 @@ import org.wikipedia.R
 import org.wikipedia.databinding.FragmentSuggestedEditsCardsItemBinding
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.ADD_DESCRIPTION
 import org.wikipedia.descriptions.DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DateUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
 import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
@@ -42,7 +42,7 @@ class SuggestedEditsCardsItemFragment : SuggestedEditsItemFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setConditionalLayoutDirection(binding.viewArticleContainer, parent().langFromCode())
+        binding.viewArticleContainer.setLayoutDirectionByLang(parent().langFromCode())
 
         binding.viewArticleImage.setOnClickListener {
             if (Prefs.showImageZoomTooltip) {

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -36,13 +36,13 @@ import org.wikipedia.databinding.FragmentSuggestedEditsImageTagsItemBinding
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.mwapi.MwQueryPage
 import org.wikipedia.descriptions.DescriptionEditActivity
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.gallery.ImageInfo
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ImageUrlUtil
-import org.wikipedia.util.L10nUtil.setConditionalLayoutDirection
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
@@ -77,7 +77,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setConditionalLayoutDirection(binding.contentContainer, callback().getLangCode())
+        binding.contentContainer.setLayoutDirectionByLang(callback().getLangCode())
         binding.cardItemErrorView.backClickListener = OnClickListener { requireActivity().finish() }
         binding.cardItemErrorView.retryClickListener = OnClickListener {
             binding.cardItemProgressBar.visibility = VISIBLE

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -29,6 +29,7 @@ import org.wikipedia.edit.insertmedia.InsertMediaActivity
 import org.wikipedia.edit.insertmedia.InsertMediaViewModel
 import org.wikipedia.edit.preview.EditPreviewFragment
 import org.wikipedia.extensions.parcelableExtra
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.login.LoginActivity
 import org.wikipedia.notifications.AnonymousNotificationHelper
@@ -43,7 +44,6 @@ import org.wikipedia.talk.db.TalkTemplate
 import org.wikipedia.talk.template.TalkTemplatesTextInputDialog
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
@@ -233,7 +233,7 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
 
     private fun onInitialLoad() {
         binding.footerContainer.tempAccountInfoContainer.isVisible = false
-        L10nUtil.setConditionalLayoutDirection(binding.talkScrollContainer, viewModel.pageTitle.wikiSite.languageCode)
+        binding.talkScrollContainer.setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
         binding.learnMoreButton.isVisible = viewModel.isFromDiff
         if (viewModel.topic != null) {
             binding.replyInputView.userNameHints = setOf(viewModel.topic!!.author)

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicActivity.kt
@@ -28,6 +28,7 @@ import org.wikipedia.dataclient.discussiontools.ThreadItem
 import org.wikipedia.diff.ArticleEditDetailsActivity
 import org.wikipedia.edit.EditHandler
 import org.wikipedia.edit.EditSectionActivity
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.history.SearchActionModeCallback
 import org.wikipedia.login.LoginActivity
@@ -38,7 +39,6 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.staticdata.UserAliasData
 import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ShareUtil
 import org.wikipedia.util.StringUtil
@@ -98,8 +98,8 @@ class TalkTopicActivity : BaseActivity() {
         linkHandler = TalkLinkHandler(this)
         linkHandler.wikiSite = viewModel.pageTitle.wikiSite
 
-        L10nUtil.setConditionalLayoutDirection(binding.talkRecyclerView, viewModel.pageTitle.wikiSite.languageCode)
-        L10nUtil.setConditionalLayoutDirection(binding.talkErrorView, viewModel.pageTitle.wikiSite.languageCode)
+        binding.talkRecyclerView.setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
+        binding.talkErrorView.setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
 
         ViewUtil.getTitleViewFromToolbar(binding.toolbar)?.let {
             it.movementMethod = linkMovementMethod

--- a/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkTopicsActivity.kt
@@ -37,6 +37,7 @@ import org.wikipedia.dataclient.okhttp.HttpStatusException
 import org.wikipedia.edit.EditHandler
 import org.wikipedia.edit.EditSectionActivity
 import org.wikipedia.extensions.parcelableExtra
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.history.SearchActionModeCallback
 import org.wikipedia.notifications.NotificationActivity
@@ -54,7 +55,6 @@ import org.wikipedia.staticdata.UserAliasData
 import org.wikipedia.staticdata.UserTalkAliasData
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ImageUrlUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.ShareUtil
 import org.wikipedia.util.StringUtil
@@ -319,7 +319,7 @@ class TalkTopicsActivity : BaseActivity(), WatchlistExpiryDialog.Callback {
 
     private fun resetViews() {
         invalidateOptionsMenu()
-        L10nUtil.setConditionalLayoutDirection(binding.talkContentsView, viewModel.pageTitle.wikiSite.languageCode)
+        binding.talkContentsView.setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
         binding.talkProgressBar.isVisible = true
         binding.talkErrorView.isVisible = false
         binding.talkEmptyContainer.isVisible = false

--- a/app/src/main/java/org/wikipedia/util/L10nUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/L10nUtil.kt
@@ -39,14 +39,6 @@ object L10nUtil {
         return TextUtils.getLayoutDirectionFromLocale(Locale(lang)) == View.LAYOUT_DIRECTION_RTL
     }
 
-    fun setConditionalTextDirection(view: View, lang: String) {
-        view.textDirection = if (isLangRTL(lang)) View.TEXT_DIRECTION_RTL else View.TEXT_DIRECTION_LTR
-    }
-
-    fun setConditionalLayoutDirection(view: View, lang: String) {
-        view.layoutDirection = TextUtils.getLayoutDirectionFromLocale(Locale(lang))
-    }
-
     fun getStringForArticleLanguage(languageCode: String, resId: Int): String {
         return getStringsForLocale(Locale(languageCode), intArrayOf(resId))[resId]
     }

--- a/app/src/main/java/org/wikipedia/views/WikiArticleCardView.kt
+++ b/app/src/main/java/org/wikipedia/views/WikiArticleCardView.kt
@@ -8,14 +8,14 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import org.wikipedia.databinding.ViewWikiArticleCardBinding
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.DimenUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.TransitionUtil
 
-class WikiArticleCardView constructor(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
+class WikiArticleCardView(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
 
     val binding = ViewWikiArticleCardBinding.inflate(LayoutInflater.from(context), this)
 
@@ -56,6 +56,6 @@ class WikiArticleCardView constructor(context: Context, attrs: AttributeSet? = n
         setTitle(title.displayText)
         setDescription(title.description)
         binding.articleDivider.visibility = View.GONE
-        L10nUtil.setConditionalLayoutDirection(this, title.wikiSite.languageCode)
+        setLayoutDirectionByLang(title.wikiSite.languageCode)
     }
 }

--- a/app/src/main/java/org/wikipedia/watchlist/WatchlistItemView.kt
+++ b/app/src/main/java/org/wikipedia/watchlist/WatchlistItemView.kt
@@ -5,7 +5,6 @@ import android.graphics.Typeface
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
-import android.view.View.OnClickListener
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
@@ -14,12 +13,12 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.databinding.ItemWatchlistBinding
 import org.wikipedia.dataclient.mwapi.MwQueryResult
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.util.DateUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.StringUtil
 
-class WatchlistItemView constructor(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
+class WatchlistItemView(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
     val binding = ItemWatchlistBinding.inflate(LayoutInflater.from(context), this, true)
     var callback: Callback? = null
     private var item: MwQueryResult.WatchlistItem? = null
@@ -92,7 +91,7 @@ class WatchlistItemView constructor(context: Context, attrs: AttributeSet? = nul
             binding.containerView.alpha = 1.0f
             binding.containerView.isClickable = true
         }
-        L10nUtil.setConditionalLayoutDirection(this, item.wiki!!.languageCode)
+        setLayoutDirectionByLang(item.wiki!!.languageCode)
         StringUtil.setHighlightedAndBoldenedText(binding.titleText, item.title, currentQuery)
         StringUtil.setHighlightedAndBoldenedText(binding.userNameText, item.user, currentQuery)
         StringUtil.setHighlightedAndBoldenedText(binding.summaryText, summary, currentQuery)

--- a/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
+++ b/app/src/main/java/org/wikipedia/wiktionary/WiktionaryDialog.kt
@@ -17,10 +17,10 @@ import org.wikipedia.databinding.ItemWiktionaryDefinitionWithExamplesBinding
 import org.wikipedia.databinding.ItemWiktionaryDefinitionsListBinding
 import org.wikipedia.databinding.ItemWiktionaryExampleBinding
 import org.wikipedia.dataclient.restbase.RbDefinition
+import org.wikipedia.extensions.setLayoutDirectionByLang
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.page.PageTitle
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 
@@ -43,7 +43,7 @@ class WiktionaryDialog : ExtendedBottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.wiktionaryDefinitionDialogTitle.text = sanitizeForDialogTitle(viewModel.selectedText)
-        L10nUtil.setConditionalLayoutDirection(binding.root, viewModel.pageTitle.wikiSite.languageCode)
+        binding.root.setLayoutDirectionByLang(viewModel.pageTitle.wikiSite.languageCode)
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 launch {


### PR DESCRIPTION
Bear with me:
This PR, and a couple of upcoming ones, will work towards solving the issue of certain UI elements showing the incorrect language strings, for devices that have multiple language keyboards enabled.
This is a preliminary PR that cleans up a couple of L10n functions, and turns them into `View.` extensions, making them slightly simpler to use and to read.