### PR TITLE
Add strings for Donation Reminder error messages

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1924,6 +1924,8 @@
   <string name="donation_reminders_settings_confirm_btn_label">Confrim Button label for the donation reminders settings screen.</string>
   <string name="donation_reminders_settings_about_experiment_btn_label">About experiment button label for the donation reminders settings screen.</string>
   <string name="donation_reminders_settings_article_frequency_input_suffix_label">Suffix label for the textField input in the donation reminders settings screen.</string>
+  <string name="donation_reminders_settings_warning_min_amount">Error message that indicates a minimum amount is allowed. %s will be replaced by the formatted amount.</string>
+  <string name="donation_reminders_settings_warning_max_amount">Error message that indicates a maximum amount is allowed. %s will be replaced by the formatted amount.</string>
   <string name="donation_reminders_snacbkbar_confirmation_label">Snackbar confirmation label which appears after user sets up donation reminders. %1$s will be replaced by the amount of donation and %2$s will be replaced by the text of the number of articles.</string>
   <string name="donation_reminders_prompt_title">Title for the donation reminder prompt. %1$s will be replaced by the text of number of articles and %2$s will be replaced by the amount of donation.</string>
   <string name="donation_reminders_prompt_message">Message for the donation reminder prompt. %1$s will be replaced by the date, %2$s will be replaced by the text of the number of articles, and %3$s will be replaced by the amount of donation.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2024,6 +2024,8 @@
     <string name="donation_reminders_settings_confirm_btn_label">Confirm reminder</string>
     <string name="donation_reminders_settings_about_experiment_btn_label">About this experiment</string>
     <string name="donation_reminders_settings_article_frequency_input_suffix_label">articles</string>
+    <string name="donation_reminders_settings_warning_min_amount">Please enter at least %s</string>
+    <string name="donation_reminders_settings_warning_max_amount">Maximum %s is allowed</string>
     <string name="donation_reminders_snacbkbar_confirmation_label">Thank you! We\'ll remind you to donate %1$s when you read %2$s while this experiment runs.</string>
     <string name="donation_reminders_prompt_title">You\'ve read %1$s since you pledged %2$s</string>
     <string name="donation_reminders_prompt_message">On %1$s, you asked us to remind you to donate after reading %2$s. If Wikipedia has provided you with %3$s of knowledge, please join the 2%% of readers who give and complete your pledge today.</string>


### PR DESCRIPTION
### What does this do?
The two strings for the input fields' error messages in the Donation Reminder Settings screen are missing.  
