### PR TITLE
Correctly display error(s) in SearchResultsFragment.

### DIFF
--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -74,6 +75,12 @@ class SearchResultsFragment : Fragment() {
                 launch {
                     searchResultsAdapter.loadStateFlow.collectLatest {
                         callback()?.onSearchProgressBar(it.append is LoadState.Loading || it.refresh is LoadState.Loading)
+                        if (it.refresh is LoadState.Error) {
+                            binding.searchErrorView.setError((it.refresh as LoadState.Error).error)
+                            binding.searchErrorView.isVisible = true
+                            return@collectLatest
+                        }
+                        binding.searchErrorView.isVisible = false
                         val showEmpty = (it.append is LoadState.NotLoading && it.append.endOfPaginationReached && searchResultsAdapter.itemCount == 0)
                         if (showEmpty) {
                             searchResultsConcatAdapter.addAdapter(noSearchResultAdapter)

--- a/app/src/main/res/layout/fragment_search_results.xml
+++ b/app/src/main/res/layout/fragment_search_results.xml
@@ -16,8 +16,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:gravity="center"
-        android:orientation="vertical"
-        android:visibility="gone" />
+        android:layout_marginHorizontal="16dp"
+        android:visibility="gone"
+        tools:visibility="visible"/>
 
 </FrameLayout>


### PR DESCRIPTION
The `SearchResultsFragment` has a WikiErrorView for showing any errors that come from the API calls, but the WikiErrorView is never actually used! So, currently API errors will just be ignored, and the screen will be blank.

This fixes the logic to display errors properly.