### PR TITLE
Fix: use legacy zh-classical as the subdomain instead of lzh

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/WikiSite.kt
@@ -158,6 +158,7 @@ data class WikiSite(
                 AppLanguageLookUpTable.NORWEGIAN_BOKMAL_LANGUAGE_CODE -> AppLanguageLookUpTable.NORWEGIAN_LEGACY_LANGUAGE_CODE // T114042
                 AppLanguageLookUpTable.BELARUSIAN_LEGACY_LANGUAGE_CODE -> AppLanguageLookUpTable.BELARUSIAN_TARASK_LANGUAGE_CODE // T111853
                 AppLanguageLookUpTable.CHINESE_LEGACY_YUE_LANGUAGE_CODE -> AppLanguageLookUpTable.CHINESE_YUE_LANGUAGE_CODE
+                AppLanguageLookUpTable.CHINESE_CLASSICAL_LANGUAGE_CODE -> AppLanguageLookUpTable.CHINESE_CLASSICAL_LEGACY_LANGUAGE_CODE
                 else -> languageCode
             }
         }

--- a/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.kt
+++ b/app/src/main/java/org/wikipedia/language/AppLanguageLookUpTable.kt
@@ -64,6 +64,9 @@ class AppLanguageLookUpTable(context: Context) {
                 BELARUSIAN_TARASK_LANGUAGE_CODE -> {
                     name = localizedNames.getOrNull(indexOfCode(BELARUSIAN_LEGACY_LANGUAGE_CODE))
                 }
+                CHINESE_CLASSICAL_LANGUAGE_CODE -> {
+                    name = localizedNames.getOrNull(indexOfCode(CHINESE_CLASSICAL_LEGACY_LANGUAGE_CODE))
+                }
             }
         }
         return name
@@ -114,6 +117,8 @@ class AppLanguageLookUpTable(context: Context) {
         const val CHINESE_LANGUAGE_CODE = "zh"
         const val NORWEGIAN_LEGACY_LANGUAGE_CODE = "no"
         const val NORWEGIAN_BOKMAL_LANGUAGE_CODE = "nb"
+        const val CHINESE_CLASSICAL_LANGUAGE_CODE = "lzh"
+        const val CHINESE_CLASSICAL_LEGACY_LANGUAGE_CODE = "zh-classical"
         const val BELARUSIAN_LEGACY_LANGUAGE_CODE = "be-x-old"
         const val BELARUSIAN_TARASK_LANGUAGE_CODE = "be-tarask"
         const val TEST_LANGUAGE_CODE = "test"


### PR DESCRIPTION
### What does this do?
If we try to request APIs from `lzh.wikipedia.org`, we will often see error codes. Instead of requesting from `lzh`, we can use the legacy `zh-classical` for the API requests. 

If you look at `lzh.wikipedia.org`, it will redirect the page to `zh-classical`.

**Phabricator:**
https://phabricator.wikimedia.org/T425545
