### PR TITLE
Re-show the onboarding card if user skip and then enable in Discover settings

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
@@ -809,8 +809,7 @@ class ReadingListsFragment : Fragment(), SortReadingListsDialog.Callback, Readin
             binding.onboardingView.isVisible = false
             return
         }
-        if (RecommendedReadingListAbTest().isTestGroupUser() &&
-            !Prefs.isRecommendedReadingListOnboardingShown && !Prefs.isRecommendedReadingListEnabled) {
+        if (RecommendedReadingListAbTest().isTestGroupUser() && !Prefs.isRecommendedReadingListOnboardingShown) {
             RecommendedReadingListEvent.submit("impression", "rrl_saved_prompt")
             binding.onboardingView.setMessageLabel(getString(R.string.recommended_reading_list_onboarding_card_new))
             binding.onboardingView.setMessageTitle(getString(R.string.recommended_reading_list_onboarding_card_title))

--- a/app/src/main/java/org/wikipedia/readinglist/db/RecommendedPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/RecommendedPageDao.kt
@@ -26,4 +26,8 @@ interface RecommendedPageDao {
 
     @Query("DELETE FROM RecommendedPage")
     suspend fun deleteAll()
+
+    // find if any recommended page exists
+    @Query("SELECT * FROM RecommendedPage WHERE id = 0")
+    fun findIfAny(): RecommendedPage?
 }

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.wikipedia.database.AppDatabase
 import org.wikipedia.settings.Prefs
 
 class RecommendedReadingListSettingsViewModel : ViewModel() {
@@ -12,6 +13,10 @@ class RecommendedReadingListSettingsViewModel : ViewModel() {
 
     fun toggleDiscoverReadingList(enabled: Boolean) {
         Prefs.isRecommendedReadingListEnabled = enabled
+        if (enabled) {
+            // Should reshow the onboarding if it was previously skipped
+            Prefs.isRecommendedReadingListOnboardingShown = AppDatabase.instance.recommendedPageDao().findIfAny() == null
+        }
         if (!enabled) {
             Prefs.isRecommendedReadingListNotificationEnabled = false
         }


### PR DESCRIPTION
### What does this do?
If user clicks on "No thanks" but then enable it in Settings, we should show the onboarding card again if there's no recommended pages in the db.
