### PR TITLE
Fix: make sure to compare the correct value for updating the list in ReadingListsFragment

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingList.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingList.kt
@@ -54,7 +54,7 @@ class ReadingList(
         return (other is ReadingList &&
                 id == other.id &&
                 pages.size == other.pages.size &&
-                numPagesOffline == numPagesOffline &&
+                numPagesOffline == other.numPagesOffline &&
                 title == other.title &&
                 description == other.description)
     }


### PR DESCRIPTION
### What does this do?
When you have a fresh install, the thumbnail on the list does not get updated correctly, and that's because we have always been comparing the same `numPagesOffline` by itself!
