### PR TITLE
Use correct help URL for Short Descriptions in enwiki.

### DIFF
--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditView.kt
@@ -110,7 +110,8 @@ class DescriptionEditView(context: Context, attrs: AttributeSet?) : LinearLayout
 
         binding.learnMoreButton.setOnClickListener {
             UriUtil.visitInExternalBrowser(context, Uri.parse(WikipediaApp.instance.getString(if (action == DescriptionEditActivity.Action.ADD_DESCRIPTION ||
-                action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION) R.string.description_edit_description_learn_more_url
+                action == DescriptionEditActivity.Action.TRANSLATE_DESCRIPTION)
+                if (pageTitle.wikiSite.languageCode == "en") R.string.short_description_help_url_en else R.string.description_edit_description_learn_more_url
             else R.string.description_edit_image_caption_learn_more_url)))
         }
     }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsCardsFragment.kt
@@ -154,7 +154,11 @@ class SuggestedEditsCardsFragment : Fragment(), MenuProvider, SuggestedEditsItem
                             R.string.suggested_edits_image_tags_help_url)
                     }
                     else -> {
-                        FeedbackUtil.showAndroidAppEditingFAQ(requireContext())
+                        if ((viewModel.action == ADD_DESCRIPTION && viewModel.langFromCode == "en") || (viewModel.action == TRANSLATE_DESCRIPTION && viewModel.langToCode == "en")) {
+                            FeedbackUtil.showAndroidAppEditingFAQ(requireContext(), R.string.short_description_help_url_en)
+                        } else {
+                            FeedbackUtil.showAndroidAppEditingFAQ(requireContext())
+                        }
                     }
                 }
                 val child = topBaseChild()

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -10,6 +10,7 @@
     <string name="survey_privacy_policy_url">https://foundation.wikimedia.org/wiki/Legal:Wikipedia_Android_App_Onboarding_Survey_Privacy_Statement</string>
     <string name="image_captions_style_url">https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Images</string>
     <string name="image_alt_text_style_url">https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Images</string>
+    <string name="short_description_help_url_en">https://en.wikipedia.org/wiki/Wikipedia:Short_description</string>
     <string name="quality_and_intent_filters_url">https://www.mediawiki.org/wiki/Help:New_filters_for_edit_review/Quality_and_Intent_Filters</string>
     <string name="temp_accounts_help_url">https://www.mediawiki.org/wiki/Help:Temporary_accounts</string>
     <string name="account_vanish_url">https://meta.m.wikimedia.org/wiki/Special:GlobalVanishRequest</string>


### PR DESCRIPTION
This updates the URL that the user is taken to, when tapping Info links about short descriptions.
In the case of English Wikipedia, the URL will now go directly to [WP:SHORTDESC](https://en.wikipedia.org/wiki/Wikipedia:Short_description), instead of our general Suggested Edits page on MediaWiki.org.

https://phabricator.wikimedia.org/T390105
