### PR TITLE
Bump androidx.compose:compose-bom from 2025.05.01 to 2025.06.00

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ swiperefreshlayout = "1.1.0"
 uiautomator = "2.3.0"
 viewpager2 = "1.1.0"
 workRuntimeKtx = "2.10.1"
-composeBom = "2025.05.01"
+composeBom = "2025.06.00"
 composeActivity = "1.10.1"
 composeViewModel = "2.9.0"
 


### PR DESCRIPTION
Bumps androidx.compose:compose-bom from 2025.05.01 to 2025.06.00.

---
updated-dependencies:
- dependency-name: androidx.compose:compose-bom dependency-version: 2025.06.00 dependency-type: direct:production ...

### What does this do?


### Why is this needed?


**Phabricator:**
https://phabricator.wikimedia.org/T...
