### PR TITLE
Hygiene: no longer use built-in Compose Material Icons.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -275,7 +275,6 @@ dependencies {
     def composeBom = platform(libs.composeBom)
     implementation(composeBom)
     implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     debugImplementation(libs.compose.ui.tooling)

--- a/app/src/main/java/org/wikipedia/compose/components/SearchEmptyView.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/SearchEmptyView.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -17,8 +15,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.wikipedia.R
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.theme.Theme
@@ -39,7 +39,7 @@ fun SearchEmptyView(
                 .clip(CircleShape)
                 .background(WikipediaTheme.colors.backgroundColor)
                 .padding(20.dp),
-            imageVector = Icons.Outlined.Search,
+            painter = painterResource(R.drawable.outline_search_24),
             tint = WikipediaTheme.colors.placeholderColor,
             contentDescription = null
         )

--- a/app/src/main/java/org/wikipedia/compose/components/SearchTopAppBar.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/SearchTopAppBar.kt
@@ -3,8 +3,6 @@ package org.wikipedia.compose.components
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -22,6 +20,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -75,7 +74,7 @@ fun SearchTopAppBar(
                 onBackButtonClick()
             }) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    painter = painterResource(R.drawable.ic_arrow_back_black_24dp),
                     contentDescription = stringResource(R.string.search_back_button_content_description),
                     tint = WikipediaTheme.colors.primaryColor
                 )

--- a/app/src/main/java/org/wikipedia/compose/components/WikiTopAppBar.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiTopAppBar.kt
@@ -1,8 +1,6 @@
 package org.wikipedia.compose.components
 
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -14,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -53,7 +52,7 @@ fun WikiTopAppBar(
                 onNavigationClick()
             }) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    painter = painterResource(R.drawable.outline_search_24),
                     tint = WikipediaTheme.colors.primaryColor,
                     contentDescription = stringResource(R.string.search_back_button_content_description)
                 )

--- a/app/src/main/java/org/wikipedia/compose/components/WikiTopAppBarWithSearch.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/WikiTopAppBarWithSearch.kt
@@ -7,9 +7,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Clear
-import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -17,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import org.wikipedia.R
 import org.wikipedia.compose.theme.WikipediaTheme
