### PR TITLE
Correctly align snackbars in Login / CreateAccount activities.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -24,8 +24,11 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
+import org.wikipedia.createaccount.CreateAccountActivity
 import org.wikipedia.databinding.ViewPlainTextTooltipBinding
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.login.LoginActivity
+import org.wikipedia.login.ResetPasswordActivity
 import org.wikipedia.main.MainActivity
 import org.wikipedia.page.LinkMovementMethodExt
 import org.wikipedia.page.PageActivity
@@ -266,6 +269,7 @@ object FeedbackUtil {
             is SuggestionsActivity -> R.id.suggestedEditsCardsCoordinator
             is EditHistoryListActivity -> R.id.edit_history_coordinator
             is TalkTopicsActivity -> R.id.talkTopicsSnackbar
+            is LoginActivity, CreateAccountActivity, ResetPasswordActivity -> R.id.layout_coordinator
             else -> android.R.id.content
         }
         return ActivityCompat.requireViewById(activity, viewId)

--- a/app/src/main/res/layout/activity_create_account.xml
+++ b/app/src/main/res/layout/activity_create_account.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
@@ -172,4 +173,4 @@
         android:indeterminate="true"
         android:visibility="gone"
         tools:visibility="visible" />
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
@@ -146,4 +147,4 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_coordinator"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:fitsSystemWindows="true">
@@ -108,4 +109,4 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-</FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
On Android 15, the snackbars in these activities are overlapping under the navigation buttons.
Let's make the base layout in these activities be a `CoordinatorLayout` instead of `FrameLayout`, which fixes the snackbar behavior.

![image](https://github.com/user-attachments/assets/d16aedbd-dedc-4dae-a8a2-077fbc09b378)

