### PR TITLE
Fix: crash when adding articles from one reading list to another

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
@@ -165,6 +165,9 @@ class ReadingListFragment : Fragment(), MenuProvider, ReadingListItemActionsDial
                             }
                             is PageDownloadEvent -> {
                                 val pagePosition = getPagePositionInList(event.page)
+                                if (pagePosition < 0) {
+                                    return@collectLatest
+                                }
                                 val readingLisPage = displayedLists[pagePosition]
                                 if (readingLisPage is ReadingListPage) {
                                     readingLisPage.downloadProgress = event.page.downloadProgress


### PR DESCRIPTION
### What does this do?
A bug from the previous simplify PR #5531, because `getPagePositionInList()` will throw `-1` if no position has found.

```
Process: org.wikipedia.dev, PID: 5183
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 5
 at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
 at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
 at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
 at java.util.Objects.checkIndex(Objects.java:359)
 at java.util.ArrayList.get(ArrayList.java:434)
 at org.wikipedia.readinglist.ReadingListFragment$onCreateView$1$1$3$1.invokeSuspend(ReadingListFragment.kt:168)
 at org.wikipedia.readinglist.ReadingListFragment$onCreateView$1$1$3$1.invoke(Unknown Source:8)
 at org.wikipedia.readinglist.ReadingListFragment$onCreateView$1$1$3$1.invoke(Unknown Source:2)
 at kotlinx.coroutines.flow.FlowKt__MergeKt$mapLatest$1.invokeSuspend(Merge.kt:213)
 at kotlinx.coroutines.flow.FlowKt__MergeKt$mapLatest$1.invoke(Unknown Source:13)
 at kotlinx.coroutines.flow.FlowKt__MergeKt$mapLatest$1.invoke(Unknown Source:4)
 at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3$1$2.invokeSuspend(Merge.kt:30)
 at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3$1$2.invoke(Unknown Source:8)
 at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3$1$2.invoke(Unknown Source:4)
 at kotlinx.coroutines.intrinsics.UndispatchedKt.startCoroutineUndispatched(Undispatched.kt:20)
 at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:360)
 at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
 at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:53)
 at kotlinx.coroutines.BuildersKt.launch(Unknown Source:1)
 at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:44)
 at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source:1)
 at kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest$flowCollect$3$1.emit(Merge.kt:29)
 at kotlinx.coroutines.flow.SharedFlowImpl.collect$suspendImpl(SharedFlow.kt:397)
 at kotlinx.coroutines.flow.SharedFlowImpl$collect$1.invokeSuspend(Unknown Source:15)
 at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
 at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
 at android.os.Handler.handleCallback(Handler.java:959)
 at android.os.Handler.dispatchMessage(Handler.java:100)
 at android.os.Looper.loopOnce(Looper.java:257)
 at android.os.Looper.loop(Looper.java:342)
 at android.app.ActivityThread.main(ActivityThread.java:9634)
 at java.lang.reflect.Method.invoke(Native Method)
 at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:619)
 at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
 Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@5238ad8, Dispatchers.Main.immediate]
```