### PR TITLE
Hygiene: don't use post() to initialize Settings.

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/PreferenceLoaderFragment.kt
+++ b/app/src/main/java/org/wikipedia/settings/PreferenceLoaderFragment.kt
@@ -10,12 +10,7 @@ import org.wikipedia.util.ResourceUtil.getThemedColor
 
 abstract class PreferenceLoaderFragment : PreferenceFragmentCompat(), PreferenceLoader {
     override fun onCreatePreferences(bundle: Bundle?, s: String?) {
-        requireActivity().window.decorView.post {
-            if (!isAdded) {
-                return@post
-            }
-            loadPreferences()
-        }
+        loadPreferences()
     }
 
     override fun onCreateRecyclerView(inflater: LayoutInflater, parent: ViewGroup, savedInstanceState: Bundle?): RecyclerView {

--- a/app/src/main/java/org/wikipedia/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/wikipedia/settings/SettingsFragment.kt
@@ -28,7 +28,7 @@ class SettingsFragment : PreferenceLoaderFragment(), MenuProvider {
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.CREATED) {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 FlowEventBus.events.collectLatest { event ->
                     when (event) {
                         is ReadingListsEnabledStatusEvent -> {
@@ -56,16 +56,11 @@ class SettingsFragment : PreferenceLoaderFragment(), MenuProvider {
 
     override fun onResume() {
         super.onResume()
-        requireActivity().window.decorView.post {
-            if (!isAdded) {
-                return@post
-            }
-            preferenceLoader.updateSyncReadingListsPrefSummary()
-            preferenceLoader.updateLanguagePrefSummary()
-            preferenceLoader.updateRecommendedReadingListSummary()
-            preferenceLoader.updateDonationRemindersDescription()
-            DonationReminderHelper.maybeShowSettingSnackbar(requireActivity())
-        }
+        preferenceLoader.updateSyncReadingListsPrefSummary()
+        preferenceLoader.updateLanguagePrefSummary()
+        preferenceLoader.updateRecommendedReadingListSummary()
+        preferenceLoader.updateDonationRemindersDescription()
+        DonationReminderHelper.maybeShowSettingSnackbar(requireActivity())
         requireActivity().invalidateOptionsMenu()
     }
 


### PR DESCRIPTION
For some reason (which we unfortunately didn't document), we are calling `loadPreferences()` from inside a `post()` call, which is a code smell.
The preferences seem to work just fine without it, so let's remove it and see if there are any side effects. (This might even explain a very obscure occasional crash being observed in production.)

Also the lifecycle state for getting EventBus events should be RESUMED, not CREATED.