### PR TITLE
Follow-up to Compose: a bit of cleanup of typography, etc.

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/HtmlText.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/HtmlText.kt
@@ -3,7 +3,6 @@ package org.wikipedia.compose.components
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.SpanStyle
@@ -33,7 +32,6 @@ fun HtmlText(
         color = WikipediaTheme.colors.primaryColor,
         fontSize = 14.sp
     ),
-    color: Color = Color.Unspecified,
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = TextOverflow.Ellipsis,
     lineHeight: TextUnit = 1.6.em,
@@ -48,7 +46,6 @@ fun HtmlText(
         ),
         lineHeight = lineHeight,
         style = style,
-        color = color,
         maxLines = maxLines,
         overflow = overflow,
     )

--- a/app/src/main/java/org/wikipedia/compose/components/HtmlText.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/HtmlText.kt
@@ -3,6 +3,7 @@ package org.wikipedia.compose.components
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.SpanStyle
@@ -29,9 +30,10 @@ fun HtmlText(
         )
     ),
     style: TextStyle = TextStyle(
-        color = WikipediaTheme.colors.secondaryColor,
+        color = WikipediaTheme.colors.primaryColor,
         fontSize = 14.sp
     ),
+    color: Color = Color.Unspecified,
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = TextOverflow.Ellipsis,
     lineHeight: TextUnit = 1.6.em,
@@ -46,6 +48,7 @@ fun HtmlText(
         ),
         lineHeight = lineHeight,
         style = style,
+        color = color,
         maxLines = maxLines,
         overflow = overflow,
     )

--- a/app/src/main/java/org/wikipedia/compose/components/SearchEmptyView.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/SearchEmptyView.kt
@@ -47,9 +47,8 @@ fun SearchEmptyView(
             modifier = Modifier
                 .padding(top = 24.dp),
             text = emptyTexTitle,
-            style = WikipediaTheme.typography.p.copy(
-                color = WikipediaTheme.colors.placeholderColor
-            )
+            style = WikipediaTheme.typography.bodyLarge,
+            color = WikipediaTheme.colors.placeholderColor
         )
     }
 }

--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
@@ -16,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -37,6 +39,7 @@ fun WikiCard(
         contentColor = WikipediaTheme.colors.paperColor
     ),
     border: BorderStroke? = null,
+    shape: Shape = RoundedCornerShape(12.dp),
     content: @Composable () -> Unit
 ) {
     val isDarkTheme = WikipediaTheme.colors.isDarkTheme
@@ -53,6 +56,7 @@ fun WikiCard(
         elevation = CardDefaults.cardElevation(defaultElevation = cardElevation),
         colors = colors,
         border = border,
+        shape = shape
     ) {
         content()
     }

--- a/app/src/main/java/org/wikipedia/compose/theme/WikipediaTypography.kt
+++ b/app/src/main/java/org/wikipedia/compose/theme/WikipediaTypography.kt
@@ -14,7 +14,8 @@ data class WikipediaTypography(
     val h3: TextStyle = TextStyle(),
     val h4: TextStyle = TextStyle(),
     val h5: TextStyle = TextStyle(),
-    val p: TextStyle = TextStyle(),
+    val bodyLarge: TextStyle = TextStyle(),
+    val bodyMedium: TextStyle = TextStyle(),
     val button: TextStyle = TextStyle(),
     val article: TextStyle = TextStyle(),
     val list: TextStyle = TextStyle(),
@@ -57,7 +58,12 @@ val Typography = WikipediaTypography(
         fontSize = 12.sp,
         lineHeight = 18.sp
     ),
-    p = TextStyle(
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+    ),
+    bodyLarge = TextStyle(
         fontFamily = FontFamily.SansSerif,
         fontSize = 16.sp,
         lineHeight = 24.sp


### PR DESCRIPTION
(This will be useful and/or necessary for the upcoming Reading Lists work)

* Update the `WikiCard` component to have a customizable `shape`.
* Remove the typography style called `p`, which is semantically ambiguous and inaccurate, and replace it with `bodyLarge` and `bodyMedium`, which are the styles used in Figma designs.