### PR TITLE
(Finally, properly) fix viewing saved articles when offline.

### DIFF
--- a/app/src/main/java/org/wikipedia/notifications/AnonymousNotificationHelper.kt
+++ b/app/src/main/java/org/wikipedia/notifications/AnonymousNotificationHelper.kt
@@ -19,7 +19,7 @@ object AnonymousNotificationHelper {
         }
     }
 
-    suspend fun observableForAnonUserInfo(wikiSite: WikiSite): MwQueryResponse {
+    suspend fun maybeGetAnonUserInfo(wikiSite: WikiSite): MwQueryResponse {
         return if (Date().time - Prefs.lastAnonEditTime < TimeUnit.DAYS.toMillis(NOTIFICATION_DURATION_DAYS)) {
             ServiceFactory.get(wikiSite).getUserInfo()
         } else {

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -30,6 +30,7 @@ import org.wikipedia.util.UriUtil
 import org.wikipedia.util.log.L
 import org.wikipedia.views.ObservableWebView
 import retrofit2.Response
+import java.io.IOException
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -149,18 +150,29 @@ class PageFragmentLoadState(private var model: PageViewModel,
                     }
                     val makeWatchRequest = WikipediaApp.instance.isOnline && AccountUtil.isLoggedIn
                     val watchedRequest = async {
-                        if (makeWatchRequest) {
-                            ServiceFactory.get(title.wikiSite).getWatchedStatusWithCategories(title.prefixedText)
-                        } else if (WikipediaApp.instance.isOnline && !AccountUtil.isLoggedIn) {
-                            AnonymousNotificationHelper.observableForAnonUserInfo(title.wikiSite)
-                        } else {
+                        try {
+                            if (makeWatchRequest) {
+                                ServiceFactory.get(title.wikiSite)
+                                    .getWatchedStatusWithCategories(title.prefixedText)
+                            } else if (WikipediaApp.instance.isOnline && !AccountUtil.isLoggedIn) {
+                                AnonymousNotificationHelper.maybeGetAnonUserInfo(title.wikiSite)
+                            } else {
+                                MwQueryResponse()
+                            }
+                        } catch (_: IOException) {
+                            L.w("Ignoring network error while fetching watched status.")
                             MwQueryResponse()
                         }
                     }
                     val categoriesRequest = async {
-                        if (!makeWatchRequest && WikipediaApp.instance.isOnline) {
-                            ServiceFactory.get(title.wikiSite).getCategoriesProps(title.text)
-                        } else {
+                        try {
+                            if (!makeWatchRequest && WikipediaApp.instance.isOnline) {
+                                ServiceFactory.get(title.wikiSite).getCategoriesProps(title.text)
+                            } else {
+                                MwQueryResponse()
+                            }
+                        } catch (_: IOException) {
+                            L.w("Ignoring network error while fetching categories.")
                             MwQueryResponse()
                         }
                     }


### PR DESCRIPTION
This ensures that saved articles will be always viewable when offline, _even if_ using a VPN (which makes the app believe it's still "online").

Here is how this is accomplished:
* For loading an article, we need two things: the `/page/summary` and the `page/mobile-html` contents, both of which are saved offline.
* However, we also make other network calls when loading a page, such as: checking its Watched status, and getting its Categories. And the problem is that we are making the display of the article _dependent on_ the success of these network calls. But in reality, these calls are really kind of "optional". If either of them fails, there's no reason not to proceed with loading the article.

https://phabricator.wikimedia.org/T354119
https://phabricator.wikimedia.org/T383950
