### PR TITLE
In the Featured Article widget, load correctly-sized bitmap.

### DIFF
--- a/app/src/main/java/org/wikipedia/widgets/WidgetProviderFeaturedPage.kt
+++ b/app/src/main/java/org/wikipedia/widgets/WidgetProviderFeaturedPage.kt
@@ -18,9 +18,11 @@ import androidx.work.WorkRequest
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
+import org.wikipedia.dataclient.Service
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
+import org.wikipedia.util.ImageUrlUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 import org.wikipedia.views.imageservice.ImageService
@@ -65,8 +67,10 @@ class WidgetProviderFeaturedPage : AppWidgetProvider() {
             if (pageTitle.thumbUrl.isNullOrEmpty()) {
                 remoteViews.setViewVisibility(R.id.widget_content_thumbnail, View.GONE)
             } else {
-                ImageService.loadImage(context, pageTitle.thumbUrl, onSuccess = { bitmap ->
+                ImageService.loadImage(context, ImageUrlUtil.getUrlForPreferredSize(pageTitle.thumbUrl!!,
+                    Service.PREFERRED_THUMB_SIZE), onSuccess = { bitmap ->
                     remoteViews.setImageViewBitmap(R.id.widget_content_thumbnail, bitmap)
+                    appWidgetManager.updateAppWidget(widgetId, remoteViews)
                 })
                 remoteViews.setViewVisibility(R.id.widget_content_thumbnail, View.VISIBLE)
             }


### PR DESCRIPTION
When we load the contents for the Featured Article widget, the `thumbnailUrl` can actually point to a full-size image, which we don't actually want. We should instead request the correctly-sized thumbnail, based on `PREFERRED_THUMB_SIZE`.

If we load a full-size image, not only is this wasteful, but it can also cause silent crashes due to exceeding bitmap memory constraints in Widgets.