### PR TITLE
Update the default visibility of recent search container to "gone"

### DIFF
--- a/app/src/main/res/layout/fragment_search_recent.xml
+++ b/app/src/main/res/layout/fragment_search_recent.xml
@@ -49,6 +49,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:paddingTop="8dp"
+        android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
### What does this do?
A minor update to the visibility for the recent search container is that if you do not have recent search queries, the view will still show up and disappear in a very quick way, which can be avoided. 

