### PR TITLE
Fix: pass default campaign ID for the processed Google payment event

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
@@ -82,7 +82,9 @@ class GooglePayActivity : BaseActivity() {
                                 onContentsReceived(resource.data)
                             }
                             is GooglePayViewModel.DonateSuccess -> {
-                                DonorExperienceEvent.logAction("impression", "gpay_processed", campaignId = intent.getStringExtra(DonateDialog.ARG_CAMPAIGN_ID).orEmpty())
+                                DonorExperienceEvent.logAction("impression", "gpay_processed",
+                                    campaignId = intent.getStringExtra(DonateDialog.ARG_CAMPAIGN_ID).orEmpty().ifEmpty { CAMPAIGN_ID_APP_MENU }
+                                )
                                 CampaignCollection.addDonationResult(
                                     amount = viewModel.finalAmount,
                                     currency = viewModel.currencyCode,


### PR DESCRIPTION
### What does this do?
For the current production, we send `"action_data": "campaign_id: enUS__Android, banner_opt_in: true",` when users finished the GPay, which the campaign ID was missing from the formatted `campaign_id`.

This PR adds a `ifEmpty` to fallback to the default `appmenu` ID and it will look like this:
`"action_data": "campaign_id: enUS_appmenu_Android, banner_opt_in: true",`

**Phabricator:**
https://phabricator.wikimedia.org/T...
