### PR TITLE
Rename wikiSite to wikiSiteForTimeline for the specific usage

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
@@ -535,7 +535,7 @@ class ActivityTabFragment : Fragment() {
                                                             requireContext(),
                                                             PageTitle(
                                                                 item.apiTitle,
-                                                                viewModel.wikiSite,
+                                                                viewModel.wikiSiteForTimeline,
                                                                 item.thumbnailUrl,
                                                                 item.description,
                                                                 item.displayTitle

--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabViewModel.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabViewModel.kt
@@ -1,7 +1,6 @@
 package org.wikipedia.activitytab
 
 import android.text.format.DateUtils
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
@@ -46,17 +45,7 @@ import java.util.Date
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
-class ActivityTabViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
-    var langCode = Prefs.userContribFilterLangCode
-
-    val wikiSite get(): WikiSite {
-        return when (langCode) {
-            Constants.WIKI_CODE_COMMONS -> WikiSite(Service.COMMONS_URL)
-            Constants.WIKI_CODE_WIKIDATA -> WikiSite(Service.WIKIDATA_URL)
-            else -> WikiSite.forLanguageCode(langCode)
-        }
-    }
-
+class ActivityTabViewModel() : ViewModel() {
     private val _readingHistoryState = MutableStateFlow<UiState<ReadingHistory>>(UiState.Loading)
     val readingHistoryState: StateFlow<UiState<ReadingHistory>> = _readingHistoryState.asStateFlow()
 
@@ -68,6 +57,14 @@ class ActivityTabViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
 
     private var currentTimelinePagingSource: TimelinePagingSource? = null
 
+    val wikiSiteForTimeline get(): WikiSite {
+        val langCode = Prefs.userContribFilterLangCode
+        return when (langCode) {
+            Constants.WIKI_CODE_COMMONS -> WikiSite(Service.COMMONS_URL)
+            Constants.WIKI_CODE_WIKIDATA -> WikiSite(Service.WIKIDATA_URL)
+            else -> WikiSite.forLanguageCode(langCode)
+        }
+    }
     val timelineFlow = Pager(
         config = PagingConfig(
             pageSize = 150,
@@ -233,7 +230,7 @@ class ActivityTabViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
 
     private fun createTimelineSources(): List<TimelineSource> {
         val historyEntryPagingSource = HistoryEntryPagingSource(AppDatabase.instance.historyEntryWithImageDao())
-        val userContribPagingSource = UserContribPagingSource(wikiSite, AccountUtil.userName, AppDatabase.instance.historyEntryWithImageDao())
+        val userContribPagingSource = UserContribPagingSource(wikiSiteForTimeline, AccountUtil.userName, AppDatabase.instance.historyEntryWithImageDao())
         val readingListPagingSource = ReadingListPagingSource(AppDatabase.instance.readingListPageDao())
         return listOf(historyEntryPagingSource, readingListPagingSource, userContribPagingSource)
     }

--- a/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
@@ -55,7 +55,7 @@ class UserContribPagingSource(
     private val historyEntryWithImageDao: HistoryEntryWithImageDao
 ) : TimelineSource {
 
-    private val MAX_BATCH_SIZE = 50
+    private val maxBatchSize = 50
 
     override val id: String = "user_contrib"
 
@@ -90,7 +90,7 @@ class UserContribPagingSource(
         }
 
         // Fetching missing page info in batches
-        missingPageInfoIds.chunked(MAX_BATCH_SIZE).forEach { batch ->
+        missingPageInfoIds.chunked(maxBatchSize).forEach { batch ->
             val pages = service.getInfoByPageIdsOrTitles(pageIds = batch.joinToString(separator = "|")).query?.pages.orEmpty()
             pages.forEach { page ->
                 timelineItemsByPageId[page.pageId.toLong()]?.let { existingItem ->


### PR DESCRIPTION
### What does this do?
We have regular `langCode` and `wikiSite` variables in the activity tab `viewModel`, but they are actually used by the timeline module. 

Since the `wikiSite` is based on the `Prefs.userContribFilterLangCode` preference, it is good to have a proper name that indicates only for the timeline module.

This PR also does a rename for  `MAX_BATCH_SIZE` since the IDE gives a warning about the syntax.