### PR TITLE
Suggested task edits espresso test fix

### DIFF
--- a/app/src/androidTest/java/org/wikipedia/base/actions/ListActions.kt
+++ b/app/src/androidTest/java/org/wikipedia/base/actions/ListActions.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
@@ -182,6 +183,25 @@ class ListActions {
                                 not(isDisplayed())
                             )
                         )
+                )
+            )
+    }
+
+    fun verifyItemDoesNotExistWithText(
+        recyclerViewId: Int,
+        text: String
+    ) {
+        onView(withId(recyclerViewId))
+            .check(
+                matches(
+                    not(
+                        hasDescendant(
+                            allOf(
+                                withText(text),
+                                isDisplayed()
+                            )
+                        )
+                    )
                 )
             )
     }

--- a/app/src/androidTest/java/org/wikipedia/robots/screen/SuggestedEditsScreenRobot.kt
+++ b/app/src/androidTest/java/org/wikipedia/robots/screen/SuggestedEditsScreenRobot.kt
@@ -1,9 +1,11 @@
 package org.wikipedia.robots.screen
 
 import BaseRobot
+import android.content.Context
 import androidx.test.espresso.action.ViewActions.click
 import org.wikipedia.R
 import org.wikipedia.base.TestConfig
+import org.wikipedia.settings.Prefs
 
 class SuggestedEditsScreenRobot : BaseRobot() {
 
@@ -44,6 +46,7 @@ class SuggestedEditsScreenRobot : BaseRobot() {
 
     fun clickImageCaptions() = apply {
         list.scrollToRecyclerViewInsideNestedScrollView(recyclerViewId = R.id.tasksRecyclerView, position = 1, viewAction = click())
+        pressBack()
         delay(TestConfig.DELAY_MEDIUM)
     }
 
@@ -60,5 +63,21 @@ class SuggestedEditsScreenRobot : BaseRobot() {
     fun pressBack() = apply {
         goBack()
         delay(TestConfig.DELAY_MEDIUM)
+    }
+
+    fun verifyArticleDescriptionDoesNotExist(context: Context) = apply {
+        list.verifyItemDoesNotExistWithText(
+            recyclerViewId = R.id.tasksRecyclerView,
+            text = context.getString(R.string.description_edit_tutorial_title_descriptions)
+        )
+    }
+
+    fun increaseContribution() = apply {
+        Prefs.overrideSuggestedEditContribution = 100
+    }
+
+    fun disableImageCaptionOnboarding() = apply {
+        Prefs.showImageTagsOnboarding = false
+        Prefs.suggestedEditsImageRecsOnboardingShown = true
     }
 }

--- a/app/src/androidTest/java/org/wikipedia/robots/screen/SuggestedEditsScreenRobot.kt
+++ b/app/src/androidTest/java/org/wikipedia/robots/screen/SuggestedEditsScreenRobot.kt
@@ -46,7 +46,6 @@ class SuggestedEditsScreenRobot : BaseRobot() {
 
     fun clickImageCaptions() = apply {
         list.scrollToRecyclerViewInsideNestedScrollView(recyclerViewId = R.id.tasksRecyclerView, position = 1, viewAction = click())
-        pressBack()
         delay(TestConfig.DELAY_MEDIUM)
     }
 

--- a/app/src/androidTest/java/org/wikipedia/tests/SuggestedEditScreenTest.kt
+++ b/app/src/androidTest/java/org/wikipedia/tests/SuggestedEditScreenTest.kt
@@ -49,13 +49,20 @@ class SuggestedEditScreenTest : BaseTest<MainActivity>(
             .verifyViewsIsVisible()
             .verifyLastEditedIsVisible()
             .verifyEditQualityIsVisible()
+        suggestedEditsScreenRobot
+            .verifyArticleDescriptionDoesNotExist(context)
+            .increaseContribution()
             .enterContributionScreen()
+        systemRobot
+            .clickOnSystemDialogWithText("No thanks")
             .pressBack()
+        suggestedEditsScreenRobot
             .clickArticleDescriptions()
             .pressBack()
-            .clickImageCaptions()
-            .pressBack()
             .clickImageTags()
+            .pressBack()
+            .disableImageCaptionOnboarding()
+            .clickImageCaptions()
             .pressBack()
             .clickSuggestedEdits()
         navRobot


### PR DESCRIPTION
### What does this do?
- fixes suggested edit screen test following the update to hide article descriptions for edits under 50 characters.