### PR TITLE
Follow-up: viewModel for YearInReview

### DIFF
--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewActivity.kt
@@ -19,6 +19,8 @@ import org.wikipedia.util.Resource
 
 class YearInReviewActivity : BaseActivity() {
 
+    private val viewModel: YearInReviewViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -27,9 +29,6 @@ class YearInReviewActivity : BaseActivity() {
                 personalizedScreenList is temporarily populated with screens
                 for testing purposes. This is will adjusted in future iterations
                  */
-                val yirViewModel: YearInReviewViewModel by viewModels()
-                yirViewModel.fetchPersonalizedData()
-                val getStartedList = listOf(getStartedData)
                 val coroutineScope = rememberCoroutineScope()
                 val navController = rememberNavController()
 
@@ -43,7 +42,7 @@ class YearInReviewActivity : BaseActivity() {
                 ) {
                     composable(route = YearInReviewNavigation.Onboarding.name) {
                         YearInReviewScreen(
-                            contentData = getStartedList,
+                            contentData = listOf(YearInReviewViewModel.getStartedData),
                             navController = navController,
                             customBottomBar = {
                                 OnboardingBottomBar(
@@ -62,7 +61,7 @@ class YearInReviewActivity : BaseActivity() {
                         )
                     }
                     composable(route = YearInReviewNavigation.ScreenDeck.name) {
-                        val screenState = yirViewModel.uiScreenListState.collectAsState().value
+                        val screenState = viewModel.uiScreenListState.collectAsState().value
                         when (screenState) {
                             is Resource.Loading -> {
                                 LoadingIndicator()

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewScreenData.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewScreenData.kt
@@ -1,7 +1,5 @@
 package org.wikipedia.yearinreview
 
-import org.wikipedia.R
-
 data class YearInReviewScreenData(
     val imageResource: Int,
     var headLineText: Any? = null,
@@ -12,30 +10,4 @@ data class YearInReviewStatistics(
     var readCount: Int = -1,
     var readCountApiTitles: List<String> = emptyList(),
     var editCount: Int = -1
-)
-
-val getStartedData = YearInReviewScreenData(
-    imageResource = R.drawable.year_in_review_block_10_resize,
-    headLineText = R.string.year_in_review_get_started_headline,
-    bodyText = R.string.year_in_review_get_started_bodytext,
-)
-
-val readCountData = YearInReviewScreenData(
-    imageResource = R.drawable.wyir_block_5_resize
-)
-
-val editCountData = YearInReviewScreenData(
-    imageResource = R.drawable.wyir_bytes
-)
-
-val nonEnglishCollectiveReadCountData = YearInReviewScreenData(
-    imageResource = R.drawable.wyir_puzzle_3,
-    headLineText = R.string.year_in_review_non_english_collective_readcount_headline,
-    bodyText = R.string.year_in_review_non_english_collective_readcount_bodytext,
-)
-
-val nonEnglishCollectiveEditCountData = YearInReviewScreenData(
-    imageResource = R.drawable.wyir_puzzle_2_v5,
-    headLineText = R.string.year_in_review_non_english_collective_editcount_headline,
-    bodyText = R.string.year_in_review_non_english_collective_editcount_bodytext,
 )

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewViewModel.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewViewModel.kt
@@ -23,37 +23,39 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 class YearInReviewViewModel() : ViewModel() {
-    private val wikiAppContext = WikipediaApp.instance
-    private var _uiScreenListState = MutableStateFlow(Resource<List<YearInReviewScreenData>>())
-    val uiScreenListState: StateFlow<Resource<List<YearInReviewScreenData>>> = _uiScreenListState.asStateFlow()
-
-    val currentYear = LocalDate.now().year
-    val startTime: Instant = LocalDateTime.of(currentYear, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC)
-    val endTime: Instant = LocalDateTime.of(currentYear, 12, 31, 23, 59, 59).toInstant(ZoneOffset.UTC)
-    val startTimeInMillis = startTime.toEpochMilli()
-    val endTimeInMillis = endTime.toEpochMilli()
-
-    val handler = CoroutineExceptionHandler { _, throwable ->
+    private val currentYear = LocalDate.now().year
+    private val startTime: Instant = LocalDateTime.of(currentYear, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC)
+    private val endTime: Instant = LocalDateTime.of(currentYear, 12, 31, 23, 59, 59).toInstant(ZoneOffset.UTC)
+    private val startTimeInMillis = startTime.toEpochMilli()
+    private val endTimeInMillis = endTime.toEpochMilli()
+    private val handler = CoroutineExceptionHandler { _, throwable ->
         L.e(throwable)
         _uiScreenListState.value = Resource.Success(
             data = listOf(nonEnglishCollectiveReadCountData, nonEnglishCollectiveEditCountData)
         )
+    }
+    private var _uiScreenListState = MutableStateFlow(Resource<List<YearInReviewScreenData>>())
+    val uiScreenListState: StateFlow<Resource<List<YearInReviewScreenData>>> = _uiScreenListState.asStateFlow()
+
+    init {
+        fetchPersonalizedData()
     }
 
     fun fetchPersonalizedData() {
         val personalizedStatistics = YearInReviewStatistics()
         viewModelScope.launch(handler) {
             _uiScreenListState.value = Resource.Loading()
+
             val readCountJob = async {
                 personalizedStatistics.readCount = AppDatabase.instance.historyEntryDao().getHistoryCount(startTimeInMillis, endTimeInMillis)
-                if (personalizedStatistics.readCount >= 3) {
+                if (personalizedStatistics.readCount >= MINIMUM_READ_COUNT) {
                     personalizedStatistics.readCountApiTitles = AppDatabase.instance.historyEntryDao().getDisplayTitles()
                         .map { StringUtil.fromHtml(it).toString() }
-                    readCountData.headLineText = wikiAppContext.getString(
+                    readCountData.headLineText = WikipediaApp.instance.getString(
                         R.string.year_in_review_read_count_headline,
                         personalizedStatistics.readCount.toString()
                     )
-                    readCountData.bodyText = wikiAppContext.getString(
+                    readCountData.bodyText = WikipediaApp.instance.getString(
                         R.string.year_in_review_read_count_bodytext,
                         personalizedStatistics.readCount.toString(),
                         personalizedStatistics.readCountApiTitles[0],
@@ -65,57 +67,87 @@ class YearInReviewViewModel() : ViewModel() {
                     nonEnglishCollectiveReadCountData
                 }
             }
-            val editCountJob = async {
-                val homeSiteCall = async {
-                    ServiceFactory.get(WikipediaApp.instance.wikiSite)
-                        .getUserContribsByTimeFrame(
-                            username = AccountUtil.userName,
-                            maxCount = 500,
-                            startDate = endTime,
-                            endDate = startTime
-                        )
-                }
-                val commonsCall = async {
-                    ServiceFactory.get(Constants.commonsWikiSite)
-                        .getUserContribsByTimeFrame(
-                            username = AccountUtil.userName,
-                            maxCount = 500,
-                            startDate = endTime,
-                            endDate = startTime
-                        )
-                }
-                val wikidataCall = async {
-                    ServiceFactory.get(Constants.wikidataWikiSite)
-                        .getUserContribsByTimeFrame(
-                            username = AccountUtil.userName,
-                            maxCount = 500,
-                            startDate = endTime,
-                            endDate = startTime,
-                            ns = 0,
-                        )
-                }
 
-                val homeSiteResponse = homeSiteCall.await()
-                val commonsResponse = commonsCall.await()
-                val wikidataResponse = wikidataCall.await()
-
-                personalizedStatistics.editCount += homeSiteResponse.query?.userInfo!!.editCount
-                personalizedStatistics.editCount += wikidataResponse.query?.userInfo!!.editCount
-                personalizedStatistics.editCount += commonsResponse.query?.userInfo!!.editCount
-
-                editCountData.headLineText = wikiAppContext.getString(
-                    R.string.year_in_review_edit_count_headline,
-                    personalizedStatistics.editCount.toString()
-                )
-                editCountData.bodyText = wikiAppContext.getString(
-                    R.string.year_in_review_edit_count_bodytext,
-                    personalizedStatistics.editCount.toString()
-                )
-                editCountData
+            //
+            val homeSiteCall = async {
+                ServiceFactory.get(WikipediaApp.instance.wikiSite)
+                    .getUserContribsByTimeFrame(
+                        username = AccountUtil.userName,
+                        maxCount = 500,
+                        startDate = endTime,
+                        endDate = startTime
+                    )
             }
+            val commonsCall = async {
+                ServiceFactory.get(Constants.commonsWikiSite)
+                    .getUserContribsByTimeFrame(
+                        username = AccountUtil.userName,
+                        maxCount = 500,
+                        startDate = endTime,
+                        endDate = startTime
+                    )
+            }
+            val wikidataCall = async {
+                ServiceFactory.get(Constants.wikidataWikiSite)
+                    .getUserContribsByTimeFrame(
+                        username = AccountUtil.userName,
+                        maxCount = 500,
+                        startDate = endTime,
+                        endDate = startTime,
+                        ns = 0,
+                    )
+            }
+
+            val homeSiteResponse = homeSiteCall.await()
+            val commonsResponse = commonsCall.await()
+            val wikidataResponse = wikidataCall.await()
+
+            personalizedStatistics.editCount += homeSiteResponse.query?.userInfo!!.editCount
+            personalizedStatistics.editCount += wikidataResponse.query?.userInfo!!.editCount
+            personalizedStatistics.editCount += commonsResponse.query?.userInfo!!.editCount
+
+            editCountData.headLineText = WikipediaApp.instance.getString(
+                R.string.year_in_review_edit_count_headline,
+                personalizedStatistics.editCount.toString()
+            )
+            editCountData.bodyText = WikipediaApp.instance.getString(
+                R.string.year_in_review_edit_count_bodytext,
+                personalizedStatistics.editCount.toString()
+            )
+
             _uiScreenListState.value = Resource.Success(
-                data = listOf(readCountJob.await(), editCountJob.await())
+                data = listOf(readCountJob.await(), editCountData)
             )
         }
+    }
+
+    companion object {
+        private const val MINIMUM_READ_COUNT = 3
+
+        val getStartedData = YearInReviewScreenData(
+            imageResource = R.drawable.year_in_review_block_10_resize,
+            headLineText = R.string.year_in_review_get_started_headline,
+            bodyText = R.string.year_in_review_get_started_bodytext,
+        )
+
+        val readCountData = YearInReviewScreenData(
+            imageResource = R.drawable.wyir_block_5_resize
+        )
+
+        val editCountData = YearInReviewScreenData(
+            imageResource = R.drawable.wyir_bytes
+        )
+
+        val nonEnglishCollectiveReadCountData = YearInReviewScreenData(
+            imageResource = R.drawable.wyir_puzzle_3,
+            headLineText = R.string.year_in_review_non_english_collective_readcount_headline,
+            bodyText = R.string.year_in_review_non_english_collective_readcount_bodytext,
+        )
+
+        val nonEnglishCollectiveEditCountData = YearInReviewScreenData(
+            imageResource = R.drawable.wyir_puzzle_2_v5,
+            headLineText = R.string.year_in_review_non_english_collective_editcount_headline,
+            bodyText = R.string.year_in_review_non_english_collective_editcount_bodytext,
+        )
     }
 }


### PR DESCRIPTION
### What does this do?
This PR utilizes the coding structure to match the project by changing:
1. Creates a `viewModel` outside the `onCreate`.
2. Keeps the `YearInReviewScreenData` clean and moves the static data to the `ViewModel` in the `companion object`.
3. Update variables `private` vs `public`.
4. Removes a redundant `async` for the edit counts calls.


@voyagerfan please review and merge this PR if it looks good to you.
