### PR TITLE
Fix: double check the source articles before showing the discover card

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/ReadingListsFragment.kt
@@ -63,6 +63,7 @@ import org.wikipedia.readinglist.database.ReadingList
 import org.wikipedia.readinglist.database.ReadingListPage
 import org.wikipedia.readinglist.database.RecommendedPage
 import org.wikipedia.readinglist.recommended.RecommendedReadingListAbTest
+import org.wikipedia.readinglist.recommended.RecommendedReadingListHelper
 import org.wikipedia.readinglist.recommended.RecommendedReadingListOnboardingActivity
 import org.wikipedia.readinglist.recommended.RecommendedReadingListUpdateFrequency
 import org.wikipedia.readinglist.sync.ReadingListSyncAdapter
@@ -353,7 +354,7 @@ class ReadingListsFragment : Fragment(), SortReadingListsDialog.Callback, Readin
 
                 // Recommended Reading List discover card
                 val recommendedArticles = AppDatabase.instance.recommendedPageDao().getNewRecommendedPages()
-                if (Prefs.isRecommendedReadingListEnabled && recommendedArticles.isNotEmpty()) {
+                if (RecommendedReadingListHelper.readyToGenerateList() && recommendedArticles.isNotEmpty()) {
                     setupRecommendedReadingListDiscoverCardView(recommendedArticles)
                 } else {
                     binding.discoverCardView.isVisible = false

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
@@ -17,7 +17,7 @@ object RecommendedReadingListHelper {
     private const val MAX_RETRIES = 10
 
     suspend fun readyToGenerateList(): Boolean {
-        if (!Prefs.isRecommendedReadingListEnabled) {
+        if (!Prefs.isRecommendedReadingListEnabled || Prefs.recommendedReadingListArticlesNumber <= 0) {
             return false
         }
         if (Prefs.resetRecommendedReadingList) {
@@ -44,13 +44,11 @@ object RecommendedReadingListHelper {
     }
 
     suspend fun generateRecommendedReadingList(shouldExpireOldPages: Boolean = false): List<RecommendedPage> {
-        if (!Prefs.isRecommendedReadingListEnabled) {
+        if (!readyToGenerateList()) {
             return emptyList()
         }
+
         var numberOfArticles = Prefs.recommendedReadingListArticlesNumber
-        if (numberOfArticles <= 0) {
-            return emptyList()
-        }
 
         if (shouldExpireOldPages) {
             // Expire old recommended pages

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListHelper.kt
@@ -16,6 +16,33 @@ object RecommendedReadingListHelper {
     private const val SUGGESTION_REQUEST_ITEMS = 50
     private const val MAX_RETRIES = 10
 
+    suspend fun readyToGenerateList(): Boolean {
+        if (!Prefs.isRecommendedReadingListEnabled) {
+            return false
+        }
+        if (Prefs.resetRecommendedReadingList) {
+            // Make sure the sources have enough articles to generate a recommended reading list.
+            when (Prefs.recommendedReadingListSource) {
+                RecommendedReadingListSource.INTERESTS -> {
+                    if (Prefs.recommendedReadingListInterests.isEmpty()) {
+                        return false
+                    }
+                }
+                RecommendedReadingListSource.READING_LIST -> {
+                    if (AppDatabase.instance.readingListPageDao().getPagesByRandom(1).isEmpty()) {
+                        return false
+                    }
+                }
+                RecommendedReadingListSource.HISTORY -> {
+                    if (AppDatabase.instance.historyEntryDao().getHistoryEntriesByRandom(1).isEmpty()) {
+                        return false
+                    }
+                }
+            }
+        }
+        return true
+    }
+
     suspend fun generateRecommendedReadingList(shouldExpireOldPages: Boolean = false): List<RecommendedPage> {
         if (!Prefs.isRecommendedReadingListEnabled) {
             return emptyList()


### PR DESCRIPTION
### What does this do?
Adds a simple database check before showing the Discover card to avoid an edge case where the users clean up the history/saved articles after they select the source. 