### PR TITLE
Pass login UI messages through parser.

### DIFF
--- a/app/src/main/java/org/wikipedia/login/LoginActivity.kt
+++ b/app/src/main/java/org/wikipedia/login/LoginActivity.kt
@@ -208,6 +208,7 @@ class LoginActivity : BaseActivity() {
             firstStepToken = token
             binding.login2faText.visibility = View.VISIBLE
             binding.login2faText.requestFocus()
+            DeviceUtil.hideSoftKeyboard(this@LoginActivity)
             FeedbackUtil.showError(this@LoginActivity, caught)
         }
 

--- a/app/src/main/java/org/wikipedia/login/LoginClient.kt
+++ b/app/src/main/java/org/wikipedia/login/LoginClient.kt
@@ -38,10 +38,11 @@ class LoginClient {
                     }
                     cb.success(loginResult)
                 } else if (LoginResult.STATUS_UI == loginResult.status) {
+                    val parsedMessage = loginResult.message?.let { ServiceFactory.get(wiki).parseText(it) }?.text
                     when (loginResult) {
-                        is LoginOAuthResult -> cb.twoFactorPrompt(LoginFailedException(loginResult.message), loginToken)
+                        is LoginOAuthResult -> cb.twoFactorPrompt(LoginFailedException(parsedMessage), loginToken)
                         is LoginResetPasswordResult -> cb.passwordResetPrompt(loginToken)
-                        else -> cb.error(LoginFailedException(loginResult.message))
+                        else -> cb.error(LoginFailedException(parsedMessage))
                     }
                 } else {
                     cb.error(LoginFailedException(loginResult.message))

--- a/app/src/main/java/org/wikipedia/login/LoginClient.kt
+++ b/app/src/main/java/org/wikipedia/login/LoginClient.kt
@@ -38,7 +38,7 @@ class LoginClient {
                     }
                     cb.success(loginResult)
                 } else if (LoginResult.STATUS_UI == loginResult.status) {
-                    val parsedMessage = loginResult.message?.let { ServiceFactory.get(wiki).parseText(it) }?.text
+                    val parsedMessage = loginResult.message?.let { ServiceFactory.get(wiki).parseText(it) }?.text ?: loginResult.message
                     when (loginResult) {
                         is LoginOAuthResult -> cb.twoFactorPrompt(LoginFailedException(parsedMessage), loginToken)
                         is LoginResetPasswordResult -> cb.passwordResetPrompt(loginToken)

--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -136,7 +136,7 @@ object FeedbackUtil {
     }
 
     fun makeSnackbar(view: View, text: CharSequence, duration: Int = LENGTH_DEFAULT, wikiSite: WikiSite = WikipediaApp.instance.wikiSite): Snackbar {
-        val snackbar = Snackbar.make(view, StringUtil.fromHtml(text.toString()), duration)
+        val snackbar = Snackbar.make(view, StringUtil.fromHtml(text.toString()).trim(), duration)
         val textView = snackbar.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
         textView.setLinkTextColor(ResourceUtil.getThemedColor(view.context, R.attr.progressive_color))
         textView.movementMethod = LinkMovementMethodExt.getExternalLinkMovementMethod(wikiSite)

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -56,8 +56,10 @@
                 android:id="@+id/login_2fa_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
                 android:hint="@string/login_2fa_hint"
-                android:visibility="gone">
+                android:visibility="gone"
+                tools:visibility="visible">
 
                 <org.wikipedia.views.PlainPasteEditText
                     style="?android:textAppearanceMedium"


### PR DESCRIPTION
When we receive "UI" messages from the Login API (for entering a 2FA code or captcha), these messages are received as wikitext, and might contain links or other syntax, and must therefore be passed through the parser.

This also takes care of a few other tiny tweaks:
* When displaying a snackbar with text that comes from `fromHtml()`, let's `trim()` it because certain messages, after being parsed, end up containing extraneous empty tags at the end (such as `<p>` or `<br />`) that produce unnecessary empty lines that don't look good in a snackbar.
* The 2FA field in the Login screen was missing top padding.
* When revealing the 2FA field, let's hide the soft keyboard, so that the full snackbar could be displayed, and not overlap the 2FA field.

https://phabricator.wikimedia.org/T390919
