### PR TITLE
Add separate notification channels for games and recommended reading lists

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameNotificationManager.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameNotificationManager.kt
@@ -10,6 +10,7 @@ import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.analytics.eventplatform.WikiGamesEvent
+import org.wikipedia.notifications.NotificationCategory
 import org.wikipedia.notifications.NotificationPollBroadcastReceiver
 import org.wikipedia.notifications.NotificationPollBroadcastReceiver.Companion.ACTION_DAILY_GAME
 import org.wikipedia.notifications.NotificationPresenter
@@ -29,8 +30,6 @@ enum class OnThisDayGameNotificationState {
 }
 
 object OnThisDayGameNotificationManager {
-
-    private const val NOTIFICATION_TYPE_LOCAL = "local"
 
     fun handleNotificationClick(activity: Activity) {
         when (Prefs.otdNotificationState) {
@@ -117,7 +116,7 @@ object OnThisDayGameNotificationManager {
             OnThisDayGameViewModel.isLangSupported(WikipediaApp.instance.wikiSite.languageCode)) {
             NotificationPresenter.showNotification(
                 context = context,
-                builder = NotificationPresenter.getDefaultBuilder(context, 1, NOTIFICATION_TYPE_LOCAL),
+                builder = NotificationPresenter.getDefaultBuilder(context, 1, notificationCategory = NotificationCategory.GAMES),
                 id = 1,
                 title = context.getString(R.string.on_this_day_game_feed_entry_card_heading),
                 text = context.getString(R.string.on_this_day_game_notification_text),

--- a/app/src/main/java/org/wikipedia/notifications/NotificationCategory.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationCategory.kt
@@ -35,7 +35,9 @@ enum class NotificationCategory(val id: String,
     ARTICLE_LINKED("article-linked", R.string.preference_title_notification_article_linked, R.string.preference_summary_notification_article_linked, R.drawable.ic_notification_page_link),
     ALPHA_BUILD_CHECKER("alpha-builder-checker", R.string.alpha_update_notification_title, R.string.alpha_update_notification_text, R.drawable.ic_w_transparent, importance = NotificationManagerCompat.IMPORTANCE_LOW, group = GROUP_OTHER),
     READING_LIST_SYNCING("reading-list-syncing", R.string.notification_syncing_reading_list_channel_title, R.string.notification_syncing_reading_list_channel_description, android.R.drawable.ic_popup_sync, importance = NotificationManagerCompat.IMPORTANCE_LOW, group = GROUP_OTHER),
-    SYNCING("syncing", R.string.notification_channel_title, R.string.notification_channel_description, android.R.drawable.stat_sys_download, importance = NotificationManagerCompat.IMPORTANCE_LOW, group = GROUP_OTHER);
+    SYNCING("syncing", R.string.notification_channel_title, R.string.notification_channel_description, android.R.drawable.stat_sys_download, importance = NotificationManagerCompat.IMPORTANCE_LOW, group = GROUP_OTHER),
+    RECOMMENDED_READING_LISTS("recommended-reading-lists", R.string.recommended_reading_list_title, R.string.recommended_reading_list_onboarding_card_title, R.drawable.ic_bookmark_white_24dp, importance = NotificationManagerCompat.IMPORTANCE_LOW, group = GROUP_OTHER),
+    GAMES("games", R.string.on_this_day_game_feed_entry_card_heading, R.string.on_this_day_game_menu_notifications, R.drawable.ic_dice_24, importance = NotificationManagerCompat.IMPORTANCE_LOW, group = GROUP_OTHER);
 
     override fun code(): Int {
         // This enumeration is not marshalled so tying declaration order to presentation order is
@@ -63,9 +65,12 @@ enum class NotificationCategory(val id: String,
             // Notification channel ( >= API 26 )
             val notificationManagerCompat = NotificationManagerCompat.from(context)
 
-            var notificationChannelGroupWikipediaNotifications = notificationManagerCompat.getNotificationChannelGroupCompat(GROUP_WIKIPEDIA_NOTIFICATIONS)
+            var notificationChannelGroupWikipediaNotifications = notificationManagerCompat.getNotificationChannelGroupCompat(GROUP_OTHER)
 
-            if (notificationChannelGroupWikipediaNotifications == null) {
+            if (notificationChannelGroupWikipediaNotifications?.channels?.find { it.id == GAMES.id } != null) {
+                L.d("Create notification channels skipped.")
+                return
+            } else {
                 notificationChannelGroupWikipediaNotifications = NotificationChannelGroupCompat.Builder(GROUP_WIKIPEDIA_NOTIFICATIONS)
                     .setName(context.getString(R.string.notifications_channel_group_wikipedia_notifications_title))
                     .setDescription(context.getString(R.string.notifications_channel_group_wikipedia_notifications_description))
@@ -77,10 +82,6 @@ enum class NotificationCategory(val id: String,
                     .setDescription(context.getString(R.string.notifications_channel_group_other_title))
                     .build()
                 notificationManagerCompat.createNotificationChannelGroup(notificationChannelGroupWikipediaNotifications)
-            } else {
-                // cancel the process because the following notification channels were created.
-                L.d("Create notification channels skipped.")
-                return
             }
 
             // Remove old channels

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPollBroadcastReceiver.kt
@@ -100,7 +100,6 @@ class NotificationPollBroadcastReceiver : BroadcastReceiver() {
         const val RESULT_EXTRA_ID = "extra_id"
         const val TYPE_MULTIPLE = "multiple"
 
-        private const val TYPE_LOCAL = "local"
         private const val FIRST_EDITOR_REACTIVATION_NOTIFICATION_SHOW_ON_DAY = 3
         private const val SECOND_EDITOR_REACTIVATION_NOTIFICATION_SHOW_ON_DAY = 7
 
@@ -199,8 +198,8 @@ class NotificationPollBroadcastReceiver : BroadcastReceiver() {
         }
 
         fun showSuggestedEditsLocalNotification(context: Context, @StringRes description: Int) {
-            val intent = NotificationPresenter.addIntentExtras(MainActivity.newIntent(context).putExtra(Constants.INTENT_EXTRA_GO_TO_SE_TAB, true), 0, TYPE_LOCAL)
-            NotificationPresenter.showNotification(context, NotificationPresenter.getDefaultBuilder(context, 0, TYPE_LOCAL), 0,
+            val intent = NotificationPresenter.addIntentExtras(MainActivity.newIntent(context).putExtra(Constants.INTENT_EXTRA_GO_TO_SE_TAB, true), 0)
+            NotificationPresenter.showNotification(context, NotificationPresenter.getDefaultBuilder(context, 0), 0,
                     context.getString(R.string.suggested_edits_reactivation_notification_title),
                     context.getString(description), context.getString(description), null,
                     R.drawable.ic_mode_edit_white_24dp, R.color.blue600, intent)

--- a/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
+++ b/app/src/main/java/org/wikipedia/notifications/NotificationPresenter.kt
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit
 
 object NotificationPresenter {
 
+    const val NOTIFICATION_TYPE_LOCAL = "local"
     private var lastPermissionRequestTime = 0L
 
     fun maybeRequestPermission(context: Context, launcher: ActivityResultLauncher<String>) {
@@ -90,19 +91,20 @@ object NotificationPresenter {
         // When showing the multiple-unread notification, we pass the unreadCount as the "id"
         // purely for analytics purposes, to get a sense of how many unread notifications are
         // typically queued up when the user has more than two of them.
-        val builder = getDefaultBuilder(context, unreadCount.toLong(), NotificationPollBroadcastReceiver.TYPE_MULTIPLE)
+        val builder = getDefaultBuilder(context, unreadCount.toLong(), type = NotificationPollBroadcastReceiver.TYPE_MULTIPLE)
         showNotification(context, builder, 0, context.getString(R.string.app_name),
                 context.getString(R.string.notification_many_unread, unreadCount), context.getString(R.string.notification_many_unread, unreadCount),
                 null, R.drawable.ic_notifications_black_24dp, R.color.blue600,
                 addIntentExtras(NotificationActivity.newIntent(context), unreadCount.toLong(), NotificationPollBroadcastReceiver.TYPE_MULTIPLE))
     }
 
-    fun addIntentExtras(intent: Intent, id: Long, type: String): Intent {
+    fun addIntentExtras(intent: Intent, id: Long, type: String = NOTIFICATION_TYPE_LOCAL): Intent {
         return intent.putExtra(Constants.INTENT_EXTRA_NOTIFICATION_ID, id)
                 .putExtra(Constants.INTENT_EXTRA_NOTIFICATION_TYPE, type)
     }
 
-    fun getDefaultBuilder(context: Context, id: Long, type: String?, notificationCategory: NotificationCategory = NotificationCategory.SYSTEM): NotificationCompat.Builder {
+    fun getDefaultBuilder(context: Context, id: Long, type: String? = NOTIFICATION_TYPE_LOCAL,
+                          notificationCategory: NotificationCategory = NotificationCategory.SYSTEM): NotificationCompat.Builder {
         return NotificationCompat.Builder(context, notificationCategory.id)
                 .setDefaults(NotificationCompat.DEFAULT_ALL)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListNotificationManager.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListNotificationManager.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.RecommendedReadingListEvent
+import org.wikipedia.notifications.NotificationCategory
 import org.wikipedia.notifications.NotificationPollBroadcastReceiver
 import org.wikipedia.notifications.NotificationPresenter
 import org.wikipedia.readinglist.ReadingListActivity
@@ -19,7 +20,6 @@ import java.time.LocalTime
 import java.time.temporal.TemporalAdjusters
 
 object RecommendedReadingListNotificationManager {
-    private const val NOTIFICATION_TYPE_LOCAL = "local"
 
     fun scheduleRecommendedReadingListNotification(context: Context) {
         // Always cancel before scheduling a new one
@@ -52,7 +52,7 @@ object RecommendedReadingListNotificationManager {
         RecommendedReadingListEvent.submit("impression", "rrl_notification")
         NotificationPresenter.showNotification(
             context = context,
-            builder = NotificationPresenter.getDefaultBuilder(context, 1, NOTIFICATION_TYPE_LOCAL),
+            builder = NotificationPresenter.getDefaultBuilder(context, 1, notificationCategory = NotificationCategory.RECOMMENDED_READING_LISTS),
             id = 1,
             title = context.getString(R.string.recommended_reading_list_notification_title, frequency),
             text = context.getString(R.string.recommended_reading_list_notification_subtitle),


### PR DESCRIPTION
This adds proper "channels" for the new notifications that we're showing from the Games and the Recommended Reading Lists features.
(At the moment these notifications are using the default "System" channel, which is confusing.)
