### PR TITLE
Follow-up to Material typography.

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/LicenseLinkText.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/LicenseLinkText.kt
@@ -10,10 +10,8 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withLink
-import androidx.compose.ui.unit.em
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.settings.LicenseActivity
 
@@ -26,8 +24,7 @@ data class LinkTextData(
 @Composable
 fun LicenseLinkText(
     links: List<LinkTextData>,
-    modifier: Modifier = Modifier,
-    textStyle: TextStyle = MaterialTheme.typography.labelMedium
+    modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
@@ -59,7 +56,6 @@ fun LicenseLinkText(
     Text(
         text = annotatedString,
         modifier = modifier,
-        style = textStyle,
-        lineHeight = 1.6.em
+        style = MaterialTheme.typography.bodyMedium
     )
 }

--- a/app/src/main/java/org/wikipedia/compose/components/WikiButtons.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiButtons.kt
@@ -16,11 +16,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import org.wikipedia.compose.ComposeColors
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
@@ -151,11 +149,8 @@ fun ThemeColorCircularButton(
     ) {
         Text(
             text = text,
-            style = MaterialTheme.typography.titleMedium.copy(
-                color = textColor,
-                letterSpacing = 0.sp,
-                fontWeight = FontWeight.Bold
-            )
+            style = MaterialTheme.typography.labelLarge,
+            color = textColor
         )
     }
 }

--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -22,12 +22,9 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.theme.Theme
@@ -105,10 +102,7 @@ fun MessageCard(
                 if (title != null) {
                     Text(
                         text = title,
-                        style = MaterialTheme.typography.titleLarge.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 20.sp
-                        ),
+                        style = MaterialTheme.typography.titleLarge,
                         color = WikipediaTheme.colors.primaryColor,
                         modifier = Modifier.padding(bottom = 12.dp)
                     )
@@ -117,14 +111,11 @@ fun MessageCard(
                 HtmlText(
                     modifier = Modifier.padding(bottom = 12.dp),
                     text = message,
-                    style = TextStyle(
-                        color = WikipediaTheme.colors.secondaryColor,
-                        fontSize = 16.sp
-                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = WikipediaTheme.colors.secondaryColor,
                     linkStyle = TextLinkStyles(
                         style = SpanStyle(
-                            color = WikipediaTheme.colors.progressiveColor,
-                            fontSize = 16.sp,
+                            color = WikipediaTheme.colors.progressiveColor
                         )
                     )
                 )
@@ -142,8 +133,7 @@ fun MessageCard(
                             contentColor = WikipediaTheme.colors.progressiveColor
                         ) {
                             Text(
-                                text = positiveButtonText,
-                                fontSize = 16.sp
+                                text = positiveButtonText
                             )
                         }
                     }
@@ -153,8 +143,7 @@ fun MessageCard(
                             onClick = { onNegativeButtonClick?.invoke() }
                         ) {
                             Text(
-                                text = negativeButtonText,
-                                fontSize = 16.sp
+                                text = negativeButtonText
                             )
                         }
                     }

--- a/app/src/main/java/org/wikipedia/compose/components/WikiSnackbar.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiSnackbar.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wikipedia.compose.theme.BaseTheme
@@ -29,10 +28,8 @@ fun Snackbar(
                 ) {
                     Text(
                         text = actionLabel,
-                        style = MaterialTheme.typography.titleMedium.copy(
-                            color = WikipediaTheme.colors.progressiveColor,
-                            fontWeight = FontWeight.Bold
-                        )
+                        color = WikipediaTheme.colors.progressiveColor,
+                        style = MaterialTheme.typography.labelLarge
                     )
                 }
             }
@@ -43,10 +40,8 @@ fun Snackbar(
     ) {
         HtmlText(
             text = message,
-            style = MaterialTheme.typography.titleMedium.copy(
-                color = WikipediaTheme.colors.primaryColor,
-                fontWeight = FontWeight.Bold
-            ),
+            style = MaterialTheme.typography.bodyMedium,
+            color = WikipediaTheme.colors.primaryColor,
             maxLines = 10
         )
     }

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
@@ -360,9 +360,7 @@ fun RecommendedReadingListInterestsContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 48.dp, bottom = 4.dp, start = 16.dp, end = 16.dp),
-                        style = MaterialTheme.typography.titleLarge.copy(
-                            fontSize = 22.sp
-                        ),
+                        style = MaterialTheme.typography.titleLarge,
                         color = WikipediaTheme.colors.primaryColor,
                         textAlign = TextAlign.Center,
                         text = stringResource(R.string.recommended_reading_list_interest_pick_title)

--- a/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/AboutActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
@@ -34,10 +35,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
 import org.wikipedia.BuildConfig
 import org.wikipedia.R
@@ -233,7 +232,6 @@ fun AboutWikipediaHeader(
                 modifier = Modifier
                     .padding(vertical = 16.dp),
                 text = versionName,
-                fontSize = 14.sp,
                 color = WikipediaTheme.colors.primaryColor
             )
         }
@@ -307,10 +305,7 @@ fun AboutScreenBody(
 
         LicenseTextWithHeader(
             header = stringResource(R.string.about_libraries_heading),
-            credits = credits,
-            textStyle = TextStyle(
-                fontSize = 14.sp
-            )
+            credits = credits
         )
 
         LinkTextWithHeader(
@@ -338,15 +333,10 @@ fun AboutScreenFooter(
         )
         HtmlText(
             text = stringResource(R.string.about_wmf),
-            style = TextStyle(
-                color = WikipediaTheme.colors.secondaryColor,
-                fontSize = 12.sp
-            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = WikipediaTheme.colors.secondaryColor,
             linkStyle = TextLinkStyles(
-                style = SpanStyle(
-                    color = WikipediaTheme.colors.progressiveColor,
-                    fontSize = 12.sp,
-                )
+                style = SpanStyle(color = WikipediaTheme.colors.progressiveColor)
             )
         )
     }
@@ -369,7 +359,7 @@ fun LinkTextWithHeader(
     ) {
         Text(
             text = header,
-            fontSize = 16.sp,
+            style = MaterialTheme.typography.bodyLarge,
             color = WikipediaTheme.colors.primaryColor
         )
         HtmlText(
@@ -383,8 +373,7 @@ fun LinkTextWithHeader(
 fun LicenseTextWithHeader(
     modifier: Modifier = Modifier,
     header: String,
-    credits: List<LinkTextData>,
-    textStyle: TextStyle
+    credits: List<LinkTextData>
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -392,12 +381,11 @@ fun LicenseTextWithHeader(
     ) {
         Text(
             text = header,
-            fontSize = 16.sp,
+            style = MaterialTheme.typography.bodyLarge,
             color = WikipediaTheme.colors.primaryColor
         )
         LicenseLinkText(
-            links = credits,
-            textStyle = textStyle
+            links = credits
         )
     }
 }


### PR DESCRIPTION
Another goal in adopting pure Material typography is to use as few explicit `fontSize`, `lineHeight`, etc. overrides as possible.
This PR focuses mostly on the AboutActivity, where there were quite a few unnecessary `.sp` overrides.

This also updates some of our custom Composables which are currently unused (WikiButtons and WikiCard), which don't need to override any text styles.