### PR TITLE
Enable HybridSearch for design research testing

### DIFF
--- a/app/src/main/java/org/wikipedia/search/HybridSearchAbCTest.kt
+++ b/app/src/main/java/org/wikipedia/search/HybridSearchAbCTest.kt
@@ -2,7 +2,6 @@ package org.wikipedia.search
 
 import org.wikipedia.analytics.ABTest
 import org.wikipedia.settings.Prefs
-import org.wikipedia.settings.RemoteConfig
 
 class HybridSearchAbCTest : ABTest("apps_hybridsearch", GROUP_SIZE_3) {
 
@@ -15,7 +14,7 @@ class HybridSearchAbCTest : ABTest("apps_hybridsearch", GROUP_SIZE_3) {
     }
 
     fun isTestActive(): Boolean {
-        return RemoteConfig.config.androidv1?.hybridSearchEnabled ?: true
+        return true
     }
 
     fun isTestGroupUser(): Boolean {
@@ -31,7 +30,7 @@ class HybridSearchAbCTest : ABTest("apps_hybridsearch", GROUP_SIZE_3) {
     }
 
     private val supportedLanguages = listOf(
-        "en", "pt", "fr", "el"
+        "en"
     )
 
     fun isHybridSearchEnabled(languageCode: String?): Boolean {

--- a/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsFragment.kt
@@ -249,7 +249,7 @@ class SearchResultsFragment : Fragment() {
         viewModel.updateSearchTerm(if (term.isNullOrBlank()) "" else term)
 
         // If user changes the language, make sure to turn off hybrid search screen.
-        showHybridSearch = !resetHybridSearch && showHybridSearch && viewModel.isHybridSearchExperimentOn
+        showHybridSearch = viewModel.isHybridSearchExperimentOn
         if (showHybridSearch) {
             viewModel.resetHybridSearchState()
             viewModel.loadHybridSearchResults()

--- a/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/search/SearchResultsViewModel.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -54,6 +56,7 @@ class SearchResultsViewModel : ViewModel() {
     val hybridSearchResultState = _hybridSearchResultState.asStateFlow()
 
     private var _refreshSearchResults = MutableStateFlow(0)
+    private var hybridSearchJob: Job? = null
 
     val getTestGroup get() = HybridSearchAbCTest().getGroupName()
 
@@ -94,10 +97,12 @@ class SearchResultsViewModel : ViewModel() {
 
     @OptIn(FlowPreview::class)
     fun loadHybridSearchResults() {
-       viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
+        hybridSearchJob?.cancel()
+        hybridSearchJob = viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
            _hybridSearchResultState.value = UiState.Error(throwable)
-       }) {
+        }) {
             _hybridSearchResultState.value = UiState.Loading
+            delay(delayMillis)
             val lexicalBatchSize = 3
             val semanticBatchSize = 3
 


### PR DESCRIPTION
### What does this do?
Enable the Hybrid Search for `English` and skip the predictive text screen.
