### PR TITLE
Activity tab to remove UI state proposal 

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
@@ -7,11 +7,11 @@ import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,7 +35,6 @@ import org.wikipedia.R
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.compose.ComposeColors
 import org.wikipedia.compose.components.error.WikiErrorClickEvents
-import org.wikipedia.compose.components.error.WikiErrorView
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.settings.Prefs
@@ -53,13 +52,7 @@ class ActivityTabFragment : Fragment() {
             setContent {
                 BaseTheme {
                     ActivityTabScreen(
-                        uiState = viewModel.uiState.collectAsState().value,
                         timeSpentState = viewModel.timeSpentState.collectAsState().value,
-                        wikiErrorClickEvents = WikiErrorClickEvents(
-                            retryClickListener = {
-                                viewModel.load()
-                            }
-                        )
                     )
                 }
             }
@@ -68,9 +61,7 @@ class ActivityTabFragment : Fragment() {
 
     @Composable
     fun ActivityTabScreen(
-        uiState: UiState<Unit>,
-        timeSpentState: UiState<Long>,
-        wikiErrorClickEvents: WikiErrorClickEvents? = null
+        timeSpentState: UiState<Long>
     ) {
         Scaffold(
             modifier = Modifier
@@ -78,105 +69,108 @@ class ActivityTabFragment : Fragment() {
                 .background(WikipediaTheme.colors.paperColor),
             containerColor = WikipediaTheme.colors.paperColor
         ) { paddingValues ->
-            when (uiState) {
-                is UiState.Loading -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(paddingValues),
-                    ) {
-                        LinearProgressIndicator(
-                            modifier = Modifier.fillMaxWidth(),
-                            color = WikipediaTheme.colors.progressiveColor,
-                            trackColor = WikipediaTheme.colors.borderColor
-                        )
-                    }
-                }
-                is UiState.Error -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(paddingValues),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        WikiErrorView(
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            caught = uiState.error,
-                            errorClickEvents = wikiErrorClickEvents
-                        )
-                    }
-                }
-                is UiState.Success -> {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(paddingValues)
-                            .background(
-                                brush = Brush.verticalGradient(
-                                    colors = listOf(
-                                        WikipediaTheme.colors.paperColor,
-                                        WikipediaTheme.colors.additionColor
-                                    )
-                                )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(paddingValues)
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                WikipediaTheme.colors.paperColor,
+                                WikipediaTheme.colors.additionColor
                             )
-                    ) {
-                        Text(
-                            text = stringResource(R.string.activity_tab_user_reading, AccountUtil.userName),
-                            modifier = Modifier.padding(top = 16.dp).align(Alignment.CenterHorizontally),
-                            fontSize = 22.sp,
-                            fontWeight = FontWeight.Medium,
-                            textAlign = TextAlign.Center,
-                            color = WikipediaTheme.colors.primaryColor
                         )
-                        Box(
-                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
-                                .background(
-                                    color = WikipediaTheme.colors.additionColor,
-                                    shape = RoundedCornerShape(8.dp)
-                                )
-                                .align(Alignment.CenterHorizontally),
-                        ) {
-                            Text(
-                                text = stringResource(R.string.activity_tab_on_wikipedia_android).uppercase(),
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                fontSize = 11.sp,
-                                fontFamily = FontFamily.Monospace,
-                                letterSpacing = TextUnit(0.8f, TextUnitType.Sp),
-                                textAlign = TextAlign.Center,
-                                color = WikipediaTheme.colors.primaryColor
-                            )
+                    )
+            ) {
+                // All module will have their own state management
+                // TimeSpentModule
+                TimeSpentModule(
+                    timeSpentState = timeSpentState,
+                    wikiErrorClickEvents = WikiErrorClickEvents(
+                        retryClickListener = {
+                            viewModel.loadTimeSpent()
                         }
-                        if (timeSpentState is UiState.Success) {
-                            Text(
-                                text = stringResource(R.string.activity_tab_weekly_time_spent_hm, (timeSpentState.data / 3600), (timeSpentState.data % 60)),
-                                modifier = Modifier.padding(top = 12.dp).align(Alignment.CenterHorizontally),
-                                fontSize = 32.sp,
-                                fontWeight = FontWeight.W500,
-                                textAlign = TextAlign.Center,
-                                style = TextStyle(
-                                    brush = Brush.linearGradient(
-                                        colors = listOf(
-                                            ComposeColors.Red700,
-                                            ComposeColors.Orange500,
-                                            ComposeColors.Yellow500,
-                                            ComposeColors.Blue300
-                                        )
-                                    )
-                                ),
-                                color = WikipediaTheme.colors.primaryColor
-                            )
-                            Text(
-                                text = "Time spent reading this week",
-                                modifier = Modifier.padding(top = 8.dp, bottom = 16.dp).align(Alignment.CenterHorizontally),
-                                fontWeight = FontWeight.W500,
-                                textAlign = TextAlign.Center,
-                                color = WikipediaTheme.colors.primaryColor
-                            )
-                        }
-                    }
-                }
+                    )
+                )
+                // Monthly insights
+
+                // Categories module
+
+                // impact module
+
+                // Game module
+
+                // other module
             }
