### PR TITLE
Enable EmailAuth support.

### DIFF
--- a/app/src/main/java/org/wikipedia/csrf/CsrfTokenClient.kt
+++ b/app/src/main/java/org/wikipedia/csrf/CsrfTokenClient.kt
@@ -32,7 +32,7 @@ object CsrfTokenClient {
                     if (retry > 0 && AccountUtil.isLoggedIn && !AccountUtil.isTemporaryAccount) {
                         // Log in explicitly
                         try {
-                            LoginClient().loginBlocking(site, AccountUtil.userName, AccountUtil.password!!, "")
+                            LoginClient().loginBlocking(site, AccountUtil.userName, AccountUtil.password!!)
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: Throwable) {

--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -298,7 +298,8 @@ interface Service {
         @Field("password") pass: String?,
         @Field("retype") retypedPass: String?,
         @Field("OATHToken") twoFactorCode: String?,
-        @Field("logintoken") token: String?,
+        @Field("token") emailAuthToken: String?,
+        @Field("logintoken") loginToken: String?,
         @Field("logincontinue") loginContinue: Boolean
     ): LoginResponse
 

--- a/app/src/main/java/org/wikipedia/dataclient/SharedPreferenceCookieManager.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/SharedPreferenceCookieManager.kt
@@ -4,6 +4,7 @@ import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.wikipedia.login.LoginClient
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.log.L
 
@@ -104,6 +105,10 @@ class SharedPreferenceCookieManager(
                 // from wikipedia.org unconditionally.
                 buildCookieList(cookieList, cookiesForDomainSpec, CENTRALAUTH_PREFIX)
             }
+        }
+        if (LoginClient.enqueueForceEmailAuth && (url.toString().contains("action=clientlogin"))) {
+            cookieList.add(Cookie.Builder().name("forceEmailAuth").value("1").domain(domain).secure().build())
+            LoginClient.enqueueForceEmailAuth = false
         }
         return cookieList
     }

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/CommonHeaderRequestInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/CommonHeaderRequestInterceptor.kt
@@ -4,19 +4,24 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.RestService
+import org.wikipedia.login.LoginClient
 import java.io.IOException
 
 internal class CommonHeaderRequestInterceptor : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val app = WikipediaApp.instance
+        val url = chain.request().url.toString()
         val builder = chain.request().newBuilder()
                 .header("User-Agent", app.userAgent)
                 .header("X-WMF-UUID", app.appInstallID)
-        if (chain.request().url.encodedPath.contains(RestService.PAGE_HTML_ENDPOINT)) {
+        if (url.contains(RestService.PAGE_HTML_ENDPOINT)) {
             builder.header("Accept", RestService.ACCEPT_HEADER_MOBILE_HTML)
-        } else if (chain.request().url.host.contains("maps.wikimedia.org")) {
+        } else if (url.contains("maps.wikimedia.org")) {
             builder.header("Referer", "https://maps.wikimedia.org/")
+        }
+        if (LoginClient.enqueueForceEmailAuth && url.contains("action=clientlogin")) {
+            builder.removeHeader("User-Agent")
         }
         return chain.proceed(builder.build())
     }

--- a/app/src/main/java/org/wikipedia/login/LoginActivity.kt
+++ b/app/src/main/java/org/wikipedia/login/LoginActivity.kt
@@ -100,6 +100,7 @@ class LoginActivity : BaseActivity() {
         }
 
         setAllViewsClickListener()
+        resetAuthState()
 
         // Assume no login by default
         setResult(RESULT_LOGIN_FAIL)
@@ -132,6 +133,13 @@ class LoginActivity : BaseActivity() {
 
     private fun getText(input: TextInputLayout): String {
         return input.editText?.text?.toString().orEmpty()
+    }
+
+    private fun resetAuthState() {
+        binding.login2faText.isVisible = false
+        binding.login2faText.editText?.setText("")
+        firstStepToken = null
+        uiPromptResult = null
     }
 
     private fun clearErrors() {
@@ -227,6 +235,8 @@ class LoginActivity : BaseActivity() {
 
         override fun error(caught: Throwable) {
             showProgressBar(false)
+            resetAuthState()
+            DeviceUtil.hideSoftKeyboard(this@LoginActivity)
             if (caught is LoginFailedException) {
                 FeedbackUtil.showError(this@LoginActivity, caught)
             } else {

--- a/app/src/main/java/org/wikipedia/login/LoginClient.kt
+++ b/app/src/main/java/org/wikipedia/login/LoginClient.kt
@@ -9,6 +9,7 @@ import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.settings.Prefs
 import org.wikipedia.util.log.L
 import java.io.IOException
 
@@ -16,19 +17,22 @@ class LoginClient {
 
     interface LoginCallback {
         fun success(result: LoginResult)
-        fun twoFactorPrompt(caught: Throwable, token: String?)
+        fun uiPrompt(result: LoginResult, caught: Throwable, token: String?)
         fun passwordResetPrompt(token: String?)
         fun error(caught: Throwable)
     }
 
     fun login(coroutineScope: CoroutineScope, wiki: WikiSite, userName: String, password: String,
-              retypedPassword: String?, twoFactorCode: String?, token: String?, cb: LoginCallback) {
+              retypedPassword: String?, twoFactorCode: String?, emailAuthCode: String?, token: String?, cb: LoginCallback) {
         coroutineScope.launch(CoroutineExceptionHandler { _, throwable ->
             L.e("Login process failed. $throwable")
             cb.error(throwable)
         }) {
+            if (Prefs.loginForceEmailAuth) {
+                enqueueForceEmailAuth = true
+            }
             val loginToken = token ?: getLoginToken(wiki)
-            val loginResult = getLoginResponse(wiki, userName, password, retypedPassword, twoFactorCode, loginToken).toLoginResult(wiki, password)
+            val loginResult = getLoginResponse(wiki, userName, password, retypedPassword, twoFactorCode, emailAuthCode, loginToken).toLoginResult(wiki, password)
             if (loginResult != null) {
                 if (loginResult.pass() && userName.isNotEmpty()) {
                     ServiceFactory.get(wiki).getUserInfo().query?.userInfo?.let {
@@ -40,7 +44,8 @@ class LoginClient {
                 } else if (LoginResult.STATUS_UI == loginResult.status) {
                     val parsedMessage = loginResult.message?.let { ServiceFactory.get(wiki).parseText(it) }?.text ?: loginResult.message
                     when (loginResult) {
-                        is LoginOAuthResult -> cb.twoFactorPrompt(LoginFailedException(parsedMessage), loginToken)
+                        is LoginOAuthResult -> cb.uiPrompt(loginResult, LoginFailedException(parsedMessage), loginToken)
+                        is LoginEmailAuthResult -> cb.uiPrompt(loginResult, LoginFailedException(parsedMessage), loginToken)
                         is LoginResetPasswordResult -> cb.passwordResetPrompt(loginToken)
                         else -> cb.error(LoginFailedException(parsedMessage))
                     }
@@ -53,15 +58,19 @@ class LoginClient {
         }
     }
 
-    suspend fun loginBlocking(wiki: WikiSite, userName: String, password: String, twoFactorCode: String?): LoginResponse {
+    suspend fun loginBlocking(wiki: WikiSite, userName: String, password: String, twoFactorCode: String? = null, emailAuthCode: String? = null): LoginResponse {
         val loginToken = getLoginToken(wiki)
-        val loginResponse = getLoginResponse(wiki, userName, password, null, twoFactorCode, loginToken)
+        val loginResponse = getLoginResponse(wiki, userName, password, null, twoFactorCode, emailAuthCode, loginToken)
         val loginResult = loginResponse.toLoginResult(wiki, password) ?: throw IOException("Unexpected response when logging in.")
         if (LoginResult.STATUS_UI == loginResult.status) {
             if (loginResult is LoginOAuthResult) {
                 // TODO: Find a better way to boil up the warning about 2FA
                 Toast.makeText(WikipediaApp.instance,
                     R.string.login_2fa_other_workflow_error_msg, Toast.LENGTH_LONG).show()
+            } else if (loginResult is LoginEmailAuthResult) {
+                // TODO: Find a better way to boil up the warning about Email auth
+                Toast.makeText(WikipediaApp.instance,
+                    R.string.login_email_auth_other_workflow_error_msg, Toast.LENGTH_LONG).show()
             }
             throw LoginFailedException(loginResult.message)
         } else if (!loginResult.pass() || loginResult.userName.isNullOrEmpty()) {
@@ -76,9 +85,14 @@ class LoginClient {
     }
 
     private suspend fun getLoginResponse(wiki: WikiSite, userName: String, password: String, retypedPassword: String?,
-        twoFactorCode: String?, loginToken: String?): LoginResponse {
-        return if (twoFactorCode.isNullOrEmpty() && retypedPassword.isNullOrEmpty())
+        twoFactorCode: String?, emailAuthCode: String?, loginToken: String?): LoginResponse {
+        return if ((!twoFactorCode.isNullOrEmpty() || !emailAuthCode.isNullOrEmpty()) || !retypedPassword.isNullOrEmpty())
+            ServiceFactory.get(wiki).postLogIn(userName, password, retypedPassword, twoFactorCode, emailAuthCode, loginToken, true)
+        else
             ServiceFactory.get(wiki).postLogIn(userName, password, loginToken, Service.WIKIPEDIA_URL)
-        else ServiceFactory.get(wiki).postLogIn(userName, password, retypedPassword, twoFactorCode, loginToken, true)
+    }
+
+    companion object {
+        var enqueueForceEmailAuth = false
     }
 }

--- a/app/src/main/java/org/wikipedia/login/LoginEmailAuthResult.kt
+++ b/app/src/main/java/org/wikipedia/login/LoginEmailAuthResult.kt
@@ -1,0 +1,6 @@
+package org.wikipedia.login
+
+import org.wikipedia.dataclient.WikiSite
+
+internal class LoginEmailAuthResult(site: WikiSite, status: String, userName: String?, password: String?,
+    message: String?) : LoginResult(site, status, userName, password, message)

--- a/app/src/main/java/org/wikipedia/login/LoginResponse.kt
+++ b/app/src/main/java/org/wikipedia/login/LoginResponse.kt
@@ -31,6 +31,8 @@ class LoginResponse : MwResponse() {
                     for (req in requests) {
                         if (req.id.orEmpty().endsWith("TOTPAuthenticationRequest")) {
                             return LoginOAuthResult(site, status, userName, password, message)
+                        } else if (req.id.orEmpty().endsWith("EmailAuthAuthenticationRequest")) {
+                            return LoginEmailAuthResult(site, status, userName, password, message)
                         } else if (req.id.orEmpty().endsWith("PasswordAuthenticationRequest")) {
                             return LoginResetPasswordResult(site, status, userName, password, message)
                         }

--- a/app/src/main/java/org/wikipedia/login/ResetPasswordActivity.kt
+++ b/app/src/main/java/org/wikipedia/login/ResetPasswordActivity.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.textfield.TextInputLayout
 import org.wikipedia.R
@@ -50,6 +51,7 @@ class ResetPasswordActivity : BaseActivity() {
         binding.loginButton.setOnClickListener { validateThenLogin() }
         userName = intent.getStringExtra(LOGIN_USER_NAME).orEmpty()
         firstStepToken = intent.getStringExtra(LOGIN_TOKEN).orEmpty()
+        resetAuthState()
     }
 
     override fun onBackPressed() {
@@ -65,6 +67,12 @@ class ResetPasswordActivity : BaseActivity() {
     private fun clearErrors() {
         binding.resetPasswordInput.isErrorEnabled = false
         binding.resetPasswordRepeat.isErrorEnabled = false
+    }
+
+    private fun resetAuthState() {
+        binding.login2faText.isVisible = false
+        binding.login2faText.editText?.setText("")
+        uiPromptResult = null
     }
 
     private fun validateThenLogin() {
@@ -147,6 +155,8 @@ class ResetPasswordActivity : BaseActivity() {
 
         override fun error(caught: Throwable) {
             showProgressBar(false)
+            resetAuthState()
+            DeviceUtil.hideSoftKeyboard(this@ResetPasswordActivity)
             if (caught is LoginFailedException) {
                 FeedbackUtil.showError(this@ResetPasswordActivity, caught)
             } else {

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -221,6 +221,10 @@ object Prefs {
         PrefsIoUtil.setInt(R.string.preference_key_reading_list_page_sort_mode, sortMode)
     }
 
+    var loginForceEmailAuth
+        get() = PrefsIoUtil.getBoolean(R.string.preference_key_login_force_email_auth, false)
+        set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_login_force_email_auth, value)
+
     val isMemoryLeakTestEnabled
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_memory_leak_test, false)
 

--- a/app/src/main/java/org/wikipedia/views/NonEmptyValidator.kt
+++ b/app/src/main/java/org/wikipedia/views/NonEmptyValidator.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.views
 
 import android.widget.Button
+import androidx.core.view.isGone
 import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputLayout
 
@@ -19,7 +20,7 @@ class NonEmptyValidator(private val actionButton: Button, private vararg val tex
     }
 
     private fun revalidate(force: Boolean = false) {
-        val isValid = textInputs.all { it.editText!!.text.isNotEmpty() }
+        val isValid = textInputs.all { it.isGone || it.editText!!.text.isNotEmpty() }
         if (isValid != lastIsValidValue || force) {
             lastIsValidValue = isValid
             actionButton.isEnabled = lastIsValidValue

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -61,19 +61,21 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/login_2fa_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/login_2fa_hint">
+                android:layout_marginTop="8dp"
+                android:hint="@string/login_2fa_hint"
+                android:visibility="gone"
+                tools:visibility="visible">
 
                 <org.wikipedia.views.PlainPasteEditText
-                    android:id="@+id/login_2fa_text"
                     style="?android:textAppearanceMedium"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:imeOptions="flagNoExtractUi"
                     android:inputType="textVisiblePassword|textNoSuggestions"
-                    android:maxLines="1"
-                    android:visibility="gone" />
+                    android:maxLines="1" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <Button

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -185,7 +185,9 @@
   <string name="login_password_hint">{{Identical|Password}}</string>
   <string name="account_creation_password_hint">Text field hint which prompts the user to enter a password in the field.\n{{Identical|Password}}</string>
   <string name="login_2fa_hint">Hint for a field where the user can enter a two-factor authentication code, if required.</string>
-  <string name="login_2fa_other_workflow_error_msg">Message for when login fails during an editing workflow because two-factor authentication is required.  Directs the user to return to the main activity, log in, and retry.</string>
+  <string name="login_2fa_other_workflow_error_msg">Message for when login fails during an editing workflow because two-factor authentication is required. Directs the user to return to the main screen and retry logging in.</string>
+  <string name="login_email_auth_hint">Hint for a field where the user can enter an email verification code, if required.</string>
+  <string name="login_email_auth_other_workflow_error_msg">Message for when login fails during an editing workflow because email verification is required. Directs the user to return to the main screen and retry logging in.</string>
   <string name="onboarding_card_login">Text on button suggesting user to login from the onboarding card.\n{{Identical|Log in}}</string>
   <string name="page_editing_login">Text on button suggesting user to login for editing a page.\n{{Identical|Log in}}</string>
   <string name="reading_lists_sync_login">Text on button suggesting user to login for syncing reading lists.\n{{Identical|Log in}}</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -27,6 +27,7 @@
     <string name="preference_key_daily_event_time_task_name">dailyEventTask</string>
     <string name="preference_key_talk_offline_cleanup_task_name">talkOfflineCleanupTask</string>
     <string name="preference_key_login_groups">groups</string>
+    <string name="preference_key_login_force_email_auth">loginForceEmailAuth</string>
     <string name="preference_key_show_developer_settings">showDeveloperSettings</string>
     <string name="preference_key_last_run_time_format">%s-lastrun</string>
     <string name="preference_key_tabs">tabs</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,8 +156,10 @@
     <string name="login_username_hint">Username</string>
     <string name="login_password_hint">Password</string>
     <string name="account_creation_password_hint">Password</string>
-    <string name="login_2fa_hint">Two-Factor Authentication Code</string>
-    <string name="login_2fa_other_workflow_error_msg">Two-factor authentication required! Please return to the main activity and log in with your 2FA token, then retry.</string>
+    <string name="login_2fa_hint">Two-factor authentication code</string>
+    <string name="login_2fa_other_workflow_error_msg">Two-factor authentication required! Please login from the main screen, and enter the code from your 2FA token.</string>
+    <string name="login_email_auth_hint">Email verification code</string>
+    <string name="login_email_auth_other_workflow_error_msg">Email verification required! Please login from the main screen, and enter your email verification code.</string>
     <string name="onboarding_card_login">Log in</string>
     <string name="page_editing_login">Log in</string>
     <string name="reading_lists_sync_login">Log in</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -213,6 +213,10 @@
             android:title="dailyEventTask-lastrun" />
 
         <org.wikipedia.settings.SwitchPreferenceMultiLine
+            android:key="@string/preference_key_login_force_email_auth"
+            android:title="Force email authentication when logging in." />
+
+        <org.wikipedia.settings.SwitchPreferenceMultiLine
             android:key="@string/preference_key_show_developer_settings"
             android:title="@string/preference_key_show_developer_settings" />
 


### PR DESCRIPTION
This enables integration with [EmailAuth](https://www.mediawiki.org/wiki/Extension:EmailAuth), where a login attempt requires a second factor that is sent to the user via email.
This basically reuses our existing logic for 2FA ([OATHAuth](https://www.mediawiki.org/wiki/Extension:OATHAuth)), just with slightly different verbiage and logic.

There is now a new Developer preference for "forcing" email authentication, if necessary for testing.

https://phabricator.wikimedia.org/T390820
