### PR TITLE
Donation reminder survey group user logic fix

### DIFF
--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderHelper.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderHelper.kt
@@ -164,8 +164,8 @@ object DonationReminderHelper {
                     showFeedbackOptionsDialog(activity)
                 }
                 "B" -> {
-                    // Group B: Show survey on the next article visit after seeing reminder impressions two times
-                    if (config.finalPromptCount >= MAX_REMINDER_PROMPTS) {
+                    // Group B: Show survey on the next article visit after seeing reminder impressions
+                    if (config.finalPromptCount >= 1) {
                         showFeedbackOptionsDialog(activity)
                     }
                 }


### PR DESCRIPTION
### What does this do?
- updates userGroup "B" logic to show survey dialog on the next article  after seeing their donation reminder impressions
