### PR TITLE
Change the userimpact request limitation from 1 day to 12 hours for Activity Tab

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabViewModel.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabViewModel.kt
@@ -192,7 +192,7 @@ class ActivityTabViewModel() : ViewModel() {
             val impact: GrowthUserImpact
             val impactLastResponseBodyMap = Prefs.impactLastResponseBody.toMutableMap()
             val impactResponse = impactLastResponseBodyMap[wikiSite.languageCode]
-            if (impactResponse.isNullOrEmpty() || abs(now - Prefs.impactLastQueryTime) > TimeUnit.DAYS.toSeconds(1)) {
+            if (impactResponse.isNullOrEmpty() || abs(now - Prefs.impactLastQueryTime) > TimeUnit.HOURS.toSeconds(12)) {
                 val userId = ServiceFactory.get(wikiSite).getUserInfo().query?.userInfo?.id!!
                 impact = ServiceFactory.getCoreRest(wikiSite).getUserImpact(userId)
                 impactLastResponseBodyMap[wikiSite.languageCode] = JsonUtil.encodeToString(impact).orEmpty()


### PR DESCRIPTION
### What does this do?
The existing setup is to refresh the local cache if the cache is older than 1 day, which might confuse users if they make edits on that day. This PR shortens the 1 day to 12 hours.