### PR TITLE
Provide a default ripple effect for all Composables.

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -4,7 +4,6 @@ import android.os.Build
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -15,7 +14,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -83,13 +81,7 @@ fun MessageCard(
         Column(
             modifier = Modifier
             .fillMaxWidth()
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = ripple(
-                    bounded = true,
-                    color = WikipediaTheme.colors.overlayColor
-                ),
-                enabled = onContainerClick != null) {
+            .clickable(enabled = onContainerClick != null) {
                 onContainerClick?.invoke()
             }
         ) {

--- a/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
+++ b/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
@@ -1,5 +1,10 @@
 package org.wikipedia.compose.theme
 
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.RippleConfiguration
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -8,6 +13,7 @@ import androidx.compose.runtime.remember
 import org.wikipedia.WikipediaApp
 import org.wikipedia.theme.Theme
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BaseTheme(
     currentTheme: Theme = WikipediaApp.instance.currentTheme,
@@ -22,9 +28,13 @@ fun BaseTheme(
         Theme.SEPIA -> SepiaColors
     }
 
+    val rippleConfig = RippleConfiguration(color = wikipediaColorSystem.overlayColor)
+
     CompositionLocalProvider(
         LocalWikipediaColor provides wikipediaColorSystem,
-        LocalWikipediaTypography provides Typography
+        LocalWikipediaTypography provides Typography,
+        LocalRippleConfiguration provides rippleConfig,
+        LocalIndication provides ripple()
     ) {
         content()
     }

--- a/app/src/main/java/org/wikipedia/language/LangLinksScreen.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksScreen.kt
@@ -2,7 +2,6 @@ package org.wikipedia.language
 
 import android.os.Build
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,7 +16,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -140,8 +138,6 @@ fun ComposeLangLinksScreen(
                             Box(
                                 modifier = Modifier
                                     .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
-                                        indication = ripple(bounded = true),
                                         onClick = { onLanguageSelected(item) }
                                     )
                             ) {

--- a/app/src/main/java/org/wikipedia/language/addlanguages/AddLanguagesListScreen.kt
+++ b/app/src/main/java/org/wikipedia/language/addlanguages/AddLanguagesListScreen.kt
@@ -2,7 +2,6 @@ package org.wikipedia.language.addlanguages
 
 import android.os.Build
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,7 +16,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -152,14 +150,10 @@ fun LanguagesListScreen(
                             val localizedLanguageName = StringUtil.capitalize(languageItem.localizedName).orEmpty()
                             LanguageListItemView(
                                 modifier = Modifier
-                                    .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
-                                        indication = ripple(bounded = true),
-                                        onClick = {
-                                            BreadCrumbLogEvent.logClick(context, "listItem.$index")
-                                            onListItemClick(languageItem.code)
-                                        }
-                                    )
+                                    .clickable(onClick = {
+                                        BreadCrumbLogEvent.logClick(context, "listItem.$index")
+                                        onListItemClick(languageItem.code)
+                                    })
                                     .fillMaxWidth()
                                     .padding(16.dp)
                                     .testTag(languageItem.canonicalName),


### PR DESCRIPTION
Are there any clickable Composables where we **don't** want a ripple effect?

If not, then let's make a `ripple()` indication be the default indication for composables.

This way, we won't need to explicitly add `indicator = ripple()` or the more bizarre `interactionSource = remember { MutableInteractionSource() }` wherever we want a ripple.