### PR TITLE
Bump androidx.lifecycle:lifecycle-viewmodel-compose from 2.9.0 to 2.9.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ viewpager2 = "1.1.0"
 workRuntimeKtx = "2.10.1"
 composeBom = "2025.05.01"
 composeActivity = "1.10.1"
-composeViewModel = "2.9.0"
+composeViewModel = "2.9.1"
 
 
 [libraries]


### PR DESCRIPTION
Bumps androidx.lifecycle:lifecycle-viewmodel-compose from 2.9.0 to 2.9.1.

---
updated-dependencies:
- dependency-name: androidx.lifecycle:lifecycle-viewmodel-compose dependency-version: 2.9.1 dependency-type: direct:production update-type: version-update:semver-patch ...

### What does this do?


### Why is this needed?


**Phabricator:**
https://phabricator.wikimedia.org/T...
