### PR TITLE
Discover pre-work: change the icons location in the readinglist header item view

### DIFF
--- a/app/src/main/res/layout/item_reading_list.xml
+++ b/app/src/main/res/layout/item_reading_list.xml
@@ -67,42 +67,13 @@
             app:icon="@drawable/ic_bookmark_border_white_24dp"
             tools:visibility="visible"/>
 
-        <ImageView
-            android:id="@+id/item_share_button"
-            android:layout_width="40dp"
-            android:layout_height="48dp"
-            android:padding="8dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/reading_list_share_menu_label"
-            android:visibility="gone"
-            app:tint="?attr/placeholder_color"
-            app:layout_constraintEnd_toStartOf="@id/item_overflow_menu"
-            app:layout_constraintTop_toTopOf="@id/item_title_container"
-            app:srcCompat="@drawable/ic_share"
-            tools:visibility="visible"/>
-
-        <ImageView
-            android:id="@+id/item_overflow_menu"
-            android:layout_width="40dp"
-            android:layout_height="48dp"
-            android:layout_marginStart="40dp"
-            android:padding="8dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/abc_action_menu_overflow_description"
-            app:tint="?attr/placeholder_color"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_more_vert_white_24dp"
-            tools:visibility="visible"/>
-
     </FrameLayout>
 
     <com.google.android.flexbox.FlexboxLayout
         android:id="@+id/item_title_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
+        android:layout_marginHorizontal="16dp"
         android:layout_marginTop="4dp"
         app:layout_constraintStart_toEndOf="@id/item_select_checkbox"
         app:layout_constraintEnd_toStartOf="@id/endContainer"
@@ -176,4 +147,33 @@
         app:tint="@android:color/white"
         tools:visibility="visible" />
 
+    <ImageView
+        android:id="@+id/item_share_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:padding="12dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/reading_list_share_menu_label"
+        android:visibility="gone"
+        android:layout_marginStart="4dp"
+        app:tint="?attr/primary_color"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/item_description"
+        app:srcCompat="@drawable/ic_share"
+        tools:visibility="visible"/>
+
+    <ImageView
+        android:id="@+id/item_overflow_menu"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:padding="12dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/abc_action_menu_overflow_description"
+        app:tint="?attr/primary_color"
+        android:visibility="gone"
+        android:rotation="90"
+        app:layout_constraintStart_toEndOf="@id/item_share_button"
+        app:layout_constraintTop_toBottomOf="@id/item_description"
+        app:srcCompat="@drawable/ic_more_vert_white_24dp"
+        tools:visibility="visible"/>
 </merge>


### PR DESCRIPTION
### What does this do?
This PR moves the two icons to the bottom of the descriptions, and updates the icons color from `placeholder_color` to `primary_color`.

**Phabricator:**
https://phabricator.wikimedia.org/T393502
