### PR TITLE
WikiGames: explicitly scroll to top on every question.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -324,6 +324,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         binding.questionDate1.text = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).format(LocalDate.of(event1.year, viewModel.currentMonth, viewModel.currentDay))
         binding.questionText1.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = 0 }
         binding.questionText1.text = event1.text
+        binding.questionText1.scrollY = 0
 
         val thumbnailUrl1 = viewModel.getThumbnailUrlForEvent(event1)
         binding.questionThumbnail1.tag = thumbnailUrl1.isNullOrEmpty()
@@ -337,6 +338,7 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         binding.questionDate2.text = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).format(LocalDate.of(event2.year, viewModel.currentMonth, viewModel.currentDay))
         binding.questionText2.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = 0 }
         binding.questionText2.text = event2.text
+        binding.questionText2.scrollY = 0
 
         val thumbnailUrl2 = viewModel.getThumbnailUrlForEvent(event2)
         binding.questionThumbnail2.tag = thumbnailUrl2.isNullOrEmpty()


### PR DESCRIPTION
When playing the game, if one of the cards is scrollable, and you scroll it all the way down, then the next question's text becomes _pre-scrolled to the same position_, even if the text is not scrollable (!), which can lead to a confusing presentation:

![image](https://github.com/user-attachments/assets/c7c67a85-3ac3-479f-83d6-60fa652860b1)

Let's explicitly scroll the TextView to the top when each question is shown, to make sure it's shown correctly.