### PR TITLE
Consolidate ActivityTabModules and ModuleType classes

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabCustomizationActivity.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabCustomizationActivity.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.serialization.Serializable
 import org.wikipedia.R
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.compose.components.WikiTopAppBar
@@ -153,47 +152,6 @@ private fun CustomizationScreenSwitch(
             )
         }
     )
-}
-
-fun ActivityTabModules.isModuleEnabled(moduleType: ModuleType): Boolean = when (moduleType) {
-    ModuleType.TIME_SPENT -> isTimeSpentEnabled
-    ModuleType.READING_INSIGHTS -> isReadingInsightsEnabled
-    ModuleType.EDITING_INSIGHTS -> isEditingInsightsEnabled
-    ModuleType.IMPACT -> isImpactEnabled
-    ModuleType.GAMES -> isGamesEnabled
-    ModuleType.DONATIONS -> isDonationsEnabled
-    ModuleType.TIMELINE -> isTimelineEnabled
-}
-
-fun ActivityTabModules.setModuleEnabled(moduleType: ModuleType, enabled: Boolean) = when (moduleType) {
-    ModuleType.TIME_SPENT -> copy(isTimeSpentEnabled = enabled)
-    ModuleType.READING_INSIGHTS -> copy(isReadingInsightsEnabled = enabled)
-    ModuleType.EDITING_INSIGHTS -> copy(isEditingInsightsEnabled = enabled)
-    ModuleType.IMPACT -> copy(isImpactEnabled = enabled)
-    ModuleType.GAMES -> copy(isGamesEnabled = enabled)
-    ModuleType.DONATIONS -> copy(isDonationsEnabled = enabled)
-    ModuleType.TIMELINE -> copy(isTimelineEnabled = enabled)
-}
-
-@Serializable
-data class ActivityTabModules(
-    val isTimeSpentEnabled: Boolean = true,
-    val isReadingInsightsEnabled: Boolean = true,
-    val isEditingInsightsEnabled: Boolean = true,
-    val isImpactEnabled: Boolean = true,
-    val isGamesEnabled: Boolean = true,
-    val isDonationsEnabled: Boolean = false,
-    val isTimelineEnabled: Boolean = true,
-)
-
-enum class ModuleType(val displayName: Int) {
-    TIME_SPENT(R.string.activity_tab_customize_screen_time_spent_switch_title),
-    READING_INSIGHTS(R.string.activity_tab_customize_screen_reading_insights_switch_title),
-    EDITING_INSIGHTS(R.string.activity_tab_customize_screen_editing_insights_switch_title),
-    IMPACT(R.string.activity_tab_customize_screen_impact_switch_title),
-    GAMES(R.string.activity_tab_customize_screen_games_switch_title),
-    DONATIONS(R.string.activity_tab_customize_screen_donations_switch_title),
-    TIMELINE(R.string.activity_tab_customize_screen_timeline_switch_title)
 }
 
 @Preview

--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabModules.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabModules.kt
@@ -1,0 +1,45 @@
+package org.wikipedia.activitytab
+
+import kotlinx.serialization.Serializable
+import org.wikipedia.R
+
+@Serializable
+data class ActivityTabModules(
+    val isTimeSpentEnabled: Boolean = true,
+    val isReadingInsightsEnabled: Boolean = true,
+    val isEditingInsightsEnabled: Boolean = true,
+    val isImpactEnabled: Boolean = true,
+    val isGamesEnabled: Boolean = true,
+    val isDonationsEnabled: Boolean = false,
+    val isTimelineEnabled: Boolean = true,
+) {
+    fun isModuleEnabled(moduleType: ModuleType): Boolean = when (moduleType) {
+        ModuleType.TIME_SPENT -> isTimeSpentEnabled
+        ModuleType.READING_INSIGHTS -> isReadingInsightsEnabled
+        ModuleType.EDITING_INSIGHTS -> isEditingInsightsEnabled
+        ModuleType.IMPACT -> isImpactEnabled
+        ModuleType.GAMES -> isGamesEnabled
+        ModuleType.DONATIONS -> isDonationsEnabled
+        ModuleType.TIMELINE -> isTimelineEnabled
+    }
+
+    fun setModuleEnabled(moduleType: ModuleType, enabled: Boolean) = when (moduleType) {
+        ModuleType.TIME_SPENT -> copy(isTimeSpentEnabled = enabled)
+        ModuleType.READING_INSIGHTS -> copy(isReadingInsightsEnabled = enabled)
+        ModuleType.EDITING_INSIGHTS -> copy(isEditingInsightsEnabled = enabled)
+        ModuleType.IMPACT -> copy(isImpactEnabled = enabled)
+        ModuleType.GAMES -> copy(isGamesEnabled = enabled)
+        ModuleType.DONATIONS -> copy(isDonationsEnabled = enabled)
+        ModuleType.TIMELINE -> copy(isTimelineEnabled = enabled)
+    }
+}
+
+enum class ModuleType(val displayName: Int) {
+    TIME_SPENT(R.string.activity_tab_customize_screen_time_spent_switch_title),
+    READING_INSIGHTS(R.string.activity_tab_customize_screen_reading_insights_switch_title),
+    EDITING_INSIGHTS(R.string.activity_tab_customize_screen_editing_insights_switch_title),
+    IMPACT(R.string.activity_tab_customize_screen_impact_switch_title),
+    GAMES(R.string.activity_tab_customize_screen_games_switch_title),
+    DONATIONS(R.string.activity_tab_customize_screen_donations_switch_title),
+    TIMELINE(R.string.activity_tab_customize_screen_timeline_switch_title)
+}


### PR DESCRIPTION
### What does this do?
The `ActivityTabModules` and `ModuleType` classes are in the customization activity. This PR separates them out into an individual class so we can easily find them later. 