### PR TITLE
Set selectableItemBackground as the foreground color in PageItemView

### DIFF
--- a/app/src/main/java/org/wikipedia/views/PageItemView.kt
+++ b/app/src/main/java/org/wikipedia/views/PageItemView.kt
@@ -39,7 +39,7 @@ class PageItemView<T>(context: Context) : FrameLayout(context) {
     var item: T? = null
 
     init {
-        layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        layoutParams = ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
         setBackgroundColor(ResourceUtil.getThemedColor(context, R.attr.paper_color))
         isFocusable = true
         setOnClickListeners()

--- a/app/src/main/res/layout/item_page_list_entry.xml
+++ b/app/src/main/res/layout/item_page_list_entry.xml
@@ -7,7 +7,7 @@
     android:layout_height="wrap_content"
     android:paddingTop="16dp"
     android:paddingBottom="16dp"
-    android:background="?attr/selectableItemBackground">
+    android:foreground="?attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/page_list_item_title"


### PR DESCRIPTION
### What does this do?
For either the Discover page or items that are available in offline mode, the list items will not have the ripple animation when you click on them. This PR applies the `?attr/selectableItemBackground` to its `foreground`.

