### PR TITLE
Check if the language code has language variants when building WikiSite object

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
@@ -59,12 +59,15 @@ data class WikiSite(
 
         // For language variant wikis, automatically switch to the preferred variant if possible.
         val parentLanguageCode = WikipediaApp.instance.languageState.getDefaultLanguageCode(languageCode)
-        if (parentLanguageCode != null) {
+        // For the default language code like "zh", we need to check if it has variants.
+        var languageVariants = WikipediaApp.instance.languageState.getLanguageVariants(languageCode)
+        if (parentLanguageCode != null || languageVariants != null) {
             // Get language variants from the parent language code
-            val languageVariants = WikipediaApp.instance.languageState.getLanguageVariants(parentLanguageCode)
+            if (languageVariants == null) {
+                languageVariants = WikipediaApp.instance.languageState.getLanguageVariants(parentLanguageCode)
+            }
             // Try to find the first selected variant that matches the URL's parent language code
-
-            // This prevents showing mixed Chinese variants article when the URL is /zh/ or /wiki/ in zh.wikipedia.org
+            // This prevents showing mixed language variants article when the URL contains parent language codes such as "zh" or "wiki"
             languageCode = WikipediaApp.instance.languageState.appLanguageCodes.firstOrNull {
                 languageVariants?.contains(it) == true
             } ?: languageCode


### PR DESCRIPTION
### What does this do?
We have a logic to automatically redirect to the first preferred app language variant from the deep link before, but it does not work properly for the parent language code (e.g. `zh`), and this introduces an issue that when users sync articles from the server in a freshly installed app, the articles will be displayed in the parent language code instead of the preferred language code.

This PR adds logic to check if the language code has language variants, and makes sure the parent language code also works properly.

**Phabricator:**
https://phabricator.wikimedia.org/T402452
