### PR TITLE
Optimize the way of re-generating new list from Settings

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
@@ -198,6 +198,9 @@ class ReadingListFragment : Fragment(), MenuProvider, ReadingListItemActionsDial
                                 binding.readingListHeader.isVisible = false
                                 binding.readingListSwipeRefresh.isVisible = false
                                 binding.errorView.setError(it.throwable)
+                                binding.errorView.backClickListener = View.OnClickListener {
+                                    requireActivity().finish()
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragmentViewModel.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragmentViewModel.kt
@@ -66,7 +66,7 @@ class ReadingListFragmentViewModel : ViewModel() {
             }
         }) {
             _recommendedListFlow.value = Resource.Loading()
-            RecommendedReadingListHelper.generateRecommendedReadingList().let { list ->
+            RecommendedReadingListHelper.generateRecommendedReadingList(shouldExpireOldPages = Prefs.resetRecommendedReadingList).let { list ->
                 val context = WikipediaApp.instance
                 if (list.isNotEmpty()) {
                     val description = when (Prefs.recommendedReadingListUpdateFrequency) {
@@ -79,6 +79,7 @@ class ReadingListFragmentViewModel : ViewModel() {
                     val recommendedListPages = list.map {
                         ReadingListPage(
                             wiki = it.wiki,
+                            lang = it.wiki.languageCode,
                             namespace = it.namespace,
                             displayTitle = it.displayTitle,
                             apiTitle = it.apiTitle,

--- a/app/src/main/java/org/wikipedia/readinglist/db/RecommendedPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/RecommendedPageDao.kt
@@ -4,7 +4,6 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Update
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.readinglist.database.RecommendedPage
 
@@ -19,8 +18,8 @@ interface RecommendedPageDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(recommendedPages: List<RecommendedPage>)
 
-    @Update
-    suspend fun updateAll(recommendedPages: List<RecommendedPage>)
+    @Query("UPDATE RecommendedPage SET status = 1 WHERE status = 0")
+    suspend fun expireOldRecommendedPages()
 
     @Query("SELECT COUNT(*) FROM RecommendedPage WHERE apiTitle = :apiTitle AND wiki = :wiki")
     suspend fun findIfAny(apiTitle: String, wiki: WikiSite): Int

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
@@ -14,7 +14,7 @@ object RecommendedReadingListHelper {
 
     private const val MAX_RETRIES = 10
 
-    suspend fun generateRecommendedReadingList(): List<RecommendedPage> {
+    suspend fun generateRecommendedReadingList(shouldExpireOldPages: Boolean = false): List<RecommendedPage> {
         if (!Prefs.isRecommendedReadingListEnabled) {
             return emptyList()
         }
@@ -22,6 +22,13 @@ object RecommendedReadingListHelper {
         if (numberOfArticles <= 0) {
             return emptyList()
         }
+
+        if (shouldExpireOldPages) {
+            // Expire old recommended pages
+            AppDatabase.instance.recommendedPageDao().expireOldRecommendedPages()
+            Prefs.resetRecommendedReadingList = false
+        }
+
         // Check if amount of new articles to see if we really need to generate a new list
         val existingRecommendedPages = AppDatabase.instance.recommendedPageDao().getNewRecommendedPages()
         if (existingRecommendedPages.size >= numberOfArticles) {

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsActivity.kt
@@ -32,13 +32,14 @@ class RecommendedReadingListSettingsActivity : BaseActivity(), BaseActivity.Call
                 showSnackBar(Prefs.recommendedReadingListSource, onAction = {
                     viewModel.updateRecommendedReadingListSource(currentRecommendedReadingListSource)
                 })
+                Prefs.resetRecommendedReadingList = true
             }
         }
     }
 
     private val recommendedReadingListInterestsLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         if (it.resultCode == RESULT_OK) {
-            // TODO
+            Prefs.resetRecommendedReadingList = true
         }
     }
 

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsViewModel.kt
@@ -19,11 +19,17 @@ class RecommendedReadingListSettingsViewModel : ViewModel() {
     }
 
     fun updateArticleNumbers(number: Int) {
+        if (number != Prefs.recommendedReadingListArticlesNumber) {
+            Prefs.resetRecommendedReadingList = true
+        }
         Prefs.recommendedReadingListArticlesNumber = number
         _uiState.value = _uiState.value.copy(articlesNumber = number)
     }
 
     fun updateFrequency(frequency: RecommendedReadingListUpdateFrequency) {
+        if (frequency != Prefs.recommendedReadingListUpdateFrequency) {
+            Prefs.resetRecommendedReadingList = true
+        }
         Prefs.recommendedReadingListUpdateFrequency = frequency
         _uiState.value = _uiState.value.copy(updateFrequency = frequency)
     }
@@ -34,6 +40,9 @@ class RecommendedReadingListSettingsViewModel : ViewModel() {
     }
 
     fun updateRecommendedReadingListSource(source: RecommendedReadingListSource) {
+        if (source != Prefs.recommendedReadingListSource) {
+            Prefs.resetRecommendedReadingList = true
+        }
         Prefs.recommendedReadingListSource = source
         _uiState.value = _uiState.value.copy(recommendedReadingListSource = source)
     }

--- a/app/src/main/java/org/wikipedia/recurring/RecommendedReadingListTask.kt
+++ b/app/src/main/java/org/wikipedia/recurring/RecommendedReadingListTask.kt
@@ -26,6 +26,6 @@ class RecommendedReadingListTask() : RecurringTask() {
     }
 
     override suspend fun run(lastRun: Date) {
-        RecommendedReadingListHelper.generateRecommendedReadingList()
+        RecommendedReadingListHelper.generateRecommendedReadingList(true)
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -820,4 +820,8 @@ object Prefs {
     var isNewRecommendedReadingListGenerated
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_recommended_reading_list_notification_enabled, false)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_recommended_reading_list_notification_enabled, value)
+
+    var resetRecommendedReadingList
+        get() = PrefsIoUtil.getBoolean(R.string.preference_key_recommended_reading_list_reset, false)
+        set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_recommended_reading_list_reset, value)
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -192,4 +192,5 @@
     <string name="preference_key_recommended_reading_list_onboarding_shown">recommendedReadingListOnboardingShown</string>
     <string name="preference_key_recommended_reading_list_notification_simulator">recommendedReadingListNotificationSimulator</string>
     <string name="preference_key_recommended_reading_list_new_list_generated">recommendedReadingListNewListGenerated</string>
+    <string name="preference_key_recommended_reading_list_reset">recommendedReadingListReset</string>
 </resources>


### PR DESCRIPTION
### What does this do?
Currently, we do not reset the recommended reading list after making changes in the Discover Settings. The way of making the app to expire old pages and regenerating new pages is to save a reset preference for the `ReadingListFragment` to be able to update the list, and not losing the entry point in the `ReadingListFragments`. 

Pending discussion: do we need a "Reset" button in the Discover settings so people can reset recommendations and back to the default?

