### PR TITLE
TestKitchen: Flush events periodically, not just when closing activity.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/testkitchen/TestKitchenAdapter.kt
+++ b/app/src/main/java/org/wikipedia/analytics/testkitchen/TestKitchenAdapter.kt
@@ -25,7 +25,13 @@ import org.wikipedia.util.ReleaseUtil
 import org.wikipedia.util.log.L
 
 object TestKitchenAdapter : ClientDataCallback, EventSender {
+    const val FLUSH_DELAY_MILLIS = 30000L
     val logger = LogAdapterImpl()
+
+    val flushEventsRunnable: Runnable = {
+        client.flushEventQueue()
+        WikipediaApp.instance.mainThreadHandler.postDelayed(flushEventsRunnable, FLUSH_DELAY_MILLIS)
+    }
 
     val client = TestKitchenClient(
         eventSender = this,
@@ -33,6 +39,10 @@ object TestKitchenAdapter : ClientDataCallback, EventSender {
         clientDataCallback = this,
         logger = logger
     )
+
+    init {
+        flushEventsRunnable.run()
+    }
 
     override fun getAgentData(): AgentData {
         return AgentData(


### PR DESCRIPTION
At the moment, Test Kitchen events are sent (flushed) only when pausing an Activity (`onPause`).
If we start sending events from inside Widget logic (independent of activities), they might get lost if the system terminates the app process before any activities are created.

Let's make an explicit timer Runnable (just like we currently have in EventPlatformClient) that flushes events every 30 seconds. Having this kind of timer is not _the best_ pattern in the Android ecosystem, but it's extremely lightweight, and will work for our purposes.