### PR TITLE
Introduce WikiSite convenience for composable Previews.

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/EditingInsightsModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/EditingInsightsModule.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import org.wikipedia.R
 import org.wikipedia.compose.components.HtmlText
@@ -438,7 +437,7 @@ private fun MostViewedCardPreview() {
         val pageTitle = PageTitle(
             text = "Test Article",
             displayText = "Test Article",
-            wiki = WikiSite("en.wikipedia.org".toUri(), "en"),
+            wiki = WikiSite.preview(),
             description = "This is a test article",
             thumbUrl = "https://example.com/thumb.jpg"
         )

--- a/app/src/main/java/org/wikipedia/activitytab/ReadingHistoryModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ReadingHistoryModule.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import org.wikipedia.R
 import org.wikipedia.categories.db.Category
@@ -500,7 +499,7 @@ private fun ArticleReadThisMonthCardPreview() {
 @Preview
 @Composable
 private fun ArticleSavedThisMonthCardPreview() {
-    val wikiSite = WikiSite("en.wikipedia.org".toUri(), "en")
+    val wikiSite = WikiSite.preview()
     BaseTheme(currentTheme = Theme.LIGHT) {
         ArticleSavedThisMonthCard(
             modifier = Modifier

--- a/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineModule.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineModule.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import org.wikipedia.R
 import org.wikipedia.compose.components.HtmlText
@@ -261,7 +260,7 @@ private fun TimelineItemPreview() {
                 timestamp = Date(),
                 source = 1,
                 activitySource = ActivitySource.EDIT,
-                wiki = WikiSite("en.wikipedia.org".toUri(), "en")
+                wiki = WikiSite.preview()
             ),
             onItemClick = {}
         )

--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
@@ -162,6 +162,14 @@ data class WikiSite(
             }
         }
 
+        /**
+         * For use only in Composable Previews, since this bypasses much of the internal constructor
+         * logic that depends on a WikipediaApp instance.
+         */
+        fun preview(languageCode: String = "en"): WikiSite {
+            return WikiSite("https://$languageCode.wikipedia.org/".toUri(), languageCode)
+        }
+
         private fun languageCodeToSubdomain(languageCode: String): String {
             return WikipediaApp.instance.languageState.getDefaultLanguageCode(languageCode) ?: normalizeLanguageCode(languageCode)
         }

--- a/app/src/main/java/org/wikipedia/search/HybridSearchResultsScreen.kt
+++ b/app/src/main/java/org/wikipedia/search/HybridSearchResultsScreen.kt
@@ -622,7 +622,7 @@ private fun SemanticSearchResultHeaderPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun SemanticSearchResultPageItemPreview() {
-    val wikiSite = WikiSite("en.wikipedia.org".toUri(), "en")
+    val wikiSite = WikiSite.preview()
     val pageTitle = PageTitle("Beyoncé", wikiSite).apply {
         description = "American singer, songwriter, and actress"
         thumbUrl = "https://example"


### PR DESCRIPTION
This adds a convenient static `preview()` function to the WikiSite class, for quick use in Composable previews, which doesn't depend on the presence of `WikipediaApp.instance`.