### PR TITLE
Design tweaks to Dot pager indicators.

### DIFF
--- a/app/src/main/java/org/wikipedia/compose/components/PageIndicator.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/PageIndicator.kt
@@ -29,7 +29,7 @@ fun PageIndicator(
     modifier: Modifier = Modifier,
     pagerState: PagerState,
     animationDuration: Int = 500,
-    indicatorSpacing: Dp = 8.dp
+    indicatorSpacing: Dp = 12.dp
 ) {
     Row(
         modifier = modifier,
@@ -67,9 +67,9 @@ fun PageIndicator(
 
 private fun paginationSizeGradient(totalIndicators: Int, iteration: Int, pagerState: PagerState): Int {
     return when {
-        totalIndicators <= 3 -> 8
-        (iteration - pagerState.currentPage).absoluteValue <= 2 -> 8
-        (iteration - pagerState.currentPage).absoluteValue == 3 -> 4
+        totalIndicators <= 5 -> 8
+        (iteration - pagerState.currentPage).absoluteValue <= 4 -> 8
+        (iteration - pagerState.currentPage).absoluteValue == 5 -> 4
         else -> 2
     }
 }
@@ -81,7 +81,7 @@ private fun PageIndicatorPreview() {
         currentTheme = Theme.LIGHT
     ) {
         PageIndicator(
-            pagerState = rememberPagerState(pageCount = { 3 })
+            pagerState = rememberPagerState(pageCount = { 8 })
         )
     }
 }

--- a/app/src/main/res/layout/fragment_references_pager.xml
+++ b/app/src/main/res/layout/fragment_references_pager.xml
@@ -57,8 +57,8 @@
             android:background="@android:color/transparent"
             app:tabIndicator="@null"
             app:tabRippleColor="?attr/placeholder_color"
-            app:tabPaddingStart="8dp"
-            app:tabPaddingEnd="8dp"
+            app:tabPaddingStart="10dp"
+            app:tabPaddingEnd="10dp"
             app:tabBackground="@drawable/shape_tab_dot"
             app:tabGravity="center" />
 

--- a/app/src/main/res/layout/view_on_this_day_event.xml
+++ b/app/src/main/res/layout/view_on_this_day_event.xml
@@ -103,7 +103,7 @@
         app:tabBackground="@drawable/shape_tab_dot"
         app:tabGravity="center"
         app:tabIndicator="@null"
-        app:tabPaddingEnd="8dp"
-        app:tabPaddingStart="8dp"
+        app:tabPaddingEnd="10dp"
+        app:tabPaddingStart="10dp"
         app:tabRippleColor="?attr/placeholder_color"/>
 </LinearLayout>

--- a/app/src/main/res/layout/view_suggested_edits_card.xml
+++ b/app/src/main/res/layout/view_suggested_edits_card.xml
@@ -24,8 +24,8 @@
         app:tabBackground="@drawable/shape_tab_dot"
         app:tabGravity="center"
         app:tabIndicator="@null"
-        app:tabPaddingEnd="8dp"
-        app:tabPaddingStart="8dp"
+        app:tabPaddingEnd="10dp"
+        app:tabPaddingStart="10dp"
         app:tabRippleColor="?attr/placeholder_color" />
 
     <org.wikipedia.feed.view.CardFooterView


### PR DESCRIPTION
As per Slack conversation, let's make our PagerIndicator composable have a dot spacing of `12dp`, and make the corresponding legacy XML dot pagers have similar spacing (`10dp` start and end padding, for some reason, to achieve the equivalent spacing).
Also let's make the PagerIndicator dots be the same size, up to `5` dots, instead of the current `3`.