### PR TITLE
Refine the flow of enable/disable the feature from the reading list

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -138,7 +138,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
                             maybeShowImportReadingListsNewInstallDialog()
                         }
                         is NewRecommendedReadingListEvent -> {
-                            binding.mainNavTabLayout.setOverlayDot(NavTab.READING_LISTS, Prefs.isNewRecommendedReadingListGenerated)
+                            binding.mainNavTabLayout.setOverlayDot(NavTab.READING_LISTS, Prefs.isRecommendedReadingListEnabled && Prefs.isNewRecommendedReadingListGenerated)
                         }
                     }
                 }
@@ -151,7 +151,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
         binding.mainNavTabLayout.descendants.filterIsInstance<TextView>().forEach {
             it.maxLines = 2
         }
-        binding.mainNavTabLayout.setOverlayDot(NavTab.READING_LISTS, Prefs.isNewRecommendedReadingListGenerated)
+        binding.mainNavTabLayout.setOverlayDot(NavTab.READING_LISTS, Prefs.isRecommendedReadingListEnabled && Prefs.isNewRecommendedReadingListGenerated)
         binding.mainNavTabLayout.setOnItemSelectedListener { item ->
             if (item.order == NavTab.MORE.code()) {
                 ExclusiveBottomSheetPresenter.show(childFragmentManager, MenuNavTabDialog.newInstance())

--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListFragment.kt
@@ -436,8 +436,10 @@ class ReadingListFragment : Fragment(), MenuProvider, ReadingListItemActionsDial
                 }
             }
             ReadingListMode.RECOMMENDED -> {
-                // Make sure the feature is enabled
-                Prefs.isRecommendedReadingListEnabled = true
+                if (!Prefs.isRecommendedReadingListEnabled) {
+                    requireActivity().finish()
+                    return
+                }
                 if (readingList == null || Prefs.isNewRecommendedReadingListGenerated) {
                     viewModel.generateRecommendedReadingList()
                 } else {

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
@@ -95,6 +95,7 @@ import org.wikipedia.page.PageTitle
 import org.wikipedia.readinglist.ReadingListActivity
 import org.wikipedia.readinglist.ReadingListMode
 import org.wikipedia.search.SearchActivity
+import org.wikipedia.settings.Prefs
 import org.wikipedia.theme.Theme
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.Resource
@@ -143,6 +144,7 @@ class RecommendedReadingListInterestsFragment : Fragment() {
                         },
                         onNextClick = {
                             viewModel.commitSelection()
+                            Prefs.isRecommendedReadingListEnabled = true
                             startActivity(ReadingListActivity.newIntent(requireContext(), readingListMode = ReadingListMode.RECOMMENDED))
                             requireActivity().finish()
                         },

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsActivity.kt
@@ -21,6 +21,8 @@ import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.RecommendedReadingListEvent
 import org.wikipedia.compose.components.error.WikiErrorClickEvents
 import org.wikipedia.compose.theme.BaseTheme
+import org.wikipedia.concurrency.FlowEventBus
+import org.wikipedia.events.NewRecommendedReadingListEvent
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.Resource
@@ -107,6 +109,7 @@ class RecommendedReadingListSettingsActivity : BaseActivity(), BaseActivity.Call
                     onRecommendedReadingListSwitchClick = {
                         RecommendedReadingListEvent.submit(if (it) "discover_on_click" else "discover_off_click", "discover_settings")
                         viewModel.toggleDiscoverReadingList(it)
+                        FlowEventBus.post(NewRecommendedReadingListEvent())
                     },
                     wikiErrorClickEvents = WikiErrorClickEvents(
                         backClickListener = {

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSourceFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSourceFragment.kt
@@ -96,6 +96,7 @@ class RecommendedReadingListSourceFragment : Fragment() {
                                         .add(android.R.id.content, RecommendedReadingListInterestsFragment.newInstance())
                                         .addToBackStack(null).commit()
                                 } else {
+                                    Prefs.isRecommendedReadingListEnabled = true
                                     startActivity(ReadingListActivity.newIntent(requireContext(), readingListMode = ReadingListMode.RECOMMENDED))
                                     requireActivity().finish()
                                 }


### PR DESCRIPTION
### What does this do?
If users enter the reading list screen, click on "Customize" to go to the settings, and turn off the feature. At this moment, we should finish the `ReadingListFramgent` instead of re-enabling it automatically. This PR refines the process and update the logic of showing the red dot for the Saved tab.
