### PR TITLE
Fix: use distinctBy to avoid showing duplicated articles in the interests screen 

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsViewModel.kt
@@ -91,7 +91,7 @@ class RecommendedReadingListInterestsViewModel(savedStateHandle: SavedStateHandl
             _uiState.value = Resource.Success(
                 UiState(
                     fromSettings = fromSettings,
-                    items = results,
+                    items = results.distinctBy { it.prefixedText },
                     selectedItems = selectedItems.toSet()
                 )
             )


### PR DESCRIPTION
### What does this do?
Somehow, the interests screen in the Recommended Reading list shows duplicated articles.

This PR adds a `.distinctBy { it.prefixedText }` to fix the issue.

<img src="https://github.com/user-attachments/assets/91792578-2583-48a7-a209-e5656e87f867" width="350" />
