### PR TITLE
Add Event: to list of Namespaces.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/Namespace.kt
+++ b/app/src/main/java/org/wikipedia/page/Namespace.kt
@@ -132,6 +132,8 @@ enum class Namespace(private val code: Int) : EnumCode {
     GRAM_TALK(1025),
     TRANSLATIONS(1198),
     TRANSLATIONS_TALK(1199),
+    EVENT(1728),
+    EVENT_TALK(1729),
     GADGET(2300),
     GADGET_TALK(2301),
     GADGET_DEFINITION(2302),


### PR DESCRIPTION
We have a very brittle and problematic way of literally hardcoding namespaces into an `enum`, which means that if a new namespace is introduced that doesn't fit into our enum, it will throw an exception. The solution in this PR is temporary, but we should really move away from having namespaces as an enum, and perhaps just use Integer constants where appropriate.

https://phabricator.wikimedia.org/T398867
