### PR TITLE
Make temp account status detection more explicit.

### DIFF
--- a/app/src/main/java/org/wikipedia/auth/AccountUtil.kt
+++ b/app/src/main/java/org/wikipedia/auth/AccountUtil.kt
@@ -41,7 +41,7 @@ object AccountUtil {
         get() = account() != null || isTemporaryAccount
 
     val isTemporaryAccount: Boolean
-        get() = account() == null && getUserNameFromCookie().isNotEmpty()
+        get() = account() == null && isUserNameTemporary(getUserNameFromCookie())
 
     val userName: String
         get() = account()?.name ?: getUserNameFromCookie()


### PR DESCRIPTION
At the moment we're detecting a temporary account by simply checking for the presence of session cookies and the absence of an account in the `AccountManager`. But this can lead to a false-positive state where the `AccountManager` credentials could go away (the user can explicitly delete the account in the device Settings, or by other means).

Let's detect the temporary account more explicitly, by checking for the magic character `~` at the start of the account name.

https://phabricator.wikimedia.org/T394013
