### PR TITLE
Fix StackOverflow when pressing Back from Interests selection.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
@@ -138,7 +138,7 @@ class RecommendedReadingListInterestsFragment : Fragment() {
                                 requireActivity().setResult(RESULT_OK)
                                 requireActivity().finish()
                             } else {
-                                requireActivity().onBackPressedDispatcher.onBackPressed()
+                                requireActivity().supportFragmentManager.popBackStack()
                             }
                         },
                         onNextClick = {


### PR DESCRIPTION
The introduction of `BackHandler { }` is conflicting with the explicit call to `onBackPressedDispatcher.onBackPressed()`, and causes a stack overflow.