### PR TITLE
Remove Notification View from Explore Feed when user logs out

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -149,7 +149,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
                     when (event) {
                         is LoggedOutEvent,
                         is LoggedOutInBackgroundEvent -> {
-                            notificationButtonView.isVisible = false
+                            requireActivity().invalidateOptionsMenu()
                             ExclusiveBottomSheetPresenter.dismiss(childFragmentManager)
                             refreshContents()
                         }

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -149,6 +149,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
                     when (event) {
                         is LoggedOutEvent,
                         is LoggedOutInBackgroundEvent -> {
+                            updateNotificationDot(false)
                             ExclusiveBottomSheetPresenter.dismiss(childFragmentManager)
                             refreshContents()
                         }
@@ -543,6 +544,11 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     }
 
     fun updateNotificationDot(animate: Boolean) {
+        if (!AccountUtil.isLoggedIn) {
+            notificationButtonView.isVisible = false
+            return
+        }
+
         if (AccountUtil.isLoggedIn && Prefs.notificationUnreadCount > 0) {
             notificationButtonView.setUnreadCount(Prefs.notificationUnreadCount)
             if (animate) {

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -149,7 +149,9 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
                     when (event) {
                         is LoggedOutEvent,
                         is LoggedOutInBackgroundEvent -> {
-                            updateNotificationDot(false)
+                            if (!AccountUtil.isLoggedIn) {
+                                notificationButtonView.isVisible = false
+                            }
                             ExclusiveBottomSheetPresenter.dismiss(childFragmentManager)
                             refreshContents()
                         }
@@ -544,11 +546,6 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     }
 
     fun updateNotificationDot(animate: Boolean) {
-        if (!AccountUtil.isLoggedIn) {
-            notificationButtonView.isVisible = false
-            return
-        }
-
         if (AccountUtil.isLoggedIn && Prefs.notificationUnreadCount > 0) {
             notificationButtonView.setUnreadCount(Prefs.notificationUnreadCount)
             if (animate) {

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -149,9 +149,7 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
                     when (event) {
                         is LoggedOutEvent,
                         is LoggedOutInBackgroundEvent -> {
-                            if (!AccountUtil.isLoggedIn) {
-                                notificationButtonView.isVisible = false
-                            }
+                            notificationButtonView.isVisible = false
                             ExclusiveBottomSheetPresenter.dismiss(childFragmentManager)
                             refreshContents()
                         }


### PR DESCRIPTION
### What does this do?
There is a timing issue between user logging out and **AccountUtil** updating its state. When user logs out, they are navigated to **MainFragment** where **onPrepareMenu** is remove. At this point `AccountUtil.isLoggedIn` still returns true and the collector which receives the **LoggedOutEvent** does not have the code to remove the notification. This PR ensures the notification button is properly removed when the user logs out.
