### PR TITLE
TestKitchen: handle case of streamConfigs being empty, not null.

### DIFF
--- a/analytics/testkitchen/src/main/java/org/wikimedia/testkitchen/EventProcessor.kt
+++ b/analytics/testkitchen/src/main/java/org/wikimedia/testkitchen/EventProcessor.kt
@@ -65,8 +65,8 @@ class EventProcessor(
      * retried on the next submission attempt.
      */
     fun sendEnqueuedEvents() {
-        val config: SourceConfig? = sourceConfig.get()
-        if (config == null) {
+        val streamConfigsMap = sourceConfig.get()?.streamConfigs
+        if (streamConfigsMap.isNullOrEmpty()) {
             logger.warn("Configuration is missing, enqueued events are not sent.")
             return
         }
@@ -75,8 +75,6 @@ class EventProcessor(
         synchronized(eventQueue) {
             eventQueue.drainTo(pending)
         }
-
-        val streamConfigsMap = config.streamConfigs
 
         pending.filter { event -> streamConfigsMap.containsKey(event.meta.stream) }
             .filter { event ->

--- a/analytics/testkitchen/src/main/java/org/wikimedia/testkitchen/TestKitchenClient.kt
+++ b/analytics/testkitchen/src/main/java/org/wikimedia/testkitchen/TestKitchenClient.kt
@@ -75,8 +75,8 @@ class TestKitchenClient(
     ) {
         // If we already have stream configs, then we can pre-validate certain conditions and exclude the event from the queue entirely.
         var streamConfig: StreamConfig? = null
-        if (sourceConfig.get() != null) {
-            streamConfig = sourceConfig.get().getStreamConfigByName(streamName)
+        if (!sourceConfig.get()?.streamConfigs.isNullOrEmpty()) {
+            streamConfig = sourceConfig.get()?.streamConfigs[streamName]
             if (streamConfig == null) {
                 logger.info("No stream config exists for this stream, the event is ignored and dropped.")
                 return

--- a/analytics/testkitchen/src/main/java/org/wikimedia/testkitchen/config/SourceConfig.kt
+++ b/analytics/testkitchen/src/main/java/org/wikimedia/testkitchen/config/SourceConfig.kt
@@ -1,7 +1,3 @@
 package org.wikimedia.testkitchen.config
 
-class SourceConfig(val streamConfigs: Map<String, StreamConfig>) {
-    fun getStreamConfigByName(streamName: String): StreamConfig? {
-        return streamConfigs[streamName]
-    }
-}
+class SourceConfig(val streamConfigs: Map<String, StreamConfig>)


### PR DESCRIPTION
This fixes a potential race condition when Stream Configurations are first initialized when instantiating the TestKitchenClient. When they are first initialized the list of StreamConfigs on the EventPlatformClient side is **empty** (but not null). After a short period, the configs are populated either from Prefs or from the network.

On the Test Kitchen side, we need to improve the check whether the stream configs are null **or empty**, otherwise events submitted during that brief window might be discarded.