### PR TITLE
Default RRL notification Preference should be false

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -806,7 +806,7 @@ object Prefs {
         set(types) = PrefsIoUtil.setString(R.string.preference_key_recommended_reading_list_interests, JsonUtil.encodeToString(types))
 
     var isRecommendedReadingListNotificationEnabled
-        get() = PrefsIoUtil.getBoolean(R.string.preference_key_recommended_reading_list_notification_enabled, true)
+        get() = PrefsIoUtil.getBoolean(R.string.preference_key_recommended_reading_list_notification_enabled, false)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_recommended_reading_list_notification_enabled, value)
 
     var recommendedReadingListSourceTitlesWithOffset


### PR DESCRIPTION
### What does this do?
- changes the default isRecommendedReadingListNotificationEnabled to false


