### PR TITLE
Fix: do not load from cache if the last entry from database is newer than the cache

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -43,6 +43,7 @@ import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.SettingsRepository
 import org.wikipedia.staticdata.MainPageNameData
 import org.wikipedia.topics.ArticleTopics
+import org.wikipedia.util.DateUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 import java.time.LocalDate
@@ -413,21 +414,24 @@ class HomeViewModel : ViewModel() {
             L.e("Failed to load modules from cache.")
         }
 
-//        if (forYouCollectionSaved.dateTime != null &&
-//            forYouCollectionSaved.dateTime.toLocalDate() == LocalDate.now() &&
-//            forYouCollectionSaved.modulesPerLanguage.containsKey(wikiSite.value.languageCode)
-//        ) {
-//            L.d("Loading modules from cache...")
-//            val modules = forYouCollectionSaved.modulesPerLanguage[wikiSite.value.languageCode].orEmpty()
-//            val newModules = mutableListOf<ForYouModule>()
-//            modules.forEach { module ->
-//                val filteredCards = module.cards.filterNot { hiddenCards.contains(it.hideKey) }
-//                if (filteredCards.isNotEmpty()) {
-//                    newModules.add(module.withCards(filteredCards))
-//                }
-//            }
-//            return newModules
-//        }
+        val lastReadEntries = AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(age + 1, 30, wikiSite.value.languageCode)
+
+        if (forYouCollectionSaved.dateTime != null &&
+            forYouCollectionSaved.dateTime.toLocalDate() == LocalDate.now() &&
+            forYouCollectionSaved.dateTime.isAfter(DateUtil.iso8601LocalDateTimeParse(lastReadEntries.first().timestamp)) &&
+            forYouCollectionSaved.modulesPerLanguage.containsKey(wikiSite.value.languageCode)
+        ) {
+            L.d("Loading modules from cache...")
+            val modules = forYouCollectionSaved.modulesPerLanguage[wikiSite.value.languageCode].orEmpty()
+            val newModules = mutableListOf<ForYouModule>()
+            modules.forEach { module ->
+                val filteredCards = module.cards.filterNot { hiddenCards.contains(it.hideKey) }
+                if (filteredCards.isNotEmpty()) {
+                    newModules.add(module.withCards(filteredCards))
+                }
+            }
+            return newModules
+        }
         L.d("Loading modules from network...")
 
         // --- Interests ---
@@ -493,7 +497,6 @@ class HomeViewModel : ViewModel() {
         // --- Continue reading ---
 
         val continueReadingCards = buildList {
-            val lastReadEntries = AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(age + 1, 30, wikiSite.value.languageCode)
             if (lastReadEntries.size > age) {
                 add(ContinueReadingCard(lastReadEntries[age].title, HistoryEntry.SOURCE_HISTORY))
             }
@@ -524,7 +527,6 @@ class HomeViewModel : ViewModel() {
         // --- Because you read ---
 
         val becauseYouReadCards = buildList {
-            val lastReadEntries = AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(age + 1, 30, wikiSite.value.languageCode)
             if (lastReadEntries.size > age) {
                 val entry = lastReadEntries[age]
                 val hasParentLanguageCode = !WikipediaApp.instance.languageState.getDefaultLanguageCode(wikiSite.value.languageCode).isNullOrEmpty()

--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -48,6 +48,7 @@ import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.Date
 
 enum class HomeTab { COMMUNITY, FOR_YOU }
 enum class CommunityModules { TOP_READ, FEATURED_ARTICLE, FEATURED_IMAGE, NEWS, ON_THIS_DAY }
@@ -415,10 +416,11 @@ class HomeViewModel : ViewModel() {
         }
 
         val lastReadEntries = AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(age + 1, 30, wikiSite.value.languageCode)
+        val lastReadEntryTimeStamp = lastReadEntries.firstOrNull()?.timestamp ?: Date()
 
         if (forYouCollectionSaved.dateTime != null &&
             forYouCollectionSaved.dateTime.toLocalDate() == LocalDate.now() &&
-            forYouCollectionSaved.dateTime.isAfter(DateUtil.iso8601LocalDateTimeParse(lastReadEntries.first().timestamp)) &&
+            forYouCollectionSaved.dateTime.isAfter(DateUtil.iso8601LocalDateTimeParse(lastReadEntryTimeStamp)) &&
             forYouCollectionSaved.modulesPerLanguage.containsKey(wikiSite.value.languageCode)
         ) {
             L.d("Loading modules from cache...")

--- a/app/src/main/java/org/wikipedia/util/DateUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/DateUtil.kt
@@ -42,6 +42,10 @@ object DateUtil {
         return LocalDateTime.ofInstant(Instant.parse(timestamp), ZoneId.systemDefault())
     }
 
+    fun iso8601LocalDateTimeParse(timestamp: Date): LocalDateTime {
+        return LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault())
+    }
+
     fun dbDateFormat(date: Date): String {
         return getCachedDateFormat("yyyyMMddHHmmss", Locale.ROOT, true).format(date)
     }


### PR DESCRIPTION
### What does this do?
If the app has the cache list for the "For you" feed, it will not show "Continue reading" and "Because you read" modules after the feed is loaded until the next day.

This PR does an additional check for the last entry from the database. We can have another PR to handle the cache mechanism for each module instead of the whole list.

