### PR TITLE
Add proper paddings for the top categories card in Activity Tab

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/TopCategoriesView.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/TopCategoriesView.kt
@@ -41,11 +41,9 @@ fun TopCategoriesView(
             color = WikipediaTheme.colors.borderColor
         )
     ) {
-        Column(
-            modifier = Modifier.padding(top = 16.dp)
-        ) {
+        Column {
             Row(
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Icon(


### PR DESCRIPTION
### What does this do?
When you click on the top item of the top categories, you will notice the header and the item ripple color stick really close. This PR adjusts the padding by adding a `8.dp` to the bottom.