### PR TITLE
Add multiline title support to CategoryActivity toolbar

### DIFF
--- a/app/src/main/java/org/wikipedia/categories/CategoryActivity.kt
+++ b/app/src/main/java/org/wikipedia/categories/CategoryActivity.kt
@@ -62,7 +62,8 @@ class CategoryActivity : BaseActivity() {
         setStatusBarColor(ResourceUtil.getThemedColor(this, android.R.attr.windowBackground))
         setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        supportActionBar?.title = StringUtil.removeHTMLTags(viewModel.pageTitle.displayText)
+        supportActionBar?.setDisplayShowTitleEnabled(false)
+        binding.toolbarTitle.text = StringUtil.removeHTMLTags(viewModel.pageTitle.displayText)
 
         binding.categoryRecycler.layoutManager = LinearLayoutManager(this)
         binding.categoryRecycler.addItemDecoration(DrawableItemDecoration(this, R.attr.list_divider, drawStart = false, drawEnd = false))

--- a/app/src/main/res/layout/activity_category.xml
+++ b/app/src/main/res/layout/activity_category.xml
@@ -10,7 +10,19 @@
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize" />
+        android:layout_height="?attr/actionBarSize">
+
+        <TextView
+            android:id="@+id/toolbar_title"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:ellipsize="end"
+            android:gravity="center_vertical"
+            android:maxLines="2"
+            android:textAppearance="@style/H2.AppBar"
+            android:textColor="?attr/primary_color"
+            tools:text="Category:People executed by the Roman Empire." />
+    </com.google.android.material.appbar.MaterialToolbar>
 
     <FrameLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
### What does this do?
- Adds `TextView` as a child of `MaterialToolbar`
- Implements multiline support (max 2 lines)
- Reduces title text size for better visual balance

<details><summary>Screenshots (before)</summary>
<p>

Before Single Line Night
![Before Single Line Night](https://github.com/user-attachments/assets/da7e2fe4-6243-45c5-b924-64f3f6f192fe)

Before Multi-line Night
![Before Multi-line Night](https://github.com/user-attachments/assets/8d58f4db-5368-4b42-b8fd-53ade8912b1e)


</p>
</details> 

<details><summary>Screenshots (after)</summary>
<p>

After Single Line Night
![After Single Line Night](https://github.com/user-attachments/assets/5a4a701b-71fe-4ec3-a07b-2fecba2ebef5)

After 2 Lines Night
![After 2 Lines Night](https://github.com/user-attachments/assets/4325622c-dc70-4aa0-9f67-f1b3bcfbb682)

After 2 Lines Day
![After 2 Lines Day](https://github.com/user-attachments/assets/4a62d0d1-1c7e-4b32-822b-241d49086d16)

After 3 Lines Ellipsized
![After 3 Lines Ellipsized](https://github.com/user-attachments/assets/d428f6b1-a87b-4aed-a1f1-b3c88cfb4982)


</p>
</details> 

### Why is this needed?
Increase the title readability

**Phabricator:**
https://phabricator.wikimedia.org/T387930