### PR TITLE
Include user-agent when posting with GitHubPRBot.

### DIFF
--- a/.github/workflows/android_phab.yml
+++ b/.github/workflows/android_phab.yml
@@ -16,7 +16,8 @@ jobs:
         message="${{ github.actor }} ${{ github.event.action }} ${{ github.event.pull_request._links.html.href }}"
         echo -e "${PR_BODY}" | grep -oEi "(^Bug:\s*T[0-9]+)|(^([*]*phabricator[*]*:[*]*\s*)?https:\/\/phabricator\.wikimedia\.org\/T[0-9]+)" | grep -oEi "T[0-9]+" | while IFS= read -r line; do
           echo "Processing: $line"
-          curl https://phabricator.wikimedia.org/api/maniphest.edit \
+          curl --header "User-Agent: GitHubPRBot/1.0 (https://phabricator.wikimedia.org/p/GitHubPRBot)" \
+              https://phabricator.wikimedia.org/api/maniphest.edit \
               -d api.token=${{ secrets.PHAB_BOT_API_KEY }} \
               -d transactions[0][type]=comment \
               -d transactions[0][value]="${message}" \


### PR DESCRIPTION
The Phabricator API is being rate-limited. The best practice is to include a proper User-Agent when making requests to the API, which should help avoid rate limiting errors.

https://phabricator.wikimedia.org/T360680
