### PR TITLE
No longer explicitly set left/right margins through JS bridge.

### DIFF
--- a/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
+++ b/app/src/main/java/org/wikipedia/bridge/JavaScriptActionHandler.kt
@@ -21,11 +21,11 @@ import kotlin.math.roundToInt
 object JavaScriptActionHandler {
 
     fun setTopMargin(top: Int): String {
-        return setMargins(16, top + 16, 16, 48)
+        return setMargins(top + 16, 48)
     }
 
-    fun setMargins(left: Int, top: Int, right: Int, bottom: Int): String {
-        return "pcs.c1.Page.setMargins({ top:'${top}px', right:'${right}px', bottom:'${bottom}px', left:'${left}px' })"
+    fun setMargins(top: Int, bottom: Int): String {
+        return "pcs.c1.Page.setMargins({ top:'${top}px', bottom:'${bottom}px' })"
     }
 
     fun getTextSelection(): String {
@@ -104,14 +104,14 @@ object JavaScriptActionHandler {
                 "   \"theme\": \"${app.currentTheme.tag}\"," +
                 "   \"bodyFont\": \"$fontFamily\"," +
                 "   \"dimImages\": ${(app.currentTheme.isDark && Prefs.dimDarkModeImages)}," +
-                "   \"margins\": { \"top\": \"%dpx\", \"right\": \"%dpx\", \"bottom\": \"%dpx\", \"left\": \"%dpx\" }," +
+                "   \"margins\": { \"top\": \"%dpx\", \"bottom\": \"%dpx\" }," +
                 "   \"leadImageHeight\": \"%dpx\"," +
                 "   \"areTablesInitiallyExpanded\": ${isPreview || !Prefs.isCollapseTablesEnabled}," +
                 "   \"textSizeAdjustmentPercentage\": \"100%%\"," +
                 "   \"loadImages\": ${Prefs.isImageDownloadEnabled}," +
                 "   \"userGroups\": ${JsonUtil.encodeToString(AccountUtil.groups)}," +
                 "   \"isEditable\": ${!Prefs.readingFocusModeEnabled}" +
-                "}", topMargin, 16, 48, 16, leadImageHeight)
+                "}", topMargin, 48, leadImageHeight)
     }
 
     fun setUpEditButtons(isEditable: Boolean, isProtected: Boolean): String {

--- a/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.kt
+++ b/app/src/main/java/org/wikipedia/edit/preview/EditPreviewFragment.kt
@@ -127,7 +127,7 @@ class EditPreviewFragment : Fragment(), CommunicationBridgeListener, ReferenceDi
                     return
                 }
                 bridge.onMetadataReady()
-                bridge.execute(JavaScriptActionHandler.setMargins(16, 0, 16, 16 + DimenUtil.roundedPxToDp(binding.licenseText.height.toFloat())))
+                bridge.execute(JavaScriptActionHandler.setMargins(0, 16 + DimenUtil.roundedPxToDp(binding.licenseText.height.toFloat())))
                 callback().showProgressBar(false)
                 requireActivity().invalidateOptionsMenu()
             }


### PR DESCRIPTION
It is no longer necessary for us to set the left and right margins on the article itself (through the Javascript bridge), because we should delegate as much styling as possible to the upstream CSS.
(we do still want control over the top and bottom margins, for the Lead image and bottom toolbar.)

In fact, explicitly setting left/right margins can actually have negative consequences, as currently observed on tablets in landscape mode:

<img width="600" height="375" alt="image" src="https://github.com/user-attachments/assets/b07da971-15b6-4bd9-b3fb-55fa9486c3a3" />

...and after:

<img width="600" height="375" alt="image" src="https://github.com/user-attachments/assets/43376ecb-6e02-45a5-9e51-4bf249a29eda" />
