### PR TITLE
Fix fdroid build (from Donation Reminder work).

### DIFF
--- a/app/src/fdroid/java/org/wikipedia/donate/GooglePayComponent.kt
+++ b/app/src/fdroid/java/org/wikipedia/donate/GooglePayComponent.kt
@@ -4,11 +4,13 @@ import android.app.Activity
 import android.content.Intent
 
 object GooglePayComponent {
+    const val CURRENCY_FALLBACK = "USD"
+
     suspend fun isGooglePayAvailable(activity: Activity): Boolean {
         return false
     }
 
-    fun getDonateActivityIntent(activity: Activity, campaignId: String? = null, donateUrl: String? = null): Intent {
+    fun getDonateActivityIntent(activity: Activity, campaignId: String? = null, donateUrl: String? = null, filledAmount: Float = 0f): Intent {
         return Intent()
     }
 }


### PR DESCRIPTION
The F-Droid build is currently failing because it looks like some of the Donation Reminder logic changed the interfacing of the `GooglePayComponent` object.