### PR TITLE
Switch to new Remote Configuration endpoint.

### DIFF
--- a/app/src/main/java/org/wikipedia/alphaupdater/AlphaUpdateChecker.kt
+++ b/app/src/main/java/org/wikipedia/alphaupdater/AlphaUpdateChecker.kt
@@ -4,11 +4,11 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
@@ -34,7 +34,7 @@ class AlphaUpdateChecker(private val context: Context) : RecurringTask() {
             try {
                 val request: Request = Request.Builder().url(ALPHA_BUILD_DATA_URL).build()
                 OkHttpConnectionFactory.client.newCall(request).execute().use {
-                    hashString = it.body?.string()
+                    hashString = it.body.string()
                 }
             } catch (e: IOException) {
                 // It's ok, we can do nothing.
@@ -52,7 +52,7 @@ class AlphaUpdateChecker(private val context: Context) : RecurringTask() {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
             return
         }
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(ALPHA_BUILD_APK_URL))
+        val intent = Intent(Intent.ACTION_VIEW, ALPHA_BUILD_APK_URL.toUri())
         val pendingIntent = PendingIntentCompat.getActivity(context, 0, intent, 0, false)
 
         val notificationManagerCompat = NotificationManagerCompat.from(context)

--- a/app/src/main/java/org/wikipedia/dataclient/RestService.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/RestService.kt
@@ -18,6 +18,7 @@ import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteIdResponseBatch
 import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingList
 import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingListEntry
 import org.wikipedia.readinglist.sync.SyncedReadingLists.RemoteReadingListEntryBatch
+import org.wikipedia.settings.RemoteConfig
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
@@ -191,6 +192,9 @@ interface RestService {
         @Path("title") title: String,
         @Body body: PreviewRequest
     ): ResponseBody
+
+    @GET("feed/configuration")
+    suspend fun getConfiguration(): RemoteConfig.RemoteConfigImpl
 
     companion object {
         const val REST_API_PREFIX = "/api/rest_v1"

--- a/app/src/main/java/org/wikipedia/recurring/RecurringTasksExecutor.kt
+++ b/app/src/main/java/org/wikipedia/recurring/RecurringTasksExecutor.kt
@@ -12,17 +12,23 @@ import org.wikipedia.util.log.L
 class RecurringTasksExecutor() {
     fun run() {
         val app = WikipediaApp.instance
-        MainScope().launch(CoroutineExceptionHandler { _, throwable ->
-            L.e(throwable)
-        }) {
-            RemoteConfigRefreshTask().runIfNecessary()
-            DailyEventTask(app).runIfNecessary()
-            TalkOfflineCleanupTask(app).runIfNecessary()
+
+        mutableListOf(
+            RemoteConfigRefreshTask(),
+            DailyEventTask(app),
+            TalkOfflineCleanupTask(app),
+            CategoriesTableCleanupTask(),
+            RecommendedReadingListTask()
+        ).also {
             if (ReleaseUtil.isAlphaRelease) {
-                AlphaUpdateChecker(app).runIfNecessary()
+                it.add(AlphaUpdateChecker(app))
             }
-            CategoriesTableCleanupTask().runIfNecessary()
-            RecommendedReadingListTask().runIfNecessary()
+        }.forEach { task ->
+            MainScope().launch(CoroutineExceptionHandler { _, throwable ->
+                L.e(throwable)
+            }) {
+                task.runIfNecessary()
+            }
         }
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/RemoteConfig.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfig.kt
@@ -7,7 +7,6 @@ import org.wikipedia.util.log.L
 object RemoteConfig {
     private var curConfig: RemoteConfigImpl? = null
 
-    // If there's no pref set, just give back the empty JSON Object
     val config: RemoteConfigImpl
         get() {
             if (curConfig == null) {
@@ -21,15 +20,28 @@ object RemoteConfig {
             return curConfig!!
         }
 
-    fun updateConfig(configStr: String) {
-        Prefs.remoteConfigJson = configStr
+    fun updateConfig(config: RemoteConfigImpl) {
+        Prefs.remoteConfigJson = JsonUtil.encodeToString(config).orEmpty()
         curConfig = null
     }
 
     @Suppress("unused")
     @Serializable
     class RemoteConfigImpl {
+        val commonv1: RemoteConfigCommonV1? = null
+        val androidv1: RemoteConfigAndroidV1? = null
+
+        val disableReadingListSync
+            get() = androidv1?.disableReadingListSync == true
+    }
+
+    @Suppress("unused")
+    @Serializable
+    class RemoteConfigCommonV1
+
+    @Suppress("unused")
+    @Serializable
+    class RemoteConfigAndroidV1 {
         val disableReadingListSync = false
-        val disableAnonEditing = false
     }
 }

--- a/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
+++ b/app/src/main/java/org/wikipedia/settings/RemoteConfigRefreshTask.kt
@@ -1,50 +1,26 @@
 package org.wikipedia.settings
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import okhttp3.Request
-import okhttp3.Response
-import okhttp3.internal.closeQuietly
 import org.wikipedia.WikipediaApp
 import org.wikipedia.dataclient.ServiceFactory
-import org.wikipedia.dataclient.okhttp.OkHttpConnectionFactory.client
 import org.wikipedia.recurring.RecurringTask
-import org.wikipedia.util.log.L
 import java.util.Date
 import java.util.concurrent.TimeUnit
 
-class RemoteConfigRefreshTask : RecurringTask() {
+class RemoteConfigRefreshTask() : RecurringTask() {
     override val name = "remote-config-refresher"
 
     override fun shouldRun(lastRun: Date): Boolean {
-        return millisSinceLastRun(lastRun) >= TimeUnit.DAYS.toMillis(RUN_INTERVAL_DAYS)
+        return millisSinceLastRun(lastRun) >= TimeUnit.DAYS.toMillis(1)
     }
 
     override suspend fun run(lastRun: Date) {
-        withContext(Dispatchers.IO) {
-            var response: Response? = null
-            try {
-                val request = Request.Builder().url(REMOTE_CONFIG_URL).build()
-                response = client.newCall(request).execute()
-                val configStr = response.body!!.string()
-                RemoteConfig.updateConfig(configStr)
-                L.d(configStr)
-            } catch (e: Exception) {
-                L.e(e)
-            } finally {
-                response?.closeQuietly()
-            }
+        val config = ServiceFactory.getRest(WikipediaApp.instance.wikiSite).getConfiguration()
+        RemoteConfig.updateConfig(config)
 
-            val userInfo = ServiceFactory.get(WikipediaApp.instance.wikiSite).getUserInfo()
-            // This clumsy comparison is necessary because the field is an integer value when enabled, but an empty string when disabled.
-            // Since we want the default to lean towards opt-in, we check very specifically for an empty string, to make sure the user has opted out.
-            val fundraisingOptOut = userInfo.query?.userInfo?.options?.fundraisingOptIn?.toString()?.replace("\"", "")?.isEmpty()
-            Prefs.donationBannerOptIn = fundraisingOptOut != true
-        }
-    }
-
-    companion object {
-        private const val REMOTE_CONFIG_URL = "https://meta.wikimedia.org/w/extensions/MobileApp/config/android.json"
-        private const val RUN_INTERVAL_DAYS = 1L
+        val userInfo = ServiceFactory.get(WikipediaApp.instance.wikiSite).getUserInfo()
+        // This clumsy comparison is necessary because the field is an integer value when enabled, but an empty string when disabled.
+        // Since we want the default to lean towards opt-in, we check very specifically for an empty string, to make sure the user has opted out.
+        val fundraisingOptOut = userInfo.query?.userInfo?.options?.fundraisingOptIn?.toString()?.replace("\"", "")?.isEmpty()
+        Prefs.donationBannerOptIn = fundraisingOptOut != true
     }
 }


### PR DESCRIPTION
This switches to using our newly-deployed REST remote-configuration [endpoint](https://en.wikipedia.org/api/rest_v1/feed/configuration).

Even though we're technically not "using" any configuration parameters yes, this will be good to adopt for the future, and also to help deprecate the [old configuration](https://meta.wikimedia.org/w/extensions/MobileApp/config/android.json) hosted in the MobileApp extension.

There is one configuration field called `disableReadingListSync` that is currently usable, but it isn't available in the current MobileApp configuration, so this is safe to transition to the new structure as it is.