### PR TITLE
Fill description to the summary view in the article bottomsheet for WikiGames

### DIFF
--- a/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameArticleBottomSheet.kt
+++ b/app/src/main/java/org/wikipedia/games/onthisday/OnThisDayGameArticleBottomSheet.kt
@@ -75,7 +75,7 @@ class OnThisDayGameArticleBottomSheet : ExtendedBottomSheetDialogFragment(), All
         if (pageSummary.thumbnailUrl.isNullOrEmpty()) {
             binding.articleThumbnail.isInvisible = true
             binding.articleSummaryContainer.isInvisible = false
-            binding.articleSummary.text = StringUtil.fromHtml(pageSummary.extractHtml)
+            binding.articleSummary.text = StringUtil.fromHtml(pageSummary.extractHtml.orEmpty().ifEmpty { pageSummary.description })
         } else {
             binding.articleThumbnail.isInvisible = false
             binding.articleSummaryContainer.isInvisible = true


### PR DESCRIPTION
### What does this do?

If you click on articles that have no `extract` and no image available, the view in the article bottomsheet in the WikiGames results screen will remain blank. This is quick solution for this situation by adding the description to it.

Before vs. After

<img src="https://github.com/user-attachments/assets/44b60527-b635-40e8-a3f5-07d89970f70e" width="350" />
<img src="https://github.com/user-attachments/assets/6867c0b8-be2e-45c9-af90-c1576ff4e9d1" width="350" />