+        }
+    }
+
+    // @TODO: error view and handling
+    @Composable
+    fun ColumnScope.TimeSpentModule(
+        modifier: Modifier = Modifier,
+        timeSpentState: UiState<Long>,
+        wikiErrorClickEvents: WikiErrorClickEvents? = null
+    ) {
+        Text(
+            text = stringResource(R.string.activity_tab_user_reading, AccountUtil.userName),
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .align(Alignment.CenterHorizontally),
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center,
+            color = WikipediaTheme.colors.primaryColor
+        )
+        Box(
+            modifier = Modifier
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+                .background(
+                    color = WikipediaTheme.colors.additionColor,
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .align(Alignment.CenterHorizontally),
+        ) {
+            Text(
+                text = stringResource(R.string.activity_tab_on_wikipedia_android).uppercase(),
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                fontSize = 11.sp,
+                fontFamily = FontFamily.Monospace,
+                letterSpacing = TextUnit(0.8f, TextUnitType.Sp),
+                textAlign = TextAlign.Center,
+                color = WikipediaTheme.colors.primaryColor
+            )
+        }
+        if (timeSpentState is UiState.Success) {
+            Text(
+                text = stringResource(R.string.activity_tab_weekly_time_spent_hm, (timeSpentState.data / 3600), (timeSpentState.data % 60)),
+                modifier = Modifier
+                    .padding(top = 12.dp)
+                    .align(Alignment.CenterHorizontally),
+                fontSize = 32.sp,
+                fontWeight = FontWeight.W500,
+                textAlign = TextAlign.Center,
+                style = TextStyle(
+                    brush = Brush.linearGradient(
+                        colors = listOf(
+                            ComposeColors.Red700,
+                            ComposeColors.Orange500,
+                            ComposeColors.Yellow500,
+                            ComposeColors.Blue300
+                        )
+                    )
+                ),
+                color = WikipediaTheme.colors.primaryColor
+            )
+            Text(
+                text = "Time spent reading this week",
+                modifier = Modifier
+                    .padding(top = 8.dp, bottom = 16.dp)
+                    .align(Alignment.CenterHorizontally),
+                fontWeight = FontWeight.W500,
+                textAlign = TextAlign.Center,
+                color = WikipediaTheme.colors.primaryColor
+            )
         }
     }
 

--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabViewModel.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabViewModel.kt
@@ -8,23 +8,16 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.wikipedia.WikipediaApp
 import org.wikipedia.categories.db.Category
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.donate.DonationResult
 import org.wikipedia.games.onthisday.OnThisDayGameViewModel
-import org.wikipedia.settings.Prefs
 import org.wikipedia.util.UiState
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 class ActivityTabViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
-
-    private val _uiState = MutableStateFlow<UiState<Unit>>(UiState.Loading)
-    val uiState: StateFlow<UiState<Unit>> = _uiState.asStateFlow()
-
     private val _timeSpentState = MutableStateFlow<UiState<Long>>(UiState.Loading)
     val timeSpentState: StateFlow<UiState<Long>> = _timeSpentState.asStateFlow()
 
@@ -34,33 +27,18 @@ class ActivityTabViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     var topCategories: List<Category> = emptyList()
 
     init {
-        load()
+        loadTimeSpent()
     }
 
-    fun load() {
+    fun loadTimeSpent() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
-            _uiState.value = UiState.Error(throwable)
+            _timeSpentState.value = UiState.Error(throwable)
         }) {
-            _uiState.value = UiState.Loading
-
-            val currentDate = LocalDate.now()
-            val languageCode = WikipediaApp.instance.wikiSite.languageCode
-
+            _timeSpentState.value = UiState.Loading
             val now = LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
             val sevenDaysAgo = now - TimeUnit.DAYS.toMillis(7)
             val totalTimeSpent = AppDatabase.instance.historyEntryWithImageDao().getTimeSpentSinceTimeStamp(sevenDaysAgo)
             _timeSpentState.value = UiState.Success(totalTimeSpent)
-
-            // TODO: do something with game statistics
-            gameStatistics = OnThisDayGameViewModel.getGameStatistics(languageCode)
-
-            // TODO: do something with donation results
-            donationResults = Prefs.donationResults
-
-            // TODO: do something with top categories
-            topCategories = AppDatabase.instance.categoryDao().getTopCategoriesByMonth(currentDate.year, currentDate.monthValue)
-
-            _uiState.value = UiState.Success(Unit)
         }
     }
 }


### PR DESCRIPTION
### What does this do?
- In the current implementation, the **UiState** in the **ViewModel** can cause the entire UI to fail if an exception occurs during loading. This means that even modules unaffected by the exception may not be displayed.
- The proposed approach is to remove this shared **UiState** and instead create separate composable views for each module, which allows them to handle their own errors and UI events independently.
