### PR TITLE
Clear WebView cache when explicitly refreshing page.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -149,7 +149,10 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
 
     private val activeTimer = ActiveTimer()
     private val scrollTriggerListener = WebViewScrollTriggerListener()
-    private val pageRefreshListener = OnRefreshListener { refreshPage() }
+    private val pageRefreshListener = OnRefreshListener {
+        webView.clearCache(true)
+        refreshPage()
+    }
     private val pageActionItemCallback = PageActionItemCallback()
 
     private lateinit var bridge: CommunicationBridge


### PR DESCRIPTION
Our WebView maintains its own internal cache of resources, such as CSS and JS files.
But since we are intercepting all WebView requests and piping them through OkHttp (which has its own cache!), it may be possible for the WebView cache to become out-of-sync with the OkHttp cache.

When the user swipes down to refresh the article, let's explicitly clear the WebView cache (which is the user's intention anyway), to make sure the WebView definitely pulls the next requests from OkHttp.