### PR TITLE
Follow-up to python build scripts.

### DIFF
--- a/build-all.py
+++ b/build-all.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """
-Cross-platform build script for all release variants.
-Compatible with Windows, macOS, and Linux.
+Convenience script for building all release variants at once.
 """
 
 import os

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -10,19 +10,12 @@ Step 1: (e.g., --beta):
 Step 2: (e.g., --beta --push):
     - Creates an annotated tag called 'releases/versionName'
 
-To run
-1) tell people on #wikimedia-mobile you're about to bump the version,
-   so hold off on merging to main
-2) git checkout main
-3) git pull
-4) git reset --hard
-5) python scripts/make-release.py --prod (or --beta, --alpha, --debug)
+To run:
+1) Ensure a clean working directory, on main branch.
+2) Execute the build:  python scripts/make-release.py --prod (or --beta, --alpha, --debug)
 Note: the apk file locations are printed to stdout
-6) manual step: test the apk(s): adb install -r <apk file>
-7) python scripts/make-release.py --prod --push
-8) compile release note of prod using
-    git log --pretty=format:"%h | %cr | %s" --abbrev-commit --no-merges `git tag -l r/*|tail -1`..
-9) Upload prod apk to Play Store and to releases.mediawiki.org
+3) Test the built APK on your device(s).
+4) Generate and push the git tag:  python scripts/make-release.py --prod --push
 
 For development/testing without signing setup, use: --debug
 This builds a debug APK that can be installed for testing.
@@ -34,7 +27,6 @@ For Windows users experiencing file locking issues:
 
 Requires the environment variable ANDROID_HOME to run.
 For production builds (--beta, --prod), also requires signing configuration in ~/.sign/signing.properties
-Ensure you have a clean working directory before running as well.
 
 See also https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/Release_process
 """

--- a/upload-all.py
+++ b/upload-all.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
 """
-Cross-platform script to upload Wikipedia Android APKs to releases server.
-
-This is a Python equivalent of the upload-all.sh bash script.
-It uploads beta and stable release APKs to the Wikimedia releases server using SCP.
-
-Usage:
-    python upload-all.py
+Uploads all built APKs to the Wikimedia releases server.
 
 Requirements:
     - SCP must be available in PATH


### PR DESCRIPTION
This just updates the comments at the top of the scripts:

* It's not necessary to advertise that the scripts are "cross-platform". It is well-known that python runs on all platforms.
* The make-release script had some very outdated comments that no longer make sense.