### PR TITLE
Don't treat redirects (HTTP 3xx) as errors.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/UnsuccessfulResponseInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/UnsuccessfulResponseInterceptor.kt
@@ -3,16 +3,18 @@ package org.wikipedia.dataclient.okhttp
 import okhttp3.Interceptor
 import okhttp3.Response
 import okhttp3.internal.closeQuietly
-import java.io.IOException
 
 class UnsuccessfulResponseInterceptor : Interceptor {
-    @Throws(IOException::class)
+    @Throws(HttpStatusException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val rsp = chain.proceed(chain.request())
-        if (rsp.isSuccessful) {
+
+        // If the response is successful (2xx) or a redirect (3xx), then proceed.
+        if (rsp.code < 400) {
             return rsp
         }
 
+        // Otherwise, treat it as an exception and throw it.
         val e = HttpStatusException(rsp)
         rsp.closeQuietly()
         throw e


### PR DESCRIPTION
There is an interesting quirk in one of our network interceptors that can potentially lead to subtle bugs, and also leads to confusing errors in Logcat.
(For example, when launching Places, some network calls result in a HTTP 304 (Unmodified) response, which is perfectly normal, but this actually manifests as an error printed in Logcat, which naturally raises alarms.)

See inline comments for explanation.