### PR TITLE
Only create table if Cateogry table does not exist

### DIFF
--- a/app/src/main/java/org/wikipedia/database/AppDatabase.kt
+++ b/app/src/main/java/org/wikipedia/database/AppDatabase.kt
@@ -278,7 +278,7 @@ abstract class AppDatabase : RoomDatabase() {
 
         val MIGRATION_28_29 = object : Migration(28, 29) {
             override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("CREATE TABLE Category (" +
+                db.execSQL("CREATE TABLE IF NOT EXISTS Category (" +
                         "title TEXT NOT NULL," +
                         "lang TEXT NOT NULL," +
                         "timeStamp INTEGER NOT NULL," +


### PR DESCRIPTION
### What does this do?
Add an additional `IF NOT EXISTS` to avoid showing an error message when we install different versions.
