### PR TITLE
Fix: function name typo in ReadingListPageDao

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
@@ -119,7 +119,7 @@ class ReadingListPagingSource(
 
     override suspend fun fetch(pageSize: Int, cursor: Cursor?): Pair<List<TimelineItem>, Cursor?> {
         val offset = (cursor as? Cursor.ReadingListCursor)?.offset ?: 0
-        val items = dao.getPagesByLocalySavedTime(pageSize, offset).map {
+        val items = dao.getPagesByLocallySavedTime(pageSize, offset).map {
             TimelineItem(
                 id = it.mtime + it.atime + it.id,
                 pageId = 0,

--- a/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
@@ -96,7 +96,7 @@ interface ReadingListPageDao {
     suspend fun getMostRecentLocallySavedPage(): ReadingListPage?
 
     @Query("SELECT * FROM ReadingListPage WHERE atime > 0 ORDER BY atime DESC LIMIT :limit OFFSET :offset")
-    suspend fun getPagesByLocalySavedTime(limit: Int, offset: Int): List<ReadingListPage>
+    suspend fun getPagesByLocallySavedTime(limit: Int, offset: Int): List<ReadingListPage>
 
     suspend fun getAllPagesToBeSaved() = getPagesByStatus(ReadingListPage.STATUS_QUEUE_FOR_SAVE, true)
 


### PR DESCRIPTION
### What does this do?
Change from `getPagesByLocalySavedTime` to `getPagesByLocallySavedTime`
