### PR TITLE
Fix minor potential crash in Final game screen.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameFinalFragment.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameFinalFragment.kt
@@ -138,7 +138,6 @@ class OnThisDayGameFinalFragment : OnThisDayGameBaseFragment(), OnThisDayGameArt
 
         handler.post(timeUpdateRunnable)
         updateOnLoading()
-        buildSharableContent(viewModel.getCurrentGameState(), viewModel.getArticlesMentioned())
         return binding.root
     }
 
@@ -196,6 +195,8 @@ class OnThisDayGameFinalFragment : OnThisDayGameBaseFragment(), OnThisDayGameArt
             R.dimen.view_list_card_margin_horizontal, R.dimen.view_list_card_margin_horizontal))
         binding.resultArticlesList.isNestedScrollingEnabled = false
         binding.resultArticlesList.adapter = RecyclerViewAdapter(viewModel.getArticlesMentioned())
+
+        buildSharableContent(gameState, viewModel.getArticlesMentioned())
     }
 
     private fun buildSharableContent(gameState: OnThisDayGameViewModel.GameState, articlesMentioned: List<PageSummary>) {


### PR DESCRIPTION
There is a crash that can happen when launching the FinalFragment of the game, when it builds the "sharing" view. The function to start building this view is called when the fragment is created, but the `gameState` in the ViewModel might not yet be initialized.
Therefore let's call this function in a more safe (and correct) place, when the ViewModel calls back with a `GameEnded` state, which guarantees the `gameState` will be valid.