### PR TITLE
Fix: convert legacy yue language code to zh-yue

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
@@ -2,6 +2,7 @@ package org.wikipedia.dataclient
 
 import android.net.Uri
 import android.os.Parcelable
+import androidx.core.net.toUri
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -134,7 +135,7 @@ data class WikiSite(
         private var DEFAULT_BASE_URL: String? = null
 
         fun supportedAuthority(authority: String): Boolean {
-            return authority.endsWith(Uri.parse(DEFAULT_BASE_URL).authority!!)
+            return authority.endsWith(DEFAULT_BASE_URL!!.toUri().authority!!)
         }
 
         fun setDefaultBaseUrl(url: String) {
@@ -142,7 +143,7 @@ data class WikiSite(
         }
 
         fun forLanguageCode(languageCode: String): WikiSite {
-            val uri = ensureScheme(Uri.parse(DEFAULT_BASE_URL))
+            val uri = ensureScheme(DEFAULT_BASE_URL!!.toUri())
             return WikiSite(
                 (if (languageCode.isEmpty()) "" else languageCodeToSubdomain(languageCode) + ".") + uri.authority,
                 languageCode
@@ -153,6 +154,7 @@ data class WikiSite(
             return when (languageCode) {
                 AppLanguageLookUpTable.NORWEGIAN_BOKMAL_LANGUAGE_CODE -> AppLanguageLookUpTable.NORWEGIAN_LEGACY_LANGUAGE_CODE // T114042
                 AppLanguageLookUpTable.BELARUSIAN_LEGACY_LANGUAGE_CODE -> AppLanguageLookUpTable.BELARUSIAN_TARASK_LANGUAGE_CODE // T111853
+                AppLanguageLookUpTable.CHINESE_LEGACY_YUE_LANGUAGE_CODE -> AppLanguageLookUpTable.CHINESE_YUE_LANGUAGE_CODE
                 else -> languageCode
             }
         }

--- a/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.kt
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.kt
@@ -108,6 +108,8 @@ class AppLanguageLookUpTable(context: Context) {
         const val CHINESE_MY_LANGUAGE_CODE = "zh-my"
         const val CHINESE_SG_LANGUAGE_CODE = "zh-sg"
         const val CHINESE_TW_LANGUAGE_CODE = "zh-tw"
+
+        const val CHINESE_LEGACY_YUE_LANGUAGE_CODE = "yue"
         const val CHINESE_YUE_LANGUAGE_CODE = "zh-yue"
         const val CHINESE_LANGUAGE_CODE = "zh"
         const val NORWEGIAN_LEGACY_LANGUAGE_CODE = "no"


### PR DESCRIPTION
### What does this do?
1. Convert `yue` to `zh-yue` in the `normalizeLanguageCode()` in `WikiSite` class.
2. Clean up the `Uri.parse()` a bit.

**Phabricator:**
https://phabricator.wikimedia.org/T400781
