### PR TITLE
Activity Tab crash fix

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
@@ -134,7 +134,7 @@ class ReadingListPagingSource(
             )
         }
         val nextCursor =
-            if (items.size < pageSize) null else Cursor.HistoryEntryCursor(offset + items.size)
+            if (items.size < pageSize) null else Cursor.ReadingListCursor(offset + items.size)
         return items to nextCursor
     }
 }


### PR DESCRIPTION
### What does this do?
- fixes crash when user scrolls the activity tab all the way to the bottom. 
- reason for crash was due to duplicate pagination keys, was returning wrong Cursor class from ReadingListPagingSource