### PR TITLE
[Reading Challenge Widget] Adds start date in dev settings for reading challenge widget

### DIFF
--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -911,6 +911,11 @@ object Prefs {
             ReadingChallengeWidgetRepository.READING_CHALLENGE_END_DATE).orEmpty()
         set(value) = PrefsIoUtil.setString(R.string.preference_key_reading_challenge_end_date, value)
 
+    var readingChallengeStartDate
+        get() = PrefsIoUtil.getString(R.string.preference_key_reading_challenge_start_date,
+            ReadingChallengeWidgetRepository.READING_CHALLENGE_END_DATE).orEmpty()
+        set(value) = PrefsIoUtil.setString(R.string.preference_key_reading_challenge_start_date, value)
+
     var readingChallengeWidgetFastCycle
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_reading_challenge_widget_fast_cycle, false)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_reading_challenge_widget_fast_cycle, value)

--- a/app/src/main/java/org/wikipedia/settings/dev/playground/ReadingChallengePlaygroundDialog.kt
+++ b/app/src/main/java/org/wikipedia/settings/dev/playground/ReadingChallengePlaygroundDialog.kt
@@ -65,6 +65,7 @@ class ReadingChallengePlayGroundDialog : ExtendedBottomSheetDialogFragment(start
 
         return ComposeView(requireContext()).apply {
             setContent {
+                val stateFlow = remember { repository.observeState() }
                 val coroutineScope = rememberCoroutineScope()
                 BaseTheme {
                     Column(modifier = Modifier.fillMaxSize()) {
@@ -96,7 +97,7 @@ class ReadingChallengePlayGroundDialog : ExtendedBottomSheetDialogFragment(start
                         }
                         ReadingChallengePlayground(
                             modifier = Modifier.padding(16.dp),
-                            state = repository.observeState().collectAsState(initial = ReadingChallengeState.NotLiveYet).value,
+                            state = stateFlow.collectAsState(initial = ReadingChallengeState.NotLiveYet).value,
                             updateWidgetsExplicitly = {
                                 coroutineScope.launch {
                                     ReadingChallengeWidget().updateAll(requireContext())
@@ -132,6 +133,7 @@ fun ReadingChallengePlayground(
     var streak by remember { mutableIntStateOf(Prefs.readingChallengeStreak) }
     var enrolled by remember { mutableStateOf(Prefs.readingChallengeEnrolled) }
     var lastReadDate by remember { mutableStateOf(Prefs.readingChallengeLastReadDate) }
+    var startDate by remember { mutableStateOf(Prefs.readingChallengeStartDate) }
     var endDate by remember { mutableStateOf(Prefs.readingChallengeEndDate) }
     var onboardingShown by remember { mutableStateOf(Prefs.readingChallengeOnboardingShown) }
     var widgetPromptShown by remember { mutableStateOf(Prefs.readingChallengeInstallPromptShown) }
@@ -141,6 +143,7 @@ fun ReadingChallengePlayground(
         streak = Prefs.readingChallengeStreak
         enrolled = Prefs.readingChallengeEnrolled
         lastReadDate = Prefs.readingChallengeLastReadDate
+        startDate = Prefs.readingChallengeStartDate
         endDate = Prefs.readingChallengeEndDate
         onboardingShown = Prefs.readingChallengeOnboardingShown
         widgetPromptShown = Prefs.readingChallengeInstallPromptShown
@@ -402,6 +405,62 @@ fun ReadingChallengePlayground(
             }
         }
 
+        // --- Challenge Start Date ---
+        Card {
+            Column(
+                Modifier
+                    .background(WikipediaTheme.colors.backgroundColor)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "readingChallengeStartDate",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = WikipediaTheme.colors.primaryColor
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedTextField(
+                        value = startDate,
+                        onValueChange = {
+                            startDate = it
+                        },
+                        placeholder = {
+                            Text(
+                                "YYYY-MM-DD",
+                                color = WikipediaTheme.colors.primaryColor
+                            )
+                        },
+                        singleLine = true,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = WikipediaTheme.colors.primaryColor,
+                            focusedBorderColor = MaterialTheme.colorScheme.outline,
+                            unfocusedTextColor = WikipediaTheme.colors.primaryColor,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+                            cursorColor = WikipediaTheme.colors.primaryColor,
+                            errorTextColor = WikipediaTheme.colors.primaryColor,
+                        ),
+                        modifier = Modifier.weight(1f)
+                    )
+                    Button(
+                        onClick = {
+                            Prefs.readingChallengeStartDate = startDate
+                            updateWidgetsExplicitly()
+                        },
+                        enabled = startDate.isEmpty() || runCatching { LocalDate.parse(startDate) }.isSuccess,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = WikipediaTheme.colors.progressiveColor,
+                            contentColor = WikipediaTheme.colors.paperColor
+                        )
+                    ) {
+                        Text("Save")
+                    }
+                }
+            }
+        }
+
         // --- Challenge End Date ---
         Card {
             Column(
@@ -465,6 +524,7 @@ fun ReadingChallengePlayground(
                 Prefs.readingChallengeEnrolled = false
                 Prefs.readingChallengeLastReadDate = ""
                 Prefs.readingChallengeEndDate = ReadingChallengeWidgetRepository.READING_CHALLENGE_END_DATE
+                Prefs.readingChallengeStartDate = ReadingChallengeWidgetRepository.READING_CHALLENGE_START_DATE
                 syncFromPrefs()
                 updateWidgetsExplicitly()
             },

--- a/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeState.kt
+++ b/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeState.kt
@@ -37,6 +37,5 @@ data class ReadingChallengeUserData(
     val currentDate: LocalDate,
     val enabled: Boolean,
     val currentStreak: Int,
-    val hasReadToday: Boolean,
-    val isPreBetaRelease: Boolean = false
+    val hasReadToday: Boolean
 )

--- a/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeWidgetRepository.kt
+++ b/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeWidgetRepository.kt
@@ -15,7 +15,6 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.settings.Prefs
-import org.wikipedia.util.ReleaseUtil
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -37,8 +36,7 @@ class ReadingChallengeWidgetRepository(private val context: Context) {
                         currentDate = currentDate,
                         enabled = Prefs.readingChallengeEnrolled,
                         currentStreak = Prefs.readingChallengeStreak,
-                        hasReadToday = hasReadToday(currentDate),
-                        isPreBetaRelease = ReleaseUtil.isPreBetaRelease
+                        hasReadToday = hasReadToday(currentDate)
                     )
                 ))
             }
@@ -71,7 +69,7 @@ class ReadingChallengeWidgetRepository(private val context: Context) {
         }
 
         // Stage 1: Pre-enrollment
-        if (!userData.isPreBetaRelease && userData.currentDate.isBefore(START_DATE)) {
+        if (userData.currentDate.isBefore(START_DATE)) {
             return ReadingChallengeState.NotLiveYet
         }
 
@@ -125,7 +123,7 @@ class ReadingChallengeWidgetRepository(private val context: Context) {
     }
 
     suspend fun updateOnArticleRead(currentDate: LocalDate) {
-        if (!ReleaseUtil.isPreBetaRelease && (currentDate.isBefore(START_DATE) || currentDate.isAfter(END_DATE))) {
+        if (currentDate.isBefore(START_DATE) || currentDate.isAfter(END_DATE)) {
             return
         }
 
@@ -140,12 +138,13 @@ class ReadingChallengeWidgetRepository(private val context: Context) {
         const val READING_STREAK_GOAL = 25
         const val INTENT_EXTRA_READING_CHALLENGE_REWARD = "reading_challenge_reward"
         const val READING_CHALLENGE_END_DATE = "2026-06-18"
-        private val START_DATE = LocalDate.of(2026, 5, 11)
+        const val READING_CHALLENGE_START_DATE = "2026-05-11"
+        private val START_DATE get() = LocalDate.parse(Prefs.readingChallengeStartDate.ifEmpty { READING_CHALLENGE_START_DATE })
         private val END_DATE get() = LocalDate.parse(Prefs.readingChallengeEndDate.ifEmpty { READING_CHALLENGE_END_DATE })
         private val REMOVE_DATE = LocalDate.of(2026, 7, 27)
 
         private val isChallengeActive: Boolean
-            get() = ReleaseUtil.isPreBetaRelease || (!LocalDate.now().isBefore(START_DATE) && LocalDate.now().isBefore(END_DATE))
+            get() = !LocalDate.now().isBefore(START_DATE) && LocalDate.now().isBefore(END_DATE)
 
         private fun isWidgetInstalled(): Boolean {
             val context = WikipediaApp.instance

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -215,6 +215,7 @@
     <string name="preference_key_reading_challenge_onboarding_shown">readingChallengeOnboardingShown</string>
     <string name="preference_key_reading_challenge_install_prompt_shown">readingChallengeInstallPromptShown</string>
     <string name="preference_key_reading_challenge_enrollment_date">readingChallengeEnrollmentDate</string>
+    <string name="preference_key_reading_challenge_start_date">readingChallengeStartDate</string>
     <string name="preference_key_reading_challenge_end_date">readingChallengeEndDate</string>
     <string name="preference_key_reading_challenge_widget_fast_cycle">readingChallengeWidgetFastCycle</string>
 </resources>

--- a/app/src/test/java/org/wikipedia/widget/ReadingChallengeWidgetRepositoryTest.kt
+++ b/app/src/test/java/org/wikipedia/widget/ReadingChallengeWidgetRepositoryTest.kt
@@ -40,26 +40,10 @@ class ReadingChallengeWidgetRepositoryTest {
                 currentDate = DAY_BEFORE_START,
                 enabled = false,
                 currentStreak = 0,
-                hasReadToday = false,
-                isPreBetaRelease = false
+                hasReadToday = false
             )
         )
         TestCase.assertTrue(state is ReadingChallengeState.NotLiveYet)
-    }
-
-    @Test
-    fun `bypasses NotLiveYet for pre-beta release even before start date`() {
-        val state = repository.resolveState(
-            ReadingChallengeUserData(
-                currentDate = DAY_BEFORE_START,
-                enabled = false,
-                currentStreak = 0,
-                hasReadToday = false,
-                isPreBetaRelease = true
-            )
-        )
-        TestCase.assertFalse(state is ReadingChallengeState.NotLiveYet)
-        TestCase.assertTrue(state is ReadingChallengeState.NotEnrolled)
     }
 
     @Test

--- a/app/src/test/java/org/wikipedia/widget/ReadingChallengeWidgetRepositoryTest.kt
+++ b/app/src/test/java/org/wikipedia/widget/ReadingChallengeWidgetRepositoryTest.kt
@@ -24,6 +24,7 @@ class ReadingChallengeWidgetRepositoryTest {
         context = mockk<Context>(relaxed = true)
         mockkObject(Prefs)
         repository = ReadingChallengeWidgetRepository(context)
+        every { Prefs.readingChallengeStartDate } returns START_DATE.toString()
         every { Prefs.readingChallengeEndDate } returns END_DATE.toString()
     }
 


### PR DESCRIPTION
### What does this do?
- adds start date for reading challenge dev settings
- infinite loop fix
The infinite loop here is from how we observe the repository here in  **ReadingChallengePlayGroundDialog** . Before we were not caching it using remember. Every recomposition created a new flow instance, which collectAsState treated as a new instance and re-emitted a fresh state which causes another recomposition, and the loop kept going. I found this when i saw log being printed infinitely. 
