### PR TITLE
[RRL] Disable Back button when no interests selected, etc.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
@@ -142,6 +142,7 @@ object RecommendedReadingListHelper {
 
         // Logic to check if the article is already in the database, if it exists, check the next one.
         val firstRecommendedPage = moreLikeResponse.query?.pages.orEmpty()
+            .sortedBy { it.index }
             .map { page ->
                 PageTitle(page.title, wikiSite).apply {
                     displayText = page.displayTitle(wikiSite.languageCode)

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
@@ -244,12 +244,14 @@ fun RecommendedReadingListInterestsScreen(
                     }
                 },
                 navigationIcon = {
+                    val enabled = !fromSettings || (uiState !is Resource.Success) || uiState.data.selectedItems.isNotEmpty()
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = stringResource(R.string.search_back_button_content_description),
                         modifier = Modifier
                             .size(48.dp)
-                            .clickable(onClick = onCloseClick)
+                            .clickable(onClick = onCloseClick, enabled = enabled)
+                            .alpha(if (enabled) 1f else 0.5f)
                             .padding(12.dp),
                         tint = WikipediaTheme.colors.primaryColor
                     )
@@ -403,7 +405,8 @@ fun RecommendedReadingListInterestsContent(
                 modifier = Modifier
                     .padding(start = 8.dp, end = 8.dp)
                     .weight(1f),
-                text = pluralStringResource(
+                text = if (fromSettings && selectedItems.isEmpty()) stringResource(R.string.recommended_reading_list_interest_select_minimum)
+                else pluralStringResource(
                     R.plurals.recommended_reading_list_interest_pick_selected_articles,
                     selectedItems.size,
                     selectedItems.size

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1806,6 +1806,7 @@
     <item quantity="one">Text indicating the number of articles the user has selected as their interests. %d is replaced by the count.</item>
     <item quantity="other">Text indicating the number of articles the user has selected as their interests. %d is replaced by the count.</item>
   </plurals>
+  <string name="recommended_reading_list_interest_select_minimum">Message requiring the user to select at least one article as an interest.</string>
   <string name="recommended_reading_list_interest_pick_random_button_content_description">Content description for the button that randomly selects articles as interests.</string>
   <string name="recommended_reading_list_interest_pick_random_snackbar">Snackbar message shown when the app randomly selects articles for the interests.</string>
   <string name="recommended_reading_list_interest_pick_random_snackbar_action">Action label on the snackbar to undo the random selection of interests.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1890,6 +1890,7 @@
         <item quantity="one">%d selected</item>
         <item quantity="other">%d selected</item>
     </plurals>
+    <string name="recommended_reading_list_interest_select_minimum">Select at least one interest</string>
     <string name="recommended_reading_list_interest_pick_random_button_content_description">Randomly select</string>
     <string name="recommended_reading_list_interest_pick_random_snackbar">We\'ve randomly selected a few articles for you.</string>
     <string name="recommended_reading_list_interest_pick_random_snackbar_action">Undo</string>


### PR DESCRIPTION
* In the Interests screen, disable the Back button if zero items selected (and coming from Settings). Also update the verbiage of the "x selected" label.
* Special bonus: Correctly sort `morelike` results by the `index` field.