### PR TITLE
Fix clickability of remainder of Game card.

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameActivity.kt
@@ -90,7 +90,6 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         binding.errorView.backClickListener = View.OnClickListener {
             finish()
         }
-
         binding.questionCard1.setOnClickListener {
             enqueueSubmit(it as WikiCardView)
         }
@@ -368,6 +367,13 @@ class OnThisDayGameActivity : BaseActivity(), BaseActivity.Callback {
         binding.centerContent.isVisible = false
         binding.correctIncorrectText.text = null
         binding.currentQuestionContainer.isVisible = true
+
+        binding.root.post {
+            if (!isDestroyed) {
+                binding.questionContainer1.minimumHeight = binding.questionScroll1.height - DimenUtil.roundedDpToPx(16f)
+                binding.questionContainer2.minimumHeight = binding.questionScroll2.height - DimenUtil.roundedDpToPx(16f)
+            }
+        }
         supportInvalidateOptionsMenu()
     }
 

--- a/app/src/main/res/layout/activity_on_this_day_game.xml
+++ b/app/src/main/res/layout/activity_on_this_day_game.xml
@@ -79,6 +79,7 @@
             android:layout_marginTop="32dp">
 
             <ScrollView
+                android:id="@+id/questionScroll1"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:paddingEnd="6dp"
@@ -226,6 +227,7 @@
                 android:contentDescription="@null" />
 
             <ScrollView
+                android:id="@+id/questionScroll2"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:paddingEnd="6dp"


### PR DESCRIPTION
The `ScrollView` component has an annoying limitation where it can't process onClick events properly. Therefore we have to manually expand the minimumHeight of the child of the ScrollView and make the child clickable.