### PR TITLE
Espresso Fix - Compose Support

### DIFF
--- a/app/src/androidTest/java/org/wikipedia/base/BaseTest.kt
+++ b/app/src/androidTest/java/org/wikipedia/base/BaseTest.kt
@@ -74,6 +74,7 @@ abstract class BaseTest<T : AppCompatActivity>(
     @Before
     open fun setup() {
         Intents.init()
+        ComposeTestManager.setComposeTestRule(composeTestRule)
         device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         IdlingPolicies.setMasterPolicyTimeout(20, TimeUnit.SECONDS)
         activityScenarioRule.scenario.onActivity {

--- a/app/src/androidTest/java/org/wikipedia/base/ComposeTestManager.kt
+++ b/app/src/androidTest/java/org/wikipedia/base/ComposeTestManager.kt
@@ -1,0 +1,15 @@
+package org.wikipedia.base
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+
+object ComposeTestManager {
+    private var _composeTestRule: ComposeTestRule? = null
+
+    fun setComposeTestRule(rule: ComposeTestRule) {
+        _composeTestRule = rule
+    }
+
+    fun getComposeTestRule(): ComposeTestRule {
+        return _composeTestRule ?: throw IllegalStateException("ComposeTestRule not initialized")
+    }
+}

--- a/app/src/androidTest/java/org/wikipedia/base/base/BaseRobot.kt
+++ b/app/src/androidTest/java/org/wikipedia/base/base/BaseRobot.kt
@@ -1,9 +1,11 @@
 package org.wikipedia.base.base
 
+import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import org.wikipedia.TestUtil.waitOnId
+import org.wikipedia.base.ComposeTestManager
 import org.wikipedia.base.actions.ClickActions
 import org.wikipedia.base.actions.InputActions
 import org.wikipedia.base.actions.ListActions
@@ -23,6 +25,9 @@ abstract class BaseRobot {
     protected val system = SystemActions()
     protected val verify = VerificationActions()
     protected val web = WebActions()
+
+    protected val composeTestRule: ComposeTestRule
+        get() = ComposeTestManager.getComposeTestRule()
 
     protected fun delay(seconds: Long) {
         onView(isRoot()).perform(waitOnId(TimeUnit.SECONDS.toMillis(seconds)))

--- a/app/src/androidTest/java/org/wikipedia/base/utils/ComposeTestExtensions.kt
+++ b/app/src/androidTest/java/org/wikipedia/base/utils/ComposeTestExtensions.kt
@@ -1,0 +1,26 @@
+package org.wikipedia.base.utils
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.text.TextLayoutResult
+
+fun SemanticsNodeInteraction.assertTextColor(
+    color: Color
+): SemanticsNodeInteraction = assert(hasColor(color))
+
+private fun hasColor(expectedColor: Color): SemanticsMatcher {
+    return SemanticsMatcher("has color $expectedColor") { semanticsNode ->
+        val textLayoutResults = mutableListOf<TextLayoutResult>()
+        semanticsNode.config.getOrNull(SemanticsActions.GetTextLayoutResult)
+            ?.action?.invoke(textLayoutResults)
+        return@SemanticsMatcher if (textLayoutResults.isEmpty()) {
+            false
+        } else {
+            textLayoutResults.first().layoutInput.style.color == expectedColor
+        }
+    }
+}

--- a/app/src/androidTest/java/org/wikipedia/robots/feature/PageRobot.kt
+++ b/app/src/androidTest/java/org/wikipedia/robots/feature/PageRobot.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -156,11 +158,6 @@ class PageRobot(private val context: Context) : BaseRobot() {
         delay(TestConfig.DELAY_MEDIUM)
     }
 
-    fun clickLanguageListedAtFourthPosition() = apply {
-        list.clickRecyclerViewItemAtPosition(R.id.langlinks_recycler, 3)
-        delay(TestConfig.DELAY_MEDIUM)
-    }
-
     fun openOverflowMenu() = apply {
         click.onViewWithId(R.id.page_toolbar_button_show_overflow_menu)
         delay(TestConfig.DELAY_SHORT)
@@ -294,12 +291,8 @@ class PageRobot(private val context: Context) : BaseRobot() {
 
     fun selectSpanishLanguage() = apply {
         val language = "Spanish"
-        list.scrollToRecyclerView(
-            recyclerViewId = R.id.langlinks_recycler,
-            title = language,
-            textViewId = R.id.non_localized_language_name
-        )
-        click.onViewWithText(language)
+        composeTestRule.onNodeWithText(language)
+            .performClick()
     }
 
     fun scrollToAboutThisArticle() = apply {

--- a/app/src/androidTest/java/org/wikipedia/robots/feature/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/wikipedia/robots/feature/SettingsRobot.kt
@@ -3,7 +3,6 @@ package org.wikipedia.robots.feature
 import android.content.Context
 import android.util.Log
 import androidx.annotation.IdRes
-import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.recyclerview.widget.RecyclerView
@@ -29,14 +28,6 @@ import org.wikipedia.base.TestConfig
 import org.wikipedia.base.base.BaseRobot
 
 class SettingsRobot : BaseRobot() {
-
-    private lateinit var composeTestRule: ComposeTestRule
-
-    fun setComposeTestRule(rule: ComposeTestRule) = apply {
-        this.composeTestRule = rule
-        return@apply
-    }
-
     fun verifyTitle() = apply {
         verify.viewWithTextDisplayed("Settings")
     }

--- a/app/src/androidTest/java/org/wikipedia/robots/screen/LanguageListRobot.kt
+++ b/app/src/androidTest/java/org/wikipedia/robots/screen/LanguageListRobot.kt
@@ -1,5 +1,14 @@
 package org.wikipedia.robots.screen
 
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTextInput
+import androidx.core.content.ContextCompat
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -10,6 +19,7 @@ import org.wikipedia.base.TestThemeColorType
 import org.wikipedia.base.TestWikipediaColors
 import org.wikipedia.base.base.BaseRobot
 import org.wikipedia.base.utils.ColorAssertions
+import org.wikipedia.base.utils.assertTextColor
 import org.wikipedia.theme.Theme
 
 class LanguageListRobot : BaseRobot() {
@@ -37,29 +47,33 @@ class LanguageListRobot : BaseRobot() {
         )).check(ColorAssertions.hasColor(color))
     }
 
-    fun openSearchLanguage() = apply {
-        click.onViewWithId(R.id.menu_search_language)
+    fun openSearchLanguage(context: Context) = apply {
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.search_icon_content_description))
+            .performClick()
         delay(TestConfig.DELAY_SHORT)
     }
 
+    fun typeInSearchView(text: String) = apply {
+        composeTestRule.onNodeWithTag("search_text_field")
+            .performTextInput(text)
+        delay(TestConfig.DELAY_LARGE)
+    }
+
     fun scrollToLanguageAndClick(title: String) = apply {
-        list.scrollToRecyclerView(
-            recyclerViewId = R.id.languages_list_recycler,
-            title = title,
-            textViewId = R.id.language_subtitle,
-        )
-        click.onDisplayedViewWithText(viewId = R.id.language_subtitle, title)
+        composeTestRule.onNode(hasTestTag("language_list"))
+            .performScrollToNode(hasTestTag(title))
+
+        composeTestRule.onNodeWithTag(title)
+            .performClick()
         delay(TestConfig.DELAY_MEDIUM)
     }
 
-    fun assertJapaneseLanguageTextColor(theme: Theme) = apply {
-        val color = TestWikipediaColors.getGetColor(theme, TestThemeColorType.SECONDARY)
-        onView(
-            allOf(
-                withId(R.id.language_subtitle),
-                withText("Japanese")
-            )
-        ).check(ColorAssertions.hasColor(color))
+    fun assertJapaneseLanguageTextColor(context: Context, theme: Theme) = apply {
+        val colorRes = TestWikipediaColors.getGetColor(theme, TestThemeColorType.PRIMARY)
+        val color = ContextCompat.getColor(context, colorRes)
+        composeTestRule
+            .onNodeWithTag("Japanese")
+            .assertTextColor(Color(color))
     }
 
     fun pressBack() = apply {

--- a/app/src/androidTest/java/org/wikipedia/tests/search/SearchExternalIntentTest.kt
+++ b/app/src/androidTest/java/org/wikipedia/tests/search/SearchExternalIntentTest.kt
@@ -86,9 +86,6 @@ class SearchExternalIntentTest {
 
         TestUtil.delay(1)
 
-        onView(withId(R.id.languages_list_recycler))
-            .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, ViewActions.click()))
-
         TestUtil.delay(1)
 
         Espresso.pressBack()

--- a/app/src/androidTest/java/org/wikipedia/tests/search/SearchIntentTest.kt
+++ b/app/src/androidTest/java/org/wikipedia/tests/search/SearchIntentTest.kt
@@ -91,9 +91,6 @@ class SearchIntentTest {
 
         TestUtil.delay(1)
 
-        onView(withId(R.id.languages_list_recycler))
-            .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, ViewActions.click()))
-
         TestUtil.delay(1)
 
         Espresso.pressBack()

--- a/app/src/androidTest/java/org/wikipedia/tests/settings/AboutSettingsTest.kt
+++ b/app/src/androidTest/java/org/wikipedia/tests/settings/AboutSettingsTest.kt
@@ -22,7 +22,6 @@ class AboutSettingsTest : BaseTest<SettingsActivity>(
         systemRobot
             .clickOnSystemDialogWithText("Allow")
         settingsRobot
-            .setComposeTestRule(composeTestRule)
             .clickAboutWikipediaAppOptionItem()
             .activateDeveloperMode(context)
             .pressBack()

--- a/app/src/androidTest/java/org/wikipedia/tests/settings/ChangingLanguageTest.kt
+++ b/app/src/androidTest/java/org/wikipedia/tests/settings/ChangingLanguageTest.kt
@@ -48,11 +48,10 @@ class ChangingLanguageTest : BaseTest<MainActivity>(
             .disableDarkMode(context)
         languageListRobot
             .addNewLanguage()
-            .openSearchLanguage()
-        searchRobot
-            .typeTextInView(JAPANESE)
+            .openSearchLanguage(context)
+            .typeInSearchView(JAPANESE)
         languageListRobot
-            .assertJapaneseLanguageTextColor(theme = Theme.LIGHT)
+            .assertJapaneseLanguageTextColor(context, Theme.LIGHT)
             .scrollToLanguageAndClick(JAPANESE)
             .pressBack()
             .pressBack()

--- a/app/src/main/java/org/wikipedia/compose/components/SearchTopAppBar.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/SearchTopAppBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -45,7 +46,8 @@ fun SearchTopAppBar(
         title = {
             OutlinedTextField(
                 modifier = Modifier
-                    .padding(top = 2.dp),
+                    .padding(top = 2.dp)
+                    .testTag("search_text_field"),
                 value = searchQuery,
                 onValueChange = onSearchQueryChange,
                 placeholder = {

--- a/app/src/main/java/org/wikipedia/language/addlanguages/AddLanguagesListScreen.kt
+++ b/app/src/main/java/org/wikipedia/language/addlanguages/AddLanguagesListScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -131,7 +132,8 @@ fun LanguagesListScreen(
                 LazyColumn(
                     modifier = modifier
                         .fillMaxSize()
-                        .padding(paddingValues),
+                        .padding(paddingValues)
+                        .testTag("language_list"),
                 ) {
                     items(languagesItems) { languageItem ->
                         if (languageItem.headerText.isNotEmpty()) {
@@ -155,7 +157,8 @@ fun LanguagesListScreen(
                                         }
                                     )
                                     .fillMaxWidth()
-                                    .padding(16.dp),
+                                    .padding(16.dp)
+                                    .testTag(languageItem.canonicalName),
                                 localizedLanguageName = localizedLanguageName,
                                 subtitle = languageItem.canonicalName
                             )


### PR DESCRIPTION
### What does this do?
- adds compose test support for language links and language list
- adds support to directly use composeTestRule in both test class and robot classes
- the search intent test will be fixed in separate PR


