### PR TITLE
T419169 - invalid URL when opening external content

### DIFF
--- a/app/src/main/java/org/wikipedia/page/LinkHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.kt
@@ -25,7 +25,7 @@ abstract class LinkHandler(protected val context: Context) : JSEventListener, Ur
     // message from JS bridge:
     override fun onMessage(messageType: String, messagePayload: JsonObject?) {
         messagePayload?.let {
-            onUrlClick(UriUtil.decodeURL(it["href"]?.jsonPrimitive?.content.orEmpty()),
+            onUrlClick(it["href"]?.jsonPrimitive?.content.orEmpty(),
                 it["title"]?.jsonPrimitive?.content,
                 it["text"]?.jsonPrimitive?.content.orEmpty())
         }

--- a/app/src/main/java/org/wikipedia/page/LinkHandler.kt
+++ b/app/src/main/java/org/wikipedia/page/LinkHandler.kt
@@ -69,7 +69,7 @@ abstract class LinkHandler(protected val context: Context) : JSEventListener, Ur
         }
 
         // TODO: remove this after the endpoint supporting language variants
-        val convertedText = UriUtil.getTitleFromUrl(href)
+        val convertedText = UriUtil.getTitleFromUrl(Uri.decode(href)) // decode '%'-escaped octets
         var titleStr = titleString
         if (convertedText != titleStr) {
             titleStr = convertedText

--- a/app/src/test/java/org/wikipedia/page/LinkHandlerTest.kt
+++ b/app/src/test/java/org/wikipedia/page/LinkHandlerTest.kt
@@ -1,0 +1,119 @@
+package org.wikipedia.page
+
+import android.net.Uri
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.wikipedia.WikipediaApp
+import org.wikipedia.dataclient.WikiSite
+
+@RunWith(RobolectricTestRunner::class)
+class LinkHandlerTest {
+    private val context get() = WikipediaApp.instance
+
+    @Test
+    fun testOnMessageWithEncodedUrl() {
+        var lastExternalUri: Uri? = null
+        val handler = object : LinkHandler(context) {
+            override var wikiSite: WikiSite = WikiSite("en.wikipedia.org")
+            override fun onExternalLinkClicked(uri: Uri) {
+                lastExternalUri = uri
+            }
+        }
+
+        // A URL with an encoded space (%20)
+        val payload = buildJsonObject {
+            put("href", "https://example.com/foo%20bar")
+        }
+
+        handler.onMessage("test", payload)
+
+        // The URI passed to onExternalLinkClicked should preserve the encoded space
+        assertEquals("https://example.com/foo%20bar", lastExternalUri.toString())
+    }
+
+    @Test
+    fun testOnMessageWithInternalLink() {
+        var lastInternalTitle: PageTitle? = null
+        val handler = object : LinkHandler(context) {
+            override var wikiSite: WikiSite = WikiSite("en.wikipedia.org")
+            override fun onInternalLinkClicked(title: PageTitle) {
+                lastInternalTitle = title
+            }
+        }
+
+        // An internal link with an encoded space
+        val payload = buildJsonObject {
+            put("href", "/wiki/Foo%20Bar")
+        }
+
+        handler.onMessage("test", payload)
+
+        // PageTitle should correctly interpret "Foo%20Bar" as "Foo Bar" for display
+        // because PageTitle handles its own decoding.
+        assertEquals("Foo Bar", lastInternalTitle?.displayText)
+        // And use underscore for the DB/Internal title
+        assertEquals("Foo_Bar", lastInternalTitle?.prefixedText)
+    }
+
+    @Test
+    fun testOnMessageWithQueryParameters() {
+        var lastExternalUri: Uri? = null
+        val handler = object : LinkHandler(context) {
+            override var wikiSite: WikiSite = WikiSite("en.wikipedia.org")
+            override fun onExternalLinkClicked(uri: Uri) {
+                lastExternalUri = uri
+            }
+        }
+
+        val payload = buildJsonObject {
+            put("href", "https://example.com/search?q=foo%20bar")
+        }
+
+        handler.onMessage("test", payload)
+
+        // The full URL should be encoded
+        assertEquals("https://example.com/search?q=foo%20bar", lastExternalUri.toString())
+        // But extracting a query parameter should yield the decoded value automatically
+        assertEquals("foo bar", lastExternalUri?.getQueryParameter("q"))
+    }
+
+    @Test
+    fun testOnMessageWithMailto() {
+        val handler = object : LinkHandler(context) {
+            override var wikiSite: WikiSite = WikiSite("en.wikipedia.org")
+        }
+
+        val payload = buildJsonObject {
+            put("href", "mailto:test@example.com")
+        }
+
+        // Verify that special schemes like mailto: are still processed without error
+        handler.onMessage("test", payload)
+    }
+
+    @Test
+    fun testOnMessageWithTitleAndEncodedUrl() {
+        var lastInternalTitle: PageTitle? = null
+        val handler = object : LinkHandler(context) {
+            override var wikiSite: WikiSite = WikiSite("en.wikipedia.org")
+            override fun onInternalLinkClicked(title: PageTitle) {
+                lastInternalTitle = title
+            }
+        }
+
+        // JS payload where title is also encoded
+        val payload = buildJsonObject {
+            put("href", "/wiki/Foo%20Bar")
+            put("title", "Foo%20Bar")
+        }
+
+        handler.onMessage("test", payload)
+
+        // PageTitle should correctly interpret "Foo%20Bar" as "Foo Bar"
+        assertEquals("Foo Bar", lastInternalTitle?.displayText)
+    }
+}


### PR DESCRIPTION
### What does this do?
Fixing incorrectly encoded URL which leads to incorrect navigation in browsers like DuckDuckGo

### Why is this needed?
The problem with the code in `LinkHandler` is that if the url embedded in the `messagePayload` transferred to `onMessage` contains an encoded space character (%20). `UriUtil.decodeURL` will decode it and replace it with a real space character. This is then passed to `onUrlClick` where it is assigned to the local variable `href`. This local variable is then used to create an `Uri` which is assigned to the local variable `uri`. In this step, the space character is not encoded again. When passing uri to external browsers using `onExternalLinkClicked`, it depends on the functionality of the browser how the raw space character is interpreted. Apparently, `DuckDuckGo` (and potentially further browsers) process only the first part of the URI - ignoring the second part after the space character.

**Problem**
<img width="370" height="618" alt="T419169_problem" src="https://github.com/user-attachments/assets/6ea0b727-6000-47cb-b3dd-afc9098d97cf" />

**Solution proposal**
<img width="820" height="626" alt="T419169_solution" src="https://github.com/user-attachments/assets/105e0939-a98f-4ce8-9e4b-19cf2af724a2" />

I also added unit testing to verify if the correct content is created in LinkHandler.

**Phabricator:**
https://phabricator.wikimedia.org/T...
