### PR TITLE
Improve and streamline edit preview API call.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/RestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.kt
@@ -1,9 +1,11 @@
 package org.wikipedia.dataclient
 
+import okhttp3.ResponseBody
 import org.wikipedia.dataclient.okhttp.OfflineCacheInterceptor
 import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.dataclient.page.TalkPage
 import org.wikipedia.dataclient.restbase.Metrics
+import org.wikipedia.dataclient.restbase.PreviewRequest
 import org.wikipedia.dataclient.restbase.RbDefinition
 import org.wikipedia.feed.aggregated.AggregatedFeedContent
 import org.wikipedia.feed.announcement.AnnouncementList
@@ -183,6 +185,12 @@ interface RestService {
         @Path("fromDate") fromDate: String,
         @Path("toDate") toDate: String
     ): Metrics
+
+    @POST("transform/wikitext/to/mobile-html/{title}")
+    suspend fun getHtmlPreviewFromWikitext(
+        @Path("title") title: String,
+        @Body body: PreviewRequest
+    ): ResponseBody
 
     companion object {
         const val REST_API_PREFIX = "/api/rest_v1"

--- a/app/src/main/java/org/wikipedia/dataclient/restbase/PreviewRequest.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/restbase/PreviewRequest.kt
@@ -1,0 +1,8 @@
+package org.wikipedia.dataclient.restbase
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class PreviewRequest(
+    val wikitext: String
+)

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.kt
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.kt
@@ -9,17 +9,22 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wikipedia.R
 import org.wikipedia.activity.FragmentUtil
 import org.wikipedia.bridge.CommunicationBridge
 import org.wikipedia.bridge.CommunicationBridge.CommunicationBridgeListener
 import org.wikipedia.bridge.JavaScriptActionHandler
 import org.wikipedia.databinding.FragmentPreviewEditBinding
-import org.wikipedia.dataclient.RestService
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.dataclient.okhttp.OkHttpWebViewClient
+import org.wikipedia.dataclient.restbase.PreviewRequest
 import org.wikipedia.diff.ArticleEditDetailsActivity
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.json.JsonUtil
@@ -35,6 +40,7 @@ import org.wikipedia.util.DeviceUtil
 import org.wikipedia.util.DimenUtil
 import org.wikipedia.util.ResourceUtil
 import org.wikipedia.util.UriUtil
+import org.wikipedia.util.log.L
 
 class EditPreviewFragment : Fragment(), CommunicationBridgeListener, ReferenceDialog.Callback {
 
@@ -83,14 +89,26 @@ class EditPreviewFragment : Fragment(), CommunicationBridgeListener, ReferenceDi
     fun showPreview(title: PageTitle, wikiText: String) {
         DeviceUtil.hideSoftKeyboard(requireActivity())
         callback().showProgressBar(true)
+        lifecycleScope.launch(CoroutineExceptionHandler { _, t ->
+            showPreview(t.message)
+            L.e(t)
+        }) {
+            var html: String?
+            withContext(Dispatchers.IO) {
+                // Workaround for T363781
+                // The preview endpoint requires the target page to exist, so if it doesn't exist yet,
+                // we will base the preview on the Main Page of the wiki.
+                val previewTitle = if (callback().isNewPage() || title.prefixedText.contains("/")) MainPageNameData.valueFor(title.wikiSite.languageCode) else title.prefixedText
+                ServiceFactory.getRest(model.title!!.wikiSite).getHtmlPreviewFromWikitext(previewTitle, PreviewRequest(wikiText)).use {
+                    html = it.string()
+                }
+            }
+            showPreview(html)
+        }
+    }
 
-        // Workaround for T363781
-        // The preview endpoint requires the target page to exist, so if it doesn't exist yet,
-        // we will base the preview on the Main Page of the wiki.
-        val url = ServiceFactory.getRestBasePath(model.title!!.wikiSite) + RestService.PAGE_HTML_PREVIEW_ENDPOINT +
-                UriUtil.encodeURL(if (callback().isNewPage()) MainPageNameData.valueFor(title.wikiSite.languageCode) else title.prefixedText)
-        val postData = "wikitext=" + UriUtil.encodeURL(wikiText)
-        binding.editPreviewWebview.postUrl(url, postData.toByteArray())
+    private fun showPreview(html: String?) {
+        binding.editPreviewWebview.loadDataWithBaseURL(ServiceFactory.getRestBasePath(model.title!!.wikiSite), html.orEmpty(), "text/html", "UTF-8", null)
         binding.editPreviewContainer.isVisible = true
         requireActivity().invalidateOptionsMenu()
     }


### PR DESCRIPTION
The API request to get the preview of an edit is a POST request that takes the wikitext as a body parameter. The thing is, we were allowing the WebView to make this request on its own; and the problem is that the WebView only knows how to do a POST request with `x-www-form-urlencoded` data, whereas our API call performs better when the data is encoded as plain Json.

Therefore, let's just manage the POST request ourselves, and pass the resulting HTML directly to the WebView, like nature intended.

https://phabricator.wikimedia.org/T403137
