### PR TITLE
Follow-up to Category table updates: Fix conversion query.

### DIFF
--- a/app/src/main/java/org/wikipedia/categories/db/CategoryDao.kt
+++ b/app/src/main/java/org/wikipedia/categories/db/CategoryDao.kt
@@ -31,7 +31,7 @@ interface CategoryDao {
     @Query("DELETE FROM Category")
     suspend fun deleteAll()
 
-    @Query("DELETE FROM Category WHERE rowid IN (SELECT rowid FROM Category WHERE year <:year)")
+    @Query("DELETE FROM Category WHERE rowid IN (SELECT rowid FROM Category WHERE year < :year)")
     suspend fun deleteOlderThan(year: Int): Int
 
     @Transaction

--- a/app/src/main/java/org/wikipedia/database/AppDatabase.kt
+++ b/app/src/main/java/org/wikipedia/database/AppDatabase.kt
@@ -333,8 +333,8 @@ abstract class AppDatabase : RoomDatabase() {
                 // Step 2: Populate the new table with the transformed data from the old table
                 db.execSQL("INSERT INTO Category_temp (year, month, title, lang, count)" +
                         "    SELECT" +
-                        "        COALESCE(CAST(strftime('%Y', timeStamp) AS INTEGER), ${LocalDate.now().year}) AS year," +
-                        "        COALESCE(CAST(strftime('%m', timeStamp) AS INTEGER), ${LocalDate.now().monthValue}) AS month," +
+                        "        COALESCE(CAST(strftime('%Y', timeStamp / 1000, 'unixepoch') AS INTEGER), ${LocalDate.now().year}) AS year," +
+                        "        COALESCE(CAST(strftime('%m', timeStamp / 1000, 'unixepoch') AS INTEGER), ${LocalDate.now().monthValue}) AS month," +
                         "        title," +
                         "        lang," +
                         "        COUNT(*) AS count" +


### PR DESCRIPTION
The previous patch executes a query that coalesces the `year` and `month` fields incorrectly, and will always produce the "default" coalesce fallback of `LocalDate.now()`, instead of the real year and month from the timestamp. (i.e. all the categories will look like they were accessed in 2025, month 6, instead of any previous time.)

SQLite has a `strftime()` function that parses a date/time, but the default format of this datetime is **not** the Unix epoch time, which is the format of our `timeStamp` column. If we want it to parse our column, we need to tell it to use the Unix epoch explicitly, and also divide the timestamp by 1000, because SQLite expects the Unix epoch in seconds, but we store the timestamp in milliseconds.