### PR TITLE
Instrument Wikipedia Android App with the bitdrift Capture SDK for mobile observability

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-parcelize'
     id 'kotlinx-serialization'
+    id 'io.bitdrift.capture-plugin' version '0.17.29'
     alias(libs.plugins.compose.compiler)
 }
 
@@ -55,6 +56,21 @@ android {
         def TEST_LOGIN_PASSWORD = System.getenv('TEST_LOGIN_PASSWORD')
         buildConfigField "String", "TEST_LOGIN_USERNAME", TEST_LOGIN_USERNAME != null ? "\"${TEST_LOGIN_USERNAME}\"" : '"Foo"'
         buildConfigField "String", "TEST_LOGIN_PASSWORD", TEST_LOGIN_PASSWORD != null ? "\"${TEST_LOGIN_PASSWORD}\"" : '"Bar"'
+
+        android {
+            defaultConfig {
+                def bitdriftApiKey = project.rootProject.file("local.properties")
+                        .withReader {
+                            def props = new Properties()
+                            props.load(it)
+                            return props.getProperty("BITDRIFT_API_KEY", "")
+                        }
+
+                buildConfigField "String", "BITDRIFT_API_KEY", "\"${bitdriftApiKey}\""
+            }
+        }
+
+
     }
 
     testOptions {
@@ -172,6 +188,8 @@ dependencies {
     // To keep the Maven Central dependencies up-to-date
     // use http://gradleplease.appspot.com/ or http://search.maven.org/.
     // Debug with ./gradlew -q app:dependencies --configuration compile
+
+    implementation libs.capture.sdk
 
     coreLibraryDesugaring libs.desugar.jdk.libs
 
@@ -305,4 +323,10 @@ private static Properties loadProperties(File file) {
         System.err.println "\"${file}\" not found"
     }
     return props
+}
+
+bitdrift {
+    instrumentation {
+        automaticOkHttpInstrumentation = true
+    }
 }

--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -15,6 +15,7 @@ import org.wikipedia.analytics.eventplatform.AppSessionEvent
 import org.wikipedia.analytics.eventplatform.EventPlatformClient
 import org.wikipedia.appshortcuts.AppShortcuts
 import org.wikipedia.auth.AccountUtil
+import org.wikipedia.BuildConfig
 import org.wikipedia.concurrency.FlowEventBus
 import org.wikipedia.connectivity.ConnectionStateMonitor
 import org.wikipedia.database.AppDatabase
@@ -39,8 +40,21 @@ import org.wikipedia.util.log.L
 import org.wikipedia.views.imageservice.CoilImageServiceLoader
 import org.wikipedia.views.imageservice.ImageService
 import java.util.UUID
+import io.bitdrift.capture.Capture.Logger
+import io.bitdrift.capture.providers.session.SessionStrategy
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+
 
 class WikipediaApp : Application() {
+
+    companion object {
+        lateinit var instance: WikipediaApp
+            private set
+
+        val launchStartTime = System.currentTimeMillis()
+    }
+
     init {
         instance = this
     }
@@ -137,6 +151,14 @@ class WikipediaApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        Logger.start(
+            // update local.properties to include BITDRIFT_API_KEY
+            apiKey = BuildConfig.BITDRIFT_API_KEY,
+            sessionStrategy = SessionStrategy.Fixed(),
+            // apiURL defaults to prod. Delete the following line unless you are a bitdrift employee
+            apiUrl = "https://api.bitdrift.dev".toHttpUrl()
+        )
 
         WikiSite.setDefaultBaseUrl(Prefs.mediaWikiBaseUrl)
 
@@ -285,10 +307,5 @@ class WikipediaApp : Application() {
         if (tabList.isEmpty()) {
             tabList.add(Tab())
         }
-    }
-
-    companion object {
-        lateinit var instance: WikipediaApp
-            private set
     }
 }

--- a/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/FeedFragment.kt
@@ -42,6 +42,7 @@ import org.wikipedia.settings.SettingsActivity
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.UriUtil
+import io.bitdrift.capture.Capture.Logger
 
 class FeedFragment : Fragment(), BackPressedHandler {
     private var _binding: FragmentFeedBinding? = null
@@ -134,6 +135,7 @@ class FeedFragment : Fragment(), BackPressedHandler {
 
     override fun onResume() {
         super.onResume()
+        Logger.logScreenView("Feed")
         maybeShowRegionalLanguageVariantDialog()
         OnThisDayGameMainMenuFragment.maybeShowOnThisDayGameDialog(requireActivity(), InvokeSource.FEED)
 

--- a/app/src/main/java/org/wikipedia/history/HistoryFragment.kt
+++ b/app/src/main/java/org/wikipedia/history/HistoryFragment.kt
@@ -43,6 +43,7 @@ import org.wikipedia.views.DefaultViewHolder
 import org.wikipedia.views.PageItemView
 import org.wikipedia.views.SwipeableItemTouchHelperCallback
 import org.wikipedia.views.WikiCardView
+import io.bitdrift.capture.Capture.Logger
 
 class HistoryFragment : Fragment(), BackPressedHandler {
     interface Callback {
@@ -103,6 +104,7 @@ class HistoryFragment : Fragment(), BackPressedHandler {
 
     override fun onResume() {
         super.onResume()
+        Logger.logScreenView("History")
         viewModel.reloadHistoryItems()
     }
 

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import io.bitdrift.capture.Capture
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.activity.SingleFragmentActivity
@@ -25,6 +26,8 @@ import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ResourceUtil
+import io.bitdrift.capture.Capture.Logger
+import kotlin.time.Duration.Companion.milliseconds
 
 class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callback {
 
@@ -45,6 +48,19 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        window.decorView.viewTreeObserver.addOnPreDrawListener(object : android.view.ViewTreeObserver.OnPreDrawListener {
+            override fun onPreDraw(): Boolean {
+                window.decorView.viewTreeObserver.removeOnPreDrawListener(this)
+
+                val launchDuration = System.currentTimeMillis() - org.wikipedia.WikipediaApp.launchStartTime
+                Logger.logAppLaunchTTI(launchDuration.milliseconds)
+
+                return true
+            }
+        })
+
+
         if (!DeviceUtil.assertAppContext(this)) {
             return
         }

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -117,6 +117,7 @@ import org.wikipedia.watchlist.WatchlistViewModel
 import org.wikipedia.wiktionary.WiktionaryDialog
 import java.time.Duration
 import java.time.Instant
+import io.bitdrift.capture.Capture.Logger
 
 class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.CommunicationBridgeListener, ThemeChooserDialog.Callback,
     ReferenceDialog.Callback, WiktionaryDialog.Callback, WatchlistExpiryDialog.Callback {
@@ -294,6 +295,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     }
 
     override fun onResume() {
+        Logger.logScreenView("Article View")
         super.onResume()
         activeTimer.resume()
         val params = CoordinatorLayout.LayoutParams(1, 1)

--- a/app/src/main/java/org/wikipedia/search/SearchFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchFragment.kt
@@ -40,6 +40,7 @@ import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.views.LanguageScrollView
 import java.util.Locale
+import io.bitdrift.capture.Capture.Logger
 
 class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearchesFragment.Callback, LanguageScrollView.Callback {
     private var _binding: FragmentSearchBinding? = null
@@ -140,6 +141,11 @@ class SearchFragment : Fragment(), SearchResultsFragment.Callback, RecentSearche
     override fun onPause() {
         super.onPause()
         Prefs.selectedLanguagePositionInSearch = binding.searchLanguageScrollView.selectedPosition
+    }
+
+    override fun onResume() {
+        super.onResume()
+        Logger.logScreenView("Search")
     }
 
     private fun handleIntent(intent: Intent) {

--- a/app/src/main/java/org/wikipedia/util/log/L.kt
+++ b/app/src/main/java/org/wikipedia/util/log/L.kt
@@ -4,32 +4,64 @@ import android.util.Log
 import org.wikipedia.BuildConfig
 import org.wikipedia.WikipediaApp
 import org.wikipedia.util.ReleaseUtil
+import io.bitdrift.capture.Capture.Logger
 
 /** Logging utility like [Log] but with implied tags.  */
 object L {
     private val LEVEL_V: LogLevel = object : LogLevel() {
         override fun logLevel(tag: String?, msg: String?, t: Throwable?) {
             Log.v(tag, msg, t)
+            Logger.logTrace(
+                fields = mapOf("tag" to tag.orEmpty()),
+                throwable = t
+            ) {
+                msg.orEmpty()
+            }
         }
     }
+
     private val LEVEL_D: LogLevel = object : LogLevel() {
         override fun logLevel(tag: String?, msg: String?, t: Throwable?) {
             Log.d(tag, msg, t)
+            Logger.logDebug(
+                fields = mapOf("tag" to tag.orEmpty()),
+                throwable = t
+            ) {
+                msg.orEmpty()
+            }
         }
     }
     private val LEVEL_I: LogLevel = object : LogLevel() {
         override fun logLevel(tag: String?, msg: String?, t: Throwable?) {
             Log.i(tag, msg, t)
+            Logger.logInfo(
+                fields = mapOf("tag" to tag.orEmpty()),
+                throwable = t
+            ) {
+                msg.orEmpty()
+            }
         }
     }
     private val LEVEL_W: LogLevel = object : LogLevel() {
         override fun logLevel(tag: String?, msg: String?, t: Throwable?) {
             Log.w(tag, msg, t)
+            Logger.logWarning(
+                fields = mapOf("tag" to tag.orEmpty()),
+                throwable = t
+            ) {
+                msg.orEmpty()
+            }
         }
     }
     private val LEVEL_E: LogLevel = object : LogLevel() {
         override fun logLevel(tag: String?, msg: String?, t: Throwable?) {
             Log.e(tag, msg, t)
+            Logger.logError(
+                fields = mapOf("tag" to tag.orEmpty()),
+                throwable = t
+            ) {
+                msg.orEmpty()
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ androidSdk = "11.12.1"
 appcompat = "1.7.1"
 balloon = "1.6.12"
 browser = "1.8.0"
+captureSdk = "0.17.29"
 coilCompose = "3.2.0"
 commonsLang3 = "3.18.0"
 constraintlayout = "2.2.1"
@@ -16,7 +17,7 @@ flexbox = "3.0.0"
 fragmentKtx = "1.8.8"
 googlePayVersion = "19.4.0"
 googleServices = "4.4.3"
-gradle = "8.11.1"
+gradle = "8.8.0"
 hamcrest = "3.0"
 installreferrer = "2.2"
 jsoup = "1.21.1"
@@ -64,6 +65,7 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
 balloon = { module = "com.github.skydoves:balloon", version.ref = "balloon" }
 browser = { module = "androidx.browser:browser", version.ref = "browser" }
+capture-sdk = { module = "io.bitdrift:capture", version.ref = "captureSdk" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coilCompose" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilCompose" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven(url = "https://dl.bitdrift.io/sdk/android-maven")
     }
 }
 dependencyResolutionManagement {
@@ -11,6 +12,11 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         mavenLocal()
+        maven(url = "https://dl.bitdrift.io/sdk/android-maven") {
+            content {
+                includeGroup("io.bitdrift")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### What does this do?
Instruments the Wikipedia Android app with mobile observability using the [bitdrift Capture SDK](https://docs.bitdrift.io/sdk/quickstart).

The intent is to serve as a learning tool for developers exploring mobile observability best practices with bitdrift.

### Why is this needed?
Many developers want to understand how to apply observability tooling in the context of real-world mobile applications. This forked and instrumented version of Wikipedia serves as a reference implementation for integrating a mobile observability SDK into an existing production-scale app. It is designed as part of bitdrift's enablement content and can be used alongside blog posts, workshops, and onboarding guides.

**Phabricator:**
(N/A – this PR is not intended for Wikimedia production use)
