### PR TITLE
Convert WikiCardView to use Compose

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -2,20 +2,26 @@ package org.wikipedia.compose.components
 
 import android.os.Build
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.wikipedia.WikipediaApp
+import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
+import org.wikipedia.theme.Theme
 
 @Composable
 fun WikiCard(
     modifier: Modifier = Modifier,
+    isDarkTheme: Boolean = WikipediaApp.instance.currentTheme.isDark,
     elevation: Dp = 8.dp,
     colors: CardColors = CardDefaults.cardColors(
         containerColor = WikipediaTheme.colors.paperColor,
@@ -24,7 +30,6 @@ fun WikiCard(
     border: BorderStroke? = null,
     content: @Composable () -> Unit
 ) {
-    val isDarkTheme = WikipediaApp.instance.currentTheme.isDark
     val cardElevation = remember(elevation, isDarkTheme) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDarkTheme) {
             0.dp
@@ -40,5 +45,49 @@ fun WikiCard(
         border = border,
     ) {
         content()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WikiCardSimpleWikiTextPreview() {
+    BaseTheme(
+        currentTheme = Theme.LIGHT
+    ) {
+        WikiCard(
+            modifier = Modifier
+                .padding(20.dp),
+            isDarkTheme = false
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(16.dp),
+                text = "Text example in a WikiCard",
+                color = WikipediaTheme.colors.progressiveColor
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BorderAndElevationWikiTextPreview() {
+    BaseTheme(
+        currentTheme = Theme.DARK
+    ) {
+        WikiCard(
+            modifier = Modifier
+                .padding(20.dp),
+            border = BorderStroke(width = 0.5.dp, color = WikipediaTheme.colors.progressiveColor),
+            elevation = 4.dp,
+            isDarkTheme = true
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(16.dp),
+                text = "Text example in a WikiCard",
+                color = WikipediaTheme.colors.progressiveColor
+            )
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -1,0 +1,42 @@
+package org.wikipedia.compose.components
+
+import android.os.Build
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.wikipedia.WikipediaApp
+import org.wikipedia.compose.theme.WikipediaTheme
+
+@Composable
+fun WikiCard(
+    modifier: Modifier = Modifier,
+    elevation: Dp = 8.dp,
+    border: BorderStroke? = null,
+    content: @Composable () -> Unit
+) {
+    val isDarkTheme = WikipediaApp.instance.currentTheme.isDark
+    val cardElevation = remember(elevation, isDarkTheme) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDarkTheme) {
+            0.dp
+        } else {
+            elevation
+        }
+    }
+
+    Card(
+        modifier = modifier,
+        elevation = CardDefaults.cardElevation(defaultElevation = cardElevation),
+        colors = CardDefaults.cardColors(
+            containerColor = WikipediaTheme.colors.paperColor,
+            contentColor = WikipediaTheme.colors.paperColor
+        ),
+        border = border,
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -3,6 +3,7 @@ package org.wikipedia.compose.components
 import android.os.Build
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -16,6 +17,10 @@ import org.wikipedia.compose.theme.WikipediaTheme
 fun WikiCard(
     modifier: Modifier = Modifier,
     elevation: Dp = 8.dp,
+    colors: CardColors = CardDefaults.cardColors(
+        containerColor = WikipediaTheme.colors.paperColor,
+        contentColor = WikipediaTheme.colors.paperColor
+    ),
     border: BorderStroke? = null,
     content: @Composable () -> Unit
 ) {
@@ -31,10 +36,7 @@ fun WikiCard(
     Card(
         modifier = modifier,
         elevation = CardDefaults.cardElevation(defaultElevation = cardElevation),
-        colors = CardDefaults.cardColors(
-            containerColor = WikipediaTheme.colors.paperColor,
-            contentColor = WikipediaTheme.colors.paperColor
-        ),
+        colors = colors,
         border = border,
     ) {
         content()


### PR DESCRIPTION
### What does this do?
Converts the `WikiCardView` to use Compose. No design review will be needed since this is a custom view conversion.

Some screenshots have been attached in the ticket if you desire to see the implementations.

**Phabricator:**
https://phabricator.wikimedia.org/T389141
