### PR TITLE
Fix: remove old dots after regenerating new screenshot for WikiGames

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameFinalFragment.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameFinalFragment.kt
@@ -73,6 +73,7 @@ class OnThisDayGameFinalFragment : Fragment(), OnThisDayGameArticleBottomSheet.C
     private val handler = Handler(Looper.getMainLooper())
     private lateinit var timeUpdateRunnable: Runnable
     private var loadedImagesForShare = 0
+    private val dotViews = mutableListOf<ImageView>()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -197,7 +198,10 @@ class OnThisDayGameFinalFragment : Fragment(), OnThisDayGameArticleBottomSheet.C
 
     private fun createDots(gameState: OnThisDayGameViewModel.GameState) {
         val dotSize = DimenUtil.roundedDpToPx(20f)
-        val dotViews = mutableListOf<ImageView>()
+        dotViews.forEach {
+            binding.shareLayout.scoreContainer.removeView(it)
+        }
+        dotViews.clear()
         for (i in 0 until gameState.totalQuestions) {
             val viewId = View.generateViewId()
             val dotView = ImageView(requireContext())
@@ -215,7 +219,6 @@ class OnThisDayGameFinalFragment : Fragment(), OnThisDayGameArticleBottomSheet.C
                 }
             dotView.imageTintList = ColorStateList.valueOf(Color.WHITE)
             dotView.id = viewId
-            dotView.isVisible = true
 
             binding.shareLayout.scoreContainer.addView(dotView)
         }


### PR DESCRIPTION
### What does this do?
Remove a weird dot from the screenshot after regenerating the image. 

**Steps to reproduce**
1. Click on share and select "Slack" to share it to your DM.
2. Switch to the Slack app and wait for upload completion.
3. Switch back to the Wikipedia app and click share again to share the image to the Slack app to your DM.
4. Switch back to the Slack app and wait for upload completion.