### PR TITLE
Fix: use SupervisorJob for analytics coroutineScope.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.wikipedia.BuildConfig
 import org.wikipedia.WikipediaApp
@@ -41,7 +42,7 @@ object EventPlatformClient {
      */
     private var ENABLED = WikipediaApp.instance.isOnline
 
-    private val coroutineScope = CoroutineScope(Dispatchers.IO)
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     fun setStreamConfig(streamConfig: StreamConfig) {
         STREAM_CONFIGS[streamConfig.streamName] = streamConfig


### PR DESCRIPTION
This is a bit of a facepalm:
When we send analytics events, our `EventPlatformClient` uses a custom `coroutineScope` that it re-uses whenever new events are sent over the network.
**However**, if the network call fails (and the coroutine executes its exception handler), the entire coroutineScope becomes _cancelled_, and no new coroutines will be executed! (i.e. no further events will be sent.)

The proper thing is to initialize the coroutineScope with a SupervisorJob, which will allow child coroutines to fail, while keeping the parent scope (the supervisor) active.