### PR TITLE
Use string resource for the "custom" menu option in Donation Reminder settings

### DIFF
--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderViewModel.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderViewModel.kt
@@ -106,7 +106,7 @@ class DonationReminderViewModel(savedStateHandle: SavedStateHandle) : ViewModel(
         val optionItems = options.map {
             OptionItem.Preset(it, context.resources.getQuantityString(R.plurals.donation_reminders_text_articles,
                 it, it))
-        } + OptionItem.Custom()
+        } + OptionItem.Custom(context.getString(R.string.donation_reminders_settings_option_custom))
 
         val selectedValue = if (Prefs.donationReminderConfig.articleFrequency <= 0) options.first()
         else Prefs.donationReminderConfig.articleFrequency
@@ -139,10 +139,11 @@ class DonationReminderViewModel(savedStateHandle: SavedStateHandle) : ViewModel(
             }
         }
 
+        val context = WikipediaApp.instance
         val presets = DonationReminderHelper.currencyAmountPresets[currentCountryCode] ?: listOf(minimumAmount)
         val options = presets.map {
             OptionItem.Preset(it, DonateUtil.currencyFormat.format(it).replace(formatRegex, ""))
-        } + OptionItem.Custom()
+        } + OptionItem.Custom(context.getString(R.string.donation_reminders_settings_option_custom))
 
         val selectedValue = if (Prefs.donationReminderConfig.donateAmount <= 0f) presets.first()
         else Prefs.donationReminderConfig.donateAmount
@@ -182,7 +183,7 @@ data class DonationReminderUiState(
 
 sealed class OptionItem<T : Number>(val displayText: String) {
     data class Preset<T : Number>(val value: T, val text: String) : OptionItem<T>(text)
-    class Custom<T : Number> : OptionItem<T>("Custom...")
+    class Custom<T : Number>(val text: String) : OptionItem<T>(text)
 }
 
 data class SelectableOption<T : Number>(

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1917,6 +1917,7 @@
   <string name="donation_reminders_settings_article_frequency_input_suffix_label">Suffix label for the textField input in the donation reminders settings screen.</string>
   <string name="donation_reminders_settings_warning_min_amount">Error message that indicates a minimum amount is allowed. %s will be replaced by the formatted amount.</string>
   <string name="donation_reminders_settings_warning_max_amount">Error message that indicates a maximum amount is allowed. %s will be replaced by the formatted amount.</string>
+  <string name="donation_reminders_settings_option_custom">Menu option that allows users to customize the number.</string>
   <string name="donation_reminders_snacbkbar_confirmation_label">Snackbar confirmation label which appears after user sets up donation reminders. %1$s will be replaced by the amount of donation and %2$s will be replaced by the text of the number of articles.</string>
   <string name="donation_reminders_prompt_title">Title for the donation reminder prompt. %1$s will be replaced by the text of number of articles and %2$s will be replaced by the amount of donation.</string>
   <string name="donation_reminders_prompt_message">Message for the donation reminder prompt. %1$s will be replaced by the date, %2$s will be replaced by the text of the number of articles, and %3$s will be replaced by the amount of donation.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2026,6 +2026,7 @@
     <string name="donation_reminders_settings_article_frequency_input_suffix_label">articles</string>
     <string name="donation_reminders_settings_warning_min_amount">Please enter at least %s</string>
     <string name="donation_reminders_settings_warning_max_amount">Maximum %s is allowed</string>
+    <string name="donation_reminders_settings_option_custom">Custom…</string>
     <string name="donation_reminders_snacbkbar_confirmation_label">Thank you! We\'ll remind you to donate %1$s when you read %2$s while this experiment runs.</string>
     <string name="donation_reminders_prompt_title">You\'ve read %1$s since you pledged %2$s</string>
     <string name="donation_reminders_prompt_message">On %1$s, you asked us to remind you to donate after reading %2$s. If Wikipedia has provided you with %3$s of knowledge, please join the 2%% of readers who give and complete your pledge today.</string>


### PR DESCRIPTION
### What does this do?
It seems like we missed this during code reviews 😓.

For the best practice, we should always use string resources for UI texts in the app.


