### PR TITLE
Add optional "New" dot over navigation tabs.

### DIFF
--- a/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
@@ -1,15 +1,47 @@
 package org.wikipedia.navtab
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
+import android.view.Gravity
 import android.view.Menu
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.core.view.isVisible
+import androidx.core.view.updateMarginsRelative
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import org.wikipedia.R
+import org.wikipedia.util.DimenUtil
+import org.wikipedia.util.ResourceUtil
 
-class NavTabLayout constructor(context: Context, attrs: AttributeSet) : BottomNavigationView(context, attrs) {
+class NavTabLayout(context: Context, attrs: AttributeSet) : BottomNavigationView(context, attrs) {
     init {
         menu.clear()
         NavTab.entries.forEachIndexed { index, tab ->
             menu.add(Menu.NONE, tab.id, index, tab.text).setIcon(tab.icon)
         }
+    }
+
+    fun setOverlayDot(tab: NavTab, enabled: Boolean) {
+        val itemView = findViewById<ViewGroup>(tab.id)
+        val imageView = itemView.findViewById<View>(com.google.android.material.R.id.navigation_bar_item_icon_view)
+        val imageParent = imageView.parent as FrameLayout
+        var overlayDotView: ImageView? = itemView.findViewById<ImageView?>(R.id.nav_tab_overlay_dot)
+        if (overlayDotView == null) {
+            overlayDotView = ImageView(context)
+            overlayDotView.id = R.id.nav_tab_overlay_dot
+            val dotSize = DimenUtil.roundedDpToPx(6f)
+            val params = LayoutParams(dotSize, dotSize)
+            params.gravity = Gravity.CENTER
+            val margin = DimenUtil.roundedDpToPx(8f)
+            params.updateMarginsRelative(start = margin, bottom = margin)
+            overlayDotView.layoutParams = params
+            overlayDotView.setBackgroundResource(R.drawable.shape_circle)
+            overlayDotView.backgroundTintList = ColorStateList.valueOf(ResourceUtil.getThemedColor(context, R.attr.destructive_color))
+            imageParent.addView(overlayDotView)
+        }
+        overlayDotView.isVisible = enabled
     }
 }

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -5,6 +5,7 @@
     <item name="nav_tab_search" type="id" />
     <item name="nav_tab_edits" type="id" />
     <item name="nav_tab_more" type="id" />
+    <item name="nav_tab_overlay_dot" type="id" />
     <item name="page_save" type="id" />
     <item name="page_language" type="id" />
     <item name="page_find_in_article" type="id" />


### PR DESCRIPTION
This adds a function that creates a red dot over any Navigation tab on the main screen.

![image](https://github.com/user-attachments/assets/8298bdf1-c3aa-43e9-8f0b-e2f8fc5525db)

This can be merged into master, since the function itself is not yet used, but can be used by the upcoming feature branch.

https://phabricator.wikimedia.org/T394113