### PR TITLE
[Reading Challenge] Fix: Reward dialog not opening

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -282,7 +282,7 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
         }
     }
 
-    private fun maybeShowReadingChallengePrompt() {
+    protected fun maybeShowReadingChallengePrompt() {
         if (ReadingChallengeWidgetRepository.shouldShowOnboardingDialog() &&
             this !is ReadingChallengeOnboardingActivity && this !is InitialOnboardingActivity) {
             requestReadingChallengeActivity.launch(ReadingChallengeOnboardingActivity.newIntent(this))

--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -55,7 +55,6 @@ import org.wikipedia.util.ResourceUtil
 import org.wikipedia.views.ImageZoomHelper
 import org.wikipedia.widgets.readingchallenge.ReadingChallengeInstallWidgetDialog
 import org.wikipedia.widgets.readingchallenge.ReadingChallengeOnboardingActivity
-import org.wikipedia.widgets.readingchallenge.ReadingChallengeRewardDialog
 import org.wikipedia.widgets.readingchallenge.ReadingChallengeWidgetRepository
 import org.wikipedia.yearinreview.YearInReviewActivity
 import org.wikipedia.yearinreview.YearInReviewOnboardingActivity
@@ -286,13 +285,6 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
         if (ReadingChallengeWidgetRepository.shouldShowOnboardingDialog() &&
             this !is ReadingChallengeOnboardingActivity && this !is InitialOnboardingActivity) {
             requestReadingChallengeActivity.launch(ReadingChallengeOnboardingActivity.newIntent(this))
-        } else if (ReadingChallengeWidgetRepository.shouldShowReward(intent)) {
-            intent.removeExtra(ReadingChallengeWidgetRepository.INTENT_EXTRA_READING_CHALLENGE_REWARD)
-            window.decorView.post {
-                if (!isDestroyed) {
-                    ExclusiveBottomSheetPresenter.show(supportFragmentManager, ReadingChallengeRewardDialog())
-                }
-            }
         }
     }
 

--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
@@ -221,7 +221,7 @@ class ActivityTabFragment : Fragment() {
 
     private fun maybeShowReadingChallengeRewardDialog() {
         val intent = requireActivity().intent
-        if (AccountUtil.isLoggedIn && ReadingChallengeWidgetRepository.shouldShowReward(intent)) {
+        if (ReadingChallengeWidgetRepository.shouldShowReward(intent)) {
             intent.removeExtra(ReadingChallengeWidgetRepository.INTENT_EXTRA_READING_CHALLENGE_REWARD)
             ExclusiveBottomSheetPresenter.show(childFragmentManager, ReadingChallengeRewardDialog())
         }

--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabFragment.kt
@@ -114,6 +114,7 @@ import org.wikipedia.history.HistoryEntry
 import org.wikipedia.history.HistoryFragment
 import org.wikipedia.login.LoginActivity
 import org.wikipedia.navtab.NavTab
+import org.wikipedia.page.ExclusiveBottomSheetPresenter
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
@@ -123,6 +124,8 @@ import org.wikipedia.usercontrib.UserContribListActivity
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.UiState
 import org.wikipedia.util.UriUtil
+import org.wikipedia.widgets.readingchallenge.ReadingChallengeRewardDialog
+import org.wikipedia.widgets.readingchallenge.ReadingChallengeWidgetRepository
 import java.time.LocalDateTime
 
 class ActivityTabFragment : Fragment() {
@@ -211,8 +214,17 @@ class ActivityTabFragment : Fragment() {
                 Prefs.isGameStatsUnavailableSnackbarShown = true
             }
         }
+        maybeShowReadingChallengeRewardDialog()
         viewModel.loadAll()
         requireActivity().invalidateOptionsMenu()
+    }
+
+    private fun maybeShowReadingChallengeRewardDialog() {
+        val intent = requireActivity().intent
+        if (AccountUtil.isLoggedIn && ReadingChallengeWidgetRepository.shouldShowReward(intent)) {
+            intent.removeExtra(ReadingChallengeWidgetRepository.INTENT_EXTRA_READING_CHALLENGE_REWARD)
+            ExclusiveBottomSheetPresenter.show(childFragmentManager, ReadingChallengeRewardDialog())
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -165,6 +165,7 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        maybeShowReadingChallengePrompt()
         fragment.handleIntent(intent)
     }
 

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -165,7 +165,6 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        maybeShowReadingChallengePrompt()
         fragment.handleIntent(intent)
     }
 

--- a/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeActions.kt
+++ b/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeActions.kt
@@ -5,9 +5,11 @@ import android.content.Intent
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
+import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.WikipediaApp
 import org.wikipedia.main.MainActivity
+import org.wikipedia.navtab.NavTab
 import org.wikipedia.random.RandomActivity
 import org.wikipedia.search.SearchActivity
 import org.wikipedia.settings.Prefs
@@ -63,6 +65,7 @@ class ChallengeRewardAction : ActionCallback {
         context.startActivity(
             MainActivity.newIntent(context)
                 .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                .putExtra(Constants.INTENT_EXTRA_GO_TO_SE_TAB, NavTab.EDITS.code())
                 .putExtra(ReadingChallengeWidgetRepository.INTENT_EXTRA_READING_CHALLENGE_REWARD, true)
         )
     }

--- a/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeActions.kt
+++ b/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeActions.kt
@@ -62,7 +62,7 @@ class ChallengeRewardAction : ActionCallback {
     ) {
         context.startActivity(
             MainActivity.newIntent(context)
-                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
                 .putExtra(ReadingChallengeWidgetRepository.INTENT_EXTRA_READING_CHALLENGE_REWARD, true)
         )
     }

--- a/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeWidgetRepository.kt
+++ b/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeWidgetRepository.kt
@@ -164,7 +164,7 @@ class ReadingChallengeWidgetRepository(private val context: Context) {
         }
 
         fun shouldShowReward(intent: Intent): Boolean {
-            return intent.hasExtra(INTENT_EXTRA_READING_CHALLENGE_REWARD)
+            return intent.hasExtra(INTENT_EXTRA_READING_CHALLENGE_REWARD) && AccountUtil.isLoggedIn
         }
     }
 }


### PR DESCRIPTION
### What does this do?
- Fixes reading challenge reward dialog not showing from widget when app is in background

**Phabricator:**
https://phabricator.wikimedia.org/T418641