### PR TITLE
Fix: show the correct tab after selection the tab preference

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
@@ -131,8 +131,8 @@ class HomeFragment : Fragment() {
 
     private val personalizationResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         if (it.resultCode == RESULT_OK) {
-            viewModel.selectTab(if (Prefs.homePreferenceSelection == HomePreferenceType.PERSONALIZED) HomeTab.FOR_YOU else HomeTab.COMMUNITY)
-            (requireActivity() as? MainActivity)?.onTabChanged(NavTab.HOME)
+            val tab = if (Prefs.homePreferenceSelection == HomePreferenceType.PERSONALIZED) HomeTab.FOR_YOU else HomeTab.COMMUNITY
+            selectTab(tab)
         }
     }
 
@@ -164,8 +164,7 @@ class HomeFragment : Fragment() {
                         overflowMenuState = pageOverflowMenuViewModel.pageOverflowMenuState,
                         tabsState = tabsState,
                         onSelectTab = {
-                            viewModel.selectTab(it)
-                            (requireActivity() as? MainActivity)?.onTabChanged(NavTab.HOME)
+                            selectTab(it)
                         },
                         onRefreshTab = {
                             if (it == HomeTab.COMMUNITY) {
@@ -290,6 +289,11 @@ class HomeFragment : Fragment() {
         super.onPause()
         cardImpressions.clear()
         instrument.stopFunnel()
+    }
+
+    fun selectTab(tab: HomeTab) {
+        viewModel.selectTab(tab)
+        (requireActivity() as? MainActivity)?.onTabChanged(NavTab.HOME)
     }
 
     private fun maybeShowExploreFeedUpdatePrompt() {

--- a/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
@@ -1,11 +1,13 @@
 package org.wikipedia.feed
 
+import android.app.Activity.RESULT_OK
 import android.os.Bundle
 import android.text.format.DateFormat
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.compose.LocalActivity
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -102,6 +104,7 @@ import org.wikipedia.feed.onthisday.OnThisDayActivity
 import org.wikipedia.feed.onthisday.OnThisDayCard
 import org.wikipedia.feed.onthisday.OnThisDayModule
 import org.wikipedia.feed.personalization.PersonalizationActivity
+import org.wikipedia.feed.personalization.homepreference.HomePreferenceType
 import org.wikipedia.feed.topread.TopReadArticlesActivity
 import org.wikipedia.feed.topread.TopReadListCard
 import org.wikipedia.feed.topread.TopReadModule
@@ -125,6 +128,13 @@ class HomeFragment : Fragment() {
     private val pageOverflowMenuViewModel: PageOverflowMenuViewModel by viewModels()
     private val cardImpressions = mutableSetOf<String>()
     private val instrument = TestKitchenAdapter.client.getInstrument("apps-home-feed")
+
+    private val personalizationResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        if (it.resultCode == RESULT_OK) {
+            viewModel.selectTab(if (Prefs.homePreferenceSelection == HomePreferenceType.PERSONALIZED) HomeTab.FOR_YOU else HomeTab.COMMUNITY)
+            (requireActivity() as? MainActivity)?.onTabChanged(NavTab.HOME)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -284,7 +294,7 @@ class HomeFragment : Fragment() {
 
     private fun maybeShowExploreFeedUpdatePrompt() {
         if (!Prefs.isInitialOnboardingEnabled && Prefs.isExploreFeedUpdatePromptShown.not()) {
-            startActivity(ExploreFeedUpdatePromptActivity.newIntent(requireContext()))
+            personalizationResultLauncher.launch(ExploreFeedUpdatePromptActivity.newIntent(requireContext()))
         }
     }
 

--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -176,6 +176,11 @@ class HomeViewModel : ViewModel() {
             !_forYouState.value.isInitialLoading
         ) {
             loadForYouContent()
+        } else if (tab == HomeTab.COMMUNITY &&
+            _communityState.value.cards.isEmpty() &&
+            !_communityState.value.isInitialLoading
+        ) {
+            loadCommunityContent()
         }
     }
 

--- a/app/src/main/java/org/wikipedia/feed/onboarding/ExploreFeedUpdatePromptActivity.kt
+++ b/app/src/main/java/org/wikipedia/feed/onboarding/ExploreFeedUpdatePromptActivity.kt
@@ -66,6 +66,7 @@ class ExploreFeedUpdatePromptActivity : BaseActivity() {
             .startFunnel("feed_announce")
 
         Prefs.isExploreFeedUpdatePromptShown = true
+        setResult(RESULT_OK)
         setContent {
             BaseTheme {
                 ExploreFeedUpdatePromptScreen(

--- a/app/src/main/java/org/wikipedia/feed/personalization/PersonalizationViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/PersonalizationViewModel.kt
@@ -24,6 +24,7 @@ import org.wikipedia.feed.personalization.interest.InterestSelectionRepository
 import org.wikipedia.feed.personalization.interest.InterestUiState
 import org.wikipedia.feed.personalization.interest.OnboardingTopic
 import org.wikipedia.page.PageTitle
+import org.wikipedia.settings.Prefs
 import org.wikipedia.topics.ArticleTopics
 import org.wikipedia.util.log.L
 
@@ -42,7 +43,7 @@ private data class PersonalizedViewModelState(
     val selectedTopics: List<OnboardingTopic> = emptyList(),
     val topicPreviewContent: Map<String, List<HomePreferenceContent>> = emptyMap(),
     // Feed preference screen properties
-    val homePreferenceType: HomePreferenceType = HomePreferenceType.COMMUNITY,
+    val homePreferenceType: HomePreferenceType = Prefs.homePreferenceSelection,
     val communityContent: List<HomePreferenceContent> = emptyList(),
     val communityLoading: Boolean = false,
     val communityError: Throwable? = null,

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -29,6 +29,7 @@ import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.feed.FeedFragment
 import org.wikipedia.feed.HomeFragment
 import org.wikipedia.feed.HomeTab
+import org.wikipedia.feed.personalization.homepreference.HomePreferenceType
 import org.wikipedia.navtab.NavTab
 import org.wikipedia.onboarding.InitialOnboardingActivity
 import org.wikipedia.page.ExclusiveBottomSheetPresenter
@@ -53,6 +54,10 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
         val fragment = fragment.currentFragment
         if (it.resultCode == InitialOnboardingActivity.RESULT_LANGUAGE_CHANGED && fragment is FeedFragment) {
             fragment.refresh()
+        }
+        if (fragment is HomeFragment) {
+            val tab = if (Prefs.homePreferenceSelection == HomePreferenceType.PERSONALIZED) HomeTab.FOR_YOU else HomeTab.COMMUNITY
+            fragment.selectTab(tab)
         }
     }
 


### PR DESCRIPTION
When selecting "For you" during onboarding, or changing it later in the dev settings, the feed is not showing the correct tab properly.

**Phabricator:**
https://phabricator.wikimedia.org/T418870#11900259
