### PR TITLE
Fix: the bookmark icon does not get updated correctly when remove the article from Saved

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/PageActivity.kt
@@ -199,7 +199,7 @@ class PageActivity : BaseActivity(), PageFragment.Callback, LinkPreviewDialog.Lo
                         }
                         is ArticleSavedOrDeletedEvent -> {
                             pageFragment.title?.run {
-                                if (event.pages.any { it.apiTitle == prefixedText && it.wiki.languageCode == wikiSite.languageCode }) {
+                                if (event.pages.any { it.apiTitle == prefixedText && it.lang == wikiSite.languageCode }) {
                                     pageFragment.updateBookmarkAndMenuOptionsFromDao()
                                 }
                             }


### PR DESCRIPTION
### What does this do?
We used `it.wiki.languageCode == wikiSite.languageCode` to check whether the language codes match or not, which only works when saving an article to the reading list. When removing from the reading list, the language code from the `WikiSite` will become the parent language code, which and lead to the logic check failing.


Steps to reproduce:
1. Find any article in any Chinese language variant
2. Save it to the reading list
3. Click the bookmark again to remove it from the reading list.
4. The bookmark icon does not get updated properly.


https://phabricator.wikimedia.org/T398524
