### PR TITLE
Fix crash when long-pressing to open from Places Search.

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -196,7 +196,7 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
         if (!isAdded) {
             return
         }
-        if (returnLink) {
+        if (returnLink && (if (invokeSource == InvokeSource.PLACES) location != null else true)) {
             if (invokeSource == InvokeSource.PLACES) {
                 PlacesEvent.logAction("search_result_click", "search_view")
             }


### PR DESCRIPTION
* Go to Places
* Search for something in the Search interface
* Long-press on a result and select "Open"

This is because the `LongPressHandler` doesn't preserve the `location` of the search result, and therefore doesn't pass it back into its callback.
I would argue the proper fix for this behavior is just to open the result in PageActivity for reading, since intuitively if someone long-presses and chooses "Open", the intention is to "open for reading".

**Phabricator:**
https://phabricator.wikimedia.org/T392660