### PR TITLE
Adds an onClick parameter for WikiCard to avoid ripple animation issue

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -38,6 +39,7 @@ fun WikiCard(
         contentColor = WikipediaTheme.colors.paperColor
     ),
     border: BorderStroke? = null,
+    onClick: (() -> Unit)? = null,
     shape: Shape = RoundedCornerShape(12.dp),
     content: @Composable () -> Unit
 ) {
@@ -57,7 +59,14 @@ fun WikiCard(
         border = border,
         shape = shape
     ) {
-        content()
+        Box(
+            modifier = Modifier
+                .clickable(enabled = onClick != null) {
+                    onClick?.invoke()
+                }
+        ) {
+            content()
+        }
     }
 }
 
@@ -79,10 +88,10 @@ fun MessageCard(
     ) {
         Column(
             modifier = Modifier
-            .fillMaxWidth()
-            .clickable(enabled = onContainerClick != null) {
-                onContainerClick?.invoke()
-            }
+                .fillMaxWidth()
+                .clickable(enabled = onContainerClick != null) {
+                    onContainerClick?.invoke()
+                }
         ) {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiCard.kt
@@ -84,14 +84,12 @@ fun MessageCard(
     onContainerClick: (() -> Unit)? = null
 ) {
     WikiCard(
-        modifier = modifier
+        modifier = modifier,
+        onClick = onContainerClick
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(enabled = onContainerClick != null) {
-                    onContainerClick?.invoke()
-                }
         ) {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
@@ -461,14 +461,14 @@ fun ReadingListInterestCard(
         colors = CardDefaults.cardColors(
             containerColor = if (isSelected) WikipediaTheme.colors.additionColor else WikipediaTheme.colors.paperColor
         ),
-        shape = RoundedCornerShape(16.dp)
+        shape = RoundedCornerShape(16.dp),
+        onClick = {
+            onItemClick(item)
+        }
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable {
-                    onItemClick(item)
-                }
         ) {
             if (!item.thumbUrl.isNullOrEmpty()) {
                 val request = ImageService.getRequest(LocalContext.current, url = item.thumbUrl, detectFace = true)


### PR DESCRIPTION
### What does this do?
For the current `WikiCard` Compose component, the ripple animation does not respect the round corners of the card. This PR adds a `Box` and separates the clickable event out as a new `onClick` parameter.