@@ -85,7 +83,7 @@ fun WikiTopAppBarWithSearch(
                                     },
                                     content = {
                                         Icon(
-                                            imageVector = Icons.Outlined.Clear,
+                                            painter = painterResource(R.drawable.ic_close_black_24dp),
                                             contentDescription = stringResource(R.string.search_clear_query_content_description),
                                             tint = WikipediaTheme.colors.placeholderColor
                                         )
@@ -106,7 +104,7 @@ fun WikiTopAppBarWithSearch(
                                 },
                                 content = {
                                     Icon(
-                                        imageVector = Icons.Outlined.Search,
+                                        painter = painterResource(R.drawable.outline_search_24),
                                         contentDescription = stringResource(R.string.search_icon_content_description),
                                         tint = WikipediaTheme.colors.primaryColor
                                     )

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -19,10 +19,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -472,7 +468,7 @@ fun DonationHeader(
                     modifier = Modifier
                         .size(20.dp)
                         .padding(start = 4.dp),
-                    imageVector = Icons.Filled.Favorite,
+                    painter = painterResource(R.drawable.ic_heart_24),
                     contentDescription = null,
                     tint = WikipediaTheme.colors.destructiveColor
                 )
@@ -544,7 +540,7 @@ fun <T : Number>OptionSelector(
                     ),
                     trailingIcon = {
                         Icon(
-                            imageVector = Icons.Filled.ArrowDropDown,
+                            painter = painterResource(R.drawable.ic_arrow_drop_down_black_24dp),
                             tint = WikipediaTheme.colors.primaryColor,
                             contentDescription = null
                         )
@@ -749,7 +745,7 @@ fun CustomInputDialog(
                     trailingIcon = if (errorMessage.isNotEmpty()) {
                         {
                             Icon(
-                                imageVector = Icons.Default.Info,
+                                painter = painterResource(R.drawable.baseline_info_24),
                                 contentDescription = null,
                                 tint = WikipediaTheme.colors.destructiveColor
                             )

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListInterestsFragment.kt
@@ -32,11 +32,6 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -258,7 +253,7 @@ fun RecommendedReadingListInterestsScreen(
                 navigationIcon = {
                     val enabled = !fromSettings || (uiState !is Resource.Success) || uiState.data.selectedItems.isNotEmpty()
                     Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        painter = painterResource(R.drawable.ic_arrow_back_black_24dp),
                         contentDescription = stringResource(R.string.search_back_button_content_description),
                         modifier = Modifier
                             .size(48.dp)
@@ -435,7 +430,7 @@ fun RecommendedReadingListInterestsContent(
                         .clickable(enabled = selectedItems.isNotEmpty(), onClick = onNextClick)
                         .padding(12.dp)
                         .alpha(if (selectedItems.isNotEmpty()) 1f else 0.5f),
-                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                    painter = painterResource(R.drawable.ic_arrow_forward_black_24dp),
                     tint = WikipediaTheme.colors.primaryColor,
                     contentDescription = stringResource(R.string.nav_item_forward)
                 )
@@ -510,7 +505,7 @@ fun ReadingListInterestCard(
                         Spacer(modifier = Modifier.width(8.dp))
                         Icon(
                             modifier = Modifier.size(24.dp).align(Alignment.Bottom),
-                            imageVector = Icons.Default.CheckCircle,
+                            painter = painterResource(R.drawable.check_circle_24px),
                             tint = WikipediaTheme.colors.primaryColor,
                             contentDescription = null
                         )
@@ -539,7 +534,7 @@ fun ReadingListInterestSearchCard(onSearchClick: () -> Unit) {
     ) {
         Spacer(modifier = Modifier.width(16.dp))
         Icon(
-            imageVector = Icons.Default.Search,
+            painter = painterResource(R.drawable.outline_search_24),
             contentDescription = stringResource(R.string.search_hint),
             tint = WikipediaTheme.colors.secondaryColor,
             modifier = Modifier.size(24.dp)

--- a/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSourceScreen.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/recommended/RecommendedReadingListSourceScreen.kt
@@ -16,10 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -86,7 +82,7 @@ fun SourceSelectionScreen(
                 },
                 navigationIcon = {
                     Icon(
-                        imageVector = if (fromSettings) Icons.AutoMirrored.Filled.ArrowBack else Icons.Default.Close,
+                        painter = painterResource(if (fromSettings) R.drawable.ic_arrow_back_black_24dp else R.drawable.ic_close_black_24dp),
                         contentDescription = stringResource(id = if (fromSettings) R.string.search_back_button_content_description else R.string.table_close),
                         modifier = Modifier
                             .size(48.dp)
@@ -247,7 +243,7 @@ fun SourceSelectionContent(
                         .background(WikipediaTheme.colors.borderColor)
                 )
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                    painter = painterResource(R.drawable.ic_arrow_forward_black_24dp),
                     contentDescription = stringResource(R.string.nav_item_forward),
                     tint = WikipediaTheme.colors.primaryColor,
                     modifier = Modifier

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,6 @@ viewpager2 = "1.1.0"
 workRuntimeKtx = "2.10.5"
 composeBom = "2025.09.01"
 composeActivity = "1.11.0"
-composeMaterialIcons = "1.7.8"
 composeViewModel = "2.9.4"
 
 
@@ -120,7 +119,6 @@ viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpag
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 composeBom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
-compose-material-icons = { module = "androidx.compose.material:material-icons-core", version.ref = "composeMaterialIcons" }
 compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }


### PR DESCRIPTION
For some reason, Material Icons are now deprecated and superseded by "Material Symbols". The thing is, Material Symbols are not available as a pre-packaged library for Compose.

In fact, Google [no longer recommends](https://developer.android.com/develop/ui/compose/graphics/images/material#:~:text=this%20artifact%20is%20no%20longer%20maintained%20or%20recommended%20for%20use%20in%20your%20apps) using the Material Icons library (!), and instead recommends using XML vector drawables as before. So let's just move away from using it sooner than later.