### PR TITLE
When injecting red overlay dot, use grandparent view instead of parent.

### DIFF
--- a/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
@@ -8,7 +8,6 @@ import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateMarginsRelative
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -27,8 +26,8 @@ class NavTabLayout(context: Context, attrs: AttributeSet) : BottomNavigationView
     fun setOverlayDot(tab: NavTab, enabled: Boolean) {
         val itemView = findViewById<ViewGroup>(tab.id)
         val imageView = itemView.findViewById<View>(com.google.android.material.R.id.navigation_bar_item_icon_view)
-        val imageParent = imageView.parent as LinearLayout
-        var overlayDotView: ImageView? = itemView.findViewById<ImageView?>(R.id.nav_tab_overlay_dot)
+        val imageParent = imageView.parent as ViewGroup
+        var overlayDotView: ImageView? = itemView.findViewById(R.id.nav_tab_overlay_dot)
         if (overlayDotView == null) {
             overlayDotView = ImageView(context)
             overlayDotView.id = R.id.nav_tab_overlay_dot

--- a/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
@@ -25,10 +25,10 @@ class NavTabLayout(context: Context, attrs: AttributeSet) : BottomNavigationView
 
     fun setOverlayDot(tab: NavTab, enabled: Boolean) {
         val itemView = findViewById<ViewGroup>(tab.id)
-        val imageView = itemView.findViewById<View>(com.google.android.material.R.id.navigation_bar_item_icon_view)
-        val imageParent = imageView.parent as ViewGroup
+        val imageView = itemView.findViewById<View?>(com.google.android.material.R.id.navigation_bar_item_icon_view)
+        val imageParent = (imageView?.parent as? ViewGroup)?.parent as? ViewGroup
         var overlayDotView: ImageView? = itemView.findViewById(R.id.nav_tab_overlay_dot)
-        if (overlayDotView == null) {
+        if (overlayDotView == null && imageParent != null) {
             overlayDotView = ImageView(context)
             overlayDotView.id = R.id.nav_tab_overlay_dot
             val dotSize = DimenUtil.roundedDpToPx(6f)
@@ -41,6 +41,6 @@ class NavTabLayout(context: Context, attrs: AttributeSet) : BottomNavigationView
             overlayDotView.backgroundTintList = ColorStateList.valueOf(ResourceUtil.getThemedColor(context, R.attr.destructive_color))
             imageParent.addView(overlayDotView)
         }
-        overlayDotView.isVisible = enabled
+        overlayDotView?.isVisible = enabled
     }
 }

--- a/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
+++ b/app/src/main/java/org/wikipedia/navtab/NavTabLayout.kt
@@ -7,8 +7,8 @@ import android.view.Gravity
 import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import android.widget.ImageView
+import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateMarginsRelative
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -27,7 +27,7 @@ class NavTabLayout(context: Context, attrs: AttributeSet) : BottomNavigationView
     fun setOverlayDot(tab: NavTab, enabled: Boolean) {
         val itemView = findViewById<ViewGroup>(tab.id)
         val imageView = itemView.findViewById<View>(com.google.android.material.R.id.navigation_bar_item_icon_view)
-        val imageParent = imageView.parent as FrameLayout
+        val imageParent = imageView.parent as LinearLayout
         var overlayDotView: ImageView? = itemView.findViewById<ImageView?>(R.id.nav_tab_overlay_dot)
         if (overlayDotView == null) {
             overlayDotView = ImageView(context)


### PR DESCRIPTION
### What does this do?
It looks like the recent material library change affects the parent layout of `NavTabLayout` from `FrameLayout` to `LinearLayout`. This PR updates it to prevent a crash when starting up the app.
