### PR TITLE
Hide the Donation module if no donation data in the app in Activity Tab

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabCustomizationActivity.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabCustomizationActivity.kt
@@ -45,7 +45,9 @@ class ActivityTabCustomizationActivity : BaseActivity() {
                 CustomizationScreen(
                     onBackButtonClick = {
                         finish()
-                    }
+                    },
+                    modules = Prefs.activityTabModules,
+                    showLastDonation = Prefs.donationResults.isNotEmpty()
                 )
             }
         }
@@ -61,9 +63,11 @@ class ActivityTabCustomizationActivity : BaseActivity() {
 @Composable
 fun CustomizationScreen(
     modifier: Modifier = Modifier,
-    onBackButtonClick: () -> Unit
+    onBackButtonClick: () -> Unit,
+    modules: ActivityTabModules,
+    showLastDonation: Boolean = false
 ) {
-    var currentModules by remember { mutableStateOf(Prefs.activityTabModules) }
+    var currentModules by remember { mutableStateOf(modules) }
 
     Scaffold(
         modifier = modifier
@@ -92,6 +96,9 @@ fun CustomizationScreen(
                     )
                 }
                 itemsIndexed(ModuleType.entries) { index, moduleType ->
+                    if (moduleType == ModuleType.DONATIONS && !showLastDonation) {
+                        return@itemsIndexed
+                    }
                     CustomizationScreenSwitch(
                         isChecked = currentModules.isModuleEnabled(moduleType),
                         title = stringResource(moduleType.displayName),
@@ -196,7 +203,8 @@ private fun CustomizationScreenPreview() {
         currentTheme = Theme.LIGHT
     ) {
         CustomizationScreen(
-            onBackButtonClick = {}
+            onBackButtonClick = {},
+            modules = ActivityTabModules()
         )
     }
 }

--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
@@ -407,7 +407,7 @@ class ActivityTabFragment : Fragment() {
                                 )
                             }
 
-                            if (modules.isModuleEnabled(ModuleType.DONATIONS)) {
+                            if (modules.isModuleEnabled(ModuleType.DONATIONS) && Prefs.donationResults.isNotEmpty()) {
                                 DonationModule(
                                     modifier = Modifier
                                         .fillMaxWidth()

--- a/app/src/main/java/org/wikipedia/activitytab/DonationModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/DonationModule.kt
@@ -5,14 +5,11 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -100,32 +97,6 @@ fun DonationModule(
                     color = WikipediaTheme.colors.progressiveColor,
                     fontWeight = FontWeight.Medium
                 )
-                if (uiState.data.isNullOrEmpty()) {
-                    Button(
-                        modifier = Modifier
-                            .padding(top = 16.dp)
-                            .fillMaxWidth()
-                            .align(Alignment.CenterHorizontally),
-                        contentPadding = PaddingValues(horizontal = 18.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = WikipediaTheme.colors.progressiveColor,
-                            contentColor = WikipediaTheme.colors.paperColor,
-                        ),
-                        onClick = { onClick?.invoke() },
-                    ) {
-                        Icon(
-                            modifier = Modifier.size(20.dp),
-                            painter = painterResource(R.drawable.ic_heart_24),
-                            tint = WikipediaTheme.colors.paperColor,
-                            contentDescription = null
-                        )
-                        Text(
-                            modifier = Modifier.padding(start = 6.dp, top = 4.dp, bottom = 4.dp),
-                            text = stringResource(R.string.activity_tab_donation_button),
-                            style = MaterialTheme.typography.labelLarge
-                        )
-                    }
-                }
             }
         }
     }
@@ -137,16 +108,6 @@ private fun DonationModulePreview() {
     BaseTheme(currentTheme = Theme.LIGHT) {
         DonationModule(
             uiState = UiState.Success("5 days ago")
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun DonationModuleEmptyPreview() {
-    BaseTheme(currentTheme = Theme.LIGHT) {
-        DonationModule(
-            uiState = UiState.Success(null)
         )
     }
 }

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1179,7 +1179,6 @@
   <string name="activity_tab_monthly_top_categories">Label on a card that lists the top categories of articles that were read this month.</string>
   <string name="activity_tab_explore_wikipedia">Button label to go to the Reading Lists screen, which will give the user further guidance for exploring Wikipedia.</string>
   <string name="activity_tab_discover_encourage">Label encouraging the user to discover new articles.</string>
-  <string name="activity_tab_donation_button">Button label to go to the donation workflow.</string>
   <string name="activity_tab_donation_unknown">Label on card that shows the last donation time.</string>
   <string name="activity_tab_game_stats">Title of the game stats card.</string>
   <string name="activity_tab_game_stats_best_streak">Label of the game stats that indicates the best streak.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1201,7 +1201,6 @@
     <string name="activity_tab_monthly_top_categories">Top categories read this month</string>
     <string name="activity_tab_explore_wikipedia">Discover through Wikipedia</string>
     <string name="activity_tab_discover_encourage">Looking for something new to read?</string>
-    <string name="activity_tab_donation_button">Donate to the Wikimedia Foundation</string>
     <string name="activity_tab_donation_unknown">Unknown</string>
     <string name="activity_tab_donation_last_donation"><![CDATA[<b>Last donation</b> in app]]></string>
     <string name="activity_tab_game_stats">Game stats</string>


### PR DESCRIPTION
### What does this do?
From the Android planning meeting, the PM requested a change to the donation module, where it should be hidden from the Activity tab if the user has not made any donations in the app. This change also affects the Customize screen.

This PR also updates the parameter to make sure the preview is working correctly.