### PR TITLE
Rename string item and move it to a proper location

### DIFF
--- a/app/src/androidTest/java/org/wikipedia/robots/feature/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/wikipedia/robots/feature/SettingsRobot.kt
@@ -86,7 +86,7 @@ class SettingsRobot : BaseRobot() {
     fun activateDeveloperMode(context: Context) = apply {
         // Click 7 times to activate developer mode
         for (i in 1 until 8) {
-            composeTestRule.onNodeWithContentDescription(context.getString(R.string.about_screen_logo_accessibility_text))
+            composeTestRule.onNodeWithContentDescription(context.getString(R.string.about_logo_content_description))
                 .performClick()
             delay(TestConfig.DELAY_MEDIUM)
         }

--- a/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
@@ -261,7 +261,7 @@ fun AboutWikipediaImage(
                     },
                 ),
             painter = painterResource(R.drawable.w_nav_mark),
-            contentDescription = stringResource(R.string.about_screen_logo_accessibility_text),
+            contentDescription = stringResource(R.string.about_logo_content_description),
         )
         Image(
             modifier = Modifier

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1982,5 +1982,5 @@
   <string name="on_this_day_game_share_link_message">ألعب لعبة \"أيهما جاء أولاً؟\" وهي لعبة تفاهات يومية على تطبيق Wikipedia Android %s</string>
   <string name="on_this_day_game_survey_q1">ما مدى رضاك عن هذه اللعبة؟</string>
   <string name="on_this_day_game_survey_q2">هل ترغب في لعب ألعاب ويكيبيديا المختلفة؟</string>
-  <string name="about_screen_logo_accessibility_text">شعار لغز ويكيبيديا</string>
+  <string name="about_logo_content_description">شعار لغز ويكيبيديا</string>
 </resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -1738,5 +1738,5 @@
   <string name="on_this_day_game_share_link_message">Mən Vikipediya Android tətbiqində \"Hansı birinci baş verib?\" gündəlik trivia oyununu oynayıram %s</string>
   <string name="on_this_day_game_survey_q1">Bu oyundan nə dərəcədə razı qaldınız?</string>
   <string name="on_this_day_game_survey_q2">Fərqli Vikipediya oyunlarını oynamaqda maraqlanırsınız?</string>
-  <string name="about_screen_logo_accessibility_text">Vikipediya tapmacası qlobus loqosu</string>
+  <string name="about_logo_content_description">Vikipediya tapmacası qlobus loqosu</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1757,5 +1757,5 @@
   <string name="on_this_day_game_share_link_message">Jeg spiller \"Hvilken kom først?\" et dagligt trivia-spil på Wikipedias Android-app %s</string>
   <string name="on_this_day_game_survey_q1">Hvor tilfreds var du med dette spil?</string>
   <string name="on_this_day_game_survey_q2">Vil du være interesseret i at spille andre Wikipedia-spil?</string>
-  <string name="about_screen_logo_accessibility_text">Wikipedia puslespil globus logo</string>
+  <string name="about_logo_content_description">Wikipedia puslespil globus logo</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1757,5 +1757,5 @@
   <string name="on_this_day_game_share_link_message">Pelaan päivittäistä \"Mikä tuli ensin?\" -triviapeliä Wikipedian Android-sovelluksessa %s</string>
   <string name="on_this_day_game_survey_q1">Kuinka tyytyväinen olit tähän peliin?</string>
   <string name="on_this_day_game_survey_q2">Olisitko kiinnostunut pelaamaan muita erilaisia Wikipedia-pelejä?</string>
-  <string name="about_screen_logo_accessibility_text">Wikipedian palapelipallon näköinen logo</string>
+  <string name="about_logo_content_description">Wikipedian palapelipallon näköinen logo</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1810,5 +1810,5 @@
   <string name="on_this_day_game_share_link_message">Je joue à « Qui est arrivé en premier ? », un jeu-questionnaire quotidien sur l\'application Android Wikipédia %s</string>
   <string name="on_this_day_game_survey_q1">Dans quelle mesure avez-vous été satisfait de ce jeu ?</string>
   <string name="on_this_day_game_survey_q2">Seriez-vous intéressé à jouer à différents jeux Wikipédia ?</string>
-  <string name="about_screen_logo_accessibility_text">Logo du globe-puzzle Wikipédia</string>
+  <string name="about_logo_content_description">Logo du globe-puzzle Wikipédia</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1790,5 +1790,5 @@
   <string name="on_this_day_game_share_link_message">Sto giocando a \"Chi è arrivato prima?\", un quiz giornaliero sull\'app Android di Wikipedia %s</string>
   <string name="on_this_day_game_survey_q1">Quanto sei soddisfatto di questo gioco?</string>
   <string name="on_this_day_game_survey_q2">Ti piacerebbe provare diversi giochi di Wikipedia?</string>
-  <string name="about_screen_logo_accessibility_text">Logo del globo puzzle di Wikipedia</string>
+  <string name="about_logo_content_description">Logo del globo puzzle di Wikipedia</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1858,5 +1858,5 @@
   <string name="on_this_day_game_share_link_message">שיחקתי ב\"מה היה קודם?\", משחק טריוויה יומי ביישום האנדרואיד של ויקיפדיה %s</string>
   <string name="on_this_day_game_survey_q1">עד כמה היית מרוצה מהמשחק הזה?</string>
   <string name="on_this_day_game_survey_q2">האם מעניין אותך לשחק במשחקי ויקיפדיה שונים?</string>
-  <string name="about_screen_logo_accessibility_text">סמול גלובוס הפאזל של ויקיפדיה</string>
+  <string name="about_logo_content_description">סמול גלובוס הפאזל של ויקיפדיה</string>
 </resources>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -1745,5 +1745,5 @@
   <string name="on_this_day_game_share_link_message">Ја играм „Што се случило попрво?“ — дневна игра за општи познавања на прилогот на Википедија за Андроид %s</string>
   <string name="on_this_day_game_survey_q1">Колку сте задоволни од оваа игра?</string>
   <string name="on_this_day_game_survey_q2">Дали сте заинтересирани да играте други Википедиини игри?</string>
-  <string name="about_screen_logo_accessibility_text">Википедиино лого со топка-сложувалка</string>
+  <string name="about_logo_content_description">Википедиино лого со топка-сложувалка</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1782,5 +1782,5 @@
   <string name="on_this_day_game_share_link_message">Ik speel “Wat gebeurde er eerst?”, een dagelijks trivia-spel op de Wikipedia Android-app %s</string>
   <string name="on_this_day_game_survey_q1">Hoe tevreden was u met dit spel?</string>
   <string name="on_this_day_game_survey_q2">Zou u geïnteresseerd zijn in het spelen van andere Wikipedia-spellen?</string>
-  <string name="about_screen_logo_accessibility_text">Wikipedia-logo met puzzel en wereldbol</string>
+  <string name="about_logo_content_description">Wikipedia-logo met puzzel en wereldbol</string>
 </resources>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -295,6 +295,7 @@
   <string name="about_app_license">Description of the license for the app, as well as links for finding our source code.\n\n  {{doc-important|Please don\'t translate links and link titles.}}</string>
   <string name="about_wmf">Text and link specifying that this app was developed by the Wikimedia Foundation</string>
   <string name="about_activity_title">{{Identical|About}}</string>
+  <string name="about_logo_content_description">Accessibility text informing users that this is a logo of a wikipedia puzzle globe.</string>
   <string name="edit_abandon_confirm">Prompt for the user to abandon any changes that were made during editing.</string>
   <string name="edit_abandon_confirm_yes">Affirmative answer to abandon any changes that were made during editing.\n{{Identical|Yes}}</string>
   <string name="edit_abandon_confirm_no">Negative answer to abandon any changes that were made during editing.\n{{Identical|No}}</string>
@@ -1775,5 +1776,4 @@
   <string name="on_this_day_game_share_link_message">Text message when users share the game link. The \"%s\" symbol is replaced with the game link.</string>
   <string name="on_this_day_game_survey_q1">The first question in a survey about the game feature.</string>
   <string name="on_this_day_game_survey_q2">The second question in a survey about the game feature.</string>
-  <string name="about_screen_logo_accessibility_text">Accessibility text informing users that this is a logo of a wikipedia puzzle globe.</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1847,5 +1847,5 @@
   <string name="on_this_day_game_share_link_message">Igram \"Kaj se je zgodilo najprej?\", vsakodnevno zanimivo igro v aplikaciji Wikipedia Android %s</string>
   <string name="on_this_day_game_survey_q1">Kako zadovoljni ste bili s to igro?</string>
   <string name="on_this_day_game_survey_q2">Bi vas zanimalo igranje različnih iger Wikipedije?</string>
-  <string name="about_screen_logo_accessibility_text">Logotip globusa sestavljanke Wikipedije</string>
+  <string name="about_logo_content_description">Logotip globusa sestavljanke Wikipedije</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1756,5 +1756,5 @@
   <string name="on_this_day_game_share_link_message">Jag spelar \"Vilket kom först?\" en daglig frågesport i Wikipedias Android-app %s</string>
   <string name="on_this_day_game_survey_q1">Hur nöjd var du med det här spelet?</string>
   <string name="on_this_day_game_survey_q2">Skulle du vara intresserad av att spela olika Wikipedia-spel?</string>
-  <string name="about_screen_logo_accessibility_text">Wikipedias pusselglob-logotyp</string>
+  <string name="about_logo_content_description">Wikipedias pusselglob-logotyp</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1863,5 +1863,5 @@
   <string name="on_this_day_game_share_link_message">Я граю в «Що було першим?» — щоденну вікторину в застосунку Вікіпедії для Android %s</string>
   <string name="on_this_day_game_survey_q1">Наскільки ви були задоволені цією грою?</string>
   <string name="on_this_day_game_survey_q2">Чи цікаво було б вам грати в різні ігри Вікіпедії?</string>
-  <string name="about_screen_logo_accessibility_text">Логотип пазла-глобуса Вікіпедії</string>
+  <string name="about_logo_content_description">Логотип пазла-глобуса Вікіпедії</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1774,5 +1774,5 @@
   <string name="on_this_day_game_share_link_message">我正在遊玩維基百科 Android 應用程式上的每日小知識遊戲「哪一個先開始？」%s</string>
   <string name="on_this_day_game_survey_q1">您對此遊戲的滿意度如何？</string>
   <string name="on_this_day_game_survey_q2">您有興趣遊玩不同的維基百科遊戲嗎？</string>
-  <string name="about_screen_logo_accessibility_text">維基百科拼圖球標誌</string>
+  <string name="about_logo_content_description">維基百科拼圖球標誌</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1746,5 +1746,5 @@
   <string name="survey_dialog_general_maybe">或许</string>
   <string name="survey_dialog_input_hint">其他反馈</string>
   <string name="survey_dialog_submitted_snackbar">已提交反馈。谢谢！</string>
-  <string name="about_screen_logo_accessibility_text">维基百科拼图地球标志</string>
+  <string name="about_logo_content_description">维基百科拼图地球标志</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,7 @@
     <string name="about_app_license"><![CDATA[Source code available on <a href=\"https://github.com/wikimedia/apps-android-wikipedia\">GitHub</a> under the <a href=\"https://www.apache.org/licenses/LICENSE-2.0\">Apache 2.0 License</a>. Unless otherwise specified, content is available under a <a href=\"https://creativecommons.org/licenses/by-sa/4.0\">Creative Commons Attribution-ShareAlike License</a>.]]></string>
     <string name="about_wmf"><![CDATA[A product of the <a href="https://wikimediafoundation.org/">Wikimedia Foundation</a>]]></string>
     <string name="about_activity_title">About</string>
+    <string name="about_logo_content_description">Wikipedia puzzle globe logo</string>
     <string name="edit_abandon_confirm">The page has been modified. Are you sure you want to exit without saving your changes?</string>
     <string name="edit_abandon_confirm_yes">Yes</string>
     <string name="edit_abandon_confirm_no">No</string>
@@ -1857,5 +1858,4 @@
     <string name="on_this_day_game_share_link_message">I\'m playing \"Which came first?\" a daily trivia game on the Wikipedia Android app %s</string>
     <string name="on_this_day_game_survey_q1">How satisfied were you with this game?</string>
     <string name="on_this_day_game_survey_q2">Would you be interested in playing different Wikipedia games?</string>
-    <string name="about_screen_logo_accessibility_text">Wikipedia puzzle globe logo</string>
 </resources>


### PR DESCRIPTION
### What does this do?
1. Renamed the string resource name from `about_screen_logo_accessibility_text` to `about_logo_content_description`
2. Moved the item under the other about screen strings.

### Why is this needed?
Most of the strings are in certain groups, and it will be easier to maintain/find.

