### PR TITLE
Remove extra language variants code and add an extra parameter to featured endpoint

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/RestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.kt
@@ -89,7 +89,8 @@ interface RestService {
     suspend fun getFeedFeatured(
         @Path("year") year: String?,
         @Path("month") month: String?,
-        @Path("day") day: String?
+        @Path("day") day: String?,
+        @Query("lang") lang: String?
     ): AggregatedFeedContent
 
     @GET("feed/availability")

--- a/app/src/main/java/org/wikipedia/feed/aggregated/AggregatedFeedContentClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/aggregated/AggregatedFeedContentClient.kt
@@ -3,12 +3,10 @@ package org.wikipedia.feed.aggregated
 import android.content.Context
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
@@ -18,12 +16,9 @@ import org.wikipedia.feed.featured.FeaturedArticleCard
 import org.wikipedia.feed.image.FeaturedImageCard
 import org.wikipedia.feed.model.Card
 import org.wikipedia.feed.news.NewsCard
-import org.wikipedia.feed.onthisday.OnThisDay
 import org.wikipedia.feed.onthisday.OnThisDayCard
-import org.wikipedia.feed.topread.TopRead
 import org.wikipedia.feed.topread.TopReadListCard
 import org.wikipedia.util.DateUtil
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.log.L
 
 class AggregatedFeedContentClient {
@@ -151,13 +146,9 @@ class AggregatedFeedContentClient {
                 val deferredResponses = WikipediaApp.instance.languageState.appLanguageCodes.map { langCode ->
                     async {
                         val wikiSite = WikiSite.forLanguageCode(langCode)
-                        val hasParentLanguageCode = !WikipediaApp.instance.languageState.getDefaultLanguageCode(langCode).isNullOrEmpty()
-                        var feedContentResponse = ServiceFactory.getRest(wikiSite).getFeedFeatured(date.year, date.month, date.day)
+                        val feedContentResponse = ServiceFactory.getRest(wikiSite).getFeedFeatured(date.year, date.month, date.day, langCode)
 
                         feedContentResponse.randomOnThisDayEvent = feedContentResponse.onthisday?.random()
-
-                        // TODO: This is a temporary fix for T355192
-                        feedContentResponse = handleLanguageVariant(feedContentResponse, wikiSite, hasParentLanguageCode)
 
                         aggregatedClient.aggregatedResponses[langCode] = feedContentResponse
                         aggregatedClient.aggregatedResponseAge = age
@@ -170,52 +161,6 @@ class AggregatedFeedContentClient {
                     getCardFromResponse(aggregatedClient.aggregatedResponses, wiki, age, cards)
                 }
                 cb.success(cards)
-            }
-        }
-
-        private suspend fun handleLanguageVariant(feedContentResponse: AggregatedFeedContent,
-                                                  wikiSite: WikiSite,
-                                                  hasParentLanguageCode: Boolean): AggregatedFeedContent {
-            return withContext(Dispatchers.IO) {
-                var response = feedContentResponse
-                if (hasParentLanguageCode) {
-                    val tfaDeferred = feedContentResponse.tfa?.let {
-                        async { L10nUtil.getPagesForLanguageVariant(listOf(it), wikiSite, shouldUpdateExtracts = true).first() }
-                    }
-
-                    val topReadDeferred = feedContentResponse.topRead?.let {
-                        async { L10nUtil.getPagesForLanguageVariant(it.articles, wikiSite) }
-                    }
-
-                    // Same logic in OnThisDayCardView and we only need to send one page to the event class.
-                    val randomOnThisDayPageDeferred = feedContentResponse.randomOnThisDayEvent?.pages?.find { it.thumbnailUrl != null }?.let {
-                        async { L10nUtil.getPagesForLanguageVariant(listOf(it), wikiSite) }
-                    }
-
-                    val tfaResponse = tfaDeferred?.await()
-                    val topReadResponse = topReadDeferred?.await()
-                    val randomOnThisDayPageResponse = randomOnThisDayPageDeferred?.await()
-
-                    response = AggregatedFeedContent(
-                        tfa = tfaResponse ?: feedContentResponse.tfa,
-                        news = feedContentResponse.news,
-                        topRead = topReadResponse?.let {
-                            TopRead(
-                                feedContentResponse.topRead.date,
-                                it
-                            )
-                        } ?: feedContentResponse.topRead,
-                        potd = feedContentResponse.potd,
-                        onthisday = feedContentResponse.onthisday
-                    ).apply {
-                        randomOnThisDayEvent = OnThisDay.Event(
-                            pages = randomOnThisDayPageResponse ?: feedContentResponse.randomOnThisDayEvent?.pages ?: emptyList(),
-                            text = feedContentResponse.randomOnThisDayEvent?.text ?: "",
-                            year = feedContentResponse.randomOnThisDayEvent?.year ?: 0
-                        )
-                    }
-                }
-                response
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameViewModel.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameViewModel.kt
@@ -24,7 +24,6 @@ import org.wikipedia.games.WikiGames
 import org.wikipedia.games.db.DailyGameHistory
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.settings.Prefs
-import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.log.L
@@ -142,22 +141,6 @@ class OnThisDayGameViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
                     events.add(event2)
                     allEvents.remove(event2)
                 }
-            }
-
-            // Update language variant if needed for pages in events
-            val hasParentLanguageCode = !WikipediaApp.instance.languageState.getDefaultLanguageCode(wikiSite.languageCode).isNullOrEmpty()
-            if (hasParentLanguageCode) {
-                val newEvents = mutableListOf<OnThisDay.Event>()
-                events.forEach { event ->
-                    val newPages = L10nUtil.getPagesForLanguageVariant(event.pages, wikiSite, shouldUpdateExtracts = true)
-                    newEvents.add(OnThisDay.Event(
-                        text = event.text,
-                        year = event.year,
-                        pages = newPages
-                    ))
-                }
-                events.clear()
-                events.addAll(newEvents)
             }
 
             totalState.langToState[wikiSite.languageCode]?.let {

--- a/app/src/main/java/org/wikipedia/widgets/WidgetFeaturedPageWorker.kt
+++ b/app/src/main/java/org/wikipedia/widgets/WidgetFeaturedPageWorker.kt
@@ -24,20 +24,20 @@ class WidgetFeaturedPageWorker(
             val mainPageTitle = PageTitle(MainPageNameData.valueFor(app.appOrSystemLanguageCode), app.wikiSite)
             val date = DateUtil.getUtcRequestDateFor(0)
 
-            val result = ServiceFactory.getRest(WikipediaApp.instance.wikiSite)
-                .getFeedFeatured(date.year, date.month, date.day)
+            val result = ServiceFactory.getRest(app.wikiSite)
+                .getFeedFeatured(date.year, date.month, date.day, app.wikiSite.languageCode)
 
             // TODO: don't use PageSummary.
             val summary = if (result.tfa != null) {
-                val hasParentLanguageCode = !WikipediaApp.instance.languageState.getDefaultLanguageCode(WikipediaApp.instance.wikiSite.languageCode).isNullOrEmpty()
+                val hasParentLanguageCode = !app.languageState.getDefaultLanguageCode(app.wikiSite.languageCode).isNullOrEmpty()
                 if (hasParentLanguageCode) {
-                    ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getPageSummary(result.tfa.apiTitle)
+                    ServiceFactory.getRest(app.wikiSite).getPageSummary(result.tfa.apiTitle)
                 } else {
                     result.tfa
                 }
             } else {
                 val response = ServiceFactory.get(mainPageTitle.wikiSite).parseTextForMainPage(mainPageTitle.prefixedText)
-                ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getPageSummary(findFeaturedArticleTitle(response.text))
+                ServiceFactory.getRest(app.wikiSite).getPageSummary(findFeaturedArticleTitle(response.text))
             }
 
             val pageTitle = summary.getPageTitle(app.wikiSite)


### PR DESCRIPTION
### What does this do?
1. Remove part of the language variants code from the project, but we still need to keep the one in the `BecauseYouReadClient` because it was for the article description.
2. Add a `lang=` parameter to the `feed/featured` endpoint to avoid the cache issue when switching between different language variants.

**Related tickets
https://phabricator.wikimedia.org/T355192
https://phabricator.wikimedia.org/T397743
