### PR TITLE
update compose to use Material typography

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/LicenseLinkText.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/LicenseLinkText.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.compose.components
 
 import android.content.Intent
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -26,7 +27,7 @@ data class LinkTextData(
 fun LicenseLinkText(
     links: List<LinkTextData>,
     modifier: Modifier = Modifier,
-    textStyle: TextStyle = WikipediaTheme.typography.small
+    textStyle: TextStyle = MaterialTheme.typography.labelMedium
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current

--- a/app/src/main/java/org/wikipedia/compose/components/SearchEmptyView.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/SearchEmptyView.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -47,7 +48,7 @@ fun SearchEmptyView(
             modifier = Modifier
                 .padding(top = 24.dp),
             text = emptyTexTitle,
-            style = WikipediaTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.bodyLarge,
             color = WikipediaTheme.colors.placeholderColor
         )
     }

--- a/app/src/main/java/org/wikipedia/compose/components/WikiButtons.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiButtons.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -149,7 +150,7 @@ fun ThemeColorCircularButton(
     ) {
         Text(
             text = text,
-            style = WikipediaTheme.typography.h3.copy(
+            style = MaterialTheme.typography.titleMedium.copy(
                 color = textColor,
                 letterSpacing = 0.sp
             )

--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -103,7 +104,7 @@ fun MessageCard(
                 if (title != null) {
                     Text(
                         text = title,
-                        style = WikipediaTheme.typography.h2,
+                        style = MaterialTheme.typography.titleLarge,
                         color = WikipediaTheme.colors.primaryColor,
                         modifier = Modifier.padding(bottom = 12.dp)
                     )

--- a/app/src/main/java/org/wikipedia/compose/components/WikiSnackbar.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiSnackbar.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.compose.components
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -27,7 +28,7 @@ fun Snackbar(
                 ) {
                     Text(
                         text = actionLabel,
-                        style = WikipediaTheme.typography.h3.copy(
+                        style = MaterialTheme.typography.titleMedium.copy(
                             color = WikipediaTheme.colors.progressiveColor
                         )
                     )
@@ -40,8 +41,8 @@ fun Snackbar(
     ) {
         HtmlText(
             text = message,
-            style = WikipediaTheme.typography.h3.copy(
-                color = WikipediaTheme.colors.primaryColor
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = WikipediaTheme.colors.primaryColor,
             ),
             maxLines = 10
         )

--- a/app/src/main/java/org/wikipedia/compose/components/WikiTopAppBar.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiTopAppBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -27,7 +28,7 @@ import org.wikipedia.compose.theme.WikipediaTheme
 fun WikiTopAppBar(
     title: String,
     onNavigationClick: (() -> Unit),
-    titleStyle: TextStyle = WikipediaTheme.typography.h1.copy(lineHeight = 24.sp),
+    titleStyle: TextStyle = MaterialTheme.typography.headlineSmall.copy(lineHeight = 24.sp),
     elevation: Dp = 0.dp,
     modifier: Modifier = Modifier,
     actions: @Composable RowScope.() -> Unit = {},

--- a/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
+++ b/app/src/main/java/org/wikipedia/compose/theme/WikipediaTheme.kt
@@ -3,6 +3,7 @@ package org.wikipedia.compose.theme
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
@@ -30,22 +31,22 @@ fun BaseTheme(
 
     val rippleConfig = RippleConfiguration(color = wikipediaColorSystem.overlayColor)
 
-    CompositionLocalProvider(
-        LocalWikipediaColor provides wikipediaColorSystem,
-        LocalWikipediaTypography provides Typography,
-        LocalRippleConfiguration provides rippleConfig,
-        LocalIndication provides ripple()
-    ) {
-        content()
-    }
+    MaterialTheme(
+        typography = WikipediaTypography,
+        content = {
+            CompositionLocalProvider(
+                LocalWikipediaColor provides wikipediaColorSystem,
+                LocalRippleConfiguration provides rippleConfig,
+                LocalIndication provides ripple()
+            ) {
+                content()
+            }
+        }
+    )
 }
 
 object WikipediaTheme {
     val colors: WikipediaColor
         @Composable
         get() = LocalWikipediaColor.current
-
-    val typography: WikipediaTypography
-        @Composable
-        get() = LocalWikipediaTypography.current
 }

--- a/app/src/main/java/org/wikipedia/compose/theme/WikipediaTypography.kt
+++ b/app/src/main/java/org/wikipedia/compose/theme/WikipediaTypography.kt
@@ -1,101 +1,34 @@
 package org.wikipedia.compose.theme
 
-import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-@Immutable
-data class WikipediaTypography(
-    val h1: TextStyle = TextStyle(),
-    val h2: TextStyle = TextStyle(),
-    val h3: TextStyle = TextStyle(),
-    val h4: TextStyle = TextStyle(),
-    val h5: TextStyle = TextStyle(),
-    val bodyLarge: TextStyle = TextStyle(),
-    val bodyMedium: TextStyle = TextStyle(),
-    val button: TextStyle = TextStyle(),
-    val article: TextStyle = TextStyle(),
-    val list: TextStyle = TextStyle(),
-    val chip: TextStyle = TextStyle(),
-    val small: TextStyle = TextStyle()
-)
-
-val LocalWikipediaTypography = staticCompositionLocalOf {
-    WikipediaTypography()
-}
-
-val Typography = WikipediaTypography(
-    h1 = TextStyle(
+val WikipediaTypography = Typography(
+    headlineSmall = TextStyle(
         fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Bold,
         fontSize = 24.sp,
         lineHeight = 32.sp
     ),
-    h2 = TextStyle(
+    titleLarge = TextStyle(
         fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Bold,
         fontSize = 20.sp,
         lineHeight = 28.sp
     ),
-    h3 = TextStyle(
+    titleMedium = TextStyle(
         fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Bold,
         fontSize = 16.sp,
         lineHeight = 24.sp
     ),
-    h4 = TextStyle(
+    titleSmall = TextStyle(
         fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Bold,
         fontSize = 14.sp,
         lineHeight = 24.sp
-    ),
-    h5 = TextStyle(
-        fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight.Bold,
-        fontSize = 12.sp,
-        lineHeight = 18.sp
-    ),
-    bodyMedium = TextStyle(
-        fontFamily = FontFamily.SansSerif,
-        fontSize = 14.sp,
-        lineHeight = 20.sp,
-    ),
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.SansSerif,
-        fontSize = 16.sp,
-        lineHeight = 24.sp
-    ),
-    button = TextStyle(
-        fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight.Medium,
-        fontSize = 16.sp,
-        lineHeight = 24.sp
-    ),
-    article = TextStyle(
-        fontFamily = FontFamily.Serif,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp
-    ),
-    list = TextStyle(
-        fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight.Normal,
-        fontSize = 14.sp,
-        lineHeight = 24.sp
-    ),
-    chip = TextStyle(
-        fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
-        lineHeight = 24.sp
-    ),
-    small = TextStyle(
-        fontFamily = FontFamily.SansSerif,
-        fontWeight = FontWeight.Medium,
-        fontSize = 12.sp,
-        lineHeight = 18.sp
     )
 )

--- a/app/src/main/java/org/wikipedia/language/LangLinksScreen.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,6 +28,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import org.wikipedia.R
 import org.wikipedia.compose.components.SearchEmptyView
 import org.wikipedia.compose.components.WikiTopAppBarWithSearch
@@ -163,8 +165,8 @@ fun ComposeLangLinksScreen(
 fun ListHeader(
     title: String,
     modifier: Modifier = Modifier,
-    titleStyle: TextStyle = WikipediaTheme.typography.h4.copy(
-        color = WikipediaTheme.colors.primaryColor,
+    titleStyle: TextStyle = MaterialTheme.typography.titleSmall.copy(
+        color = WikipediaTheme.colors.primaryColor
     )
 ) {
     Box(
@@ -194,8 +196,8 @@ fun LangLinksItemView(
             modifier = Modifier
                 .fillMaxWidth(),
             text = localizedLanguageName,
-            style = WikipediaTheme.typography.h3.copy(
-                color = WikipediaTheme.colors.primaryColor,
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = WikipediaTheme.colors.primaryColor
             )
         )
         if (!canonicalName.isNullOrEmpty()) {
@@ -203,8 +205,9 @@ fun LangLinksItemView(
                 modifier = Modifier
                     .fillMaxWidth(),
                 text = canonicalName,
-                style = WikipediaTheme.typography.list.copy(
-                    color = WikipediaTheme.colors.secondaryColor
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = WikipediaTheme.colors.secondaryColor,
+                    lineHeight = 24.sp
                 )
             )
         }
@@ -212,8 +215,9 @@ fun LangLinksItemView(
             modifier = Modifier
                 .fillMaxWidth(),
             text = articleName,
-            style = WikipediaTheme.typography.list.copy(
-                color = WikipediaTheme.colors.secondaryColor
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = WikipediaTheme.colors.secondaryColor,
+                lineHeight = 24.sp
             )
         )
     }

--- a/app/src/main/java/org/wikipedia/language/addlanguages/AddLanguagesListScreen.kt
+++ b/app/src/main/java/org/wikipedia/language/addlanguages/AddLanguagesListScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,6 +32,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.compose.components.SearchEmptyView
@@ -172,8 +174,8 @@ fun LanguagesListScreen(
 fun ListHeader(
     title: String,
     modifier: Modifier = Modifier,
-    titleStyle: TextStyle = WikipediaTheme.typography.h4.copy(
-        color = WikipediaTheme.colors.primaryColor,
+    titleStyle: TextStyle = MaterialTheme.typography.titleSmall.copy(
+        color = WikipediaTheme.colors.primaryColor
     )
 ) {
     Box(
@@ -200,16 +202,17 @@ fun LanguageListItemView(
     ) {
         Text(
             text = localizedLanguageName,
-            style = WikipediaTheme.typography.h3.copy(
-                color = WikipediaTheme.colors.primaryColor,
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = WikipediaTheme.colors.primaryColor
             )
         )
         if (subtitle != null) {
             Text(
                 text = subtitle,
-                style = WikipediaTheme.typography.list.copy(
+                style = MaterialTheme.typography.bodyMedium.copy(
                     color = WikipediaTheme.colors.secondaryColor,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
+                    lineHeight = 24.sp
                 )
             )
         }

--- a/app/src/main/java/org/wikipedia/readinglist/RecommendedReadingListDiscoverCardView.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/RecommendedReadingListDiscoverCardView.kt
@@ -67,7 +67,7 @@ fun RecommendedReadingListDiscoverCardView(
                 ) {
                     Text(
                         text = title,
-                        style = WikipediaTheme.typography.h3,
+                        style = MaterialTheme.typography.titleMedium,
                         color = WikipediaTheme.colors.primaryColor
                     )
                     if (isNewListGenerated) {

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -247,7 +248,7 @@ fun RecommendedReadingListInterestsScreen(
                         Text(
                             text = stringResource(R.string.recommended_reading_list_interest_pick_title),
                             color = WikipediaTheme.colors.primaryColor,
-                            style = WikipediaTheme.typography.h2
+                            style = MaterialTheme.typography.titleLarge
                         )
                     }
                 },
@@ -356,7 +357,10 @@ fun RecommendedReadingListInterestsContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 48.dp, bottom = 4.dp, start = 16.dp, end = 16.dp),
-                        style = MaterialTheme.typography.titleLarge,
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.Normal,
+                            fontSize = 22.sp
+                        ),
                         color = WikipediaTheme.colors.primaryColor,
                         textAlign = TextAlign.Center,
                         text = stringResource(R.string.recommended_reading_list_interest_pick_title)

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsScreen.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsScreen.kt
@@ -347,7 +347,7 @@ private fun ArticlesNumberView(
                 )
                 Text(
                     text = stringResource(R.string.recommended_reading_list_settings_articles),
-                    style = WikipediaTheme.typography.bodyLarge,
+                    style = MaterialTheme.typography.bodyLarge,
                     color = WikipediaTheme.colors.primaryColor
                 )
             }
@@ -393,7 +393,7 @@ private fun UpdatesFrequencyView(
         headlineContent = {
             Text(
                 text = updateFrequencyString,
-                style = WikipediaTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.bodyLarge,
                 color = WikipediaTheme.colors.primaryColor
             )
         }
@@ -477,7 +477,7 @@ private fun SourceView(
         headlineContent = {
             Text(
                 text = stringResource(R.string.recommended_reading_list_settings_updates_base_title),
-                style = WikipediaTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.bodyLarge,
                 color = WikipediaTheme.colors.primaryColor
             )
         },
@@ -514,7 +514,7 @@ private fun InterestsView(
         headlineContent = {
             Text(
                 text = stringResource(R.string.recommended_reading_list_settings_interests),
-                style = WikipediaTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.bodyLarge,
                 color = WikipediaTheme.colors.primaryColor
             )
         }
@@ -553,7 +553,7 @@ private fun NotificationView(
         headlineContent = {
             Text(
                 text = stringResource(R.string.recommended_reading_list_settings_notifications_title),
-                style = WikipediaTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.bodyLarge,
                 color = WikipediaTheme.colors.primaryColor
             )
         },

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSourceScreen.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSourceScreen.kt
@@ -77,7 +77,7 @@ fun SourceSelectionScreen(
                         Text(
                             text = stringResource(id = R.string.recommended_reading_list_settings_updates_base_title),
                             color = WikipediaTheme.colors.primaryColor,
-                            style = WikipediaTheme.typography.h1.copy(lineHeight = 24.sp)
+                            style = MaterialTheme.typography.headlineSmall.copy(lineHeight = 24.sp)
                         )
                     }
                 },

--- a/app/src/main/java/org/wikipedia/settings/dev/playground/CategoryDeveloperPlayGroundActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/dev/playground/CategoryDeveloperPlayGroundActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
@@ -606,19 +607,19 @@ fun CategoryTable(
                     text = "Title",
                     modifier = Modifier.weight(0.4f),
                     color = WikipediaTheme.colors.primaryColor,
-                    style = WikipediaTheme.typography.h3
+                    style = MaterialTheme.typography.titleMedium
                 )
                 Text(
                     text = "Language",
                     modifier = Modifier.weight(0.3f),
                     color = WikipediaTheme.colors.primaryColor,
-                    style = WikipediaTheme.typography.h3
+                    style = MaterialTheme.typography.titleMedium
                 )
                 Text(
                     text = if (categoriesCount != null) "Count" else "Timestamp",
                     modifier = Modifier.weight(0.3f),
                     color = WikipediaTheme.colors.primaryColor,
-                    style = WikipediaTheme.typography.h3
+                    style = MaterialTheme.typography.titleMedium
                 )
             }
         }


### PR DESCRIPTION
### What does this do?
This replaces the current Wikipedia typography with Material Typography. Since the default font weight of most of the styles in Material Typography is set to normal, I had to override it and in doing so, I also needed to apply additional style adjustments.

Mapping of our current styles to Material3 styles with changes applied:

1. h1 (24sp/32sp Bold) -> headlineSmall (24/32) — made it bold
2. h2 (20sp/28sp Bold) -> titleLarge (22/28) — made it bold and adjusted the font size
3. h3 (16sp/24sp Bold) -> titleMedium (16/24) — made it bold
4. h4 (14sp/24sp Bold) -> titleSmall (14/20) — made it bold and adjusted the lineHeight
5. h5 (12sp/18sp Bold) -> We haven’t used this style, so I didn’t include an equivalent Material3 mapping.
6. bodyLarge and bodyMedium are directly equivalent

Once design completes the M3 alignment work we can update these styles accordingly and also convert the `WikipediaColor` to use `MaterialColor`. 

**Phabricator:**
https://phabricator.wikimedia.org/T396876