### PR TITLE
Customize screen description view

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabCustomizationActivity.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabCustomizationActivity.kt
@@ -79,8 +79,18 @@ fun CustomizationScreen(
             LazyColumn(
                 modifier = Modifier
                     .padding(paddingValues)
-                    .padding(vertical = 24.dp)
+                    .padding(vertical = 16.dp),
             ) {
+                item {
+                    Text(
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .padding(bottom = 16.dp),
+                        text = stringResource(R.string.activity_tab_menu_customize_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = WikipediaTheme.colors.secondaryColor
+                    )
+                }
                 itemsIndexed(ModuleType.entries) { index, moduleType ->
                     CustomizationScreenSwitch(
                         isChecked = currentModules.isModuleEnabled(moduleType),

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1191,6 +1191,7 @@
   <string name="activity_tab_menu_feedback">Menu label for providing feedback on the activity tab.</string>
   <string name="activity_tab_menu_info">Menu label for visiting the information page of the activity tab.</string>
   <string name="activity_tab_menu_customize">Menu label for opening the activity tab customization screen.</string>
+  <string name="activity_tab_menu_customize_description">Text shown in the Customize screen explaining how Activity tab work.</string>
   <string name="activity_tab_highlights">Label for the Highlights section of the Activity tab.</string>
   <string name="activity_tab_customize_screen_reading_history_switch_title">Title of the switch for the Reading history module in the customize screen.</string>
   <string name="activity_tab_customize_screen_impact_switch_title">Title of the switch for the Impact module in the customize screen.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1210,6 +1210,7 @@
     <string name="activity_tab_menu_feedback">Problem with feature</string>
     <string name="activity_tab_menu_info">Learn more</string>
     <string name="activity_tab_menu_customize">Customize</string>
+    <string name="activity_tab_menu_customize_description">Activity tab insights are based on the primary language set in settings and is leveraging local data with the exception of edits which are public.</string>
     <string name="activity_tab_highlights">Highlights</string>
     <string name="activity_tab_customize_screen_reading_history_switch_title">Reading history</string>
     <string name="activity_tab_customize_screen_impact_switch_title">Impact</string>


### PR DESCRIPTION
### What does this do?
- adds description view to customize screen

[Figma](https://www.figma.com/design/MXUBnIJvHfMBHhPZta7yRm/Android---%3E-Activity-Tab?node-id=53-4976&m=dev)