### PR TITLE
Update mediawiki URL for help with edit summaries.

### DIFF
--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -74,7 +74,7 @@
     <string name="page_moved">move</string>
     <string name="page_deleted">delete</string>
     <string name="page_protected">protect</string>
-    <string name="meta_edit_summary_url">https://meta.wikimedia.org/wiki/Help:Edit_summary</string>
+    <string name="meta_edit_summary_url">https://www.mediawiki.org/wiki/Help:Edit_summary</string>
     <string name="meta_minor_edit_url">https://www.mediawiki.org/wiki/Help:Minor_edit</string>
     <string name="meta_watching_pages_url">https://www.mediawiki.org/wiki/Help:Watching_pages</string>
 


### PR DESCRIPTION
The current URL is a redirect to an updated one.

https://phabricator.wikimedia.org/T398141
