### PR TITLE
NewExploreFeed: Add Share and Save to the overflow menu in For you tab

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/ForYouCard.kt
+++ b/app/src/main/java/org/wikipedia/feed/ForYouCard.kt
@@ -74,6 +74,8 @@ fun ForYouCardContent(
     footerIcon: Painter? = null,
     footerText: String? = null,
     onPageClick: (HistoryEntry) -> Unit = {},
+    onShareClick: (HistoryEntry) -> Unit = {},
+    onSaveClick: (HistoryEntry) -> Unit = {},
     onHideCardClick: (module: ForYouModule, card: Card) -> Unit = { _, _ -> },
     onHideModuleClick: () -> Unit = {},
     onCustomizeInterestsClick: () -> Unit = {}
@@ -184,6 +186,12 @@ fun ForYouCardContent(
                                 expanded = overflowMenuExpanded,
                                 wikiSite = wikiSite,
                                 onDismiss = { overflowMenuExpanded = false },
+                                onShareClick = {
+                                    onShareClick(entry)
+                                },
+                                onSaveClick = {
+                                    onSaveClick(entry)
+                                },
                                 onHideCardClick = {
                                     if (module != null && card != null) {
                                         onHideCardClick(module, card)
@@ -273,6 +281,12 @@ fun ForYouCardContent(
                             expanded = overflowMenuExpanded,
                             wikiSite = wikiSite,
                             onDismiss = { overflowMenuExpanded = false },
+                            onShareClick = {
+                                onShareClick(entry)
+                            },
+                            onSaveClick = {
+                                onSaveClick(entry)
+                            },
                             onHideCardClick = {
                                 if (module != null && card != null) {
                                     onHideCardClick(module, card)
@@ -332,6 +346,8 @@ fun ForYouCardDropdownMenu(
     expanded: Boolean,
     wikiSite: WikiSite,
     onDismiss: () -> Unit = {},
+    onShareClick: () -> Unit = {},
+    onSaveClick: () -> Unit = {},
     onHideCardClick: () -> Unit = {},
     onHideModuleClick: () -> Unit = {},
     onCustomizeInterestsClick: () -> Unit
@@ -343,6 +359,48 @@ fun ForYouCardDropdownMenu(
         onDismissRequest = onDismiss,
         containerColor = WikipediaTheme.colors.paperColor
     ) {
+        DropdownMenuItem(
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(R.drawable.ic_share),
+                    contentDescription = null,
+                    tint = WikipediaTheme.colors.secondaryColor,
+                    modifier = Modifier.size(24.dp)
+                )
+            },
+            text = {
+                Text(
+                    text = context.getString(wikiSite.languageCode, R.string.menu_page_article_share),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = WikipediaTheme.colors.primaryColor
+                )
+            },
+            onClick = {
+                onShareClick()
+                onDismiss()
+            }
+        )
+        DropdownMenuItem(
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(R.drawable.ic_bookmark_border_white_24dp),
+                    contentDescription = null,
+                    tint = WikipediaTheme.colors.secondaryColor,
+                    modifier = Modifier.size(24.dp)
+                )
+            },
+            text = {
+                Text(
+                    text = context.getString(wikiSite.languageCode, R.string.menu_page_add_to_default_list),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = WikipediaTheme.colors.primaryColor
+                )
+            },
+            onClick = {
+                onSaveClick()
+                onDismiss()
+            }
+        )
         DropdownMenuItem(
             leadingIcon = {
                 Icon(

--- a/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
@@ -851,6 +851,8 @@ fun ForYouContentTab(
                                         wikiSite = wikiSite,
                                         module = module,
                                         onPageClick = { entry -> onPageClick(entry) },
+                                        onShareClick = { entry -> onPageShareClick(entry) },
+                                        onSaveClick = { entry -> onPageBookmarkClick(entry) },
                                         onHideCardClick = onHideCardClick,
                                         onCardInView = { onCardImpression(it) },
                                         onCustomizeInterestsClick = onCustomizeInterestsClick
@@ -867,6 +869,8 @@ fun ForYouContentTab(
                                         wikiSite = wikiSite,
                                         module = module,
                                         onPageClick = { entry -> onPageClick(entry) },
+                                        onShareClick = { entry -> onPageShareClick(entry) },
+                                        onSaveClick = { entry -> onPageBookmarkClick(entry) },
                                         onHideCardClick = onHideCardClick,
                                         onCardInView = { onCardImpression(it) },
                                         onCustomizeInterestsClick = onCustomizeInterestsClick
@@ -883,6 +887,8 @@ fun ForYouContentTab(
                                         wikiSite = wikiSite,
                                         module = module,
                                         onPageClick = { entry -> onPageClick(entry) },
+                                        onShareClick = { entry -> onPageShareClick(entry) },
+                                        onSaveClick = { entry -> onPageBookmarkClick(entry) },
                                         onHideCardClick = onHideCardClick,
                                         onCardInView = { onCardImpression(it) },
                                         onCustomizeInterestsClick = onCustomizeInterestsClick

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadModule.kt
@@ -25,6 +25,8 @@ fun BecauseYouReadModule(
     wikiSite: WikiSite,
     module: ForYouModule.BecauseYouRead,
     onPageClick: (item: HistoryEntry) -> Unit = {},
+    onShareClick: (entry: HistoryEntry) -> Unit = {},
+    onSaveClick: (entry: HistoryEntry) -> Unit = {},
     onHideCardClick: (module: ForYouModule, card: Card) -> Unit = { _, _ -> },
     onHideModuleClick: () -> Unit = {},
     onCardInView: (card: Card) -> Unit = {},
@@ -49,6 +51,8 @@ fun BecauseYouReadModule(
             footerIcon = painterResource(R.drawable.ic_history_24),
             footerText = context.getString(wikiSite.languageCode, R.string.explore_feed_because_you_read, card.sourceDisplayTitle),
             onPageClick = onPageClick,
+            onShareClick = onShareClick,
+            onSaveClick = onSaveClick,
             onHideCardClick = onHideCardClick,
             onHideModuleClick = onHideModuleClick,
             onCustomizeInterestsClick = onCustomizeInterestsClick

--- a/app/src/main/java/org/wikipedia/feed/continuereading/ContinueReadingModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/continuereading/ContinueReadingModule.kt
@@ -25,6 +25,8 @@ fun ContinueReadingModule(
     wikiSite: WikiSite,
     module: ForYouModule.ContinueReading,
     onPageClick: (item: HistoryEntry) -> Unit = {},
+    onShareClick: (entry: HistoryEntry) -> Unit = {},
+    onSaveClick: (entry: HistoryEntry) -> Unit = {},
     onHideCardClick: (module: ForYouModule, card: Card) -> Unit = { _, _ -> },
     onHideModuleClick: () -> Unit = {},
     onCardInView: (card: Card) -> Unit = {},
@@ -49,6 +51,8 @@ fun ContinueReadingModule(
             footerIcon = painterResource(if (entry.source == HistoryEntry.SOURCE_READING_LIST) R.drawable.ic_bookmark_border_white_24dp else R.drawable.ic_read_more_24dp),
             footerText = context.getString(wikiSite.languageCode, if (entry.source == HistoryEntry.SOURCE_READING_LIST) R.string.explore_feed_from_reading_list else R.string.app_shortcuts_continue_reading),
             onPageClick = onPageClick,
+            onShareClick = onShareClick,
+            onSaveClick = onSaveClick,
             onHideCardClick = onHideCardClick,
             onHideModuleClick = onHideModuleClick,
             onCustomizeInterestsClick = onCustomizeInterestsClick

--- a/app/src/main/java/org/wikipedia/feed/interests/BasedOnInterestModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/interests/BasedOnInterestModule.kt
@@ -25,6 +25,8 @@ fun BasedOnInterestModule(
     wikiSite: WikiSite,
     module: ForYouModule.BasedOnInterest,
     onPageClick: (item: HistoryEntry) -> Unit = {},
+    onShareClick: (entry: HistoryEntry) -> Unit = {},
+    onSaveClick: (entry: HistoryEntry) -> Unit = {},
     onHideCardClick: (module: ForYouModule, card: Card) -> Unit = { _, _ -> },
     onHideModuleClick: () -> Unit = {},
     onCardInView: (card: Card) -> Unit = {},
@@ -55,6 +57,8 @@ fun BasedOnInterestModule(
                 context.getString(wikiSite.languageCode, R.string.explore_feed_because_of_interest, it)
             },
             onPageClick = onPageClick,
+            onShareClick = onShareClick,
+            onSaveClick = onSaveClick,
             onHideCardClick = onHideCardClick,
             onHideModuleClick = onHideModuleClick,
             onCustomizeInterestsClick = onCustomizeInterestsClick


### PR DESCRIPTION
### What does this do?
This PR adds the missing `Share` and `Save` menu options to the overflow menu. I also left a comment to suggest to the designer to simplify the save behavior 🤞 


**Phabricator:**
https://phabricator.wikimedia.org/T419626