### PR TITLE
Bump androidx.appcompat:appcompat from 1.7.0 to 1.7.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 androidPluginAnnotationV9 = "3.0.2"
 androidSdk = "11.9.0"
-appcompat = "1.7.0"
+appcompat = "1.7.1"
 balloon = "1.6.12"
 browser = "1.8.0"
 coilCompose = "3.2.0"


### PR DESCRIPTION
Bumps androidx.appcompat:appcompat from 1.7.0 to 1.7.1.

---
updated-dependencies:
- dependency-name: androidx.appcompat:appcompat dependency-version: 1.7.1 dependency-type: direct:production update-type: version-update:semver-patch ...

### What does this do?


### Why is this needed?


**Phabricator:**
https://phabricator.wikimedia.org/T...
