### PR TITLE
Use text instead of prefixedText for generating RRL

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
@@ -63,8 +63,8 @@ object RecommendedReadingListHelper {
         // Step 2: combine the titles with the offsite from Prefs.
         val sourcesWithOffset = mutableListOf<SourceWithOffset>()
         titles.forEach { pageTitle ->
-            val offset = Prefs.recommendedReadingListSourceTitlesWithOffset.find { it.title == pageTitle.prefixedText }?.offset ?: 0
-            sourcesWithOffset.add(SourceWithOffset(pageTitle.prefixedText, pageTitle.wikiSite.languageCode, offset))
+            val offset = Prefs.recommendedReadingListSourceTitlesWithOffset.find { it.title == pageTitle.text }?.offset ?: 0
+            sourcesWithOffset.add(SourceWithOffset(pageTitle.text, pageTitle.wikiSite.languageCode, offset))
         }
 
         val newSourcesWithOffset = mutableListOf<SourceWithOffset>()


### PR DESCRIPTION
### What does this do?
- When the user selects 'Saved articles' as the source, the `prefixedText` includes 'Main' at the beginning of the title, which prevents the generation of a recommended reading list. Replacing it with `text` ensures the title is correct for generating the list.
![Screenshot 2025-06-06 at 10 07 41 AM](https://github.com/user-attachments/assets/b1341886-4267-49db-94af-f8a0a99586d3)