### PR TITLE
Add background color to the reading lists recyclerview

### DIFF
--- a/app/src/main/res/layout/fragment_reading_lists.xml
+++ b/app/src/main/res/layout/fragment_reading_lists.xml
@@ -50,7 +50,8 @@
                    android:id="@+id/recycler_view"
                    android:layout_width="match_parent"
                    android:layout_height="wrap_content"
-                   android:scrollbars="vertical" />
+                   android:scrollbars="vertical"
+                   android:background="?attr/paper_color"/>
 
            </LinearLayout>
 


### PR DESCRIPTION
### What does this do?
When you visit the Saved tab for the first time after you open the app, the layout animation shifts the recyclerview below the onboarding/Discover card. Since the view does not have a background color, the text on the list overlaps a bit.