### PR TITLE
Follow-up to sharing of game results.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameFinalFragment.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameFinalFragment.kt
@@ -85,24 +85,27 @@ class OnThisDayGameFinalFragment : Fragment(), OnThisDayGameArticleBottomSheet.C
 
         binding.shareButton.setOnClickListener {
             WikiGamesEvent.submit("share_game_click", "game_play", slideName = viewModel.getCurrentScreenName())
-            buildSharableContent(viewModel.getCurrentGameState(), viewModel.getArticlesMentioned()).run {
-                binding.shareLayout.shareContainer.post {
-                    val shareMessage = getString(
-                        R.string.on_this_day_game_share_link_message,
-                        getString(R.string.on_this_day_game_share_url)
-                    )
-                    lifecycleScope.launch {
-                        while (loadedImagesForShare < (binding.shareLayout.shareArticlesList.adapter?.itemCount ?: 0)) {
-                            delay(100)
-                            if (!isAdded) return@launch
-                        }
-                        binding.shareLayout.shareContainer.drawToBitmap(Bitmap.Config.RGB_565).run {
-                            ShareUtil.shareImage(lifecycleScope, requireContext(), this,
-                                "wikipedia_on_this_day_game_" + LocalDateTime.now(),
-                                binding.shareLayout.shareResultText.text.toString(), shareMessage)
-                        }
-                    }
+            buildSharableContent(viewModel.getCurrentGameState(), viewModel.getArticlesMentioned())
+            lifecycleScope.launch {
+                binding.shareButton.isEnabled = false
+                binding.shareButton.alpha = 0.5f
+                while (loadedImagesForShare < (binding.shareLayout.shareArticlesList.adapter?.itemCount ?: 0)) {
+                    delay(100)
+                    if (!isAdded) return@launch
                 }
+                val shareMessage = getString(
+                    R.string.on_this_day_game_share_link_message,
+                    getString(R.string.on_this_day_game_share_url)
+                )
+                binding.shareLayout.shareContainer.drawToBitmap(Bitmap.Config.RGB_565).run {
+                    ShareUtil.shareImage(lifecycleScope, requireContext(), this,
+                        "wikipedia_on_this_day_game_" + LocalDateTime.now(),
+                        binding.shareLayout.shareResultText.text.toString(), shareMessage)
+                }
+                // Delay just a bit more, while the system share dialog pops up.
+                delay(1000)
+                binding.shareButton.alpha = 1f
+                binding.shareButton.isEnabled = true
             }
         }
 


### PR DESCRIPTION
When the Share button is tapped, it kicks off a relatively long-running operation to generate the shareable image. But during this process, the UI is still responsive, and the Share button could be _tapped agai_n, and again, etc.

Let's disable the Share button when it's tapped, and re-enable it when the generated image is complete.
(Also, it's no longer necessary to `post { }` the logic of generating the image.)