### PR TITLE
Fix: set correct icon color for the multiple delete action

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.ColorUtils
 import androidx.core.text.buildSpannedString
 import androidx.core.text.color
-import androidx.core.view.MenuItemCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
@@ -638,9 +637,7 @@ class ReadingListsFragment : Fragment(), SortReadingListsDialog.Callback, Readin
             mode.menuInflater.inflate(R.menu.menu_action_mode_reading_lists, menu)
             actionMode = mode
             val deleteItem = menu.findItem(R.id.menu_delete_selected)
-            val deleteIconColor = ResourceUtil.getThemedColorStateList(requireContext(), R.attr.warning_color)
             deleteItem.isEnabled = false
-            MenuItemCompat.setIconTintList(deleteItem, deleteIconColor)
             return true
         }
 

--- a/app/src/main/res/menu/menu_action_mode_reading_lists.xml
+++ b/app/src/main/res/menu/menu_action_mode_reading_lists.xml
@@ -12,7 +12,7 @@
     <item
         android:id="@+id/menu_delete_selected"
         android:icon="@drawable/ic_delete_white_24dp"
-        app:iconTint="?attr/primary_color"
+        app:iconTint="?attr/destructive_color"
         android:title="@string/delete_selected_items"
         app:showAsAction="always" />
 


### PR DESCRIPTION
### What does this do?
The icon color has been set to the `warning_color`, but it should have either the Android system `error` color, or the custom `destructive_color`, which can be set in the XML.
