### PR TITLE
Simplify detection of Dark theme in WikiCard composable.

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -1,6 +1,5 @@
 package org.wikipedia.compose.components
 
-import android.os.Build
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -27,7 +26,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import org.wikipedia.WikipediaApp
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.theme.Theme
@@ -35,7 +33,6 @@ import org.wikipedia.theme.Theme
 @Composable
 fun WikiCard(
     modifier: Modifier = Modifier,
-    isDarkTheme: Boolean = WikipediaApp.instance.currentTheme.isDark,
     elevation: Dp = 8.dp,
     colors: CardColors = CardDefaults.cardColors(
         containerColor = WikipediaTheme.colors.paperColor,
@@ -44,8 +41,9 @@ fun WikiCard(
     border: BorderStroke? = null,
     content: @Composable () -> Unit
 ) {
-    val cardElevation = remember(elevation, isDarkTheme) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isDarkTheme) {
+    val isDarkTheme = WikipediaTheme.colors.isDarkTheme
+    val cardElevation = remember(elevation) {
+        if (isDarkTheme) {
             0.dp
         } else {
             elevation
@@ -66,7 +64,6 @@ fun WikiCard(
 @Composable
 fun MessageCard(
     modifier: Modifier = Modifier,
-    isDarkTheme: Boolean = WikipediaApp.instance.currentTheme.isDark,
     title: String? = null,
     message: String,
     imageRes: Int? = null,
@@ -77,8 +74,7 @@ fun MessageCard(
     onContainerClick: (() -> Unit)? = null
 ) {
     WikiCard(
-        modifier = modifier,
-        isDarkTheme = isDarkTheme
+        modifier = modifier
     ) {
         Column(
             modifier = Modifier
@@ -175,8 +171,7 @@ private fun WikiCardSimpleWikiTextPreview() {
     ) {
         WikiCard(
             modifier = Modifier
-                .padding(20.dp),
-            isDarkTheme = false
+                .padding(20.dp)
         ) {
             Text(
                 modifier = Modifier
@@ -198,8 +193,7 @@ private fun BorderAndElevationWikiTextPreview() {
             modifier = Modifier
                 .padding(20.dp),
             border = BorderStroke(width = 0.5.dp, color = WikipediaTheme.colors.progressiveColor),
-            elevation = 4.dp,
-            isDarkTheme = true
+            elevation = 4.dp
         ) {
             Text(
                 modifier = Modifier
@@ -221,7 +215,6 @@ private fun MessageCardPreview() {
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(8.dp),
-            isDarkTheme = true,
             title = "Title text",
             message = "Message text",
             positiveButtonText = "Positive button",

--- a/app/src/main/java/org/wikipedia/compose/theme/WikipediaColor.kt
+++ b/app/src/main/java/org/wikipedia/compose/theme/WikipediaColor.kt
@@ -7,6 +7,7 @@ import org.wikipedia.compose.ComposeColors
 
 @Immutable
 data class WikipediaColor(
+    val isDarkTheme: Boolean = false,
     val primaryColor: Color,
     val paperColor: Color,
     val backgroundColor: Color,
@@ -63,6 +64,7 @@ val LightColors = WikipediaColor(
 )
 
 val DarkColors = WikipediaColor(
+    isDarkTheme = true,
     primaryColor = ComposeColors.Gray200,
     paperColor = ComposeColors.Gray700,
     backgroundColor = ComposeColors.Gray675,
@@ -81,6 +83,7 @@ val DarkColors = WikipediaColor(
 )
 
 val BlackColors = WikipediaColor(
+    isDarkTheme = true,
     primaryColor = ComposeColors.Gray200,
     paperColor = ComposeColors.Black,
     backgroundColor = ComposeColors.Gray700,

--- a/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
+++ b/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
@@ -38,8 +38,4 @@ object WikipediaTheme {
     val typography: WikipediaTypography
         @Composable
         get() = LocalWikipediaTypography.current
-
-    val isDark: Boolean
-        @Composable
-        get() = LocalWikipediaColor.current.isDarkTheme
 }

--- a/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
+++ b/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
@@ -38,4 +38,8 @@ object WikipediaTheme {
     val typography: WikipediaTypography
         @Composable
         get() = LocalWikipediaTypography.current
+
+    val isDark: Boolean
+        @Composable
+        get() = LocalWikipediaColor.current.isDarkTheme
 }


### PR DESCRIPTION
This removes the necessity to pass around an `isDarkTheme` parameter wherever a `WikiCard` composable is used.

The only purpose of this parameter is whether or not to apply an elevation to the card, and the reason it became a parameter is to make Previews work, since a Preview is not aware of `WikipediaApp.instance`.

But now, we can encode directly into the `WikipediaTheme` composable whether the current theme is Dark or not, and remove the actual dependency on `WikipediaApp.instance`.