### PR TITLE
Fix: set the width correctly for the WikiGames feed card view

### DIFF
--- a/app/src/main/res/layout/view_wiki_games_card.xml
+++ b/app/src/main/res/layout/view_wiki_games_card.xml
@@ -35,9 +35,10 @@
             <TextView
                 android:id="@+id/viewWikiGamesCardTitle"
                 style="@style/H1.Article"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:textColor="?attr/paper_color"
+                android:layout_marginEnd="16dp"
                 app:layout_constraintEnd_toStartOf="@+id/viewWikiGamesCardImage"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### What does this do?
The width of  `viewWikiGamesCardTitle` view was set to `wrap_content`, which was incorrect in a `ConstraintLayout` if you have other views connected to it, which led to an incorrect display if the title text is short.

Before vs. After

<img src="https://github.com/user-attachments/assets/4a4a650f-8ee1-4fcd-80aa-4c7d03dc2cc2" width="350" />
<img src="https://github.com/user-attachments/assets/48b0283b-5218-4ff0-a40d-fa274bd2e5d8" width="350" />

