### PR TITLE
Follow-up to Coil: expose getRequest() for use in AsyncImage.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/imageservice/CoilImageServiceLoader.kt
+++ b/app/src/main/java/org/wikipedia/views/imageservice/CoilImageServiceLoader.kt
@@ -55,8 +55,53 @@ class CoilImageServiceLoader : ImageServiceLoader {
         listener: ImageLoadListener?
     ) {
         val context = imageView.context
+        val request = getRequestBuilder(context, url, detectFace, force, placeholderId, listener).target(imageView).build()
+        context.imageLoader.enqueue(request)
+    }
+
+    override fun loadImage(
+        context: Context,
+        imageUrl: String?,
+        whiteBackground: Boolean,
+        onSuccess: (Bitmap) -> Unit
+    ) {
+        val request = ImageRequest.Builder(context)
+            .data(imageUrl)
+            .apply {
+                if (whiteBackground) {
+                    transformations(WhiteBackgroundTransformation())
+                }
+            }
+            .target(
+                onSuccess = { result ->
+                    onSuccess(result.toBitmap())
+                }
+            )
+            .build()
+        context.imageLoader.enqueue(request)
+    }
+
+    override fun getRequest(
+        context: Context,
+        url: String?,
+        detectFace: Boolean?,
+        force: Boolean?,
+        placeholderId: Int?,
+        listener: ImageLoadListener?
+    ): Any {
+        return getRequestBuilder(context, url, detectFace, force, placeholderId, listener).build()
+    }
+
+    fun getRequestBuilder(
+        context: Context,
+        url: String?,
+        detectFace: Boolean?,
+        force: Boolean?,
+        placeholderId: Int?,
+        listener: ImageLoadListener?
+    ): ImageRequest.Builder {
         val imageUrl = if ((Prefs.isImageDownloadEnabled || force == true) && !url.isNullOrEmpty()) url.toUri() else null
-        val requestBuilder = ImageRequest.Builder(imageView.context)
+        val requestBuilder = ImageRequest.Builder(context)
             .data(imageUrl)
 
         if (placeholderId != null) {
@@ -82,30 +127,7 @@ class CoilImageServiceLoader : ImageServiceLoader {
                 }
             })
         }
-        val request = requestBuilder.target(imageView).build()
-        context.imageLoader.enqueue(request)
-    }
-
-    override fun loadImage(
-        context: Context,
-        imageUrl: String?,
-        whiteBackground: Boolean,
-        onSuccess: (Bitmap) -> Unit
-    ) {
-        val request = ImageRequest.Builder(context)
-            .data(imageUrl)
-            .apply {
-                if (whiteBackground) {
-                    transformations(WhiteBackgroundTransformation())
-                }
-            }
-            .target(
-                onSuccess = { result ->
-                    onSuccess(result.toBitmap())
-                }
-            )
-            .build()
-        context.imageLoader.enqueue(request)
+        return requestBuilder
     }
 
     override fun getBitmap(image: Any): Bitmap {

--- a/app/src/main/java/org/wikipedia/views/imageservice/ImageService.kt
+++ b/app/src/main/java/org/wikipedia/views/imageservice/ImageService.kt
@@ -34,6 +34,17 @@ object ImageService {
         implementation.loadImage(context, url, whiteBackground, onSuccess)
     }
 
+    fun getRequest(
+        context: Context,
+        url: String?,
+        detectFace: Boolean? = false,
+        force: Boolean? = false,
+        @DrawableRes placeholderId: Int? = null,
+        listener: ImageLoadListener? = null
+    ): Any? {
+        return _implementation?.getRequest(context, url, detectFace, force, placeholderId, listener)
+    }
+
     fun getBitmap(image: Any): Bitmap {
         return implementation.getBitmap(image)
     }
@@ -60,6 +71,15 @@ interface ImageServiceLoader {
         whiteBackground: Boolean = false,
         onSuccess: (Bitmap) -> Unit
     )
+
+    fun getRequest(
+        context: Context,
+        url: String?,
+        detectFace: Boolean? = false,
+        force: Boolean? = false,
+        @DrawableRes placeholderId: Int? = null,
+        listener: ImageLoadListener? = null
+    ): Any
 
     fun getBitmap(image: Any): Bitmap
 }


### PR DESCRIPTION
(This will be useful and/or necessary for the upcoming Reading Lists work)

If we expose a `getRequest()` function from our ImageService, we will be able to use it with `AsyncImage` blocks in our Composables, and get all the benefits of our ImageLoader including Face detection, white background, etc.