### PR TITLE
Fix: should use hard-coded text for the event in RRL

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSettingsActivity.kt
@@ -97,7 +97,11 @@ class RecommendedReadingListSettingsActivity : BaseActivity(), BaseActivity.Call
                         }
                     },
                     onUpdateFrequency = {
-                        val frequencyForEvent = getString(it.displayStringRes)
+                        val frequencyForEvent = when (it) {
+                            RecommendedReadingListUpdateFrequency.DAILY -> "daily"
+                            RecommendedReadingListUpdateFrequency.WEEKLY -> "weekly"
+                            RecommendedReadingListUpdateFrequency.MONTHLY -> "monthly"
+                        }
                         RecommendedReadingListEvent.submit("update_${frequencyForEvent}_click", "discover_settings")
                         viewModel.updateFrequency(it)
                         requestPermissionAndScheduleRecommendedReadingNotification()


### PR DESCRIPTION
### What does this do?
A fix for showing the "translated" frequency text in the event, regarding the analyst's feedback. 
