### PR TITLE
Fix: incorrect status bar on Android 15 when applies enableEdgeToEdge()

### DIFF
--- a/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksActivity.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.safeDrawingPadding
@@ -26,7 +25,7 @@ class LangLinksActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        DeviceUtil.setEdgeToEdge(this)
         setContent {
             BaseTheme {
                 val uiState by viewModel.uiState.collectAsState()

--- a/app/src/main/java/org/wikipedia/language/addlanguages/AddLanguagesListActivity.kt
+++ b/app/src/main/java/org/wikipedia/language/addlanguages/AddLanguagesListActivity.kt
@@ -3,7 +3,6 @@ package org.wikipedia.language.addlanguages
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
@@ -23,7 +22,7 @@ class AddLanguagesListActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        DeviceUtil.setEdgeToEdge(this)
         setContent {
             BaseTheme {
                 val uiState = viewModel.uiState.collectAsState().value

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsActivity.kt
@@ -6,7 +6,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,6 +23,7 @@ import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.concurrency.FlowEventBus
 import org.wikipedia.events.NewRecommendedReadingListEvent
 import org.wikipedia.settings.Prefs
+import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.Resource
 
@@ -58,7 +58,7 @@ class RecommendedReadingListSettingsActivity : BaseActivity(), BaseActivity.Call
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         callback = this
-        enableEdgeToEdge()
+        DeviceUtil.setEdgeToEdge(this)
         RecommendedReadingListEvent.submit("impression", "discover_settings")
         setContent {
             val uiState by viewModel.uiState.collectAsState()

--- a/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
@@ -2,7 +2,6 @@ package org.wikipedia.settings
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -51,6 +50,7 @@ import org.wikipedia.compose.components.WikiTopAppBar
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.theme.Theme
+import org.wikipedia.util.DeviceUtil
 
 class AboutActivity : BaseActivity() {
     private val credits = listOf(
@@ -97,7 +97,7 @@ class AboutActivity : BaseActivity() {
     )
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        DeviceUtil.setEdgeToEdge(this)
         setContent {
             BaseTheme {
                 AboutWikipediaScreen(

--- a/app/src/main/java/org/wikipedia/util/DeviceUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DeviceUtil.kt
@@ -14,7 +14,9 @@ import android.view.View
 import android.view.Window
 import android.view.accessibility.AccessibilityManager
 import android.view.inputmethod.InputMethodManager
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.ColorInt
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -96,6 +98,11 @@ object DeviceUtil {
             return false
         }
         return true
+    }
+
+    fun setEdgeToEdge(activity: AppCompatActivity) {
+        activity.enableEdgeToEdge()
+        WindowCompat.getInsetsController(activity.window, activity.window.decorView).isAppearanceLightStatusBars = !WikipediaApp.instance.currentTheme.isDark
     }
 
     val isOnWiFi: Boolean


### PR DESCRIPTION
### What does this do?
The previous fix works for my Samsung S24 but does not work for my Samsung S25 with Android 15.

Before vs After
<img src="https://github.com/user-attachments/assets/4e00416a-5f5b-4737-9407-b0e76669763a" width="400" />
<img src="https://github.com/user-attachments/assets/827bde27-bb09-4384-b309-f3cea1c2f8e2" width="400" />

