### PR TITLE
Separate Contributions and Most viewed cards to Editing insights card for Activity Tab

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
@@ -324,15 +324,16 @@ class ActivityTabFragment : Fragment() {
                                     )
                                 )
                         ) {
-                            if (modules.isModuleEnabled(ModuleType.IMPACT)) {
-                                Text(
-                                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
-                                    text = stringResource(R.string.activity_tab_impact),
-                                    style = MaterialTheme.typography.titleLarge,
-                                    fontWeight = FontWeight.Medium,
-                                    color = WikipediaTheme.colors.primaryColor
-                                )
-                                ImpactModule(
+                            Text(
+                                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
+                                text = stringResource(R.string.activity_tab_impact),
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Medium,
+                                color = WikipediaTheme.colors.primaryColor
+                            )
+
+                            if (modules.isModuleEnabled(ModuleType.EDITING_INSIGHTS)) {
+                                EditingInsightsModule(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(start = 16.dp, end = 16.dp, top = 16.dp),
@@ -342,23 +343,40 @@ class ActivityTabFragment : Fragment() {
                                             title = it,
                                             source = HistoryEntry.SOURCE_ACTIVITY_TAB
                                         )
-                                        requireActivity().startActivity(PageActivity.newIntentForNewTab(
+                                        requireActivity().startActivity(
+                                            PageActivity.newIntentForNewTab(
                                             context = requireActivity(),
                                             entry = entry,
                                             title = it
                                         ))
                                     },
                                     onContributionClick = {
-                                        requireActivity().startActivity(UserContribListActivity.newIntent(
+                                        requireActivity().startActivity(
+                                            UserContribListActivity.newIntent(
                                             context = requireActivity(),
                                             userName = userName
                                         ))
                                     },
                                     onSuggestedEditsClick = {
-                                        requireActivity().startActivity(SuggestedEditsTasksActivity.newIntent(
+                                        requireActivity().startActivity(
+                                            SuggestedEditsTasksActivity.newIntent(
                                             context = requireActivity()
                                         ))
                                     },
+                                    wikiErrorClickEvents = WikiErrorClickEvents(
+                                        retryClickListener = {
+                                            viewModel.loadImpact()
+                                        }
+                                    )
+                                )
+                            }
+
+                            if (modules.isModuleEnabled(ModuleType.IMPACT)) {
+                                ImpactModule(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(start = 16.dp, end = 16.dp, top = 16.dp),
+                                    uiState = impactUiState,
                                     wikiErrorClickEvents = WikiErrorClickEvents(
                                         retryClickListener = {
                                             viewModel.loadImpact()

--- a/app/src/main/java/org/wikipedia/activitytab/EditingInsightsModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/EditingInsightsModule.kt
@@ -1,0 +1,513 @@
+package org.wikipedia.activitytab
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.painter.BrushPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.net.toUri
+import coil3.compose.AsyncImage
+import org.wikipedia.R
+import org.wikipedia.compose.components.HtmlText
+import org.wikipedia.compose.components.LineChart
+import org.wikipedia.compose.components.WikiCard
+import org.wikipedia.compose.components.error.WikiErrorClickEvents
+import org.wikipedia.compose.components.error.WikiErrorView
+import org.wikipedia.compose.theme.BaseTheme
+import org.wikipedia.compose.theme.WikipediaTheme
+import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.growthtasks.GrowthUserImpact
+import org.wikipedia.dataclient.growthtasks.GrowthUserImpact.ArticleViews
+import org.wikipedia.page.PageTitle
+import org.wikipedia.theme.Theme
+import org.wikipedia.util.UiState
+import org.wikipedia.views.imageservice.ImageService
+import java.text.NumberFormat
+import java.util.Locale
+
+@Composable
+fun EditingInsightsModule(
+    modifier: Modifier = Modifier,
+    uiState: UiState<GrowthUserImpact>,
+    onPageItemClick: (PageTitle) -> Unit,
+    onContributionClick: (() -> Unit),
+    onSuggestedEditsClick: (() -> Unit),
+    wikiErrorClickEvents: WikiErrorClickEvents? = null
+) {
+    when (uiState) {
+        UiState.Loading -> {
+            Box(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
+                    color = WikipediaTheme.colors.progressiveColor
+                )
+            }
+        }
+        is UiState.Success -> {
+            MostViewedCard(
+                modifier = modifier
+                    .fillMaxWidth(),
+                data = uiState.data.topViewedArticlesWithPageTitle,
+                onClick = {
+                    onPageItemClick(it)
+                }
+            )
+            ContributionCard(
+                modifier = modifier
+                    .fillMaxWidth(),
+                lastEditRelativeTime = uiState.data.lastEditRelativeTime,
+                editsThisMonth = uiState.data.editsThisMonth,
+                editsLastMonth = uiState.data.editsLastMonth,
+                totalEdits = uiState.data.totalEditsCount,
+                onContributionClick = {
+                    onContributionClick()
+                },
+                onSuggestedEditsClick = {
+                    onSuggestedEditsClick()
+                }
+            )
+        }
+
+        is UiState.Error -> {
+            Box(
+                modifier = modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                WikiErrorView(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    caught = uiState.error,
+                    errorClickEvents = wikiErrorClickEvents
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun MostViewedCard(
+    modifier: Modifier = Modifier,
+    data: Map<PageTitle, ArticleViews>,
+    showSize: Int = 3,
+    onClick: (PageTitle) -> Unit
+) {
+    if (data.isEmpty()) {
+        return
+    }
+    val formatter = remember { NumberFormat.getNumberInstance(Locale.getDefault()) }
+    WikiCard(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = WikipediaTheme.colors.paperColor,
+            contentColor = WikipediaTheme.colors.paperColor
+        ),
+        elevation = 0.dp,
+        border = BorderStroke(
+            width = 1.dp,
+            color = WikipediaTheme.colors.borderColor
+        )
+    ) {
+        Column {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    modifier = Modifier.size(16.dp),
+                    painter = painterResource(R.drawable.outline_trending_up_24),
+                    tint = WikipediaTheme.colors.primaryColor,
+                    contentDescription = null
+                )
+                Text(
+                    text = stringResource(R.string.activity_tab_impact_most_viewed),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = WikipediaTheme.colors.primaryColor
+                )
+            }
+
+            var index = 1
+            data.forEach { (pageTitle, articleViews) ->
+                if (index > showSize) return@forEach
+                var iconResource = when (index++) {
+                    1 -> R.drawable.outline_looks_one_24
+                    2 -> R.drawable.outline_looks_two_24
+                    3 -> R.drawable.outline_looks_three_24
+                    else -> null
+                }
+                if (data.size <= 1) {
+                    iconResource = null
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = { onClick(pageTitle) })
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        iconResource?.let {
+                            Icon(
+                                modifier = Modifier.size(24.dp),
+                                painter = painterResource(it),
+                                tint = WikipediaTheme.colors.primaryColor,
+                                contentDescription = null
+                            )
+                        }
+                        Column(
+                            modifier = Modifier
+                                .weight(1f)
+                        ) {
+                            HtmlText(
+                                text = pageTitle.displayText,
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontFamily = FontFamily.Serif
+                                ),
+                                color = WikipediaTheme.colors.primaryColor,
+                            )
+                            pageTitle.description?.let { description ->
+                                Text(
+                                    text = description,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = WikipediaTheme.colors.secondaryColor
+                                )
+                            }
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                LineChart(
+                                    map = articleViews.viewsByDay,
+                                    modifier = Modifier
+                                        .width(24.dp)
+                                        .height(6.dp),
+                                    chartSampleSize = 10,
+                                    strokeWidth = 1.dp,
+                                    strokeColor = WikipediaTheme.colors.progressiveColor
+                                )
+                                Text(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(start = 8.dp),
+                                    text = formatter.format(articleViews.viewsCount),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = WikipediaTheme.colors.progressiveColor
+                                )
+                            }
+                        }
+                        if (pageTitle.thumbUrl != null) {
+                            val request =
+                                ImageService.getRequest(
+                                    LocalContext.current,
+                                    url = pageTitle.thumbUrl
+                                )
+                            AsyncImage(
+                                model = request,
+                                placeholder = BrushPainter(SolidColor(WikipediaTheme.colors.borderColor)),
+                                error = BrushPainter(SolidColor(WikipediaTheme.colors.borderColor)),
+                                contentScale = ContentScale.Crop,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(56.dp)
+                                    .clip(RoundedCornerShape(8.dp))
+                            )
+                        }
+                    }
+                }
+                if (index < data.size - 1) {
+                    HorizontalDivider(
+                        color = WikipediaTheme.colors.borderColor
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ContributionCard(
+    modifier: Modifier = Modifier,
+    lastEditRelativeTime: String,
+    editsThisMonth: Int,
+    editsLastMonth: Int,
+    totalEdits: Int = 0,
+    onContributionClick: (() -> Unit)? = null,
+    onSuggestedEditsClick: (() -> Unit)? = null
+) {
+    WikiCard(
+        modifier = modifier
+            .clickable(onClick = { onContributionClick?.invoke() }),
+        colors = CardDefaults.cardColors(
+            containerColor = WikipediaTheme.colors.paperColor,
+            contentColor = WikipediaTheme.colors.paperColor
+        ),
+        elevation = 0.dp,
+        border = BorderStroke(
+            width = 1.dp,
+            color = WikipediaTheme.colors.borderColor
+        )
+    ) {
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth()
+                    .padding(top = 16.dp, start = 16.dp, end = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    modifier = Modifier.size(16.dp),
+                    painter = painterResource(R.drawable.ic_icon_user_contributions_ooui),
+                    tint = WikipediaTheme.colors.primaryColor,
+                    contentDescription = null
+                )
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = stringResource(R.string.activity_tab_impact_contributions_this_month),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = WikipediaTheme.colors.primaryColor
+                )
+                Icon(
+                    modifier = Modifier.size(24.dp),
+                    painter = painterResource(R.drawable.ic_chevron_forward_white_24dp),
+                    tint = WikipediaTheme.colors.secondaryColor,
+                    contentDescription = null
+                )
+            }
+
+            Text(
+                text = lastEditRelativeTime,
+                modifier = Modifier.padding(start = 16.dp),
+                style = MaterialTheme.typography.bodySmall,
+                color = WikipediaTheme.colors.secondaryColor
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp)
+            ) {
+                val maxEditsCount = maxOf(editsThisMonth, editsLastMonth).toFloat()
+
+                ContributionEditsView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                    text = pluralStringResource(
+                        R.plurals.activity_tab_impact_edits_this_month,
+                        editsThisMonth
+                    ).lowercase(),
+                    edits = editsThisMonth,
+                    maxEdits = maxEditsCount,
+                    barColor = WikipediaTheme.colors.successColor
+                )
+
+                ContributionEditsView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                    text = pluralStringResource(
+                        R.plurals.activity_tab_impact_edits_last_month,
+                        editsLastMonth
+                    ).lowercase(),
+                    edits = editsLastMonth,
+                    maxEdits = maxEditsCount,
+                    barColor = WikipediaTheme.colors.borderColor
+                )
+            }
+            if (totalEdits == 0) {
+                HorizontalDivider(
+                    modifier = Modifier.padding(top = 16.dp),
+                    color = WikipediaTheme.colors.borderColor
+                )
+                SuggestedEditsView(
+                    onClick = onSuggestedEditsClick
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SuggestedEditsView(
+    onClick: (() -> Unit)? = null
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            modifier = Modifier.padding(bottom = 8.dp),
+            text = stringResource(R.string.activity_tab_impact_suggested_edits_title),
+            style = MaterialTheme.typography.titleSmall.copy(
+                fontWeight = FontWeight.Medium
+            ),
+            color = WikipediaTheme.colors.primaryColor
+        )
+        Text(
+            textAlign = TextAlign.Center,
+            text = stringResource(R.string.activity_tab_impact_suggested_edits_message),
+            style = MaterialTheme.typography.bodyMedium,
+            color = WikipediaTheme.colors.primaryColor
+        )
+        Button(
+            modifier = Modifier.padding(top = 16.dp).align(Alignment.CenterHorizontally),
+            contentPadding = PaddingValues(horizontal = 18.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = WikipediaTheme.colors.progressiveColor,
+                contentColor = WikipediaTheme.colors.paperColor,
+            ),
+            onClick = { onClick?.invoke() },
+        ) {
+            Icon(
+                modifier = Modifier.size(20.dp),
+                painter = painterResource(R.drawable.ic_mode_edit_white_24dp),
+                tint = WikipediaTheme.colors.paperColor,
+                contentDescription = null
+            )
+            Text(
+                modifier = Modifier.padding(start = 6.dp, top = 4.dp, bottom = 4.dp),
+                text = stringResource(R.string.activity_tab_impact_suggested_edits_button),
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+    }
+}
+
+@Composable
+fun ContributionEditsView(
+    modifier: Modifier,
+    text: String,
+    edits: Int,
+    maxEdits: Float,
+    barColor: Color
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Bottom
+    ) {
+        Text(
+            text = edits.toString(),
+            modifier = Modifier.padding(start = 16.dp).align(Alignment.Bottom),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Medium,
+            color = WikipediaTheme.colors.primaryColor
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall.copy(
+                fontWeight = FontWeight.Medium,
+                lineHeight = 22.sp
+            ),
+            color = WikipediaTheme.colors.secondaryColor
+        )
+    }
+
+    if (edits > 0) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(edits.toFloat() / maxEdits)
+                .padding(horizontal = 16.dp)
+                .height(20.dp)
+                .background(
+                    color = barColor,
+                    shape = RoundedCornerShape(16.dp)
+                )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MostViewedCardPreview() {
+    BaseTheme(
+        currentTheme = Theme.LIGHT
+    ) {
+        val pageTitle = PageTitle(
+            text = "Test Article",
+            displayText = "Test Article",
+            wiki = WikiSite("en.wikipedia.org".toUri(), "en"),
+            description = "This is a test article",
+            thumbUrl = "https://example.com/thumb.jpg"
+        )
+        val articleViews = ArticleViews(
+            firstEditDate = "2023-01-01",
+            newestEdit = "2023-10-01",
+            imageUrl = "https://example.com/image.jpg",
+            viewsCount = 1000
+        )
+        MostViewedCard(
+            data = mapOf(
+                pageTitle to articleViews
+            ),
+            onClick = { },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ContributionCardPreview() {
+    BaseTheme(
+        currentTheme = Theme.LIGHT
+    ) {
+        ContributionCard(
+            modifier = Modifier.fillMaxWidth(),
+            lastEditRelativeTime = "2 days ago",
+            totalEdits = 9,
+            editsThisMonth = 9,
+            editsLastMonth = 2,
+            onContributionClick = null,
+            onSuggestedEditsClick = null
+        )
+    }
+}

--- a/app/src/main/java/org/wikipedia/activitytab/ImpactModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ImpactModule.kt
@@ -2,21 +2,16 @@ package org.wikipedia.activitytab
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -27,39 +22,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.painter.BrushPainter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.net.toUri
-import coil3.compose.AsyncImage
 import org.wikipedia.R
-import org.wikipedia.compose.components.HtmlText
 import org.wikipedia.compose.components.LineChart
 import org.wikipedia.compose.components.WikiCard
 import org.wikipedia.compose.components.error.WikiErrorClickEvents
 import org.wikipedia.compose.components.error.WikiErrorView
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
-import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.growthtasks.GrowthUserImpact
-import org.wikipedia.dataclient.growthtasks.GrowthUserImpact.ArticleViews
-import org.wikipedia.page.PageTitle
 import org.wikipedia.theme.Theme
 import org.wikipedia.util.DateUtil
 import org.wikipedia.util.UiState
-import org.wikipedia.views.imageservice.ImageService
 import java.text.NumberFormat
 import java.util.Date
 import java.util.Locale
@@ -68,9 +48,6 @@ import java.util.Locale
 fun ImpactModule(
     modifier: Modifier = Modifier,
     uiState: UiState<GrowthUserImpact>,
-    onPageItemClick: (PageTitle) -> Unit,
-    onContributionClick: (() -> Unit),
-    onSuggestedEditsClick: (() -> Unit),
     wikiErrorClickEvents: WikiErrorClickEvents? = null
 ) {
     when (uiState) {
@@ -89,24 +66,6 @@ fun ImpactModule(
             }
         }
         is UiState.Success -> {
-            MostViewedCard(
-                modifier = modifier
-                    .fillMaxWidth(),
-                data = uiState.data.topViewedArticlesWithPageTitle,
-                onClick = {
-                    onPageItemClick(it)
-                }
-            )
-            ContributionCard(
-                modifier = modifier
-                    .fillMaxWidth(),
-                lastEditRelativeTime = uiState.data.lastEditRelativeTime,
-                editsThisMonth = uiState.data.editsThisMonth,
-                editsLastMonth = uiState.data.editsLastMonth,
-                onClick = {
-                    onContributionClick()
-                }
-            )
             AllTimeImpactCard(
                 modifier = modifier
                     .fillMaxWidth(),
@@ -116,10 +75,7 @@ fun ImpactModule(
                 lastEditTimestamp = uiState.data.lastEditTimestamp,
                 lastThirtyDaysEdits = uiState.data.lastThirtyDaysEdits,
                 totalPageviewsCount = uiState.data.totalPageviewsCount,
-                dailyTotalViews = uiState.data.dailyTotalViews,
-                onClick = {
-                    onSuggestedEditsClick()
-                }
+                dailyTotalViews = uiState.data.dailyTotalViews
             )
         }
 
@@ -141,241 +97,6 @@ fun ImpactModule(
 }
 
 @Composable
-fun MostViewedCard(
-    modifier: Modifier = Modifier,
-    data: Map<PageTitle, ArticleViews>,
-    showSize: Int = 3,
-    onClick: (PageTitle) -> Unit
-) {
-    if (data.isEmpty()) {
-        return
-    }
-    val formatter = remember { NumberFormat.getNumberInstance(Locale.getDefault()) }
-    WikiCard(
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = WikipediaTheme.colors.paperColor,
-            contentColor = WikipediaTheme.colors.paperColor
-        ),
-        elevation = 0.dp,
-        border = BorderStroke(
-            width = 1.dp,
-            color = WikipediaTheme.colors.borderColor
-        )
-    ) {
-        Column {
-            Row(
-                modifier = Modifier.padding(16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Icon(
-                    modifier = Modifier.size(16.dp),
-                    painter = painterResource(R.drawable.outline_trending_up_24),
-                    tint = WikipediaTheme.colors.primaryColor,
-                    contentDescription = null
-                )
-                Text(
-                    text = stringResource(R.string.activity_tab_impact_most_viewed),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = WikipediaTheme.colors.primaryColor
-                )
-            }
-
-            var index = 1
-            data.forEach { (pageTitle, articleViews) ->
-                if (index > showSize) return@forEach
-                var iconResource = when (index++) {
-                    1 -> R.drawable.outline_looks_one_24
-                    2 -> R.drawable.outline_looks_two_24
-                    3 -> R.drawable.outline_looks_three_24
-                    else -> null
-                }
-                if (data.size <= 1) {
-                    iconResource = null
-                }
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(onClick = { onClick(pageTitle) })
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        iconResource?.let {
-                            Icon(
-                                modifier = Modifier.size(24.dp),
-                                painter = painterResource(it),
-                                tint = WikipediaTheme.colors.primaryColor,
-                                contentDescription = null
-                            )
-                        }
-                        Column(
-                            modifier = Modifier
-                                .weight(1f)
-                        ) {
-                            HtmlText(
-                                text = pageTitle.displayText,
-                                style = MaterialTheme.typography.titleMedium.copy(
-                                    fontFamily = FontFamily.Serif
-                                ),
-                                color = WikipediaTheme.colors.primaryColor,
-                            )
-                            pageTitle.description?.let { description ->
-                                Text(
-                                    text = description,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = WikipediaTheme.colors.secondaryColor
-                                )
-                            }
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 8.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                LineChart(
-                                    map = articleViews.viewsByDay,
-                                    modifier = Modifier
-                                        .width(24.dp)
-                                        .height(6.dp),
-                                    chartSampleSize = 10,
-                                    strokeWidth = 1.dp,
-                                    strokeColor = WikipediaTheme.colors.progressiveColor
-                                )
-                                Text(
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(start = 8.dp),
-                                    text = formatter.format(articleViews.viewsCount),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = WikipediaTheme.colors.progressiveColor
-                                )
-                            }
-                        }
-                        if (pageTitle.thumbUrl != null) {
-                            val request =
-                                ImageService.getRequest(
-                                    LocalContext.current,
-                                    url = pageTitle.thumbUrl
-                                )
-                            AsyncImage(
-                                model = request,
-                                placeholder = BrushPainter(SolidColor(WikipediaTheme.colors.borderColor)),
-                                error = BrushPainter(SolidColor(WikipediaTheme.colors.borderColor)),
-                                contentScale = ContentScale.Crop,
-                                contentDescription = null,
-                                modifier = Modifier
-                                    .size(56.dp)
-                                    .clip(RoundedCornerShape(8.dp))
-                            )
-                        }
-                    }
-                }
-                if (index < data.size - 1) {
-                    HorizontalDivider(
-                        color = WikipediaTheme.colors.borderColor
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun ContributionCard(
-    modifier: Modifier = Modifier,
-    lastEditRelativeTime: String,
-    editsThisMonth: Int,
-    editsLastMonth: Int,
-    onClick: (() -> Unit)? = null
-) {
-    WikiCard(
-        modifier = modifier
-            .clickable(onClick = { onClick?.invoke() }),
-        colors = CardDefaults.cardColors(
-            containerColor = WikipediaTheme.colors.paperColor,
-            contentColor = WikipediaTheme.colors.paperColor
-        ),
-        elevation = 0.dp,
-        border = BorderStroke(
-            width = 1.dp,
-            color = WikipediaTheme.colors.borderColor
-        )
-    ) {
-        Column {
-            Row(
-                modifier = Modifier.fillMaxWidth()
-                    .padding(top = 16.dp, start = 16.dp, end = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Icon(
-                    modifier = Modifier.size(16.dp),
-                    painter = painterResource(R.drawable.ic_icon_user_contributions_ooui),
-                    tint = WikipediaTheme.colors.primaryColor,
-                    contentDescription = null
-                )
-                Text(
-                    modifier = Modifier.weight(1f),
-                    text = stringResource(R.string.activity_tab_impact_contributions_this_month),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = WikipediaTheme.colors.primaryColor
-                )
-                Icon(
-                    modifier = Modifier.size(24.dp),
-                    painter = painterResource(R.drawable.ic_chevron_forward_white_24dp),
-                    tint = WikipediaTheme.colors.secondaryColor,
-                    contentDescription = null
-                )
-            }
-
-            Text(
-                text = lastEditRelativeTime,
-                modifier = Modifier.padding(start = 16.dp),
-                style = MaterialTheme.typography.bodySmall,
-                color = WikipediaTheme.colors.secondaryColor
-            )
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp)
-            ) {
-                val maxEditsCount = maxOf(editsThisMonth, editsLastMonth).toFloat()
-
-                ContributionEditsView(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp),
-                    text = pluralStringResource(
-                        R.plurals.activity_tab_impact_edits_this_month,
-                        editsThisMonth
-                    ).lowercase(),
-                    edits = editsThisMonth,
-                    maxEdits = maxEditsCount,
-                    barColor = WikipediaTheme.colors.successColor
-                )
-
-                ContributionEditsView(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp),
-                    text = pluralStringResource(
-                        R.plurals.activity_tab_impact_edits_last_month,
-                        editsLastMonth
-                    ).lowercase(),
-                    edits = editsLastMonth,
-                    maxEdits = maxEditsCount,
-                    barColor = WikipediaTheme.colors.borderColor
-                )
-            }
-        }
-    }
-}
-
-@Composable
 fun AllTimeImpactCard(
     modifier: Modifier = Modifier,
     totalEdits: Int = 0,
@@ -384,8 +105,7 @@ fun AllTimeImpactCard(
     lastEditTimestamp: Long = 0,
     lastThirtyDaysEdits: Map<String, Int> = emptyMap(),
     totalPageviewsCount: Long = 0,
-    dailyTotalViews: Map<String, Int> = emptyMap(),
-    onClick: (() -> Unit)? = null
+    dailyTotalViews: Map<String, Int> = emptyMap()
 ) {
     val formatter = remember { NumberFormat.getNumberInstance(Locale.getDefault()) }
     WikiCard(
@@ -460,14 +180,12 @@ fun AllTimeImpactCard(
                 )
             }
 
-            HorizontalDivider(
-                modifier = Modifier.padding(top = 16.dp),
-                color = WikipediaTheme.colors.borderColor
-            )
+            if (totalEdits > 0) {
+                HorizontalDivider(
+                    modifier = Modifier.padding(top = 16.dp),
+                    color = WikipediaTheme.colors.borderColor
+                )
 
-            if (totalEdits == 0) {
-                ImpactSuggestedEditsView(onClick = onClick)
-            } else {
                 Column(
                     modifier = Modifier.padding(top = 16.dp)
                 ) {
@@ -594,98 +312,6 @@ fun AllTimeImpactCard(
 }
 
 @Composable
-fun ImpactSuggestedEditsView(
-    onClick: (() -> Unit)? = null
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            modifier = Modifier.padding(bottom = 8.dp),
-            text = stringResource(R.string.activity_tab_impact_suggested_edits_title),
-            style = MaterialTheme.typography.titleSmall.copy(
-                fontWeight = FontWeight.Medium
-            ),
-            color = WikipediaTheme.colors.primaryColor
-        )
-        Text(
-            textAlign = TextAlign.Center,
-            text = stringResource(R.string.activity_tab_impact_suggested_edits_message),
-            style = MaterialTheme.typography.bodyMedium,
-            color = WikipediaTheme.colors.primaryColor
-        )
-        Button(
-            modifier = Modifier.padding(top = 16.dp).align(Alignment.CenterHorizontally),
-            contentPadding = PaddingValues(horizontal = 18.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = WikipediaTheme.colors.progressiveColor,
-                contentColor = WikipediaTheme.colors.paperColor,
-            ),
-            onClick = { onClick?.invoke() },
-        ) {
-            Icon(
-                modifier = Modifier.size(20.dp),
-                painter = painterResource(R.drawable.ic_mode_edit_white_24dp),
-                tint = WikipediaTheme.colors.paperColor,
-                contentDescription = null
-            )
-            Text(
-                modifier = Modifier.padding(start = 6.dp, top = 4.dp, bottom = 4.dp),
-                text = stringResource(R.string.activity_tab_impact_suggested_edits_button),
-                style = MaterialTheme.typography.labelLarge
-            )
-        }
-    }
-}
-
-@Composable
-fun ContributionEditsView(
-    modifier: Modifier,
-    text: String,
-    edits: Int,
-    maxEdits: Float,
-    barColor: Color
-) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.Bottom
-    ) {
-        Text(
-            text = edits.toString(),
-            modifier = Modifier.padding(start = 16.dp).align(Alignment.Bottom),
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Medium,
-            color = WikipediaTheme.colors.primaryColor
-        )
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodySmall.copy(
-                fontWeight = FontWeight.Medium,
-                lineHeight = 22.sp
-            ),
-            color = WikipediaTheme.colors.secondaryColor
-        )
-    }
-
-    if (edits > 0) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth(edits.toFloat() / maxEdits)
-                .padding(horizontal = 16.dp)
-                .height(20.dp)
-                .background(
-                    color = barColor,
-                    shape = RoundedCornerShape(16.dp)
-                )
-        )
-    }
-}
-
-@Composable
 fun ImpactStatView(
     modifier: Modifier,
     iconResource: Int,
@@ -717,50 +343,6 @@ fun ImpactStatView(
                 color = WikipediaTheme.colors.primaryColor
             )
         }
-    }
-}
-
-@Preview
-@Composable
-private fun MostViewedCardPreview() {
-    BaseTheme(
-        currentTheme = Theme.LIGHT
-    ) {
-        val pageTitle = PageTitle(
-            text = "Test Article",
-            displayText = "Test Article",
-            wiki = WikiSite("en.wikipedia.org".toUri(), "en"),
-            description = "This is a test article",
-            thumbUrl = "https://example.com/thumb.jpg"
-        )
-        val articleViews = ArticleViews(
-            firstEditDate = "2023-01-01",
-            newestEdit = "2023-10-01",
-            imageUrl = "https://example.com/image.jpg",
-            viewsCount = 1000
-        )
-        MostViewedCard(
-            data = mapOf(
-                pageTitle to articleViews
-            ),
-            onClick = { },
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun ContributionCardPreview() {
-    BaseTheme(
-        currentTheme = Theme.LIGHT
-    ) {
-        ContributionCard(
-            modifier = Modifier.fillMaxWidth(),
-            lastEditRelativeTime = "2 days ago",
-            editsThisMonth = 9,
-            editsLastMonth = 2,
-            onClick = {}
-        )
     }
 }
 
@@ -817,8 +399,7 @@ private fun AllTimeImpactCardPreview() {
                 "2023-10-04" to 120,
                 "2023-10-05" to 180,
                 "2023-10-06" to 220
-            ),
-            onClick = {}
+            )
         )
     }
 }


### PR DESCRIPTION
### What does this do?
This is from the PM request, where the "Contributions this month" and "Most viewed since your edit" should be inside the `Editing insights` module.

[See the conversation](https://click.figma.com/uni/ls/click?upn=u001.Y4GnNWhdnCDA1MWI-2FhIyfOSqzSOOn-2BuE-2BZrF9-2BcnUGiivhcOhY3M9uAFq63kbTUtR394Qn5A4XzkUEvl-2Byqtsc9iAq-2BLqjmX6uA2pJdnGhAAbf94-2B4vUxzOvCkhhPecgtFlWTTSn2BJTQFJSbB5FD-2B-2FI8gdTWJ-2B9HAtaEcpJ3dY-3DoC3Z_Bvp-2FqVwmjDd6FbPccy0YqCQyw18MF50d8MeieuvPc99xVnLfzyrABfmdy9qy6PKuFePCbKn-2BomLgt6xvvyP0HmFl9tkaMsgQ8arXLenyguIHmO1cVLosP-2BKDaTa2sMUydQbpO2GMcZHKLch0C8vxHvyXn-2Ff5ice4XLZOclPHuG4ETkGvWqz2BZSspUTSbNO8sderp-2FNl8gD4LmI27-2FlXyO5GjHS9jr0t02LISgJUwg-2BlRh2nXLTfLbHGJnj0VoAbCd7tYDJIN37NNseLYM7eF8z6Ca8VYBryRSZn0I3ve9i9VHI-2FjOvdJ7kj5zJjcwy9uOEOKJPrn7OVBoOjbq7S3NgDjdGSfSmCAHTe8AWkIo8-3D).

This PR also moves the suggested edit card to the "Contributions this month" card and it will show up if the total edits are zero. (this is TBD but okay to be included now).
