### PR TITLE
Show a retry button for the WikiErrorView for generic error messages

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/EditingInsightsModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/EditingInsightsModule.kt
@@ -121,7 +121,8 @@ fun EditingInsightsModule(
                     modifier = Modifier
                         .fillMaxWidth(),
                     caught = uiState.error,
-                    errorClickEvents = wikiErrorClickEvents
+                    errorClickEvents = wikiErrorClickEvents,
+                    retryForGenericError = true
                 )
             }
         }

--- a/app/src/main/java/org/wikipedia/activitytab/ImpactModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ImpactModule.kt
@@ -89,7 +89,8 @@ fun ImpactModule(
                     modifier = Modifier
                         .fillMaxWidth(),
                     caught = uiState.error,
-                    errorClickEvents = wikiErrorClickEvents
+                    errorClickEvents = wikiErrorClickEvents,
+                    retryForGenericError = true
                 )
             }
         }

--- a/app/src/main/java/org/wikipedia/activitytab/ReadingHistoryModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ReadingHistoryModule.kt
@@ -222,7 +222,8 @@ fun ReadingHistoryModule(
                 modifier = Modifier
                     .fillMaxWidth(),
                 caught = readingHistoryState.error,
-                errorClickEvents = wikiErrorClickEvents
+                errorClickEvents = wikiErrorClickEvents,
+                retryForGenericError = true
             )
         }
     }

--- a/app/src/main/java/org/wikipedia/activitytab/WikiGamesModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/WikiGamesModule.kt
@@ -85,7 +85,8 @@ fun WikiGamesModule(
                 modifier = Modifier
                     .fillMaxWidth(),
                 caught = uiState.error,
-                errorClickEvents = wikiErrorClickEvents
+                errorClickEvents = wikiErrorClickEvents,
+                retryForGenericError = true
             )
         }
     }

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -166,7 +166,8 @@ fun DonationReminderScreen(
                     modifier = Modifier
                         .fillMaxWidth(),
                     caught = uiState.error,
-                    errorClickEvents = wikiErrorClickEvents
+                    errorClickEvents = wikiErrorClickEvents,
+                    retryForGenericError = true
                 )
             }
             return@Scaffold


### PR DESCRIPTION
### What does this do?
In some cases, the `WikiErrorView` will still show the "Go back" button if the error is a generic error type, which does not make sense if we are in a single activity without any way to "go back". This PR adds a parameter for us to show the retry button for generic errors explicitly. 