### PR TITLE
Configure `android:windowSplashScreenBackground` to avoid white flash when the app opens in dark mode

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <color name="splash_background_color">#27292D</color>
+
     <color name="widget_background">#27292D</color>
     <color name="widget_paper">#202122</color>
     <color name="widget_border">#2E3136</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -47,6 +47,7 @@
     <color name="orange500_50">#80FF9500</color>
     <color name="orange200">#FFC894</color>
 
+    <color name="splash_background_color">#F8F9FA</color>
 
     <color name="widget_background">#F8F9FA</color>
     <color name="widget_paper">#FFFFFF</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -35,6 +35,7 @@
         <item name="longPreferenceStyle">@style/LongPreference</item>
         <item name="intPreferenceStyle">@style/IntPreference</item>
 
+        <item name="android:windowSplashScreenBackground" tools:targetApi="s">@color/splash_background_color</item>
         <item name="android:windowBackground">?attr/border_color</item>
         <item name="android:colorBackground">?attr/background_color</item>
         <item name="android:textColorPrimary">?attr/primary_color</item>


### PR DESCRIPTION

### What does this do?

If you have your phone in dark mode and then open the app you will get a white flash. This change fixes this by configuring `android:windowSplashScreenBackground`.


### Why is this needed?

Screen recording of what it did before:

[before.webm](https://github.com/user-attachments/assets/624a7f25-8fcd-4363-bf5c-184b10a7b299)


After this change it does not flash:

[after.webm](https://github.com/user-attachments/assets/bf22bd88-061a-4803-9d57-39851263b1b1)


