### PR TITLE
[Reading Challenge] Missing ChallengeRemoved instrumentation

### DIFF
--- a/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeAnalyticsHelper.kt
+++ b/app/src/main/java/org/wikipedia/widgets/readingchallenge/ReadingChallengeAnalyticsHelper.kt
@@ -14,6 +14,7 @@ object ReadingChallengeAnalyticsHelper {
             ReadingChallengeState.NotEnrolled -> logHeartbeat(elementId = "not_enrolled")
             ReadingChallengeState.NotLiveYet -> logHeartbeat(elementId = "not_yet_live")
             ReadingChallengeState.EnrolledNotStarted -> logHeartbeat(elementId = "enrolled_not_started")
+            ReadingChallengeState.ChallengeRemoved -> logHeartbeat(elementId = "challenge_removed", includeStreak = true)
             else -> {}
         }
     }


### PR DESCRIPTION
### What does this do?
- adds instrumentation for ChallengeRemoved state
- reference: https://docs.google.com/presentation/d/11v2n_Beam172R-nRsTXhcN7C3xQMP3ETmOhUn369M60/edit?slide=id.g3da6a7f7438_0_35#slide=id.g3da6a7f7438_0_35

https://phabricator.wikimedia.org/T419306