### PR TITLE
Fix listing of language variants where the first variant is the code.

### DIFF
--- a/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.kt
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.kt
@@ -28,11 +28,11 @@ class AppLanguageLookUpTable(context: Context) {
         getStringList(R.array.preference_language_local_names)
     }
 
-    private val languagesVariants by lazy {
+    private val languageVariants by lazy {
         getStringList(R.array.preference_language_variants)
             .map { it.split(",") }
             .filter { it.size > 1 }
-            .associate { it[0] to ArrayList(it.subList(1, it.size)) }
+            .associate { it[0] to (if (it.size > 2) it.subList(1, it.size) else it) }
     }
 
     fun getCanonicalName(code: String?): String? {
@@ -66,11 +66,11 @@ class AppLanguageLookUpTable(context: Context) {
     }
 
     fun getLanguageVariants(code: String?): List<String>? {
-        return languagesVariants[code]
+        return languageVariants[code]
     }
 
     fun getDefaultLanguageCodeFromVariant(code: String?): String? {
-        return languagesVariants.entries.firstOrNull { (_, value) -> code in value }?.key
+        return languageVariants.entries.firstOrNull { (_, value) -> code in value }?.key
     }
 
     fun getBcp47Code(code: String): String {

--- a/app/src/main/java/org/wikipedia/language/LangLinksViewModel.kt
+++ b/app/src/main/java/org/wikipedia/language/LangLinksViewModel.kt
@@ -56,7 +56,7 @@ class LangLinksViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
             val langLinks = langLinksDeferred.await()
             siteInfoList = siteInfoDeferred.await()
 
-            precessLanguageEntries(langLinks)
+            processLanguageEntries(langLinks)
             originalLanguageEntries = langLinks
             appLanguageEntries = filterAppLanguages(langLinks)
 
@@ -94,7 +94,7 @@ class LangLinksViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
         }
     }
 
-    private fun precessLanguageEntries(langLinks: MutableList<PageTitle>) {
+    private fun processLanguageEntries(langLinks: MutableList<PageTitle>) {
         updateLanguageEntriesSupported(langLinks)
         sortLanguageEntriesByMru(langLinks)
     }


### PR DESCRIPTION
There are a few languages, namely `mni`, `tg`, `tly`, and `zgh`, where the language code _is itself_ one of the variants, instead of other languages like `zh`, where the variants are `zh-*`, and the base code `zh` is _not_ a variant. And so, the languages where the base code is its own variant need to be treated slightly differently.

https://phabricator.wikimedia.org/T399562
