### PR TITLE
Adjust the A/B test logic from PreBetaRelease to DevRelease for Recommended Reading List

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListAbTest.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListAbTest.kt
@@ -12,6 +12,6 @@ class RecommendedReadingListAbTest : ABTest("recommendedReadingList", GROUP_SIZE
     }
 
     fun isTestGroupUser(): Boolean {
-        return ReleaseUtil.isPreBetaRelease || group == GROUP_2
+        return ReleaseUtil.isDevRelease || group == GROUP_2
     }
 }


### PR DESCRIPTION
### What does this do?
Based on the request from the PM signoff, this PR changes the logic of enabling test groups for `DevRelease` instead of `PreBetaRelease`.
