### PR TITLE
No longer use WebView in LinkPreviewDialog.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -6,7 +6,6 @@ import org.wikipedia.BuildConfig
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.extensions.getStrings
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.page.Namespace
@@ -22,13 +21,6 @@ import java.util.concurrent.TimeUnit
 import kotlin.math.roundToInt
 
 object JavaScriptActionHandler {
-
-    fun getCssStyles(wikiSite: WikiSite): String {
-        val baseCSS = "<link rel=\"stylesheet\" href=\"https://meta.wikimedia.org/api/rest_v1/data/css/mobile/base\">"
-        val siteCSS = "<link rel=\"stylesheet\" href=\"https://${wikiSite.subdomain()}.wikipedia.org/api/rest_v1/data/css/mobile/site\">"
-        val extraCSS = if (WikipediaApp.instance.currentTheme.isDark) "<style>img.mwe-math-fallback-image-inline { -webkit-filter: invert(1); } </style>" else ""
-        return baseCSS + siteCSS + extraCSS
-    }
 
     fun setTopMargin(top: Int): String {
         return setMargins(16, top + 16, 16, 48)

--- a/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
+++ b/app/src/main/java/org/wikipedia/page/linkpreview/LinkPreviewDialog.kt
@@ -1,7 +1,6 @@
 package org.wikipedia.page.linkpreview
 
 import android.content.DialogInterface
-import android.graphics.Color
 import android.location.Location
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -50,8 +49,6 @@ import org.wikipedia.readinglist.database.ReadingListPage
 import org.wikipedia.util.ClipboardUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.GeoUtil
-import org.wikipedia.util.L10nUtil
-import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.ShareUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
@@ -373,25 +370,13 @@ class LinkPreviewDialog : ExtendedBottomSheetDialogFragment(), LinkPreviewErrorV
     }
 
     private fun setPreviewContents(contents: LinkPreviewContents) {
-        binding.linkPreviewExtractWebview.setBackgroundColor(Color.TRANSPARENT)
-        val colorHex = ResourceUtil.colorToCssString(
-            ResourceUtil.getThemedColor(
-                requireContext(),
-                android.R.attr.textColorPrimary
-            )
-        )
-        val dir = if (L10nUtil.isLangRTL(viewModel.pageTitle.wikiSite.languageCode)) "rtl" else "ltr"
         val editVisibility = contents.extract.isNullOrBlank() && contents.ns?.id == Namespace.MAIN.code()
         binding.linkPreviewEditButton.isVisible = editVisibility
         binding.linkPreviewThumbnailGallery.isVisible = !editVisibility
+
         val extract = if (editVisibility) "<i>" + getString(R.string.link_preview_stub_placeholder_text) + "</i>" else contents.extract
-        binding.linkPreviewExtractWebview.loadDataWithBaseURL(
-            null,
-            "${JavaScriptActionHandler.getCssStyles(viewModel.pageTitle.wikiSite)}<div style=\"line-height: 150%; color: #$colorHex\" dir=\"$dir\">$extract</div>",
-            "text/html",
-            "UTF-8",
-            null
-        )
+        binding.linkPreviewExtract.text = StringUtil.fromHtml(extract)
+
         contents.title.thumbUrl?.let {
             binding.linkPreviewThumbnail.visibility = View.VISIBLE
             ViewUtil.loadImage(binding.linkPreviewThumbnail, it)

--- a/app/src/main/res/layout/dialog_link_preview.xml
+++ b/app/src/main/res/layout/dialog_link_preview.xml
@@ -102,11 +102,18 @@
                 android:layout_height="match_parent"
                 android:orientation="vertical">
 
-                <WebView
-                    android:id="@+id/link_preview_extract_webview"
+                <TextView
+                    android:id="@+id/link_preview_extract"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="8dp" />
+                    android:lineSpacingMultiplier="1.3"
+                    android:paddingStart="16dp"
+                    android:paddingTop="8dp"
+                    android:paddingEnd="16dp"
+                    android:textColor="?attr/primary_color"
+                    android:textIsSelectable="true"
+                    android:textSize="16sp"
+                    tools:text="Lorem ipsum" />
 
                 <org.wikipedia.gallery.GalleryThumbnailScrollView
                     android:id="@+id/link_preview_thumbnail_gallery"


### PR DESCRIPTION
Recent updates in PCS have affected the display of link previews in Dark mode.
Rather than reverting the PCS changes, let's no longer use a WebView in link previews, and figure out a more sensible balance of showing html content in link previews going forward.