### PR TITLE
Revert: add allowMainThreadQueries back to the AppDatabase instance

### DIFF
--- a/app/src/main/java/org/wikipedia/database/AppDatabase.kt
+++ b/app/src/main/java/org/wikipedia/database/AppDatabase.kt
@@ -354,6 +354,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26, MIGRATION_26_27,
                     MIGRATION_26_28, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30,
                     MIGRATION_30_31)
+                .allowMainThreadQueries() // TODO: remove after resolving main thread issues in DAO classes
                 .fallbackToDestructiveMigration(false)
                 .build()
         }


### PR DESCRIPTION
### What does this do?
Add the `allowMainThreadQueries` back to prevent app crashes.

### Why is this needed?
In the `ReadingListDao` or some other `DAO` classes, we do not add `suspend` to the query functions, as they will be executed in the main thread. We can revert this temporarily and have another PR to fix it properly. 

