### PR TITLE
Activity tab: update design and logic for suggested edits card

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/EditingInsightsModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/EditingInsightsModule.kt
@@ -87,6 +87,15 @@ fun EditingInsightsModule(
             }
         }
         is UiState.Success -> {
+            if (uiState.data.totalEditsCount == 0) {
+                SuggestedEditsCard(
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = {
+                        onSuggestedEditsClick()
+                    }
+                )
+                return
+            }
             MostViewedCard(
                 modifier = modifier
                     .fillMaxWidth(),
@@ -101,12 +110,8 @@ fun EditingInsightsModule(
                 lastEditRelativeTime = uiState.data.lastEditRelativeTime,
                 editsThisMonth = uiState.data.editsThisMonth,
                 editsLastMonth = uiState.data.editsLastMonth,
-                totalEdits = uiState.data.totalEditsCount,
                 onContributionClick = {
                     onContributionClick()
-                },
-                onSuggestedEditsClick = {
-                    onSuggestedEditsClick()
                 }
             )
         }
@@ -279,9 +284,7 @@ fun ContributionCard(
     lastEditRelativeTime: String,
     editsThisMonth: Int,
     editsLastMonth: Int,
-    totalEdits: Int = 0,
     onContributionClick: (() -> Unit)? = null,
-    onSuggestedEditsClick: (() -> Unit)? = null
 ) {
     WikiCard(
         modifier = modifier,
@@ -368,63 +371,68 @@ fun ContributionCard(
                     barColor = WikipediaTheme.colors.borderColor
                 )
             }
-            if (totalEdits == 0) {
-                HorizontalDivider(
-                    modifier = Modifier.padding(top = 16.dp),
-                    color = WikipediaTheme.colors.borderColor
-                )
-                SuggestedEditsView(
-                    onClick = onSuggestedEditsClick
-                )
-            }
         }
     }
 }
 
 @Composable
-fun SuggestedEditsView(
+fun SuggestedEditsCard(
+    modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
+    WikiCard(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = WikipediaTheme.colors.paperColor,
+            contentColor = WikipediaTheme.colors.paperColor
+        ),
+        elevation = 0.dp,
+        border = BorderStroke(
+            width = 1.dp,
+            color = WikipediaTheme.colors.borderColor
+        ),
     ) {
-        Text(
-            modifier = Modifier.padding(bottom = 8.dp),
-            text = stringResource(R.string.activity_tab_impact_suggested_edits_title),
-            style = MaterialTheme.typography.titleSmall.copy(
-                fontWeight = FontWeight.Medium
-            ),
-            color = WikipediaTheme.colors.primaryColor
-        )
-        Text(
-            textAlign = TextAlign.Center,
-            text = stringResource(R.string.activity_tab_impact_suggested_edits_message),
-            style = MaterialTheme.typography.bodyMedium,
-            color = WikipediaTheme.colors.primaryColor
-        )
-        Button(
-            modifier = Modifier.padding(top = 16.dp).align(Alignment.CenterHorizontally),
-            contentPadding = PaddingValues(horizontal = 18.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = WikipediaTheme.colors.progressiveColor,
-                contentColor = WikipediaTheme.colors.paperColor,
-            ),
-            onClick = { onClick?.invoke() },
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Icon(
-                modifier = Modifier.size(20.dp),
-                painter = painterResource(R.drawable.ic_mode_edit_white_24dp),
-                tint = WikipediaTheme.colors.paperColor,
-                contentDescription = null
+            Text(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(R.string.activity_tab_impact_suggested_edits_title),
+                style = MaterialTheme.typography.titleSmall.copy(
+                    fontWeight = FontWeight.Medium
+                ),
+                color = WikipediaTheme.colors.primaryColor
             )
             Text(
-                modifier = Modifier.padding(start = 6.dp, top = 4.dp, bottom = 4.dp),
-                text = stringResource(R.string.activity_tab_impact_suggested_edits_button),
-                style = MaterialTheme.typography.labelLarge
+                textAlign = TextAlign.Center,
+                text = stringResource(R.string.activity_tab_impact_suggested_edits_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = WikipediaTheme.colors.primaryColor
             )
+            Button(
+                modifier = Modifier.padding(top = 16.dp).align(Alignment.CenterHorizontally),
+                contentPadding = PaddingValues(horizontal = 18.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = WikipediaTheme.colors.progressiveColor,
+                    contentColor = WikipediaTheme.colors.paperColor,
+                ),
+                onClick = { onClick?.invoke() },
+            ) {
+                Icon(
+                    modifier = Modifier.size(20.dp),
+                    painter = painterResource(R.drawable.ic_mode_edit_white_24dp),
+                    tint = WikipediaTheme.colors.paperColor,
+                    contentDescription = null
+                )
+                Text(
+                    modifier = Modifier.padding(start = 6.dp, top = 4.dp, bottom = 4.dp),
+                    text = stringResource(R.string.activity_tab_impact_suggested_edits_button),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
         }
     }
 }
@@ -510,11 +518,22 @@ private fun ContributionCardPreview() {
         ContributionCard(
             modifier = Modifier.fillMaxWidth(),
             lastEditRelativeTime = "2 days ago",
-            totalEdits = 9,
             editsThisMonth = 9,
             editsLastMonth = 2,
-            onContributionClick = null,
-            onSuggestedEditsClick = null
+            onContributionClick = null
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SuggestedEditsCardPreview() {
+    BaseTheme(
+        currentTheme = Theme.LIGHT
+    ) {
+        SuggestedEditsCard(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = {}
         )
     }
 }


### PR DESCRIPTION
### What does this do?
The Suggested edits card will show up separately if no edits in the account, and the UI needs to be changed a little bit based on the logic. 

[Figma](https://www.figma.com/design/MXUBnIJvHfMBHhPZta7yRm/Android---%3E-Activity-Tab?node-id=46-3624&m=dev)