### PR TITLE
Update the game sound preference key name to keep the naming consistent

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -775,6 +775,6 @@ object Prefs {
         set(value) = PrefsIoUtil.setString(R.string.preference_key_otd_notification_state, value.name)
 
     var isOtdSoundOn: Boolean
-        get() = PrefsIoUtil.getBoolean(R.string.pref_key_otd_sound_on, true)
-        set(value) = PrefsIoUtil.setBoolean(R.string.pref_key_otd_sound_on, value)
+        get() = PrefsIoUtil.getBoolean(R.string.preference_key_otd_sound_on, true)
+        set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_otd_sound_on, value)
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -180,5 +180,5 @@
     <string name="preference_key_delete_local_donation_history">deleteLocalDonationHistory</string>
     <string name="preference_key_playground_category">categoryPlayground</string>
     <string name="preference_key_otd_is_archive_game_playing">isArchiveGamePlaying</string>
-    <string name="pref_key_otd_sound_on">isOtdSoundOn</string>
+    <string name="preference_key_otd_sound_on">isOtdSoundOn</string>
 </resources>


### PR DESCRIPTION
### What does this do?
Did not notice until now, and it is better to keep the naming style consistent in the app. (but we may re-release to beta if possible, but that's probably fine for the next release too).
