### PR TITLE
Fix sequential parameters in new strings, and add tests.

### DIFF
--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -1789,7 +1789,7 @@
   <string name="recommended_reading_list_page_description_monthly">Вшаиот месечен список за читање. Осознајте повеќе теми, избрани токму за вас. Се подновува на почетокот на секој месец.</string>
   <string name="recommended_reading_list_page_overflow_customize">Прилагоди</string>
   <string name="recommended_reading_list_page_overflow_about">За функцијава</string>
-  <string name="recommended_reading_list_page_snackbar">Откриј ќе се подновува со %d нови статии на секој %s. Вашите препораки се складираат месно на вашиот уред.</string>
+  <string name="recommended_reading_list_page_snackbar">Откриј ќе се подновува со %1$d нови статии на секој %2$s. Вашите препораки се складираат месно на вашиот уред.</string>
   <string name="recommended_reading_list_page_snackbar_action">Прилагоди го Откриј</string>
   <string name="recommended_reading_list_settings_title">Поставки за Откриј</string>
   <string name="recommended_reading_list_settings_toggle">Список на читање од Откриј</string>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1823,7 +1823,7 @@
   <string name="recommended_reading_list_page_description_monthly">Description of the monthly reading list, explaining its purpose and update frequency.</string>
   <string name="recommended_reading_list_page_overflow_customize">Menu item label to customize the recommended reading list settings.</string>
   <string name="recommended_reading_list_page_overflow_about">Menu item label to learn more about the recommended reading list feature.</string>
-  <string name="recommended_reading_list_page_snackbar">Snackbar message displayed on the recommended reading list page, informing the user about the update frequency and data storage. %d is replaced by the number of articles, and %s is replaced by the update frequency.</string>
+  <string name="recommended_reading_list_page_snackbar">Snackbar message displayed on the recommended reading list page, informing the user about the update frequency and data storage. %1$d is replaced by the number of articles, and %2$s is replaced by the update frequency.</string>
   <string name="recommended_reading_list_page_snackbar_action">Action label on the snackbar to navigate to the customization settings.</string>
   <string name="recommended_reading_list_page_snackbar_day">Text for the snackbar message that indicates a daily update frequency.</string>
   <string name="recommended_reading_list_page_snackbar_week">Text for the snackbar message that indicates a weekly update frequency.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1907,7 +1907,7 @@
     <string name="recommended_reading_list_page_description_monthly">Your monthly reading list. Learn about new topics,  picked just for you. Updates on the first of each month.</string>
     <string name="recommended_reading_list_page_overflow_customize">Customize</string>
     <string name="recommended_reading_list_page_overflow_about">About this feature</string>
-    <string name="recommended_reading_list_page_snackbar">Discover will update with %d new articles each %s. Your recommendations are stored locally on your device.</string>
+    <string name="recommended_reading_list_page_snackbar">Discover will update with %1$d new articles each %2$s. Your recommendations are stored locally on your device.</string>
     <string name="recommended_reading_list_page_snackbar_action">Customize Discover</string>
     <string name="recommended_reading_list_page_snackbar_day">Day</string>
     <string name="recommended_reading_list_page_snackbar_week">Week</string>

--- a/app/src/test/java/org/wikipedia/language/TranslationTests.kt
+++ b/app/src/test/java/org/wikipedia/language/TranslationTests.kt
@@ -17,6 +17,17 @@ class TranslationTests {
         // Step 1: collect counts of parameters in en/strings.xml
         val baseMap = findMatchedParamsInXML(baseFile, POSSIBLE_PARAMS, true)
 
+        // Check for multiple single (non-sequential) parameters
+        baseMap.forEach { (key, list) ->
+            val singleIntParam = POSSIBLE_PARAMS.indexOf("%d")
+            val singleStrParam = POSSIBLE_PARAMS.indexOf("%s")
+            if ((list[singleIntParam] + list[singleStrParam] > 1) && !key.contains('[')) {
+                mismatches.append("Too many single parameters in ")
+                    .append(STRINGS_XML_NAME).append(": ")
+                    .append(key).append(" \n")
+            }
+        }
+
         // Step 2: finding parameters in other languages
         for (dir in allFiles) {
             val lang =


### PR DESCRIPTION
When adding a string resource with multiple parameters, the parameters _must be in the explicit sequential format_ (`%1$d`, `%2$s`, and so on) instead of the plain `%d` `%s`. This is because some languages could change the order of the parameters, which will confuse the string formatting functions, and may even cause crashes.

I'm adding a test to catch these cases in the future.