### PR TITLE
Make ReadingLists correctly use remote Create and Modify time.

### DIFF
--- a/app/src/main/java/org/wikipedia/activitytab/ActivityTabViewModel.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/ActivityTabViewModel.kt
@@ -150,10 +150,10 @@ class ActivityTabViewModel : ViewModel() {
             }
             val mostRecentReadTime = AppDatabase.instance.historyEntryDao().getMostRecentEntry()?.timestamp?.toInstant()?.atZone(ZoneId.systemDefault())?.toLocalDateTime()
 
-            val articlesSavedThisMonth = AppDatabase.instance.readingListPageDao().getTotalLocallySavedPagesBetween(thirtyDaysAgo) ?: 0
-            val articlesSaved = AppDatabase.instance.readingListPageDao().getLocallySavedPagesSince(thirtyDaysAgo, 4)
+            val articlesSavedThisMonth = AppDatabase.instance.readingListPageDao().getTotalSavedPagesBetween(thirtyDaysAgo) ?: 0
+            val articlesSaved = AppDatabase.instance.readingListPageDao().getSavedPagesSince(thirtyDaysAgo, 4)
                 .map { ReadingListPage.toPageTitle(it) }
-            val mostRecentSaveTime = AppDatabase.instance.readingListPageDao().getMostRecentLocallySavedPage()?.atime?.let { Instant.ofEpochMilli(it) }?.atZone(ZoneId.systemDefault())?.toLocalDateTime()
+            val mostRecentSaveTime = AppDatabase.instance.readingListPageDao().getMostRecentSavedPage()?.atime?.let { Instant.ofEpochMilli(it) }?.atZone(ZoneId.systemDefault())?.toLocalDateTime()
 
             val currentDate = LocalDate.now()
             val topCategories = AppDatabase.instance.categoryDao().getTopCategoriesByMonth(currentDate.year, currentDate.monthValue)

