### PR TITLE
Follow-up: YiR entry dialog code optimization

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -86,7 +86,7 @@ import org.wikipedia.util.TabUtil
 import org.wikipedia.views.NotificationButtonView
 import org.wikipedia.views.TabCountsView
 import org.wikipedia.watchlist.WatchlistActivity
-import org.wikipedia.yearinreview.YearInReviewDialog
+import org.wikipedia.yearinreview.YearInReviewEntryDialog
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -473,7 +473,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     }
 
     override fun yearInReviewClick() {
-        ExclusiveBottomSheetPresenter.show(childFragmentManager, YearInReviewDialog.newInstance())
+        ExclusiveBottomSheetPresenter.show(childFragmentManager, YearInReviewEntryDialog.newInstance())
     }
 
     fun setBottomNavVisible(visible: Boolean) {

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewEntryDialog.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewEntryDialog.kt
@@ -10,7 +10,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.page.ExtendedBottomSheetDialogFragment
 
-class YearInReviewDialog : ExtendedBottomSheetDialogFragment() {
+class YearInReviewEntryDialog : ExtendedBottomSheetDialogFragment() {
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -23,15 +23,15 @@ class YearInReviewDialog : ExtendedBottomSheetDialogFragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 BaseTheme {
-                    YearInReviewBottomSheet()
+                    YearInReviewEntryDialogScreen()
                 }
             }
         }
     }
 
     companion object {
-        fun newInstance(): YearInReviewDialog {
-            return YearInReviewDialog()
+        fun newInstance(): YearInReviewEntryDialog {
+            return YearInReviewEntryDialog()
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewEntryDialogScreen.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewEntryDialogScreen.kt
@@ -3,8 +3,8 @@ package org.wikipedia.yearinreview
 import android.widget.ImageView
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
@@ -19,7 +19,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,24 +33,24 @@ import org.wikipedia.compose.theme.WikipediaTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun YearInReviewBottomSheet() {
+fun YearInReviewEntryDialogScreen() {
     val context = LocalContext.current
-    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
             .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
-            .padding(20.dp)
-            .verticalScroll(scrollState),
+            .padding(vertical = 16.dp)
+            .nestedScroll(rememberNestedScrollInteropConnection())
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         Text(
             modifier = Modifier.padding(
-                horizontal = 30.dp
+                horizontal = 32.dp
             ),
-            text = stringResource(R.string.year_in_review_explore_screen_title),
+            text = stringResource(R.string.year_in_review_entry_dialog_title),
             color = WikipediaTheme.colors.primaryColor,
             style = MaterialTheme.typography.headlineSmall,
             textAlign = TextAlign.Center
@@ -56,9 +58,9 @@ fun YearInReviewBottomSheet() {
         )
         Text(
             modifier = Modifier.padding(
-                horizontal = 45.dp
+                horizontal = 16.dp
             ),
-            text = stringResource(R.string.year_in_review_explore_screen_bodytext),
+            text = stringResource(R.string.year_in_review_entry_dialog_bodytext),
             color = WikipediaTheme.colors.primaryColor,
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center
@@ -69,13 +71,12 @@ fun YearInReviewBottomSheet() {
                     Glide.with(this)
                         .asGif()
                         .load(R.drawable.wyir_puzzle_4_v2)
-                        .centerCrop()
                         .into(this)
                 }
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(3f / 2f)
+                .heightIn(max = 240.dp)
                 .clip(RoundedCornerShape(16.dp))
         )
         Button(
@@ -91,7 +92,7 @@ fun YearInReviewBottomSheet() {
             )
         ) {
             Text(
-                text = stringResource(R.string.year_in_review_explore_screen_continue),
+                text = stringResource(R.string.year_in_review_entry_dialog_continue),
                 color = WikipediaTheme.colors.paperColor,
                 style = MaterialTheme.typography.labelLarge
             )
@@ -99,8 +100,8 @@ fun YearInReviewBottomSheet() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun PreviewBottomSheet() {
-    YearInReviewBottomSheet()
+    YearInReviewEntryDialogScreen()
 }

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1793,7 +1793,7 @@
   <string name="year_in_review_read_count_bodytext">Body text for the year in review readcount page. \"%d\" represents the total number of articles in the HistoryEntry table for the current year</string>
   <string name="year_in_review_edit_count_headline">Headline text for the year in review editcount page. \"%d\" represents the total number of userContribs for the current year</string>
   <string name="year_in_review_edit_count_bodytext">Body text for the year in review editcount page. \"%d\" represents the total number of userContribs for the current year</string>
-  <string name="year_in_review_explore_screen_title">Headline for the year in review Explore Screen</string>
-  <string name="year_in_review_explore_screen_bodytext">Body text for the year in review Explore Screen</string>
-  <string name="year_in_review_explore_screen_continue">Button text for the year in review Explore Screen</string>
+  <string name="year_in_review_entry_dialog_title">Headline for the year in review Explore Screen</string>
+  <string name="year_in_review_entry_dialog_bodytext">Body text for the year in review Explore Screen</string>
+  <string name="year_in_review_entry_dialog_continue">Button text for the year in review Explore Screen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1876,7 +1876,7 @@
     <string name="year_in_review_read_count_bodytext">This year, you read %d articles, including Climate change, Dogs, and Cats. Wikipedia had more than 63 million articles available across over 300 languages. You joined millions in expanding knowledge and exploring diverse topics.</string>
     <string name="year_in_review_edit_count_headline">You edited Wikipedia %d times</string>
     <string name="year_in_review_edit_count_bodytext">You edited Wikipedia %d times. Thank you for being one of the volunteer editors making a difference on Wikimedia projects around the world.</string>
-    <string name="year_in_review_explore_screen_title">Explore your Wikipedia in Review</string>
-    <string name="year_in_review_explore_screen_bodytext">See insights about what articles we read and edited, and share highlights from our year on Wikipedia.</string>
-    <string name="year_in_review_explore_screen_continue">Continue</string>
+    <string name="year_in_review_entry_dialog_title">Explore your Wikipedia in Review</string>
+    <string name="year_in_review_entry_dialog_bodytext">See insights about what articles we read and edited, and share highlights from our year on Wikipedia.</string>
+    <string name="year_in_review_entry_dialog_continue">Continue</string>
 </resources>


### PR DESCRIPTION
### What does this do?
A follow-up PR of #5465 that does the following optimization:
- Renames classes to `EntryDialog` instead of a plain `Dialog`.
- Renames `BottomSheetScaffold` to `YearInReviewEntryDialogScreen`, since there might be another bottomsheet that exists in the YiR package, and also for easier access.
- Renames the string resources with `entry_dialog` in them.
- Optimizes the scrolling experience.
- Optimizes the padding for title, body text, and the image - the current image is cut because of the `centerCrop`.

@voyagerfan Please help review, and we can discuss this in our 1:1 for you to have a better picture of this PR.