### PR TITLE
Fix for Timeline items not updating the history entry table on click

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
@@ -167,7 +167,6 @@ data class TimelineItem(
             displayTitle = displayTitle,
             id = id,
             namespace = namespace,
-            timestamp = timestamp,
             source = source
         )
         entry.title.thumbUrl = thumbnailUrl


### PR DESCRIPTION
### What does this do?
- fixes timeline items not updating history entry table 
- Root cause: the timestamp was being set to the previous timestamp

**Phabricator:**
https://phabricator.wikimedia.org/T405014