--- a/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
+++ b/app/src/main/java/org/wikipedia/activitytab/timeline/TimelineRepository.kt
@@ -119,7 +119,7 @@ class ReadingListPagingSource(
 
     override suspend fun fetch(pageSize: Int, cursor: Cursor?): Pair<List<TimelineItem>, Cursor?> {
         val offset = (cursor as? Cursor.ReadingListCursor)?.offset ?: 0
-        val items = dao.getPagesByLocallySavedTime(pageSize, offset).map {
+        val items = dao.getPagesBySavedTime(pageSize, offset).map {
             TimelineItem(
                 id = it.mtime + it.atime + it.id,
                 pageId = 0,

--- a/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPage.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/database/ReadingListPage.kt
@@ -31,15 +31,12 @@ data class ReadingListPage(
     var remoteId: Long = 0
 ) : Serializable {
 
-    constructor(title: PageTitle, fromRemoteSync: Boolean = false) :
+    constructor(title: PageTitle) :
             this(title.wikiSite, title.namespace(), title.displayText, title.prefixedText,
                 title.description, title.thumbUrl, lang = title.wikiSite.languageCode) {
         val now = System.currentTimeMillis()
         mtime = now
-        // The `atime` (added time) field is used for sorting pages added *locally* only.
-        // For pages added from a remote sync, we set the atime to zero, so that these pages
-        // will not be counted as locally-added pages when sorting.
-        atime = if (fromRemoteSync) 0 else now
+        atime = now
     }
 
     @delegate:Transient

--- a/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
@@ -90,16 +90,16 @@ interface ReadingListPageDao {
     suspend fun getAllPagesToBeSynced(): List<ReadingListPage>
 
     @Query("SELECT COUNT(*) FROM ReadingListPage WHERE atime > 0 AND atime BETWEEN :startMillis AND :endMillis")
-    suspend fun getTotalLocallySavedPagesBetween(startMillis: Long, endMillis: Long = System.currentTimeMillis()): Int?
+    suspend fun getTotalSavedPagesBetween(startMillis: Long, endMillis: Long = System.currentTimeMillis()): Int?
 
     @Query("SELECT * FROM ReadingListPage WHERE atime > 0 AND atime > :timestamp ORDER BY atime DESC LIMIT :limit")
-    suspend fun getLocallySavedPagesSince(timestamp: Long, limit: Int): List<ReadingListPage>
+    suspend fun getSavedPagesSince(timestamp: Long, limit: Int): List<ReadingListPage>
 
     @Query("SELECT * FROM ReadingListPage WHERE atime > 0 ORDER BY atime DESC LIMIT 1")
-    suspend fun getMostRecentLocallySavedPage(): ReadingListPage?
+    suspend fun getMostRecentSavedPage(): ReadingListPage?
 
     @Query("SELECT * FROM ReadingListPage WHERE atime > 0 ORDER BY atime DESC LIMIT :limit OFFSET :offset")
-    suspend fun getPagesByLocallySavedTime(limit: Int, offset: Int): List<ReadingListPage>
+    suspend fun getPagesBySavedTime(limit: Int, offset: Int): List<ReadingListPage>
 
     suspend fun getAllPagesToBeSaved() = getPagesByStatus(ReadingListPage.STATUS_QUEUE_FOR_SAVE, true)
 

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
@@ -34,6 +34,9 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.RemoteConfig
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class ReadingListSyncAdapter(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
 
@@ -197,6 +200,8 @@ class ReadingListSyncAdapter(context: Context, params: WorkerParameters) : Corou
                             AppDatabase.instance.readingListDao().createList(remoteList.name(), remoteList.description())
                         }
                         localList.remoteId = remoteList.id
+                        localList.atime = remoteList.created.toInstant(ZoneOffset.UTC).toEpochMilli()
+                        localList.mtime = remoteList.updated.toInstant(ZoneOffset.UTC).toEpochMilli()
                         allLocalLists.add(localList)
                         upsertNeeded = true
                     } else {
@@ -460,6 +465,8 @@ class ReadingListSyncAdapter(context: Context, params: WorkerParameters) : Corou
             updateOnly = AppDatabase.instance.readingListPageDao().getPageByTitle(listForPage, remoteTitle) != null
         }
         localPage.remoteId = remotePage.id
+        localPage.atime = remotePage.created.toInstant(ZoneOffset.UTC).toEpochMilli()
+        localPage.mtime = remotePage.updated.toInstant(ZoneOffset.UTC).toEpochMilli()
         if (updateOnly) {
             L.d("Updating local page " + localPage.apiTitle)
             AppDatabase.instance.readingListPageDao().updateReadingListPage(localPage)
@@ -488,7 +495,9 @@ class ReadingListSyncAdapter(context: Context, params: WorkerParameters) : Corou
     private fun remoteEntryFromLocalPage(localPage: ReadingListPage): RemoteReadingListEntry {
         val title = ReadingListPage.toPageTitle(localPage)
         return RemoteReadingListEntry(0, 0,
-            "${title.wikiSite.scheme()}://${title.wikiSite.authority()}", title.prefixedText)
+            "${title.wikiSite.scheme()}://${title.wikiSite.authority()}", title.prefixedText,
+            created = if (localPage.atime == 0L) LocalDateTime.now() else LocalDateTime.ofInstant(Instant.ofEpochMilli(localPage.atime), ZoneOffset.UTC),
+            updated = if (localPage.mtime == 0L) LocalDateTime.now() else LocalDateTime.ofInstant(Instant.ofEpochMilli(localPage.mtime), ZoneOffset.UTC))
     }
 
     companion object {

--- a/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/ReadingListSyncAdapter.kt
@@ -455,7 +455,7 @@ class ReadingListSyncAdapter(context: Context, params: WorkerParameters) : Corou
         var updateOnly = localPage != null
 
         if (localPage == null) {
-            localPage = ReadingListPage(pageTitleFromRemoteEntry(remotePage), fromRemoteSync = true)
+            localPage = ReadingListPage(pageTitleFromRemoteEntry(remotePage))
             localPage.listId = listForPage.id
             updateOnly = AppDatabase.instance.readingListPageDao().getPageByTitle(listForPage, remoteTitle) != null
         }

--- a/app/src/main/java/org/wikipedia/readinglist/sync/SyncedReadingLists.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/sync/SyncedReadingLists.kt
@@ -2,7 +2,9 @@ package org.wikipedia.readinglist.sync
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.wikipedia.json.LocalDateTimeSerializer
 import java.text.Normalizer
+import java.time.LocalDateTime
 
 @Serializable
 data class SyncedReadingLists(val lists: List<RemoteReadingList>? = null,
@@ -15,7 +17,9 @@ data class SyncedReadingLists(val lists: List<RemoteReadingList>? = null,
         @SerialName("default") val isDefault: Boolean = false,
         private val name: String,
         private val description: String? = null,
-        @SerialName("deleted") val isDeleted: Boolean = false
+        @SerialName("deleted") val isDeleted: Boolean = false,
+        @Serializable(with = LocalDateTimeSerializer::class) val created: LocalDateTime = LocalDateTime.now(),
+        @Serializable(with = LocalDateTimeSerializer::class) val updated: LocalDateTime = LocalDateTime.now()
     ) {
         fun name(): String = Normalizer.normalize(name, Normalizer.Form.NFC)
         fun description(): String? = Normalizer.normalize(description.orEmpty(), Normalizer.Form.NFC)
@@ -27,7 +31,9 @@ data class SyncedReadingLists(val lists: List<RemoteReadingList>? = null,
         val listId: Long = -1,
         private val project: String,
         private val title: String,
-        @SerialName("deleted") val isDeleted: Boolean = false
+        @SerialName("deleted") val isDeleted: Boolean = false,
+        @Serializable(with = LocalDateTimeSerializer::class) val created: LocalDateTime = LocalDateTime.now(),
+        @Serializable(with = LocalDateTimeSerializer::class) val updated: LocalDateTime = LocalDateTime.now()
     ) {
         fun project(): String = Normalizer.normalize(project, Normalizer.Form.NFC)
         fun title(): String = Normalizer.normalize(title, Normalizer.Form.NFC)

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewViewModel.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewViewModel.kt
@@ -70,7 +70,7 @@ class YearInReviewViewModel : ViewModel() {
             if (yearInReviewModelMap[YIR_YEAR] == null) {
                 val totalSavedArticlesCount = async {
                     AppDatabase.instance.readingListPageDao()
-                        .getTotalLocallySavedPagesBetween(dataStartMillis, dataEndMillis) ?: 0
+                        .getTotalSavedPagesBetween(dataStartMillis, dataEndMillis) ?: 0
                 }
                 val randomSavedArticleTitles = async {
                     AppDatabase.instance.readingListPageDao()


### PR DESCRIPTION
Well, this is interesting:
It looks like Reading List entries (on the server side) have a `created` and `updated` time, which are persisted in the database. And _we never integrated with these dates_ in our client-side code 🫠

So... let's.

https://phabricator.wikimedia.org/T424161
