### PR TITLE
Show a confirm dialog when adjust source from settings

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSourceFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSourceFragment.kt
@@ -9,10 +9,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.wikipedia.R
 import org.wikipedia.compose.components.error.WikiErrorClickEvents
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.readinglist.ReadingListActivity
 import org.wikipedia.readinglist.ReadingListMode
+import org.wikipedia.settings.Prefs
 
 class RecommendedReadingListSourceFragment : Fragment() {
 
@@ -34,16 +37,22 @@ class RecommendedReadingListSourceFragment : Fragment() {
                             requireActivity().finish()
                         },
                         onSourceClick = {
-                            when (it) {
-                                RecommendedReadingListSource.INTERESTS -> {
-                                    viewModel.updateSourceSelection(newSource = RecommendedReadingListSource.INTERESTS)
+                            if (viewModel.fromSettings) {
+                                if (it == Prefs.recommendedReadingListSource || viewModel.adjustDialogShown) {
+                                    viewModel.updateSourceSelection(newSource = it)
+                                    return@SourceSelectionScreen
                                 }
-                                RecommendedReadingListSource.READING_LIST -> {
-                                    viewModel.updateSourceSelection(newSource = RecommendedReadingListSource.READING_LIST)
-                                }
-                                RecommendedReadingListSource.HISTORY -> {
-                                    viewModel.updateSourceSelection(newSource = RecommendedReadingListSource.HISTORY)
-                                }
+                                viewModel.adjustDialogShown = true
+                                MaterialAlertDialogBuilder(requireContext())
+                                    .setTitle(R.string.recommended_reading_list_settings_updates_base_dialog_title)
+                                    .setMessage(R.string.recommended_reading_list_settings_updates_base_dialog_message)
+                                    .setPositiveButton(R.string.recommended_reading_list_settings_updates_base_dialog_positive_button) { _, _ ->
+                                        viewModel.updateSourceSelection(newSource = it)
+                                    }
+                                    .setNegativeButton(R.string.recommended_reading_list_settings_updates_base_dialog_negative_button, null)
+                                    .show()
+                            } else {
+                                viewModel.updateSourceSelection(newSource = it)
                             }
                         },
                         onNextClick = {

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListViewModel.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListViewModel.kt
@@ -15,6 +15,7 @@ import org.wikipedia.util.Resource
 class RecommendedReadingListViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
 
     val fromSettings = savedStateHandle.get<Boolean>(RecommendedReadingListOnboardingActivity.EXTRA_FROM_SETTINGS) == true
+    var adjustDialogShown = false
 
     private val _uiSourceState = MutableStateFlow(Resource<SourceSelectionUiState>())
     val uiSourceState: StateFlow<Resource<SourceSelectionUiState>> = _uiSourceState.asStateFlow()


### PR DESCRIPTION
### What does this do?
If the user entered the source selection screen from the Settings screen, we should show the confirmation dialog after it changes.

https://www.figma.com/design/Z2n0gZOOAbgsIdHgUS5ocQ/Android-%E2%86%92-Rabbit-Holes-%E2%86%92-T378612?node-id=1210-18522&t=5EYUyKoJosPad3bC-4
