### PR TITLE
Fix: add the correct contentDescription to the close icon in tab items

### DIFF
--- a/app/src/main/res/layout/fragment_places.xml
+++ b/app/src/main/res/layout/fragment_places.xml
@@ -39,7 +39,7 @@
                     android:layout_width="48dp"
                     android:layout_height="match_parent"
                     android:background="?attr/selectableItemBackground"
-                    android:contentDescription="@string/search_hint"
+                    android:contentDescription="@string/nav_item_back"
                     android:scaleType="center"
                     app:srcCompat="@drawable/ic_arrow_back_black_24dp"
                     app:tint="?attr/primary_color" />

--- a/app/src/main/res/layout/item_tab_contents.xml
+++ b/app/src/main/res/layout/item_tab_contents.xml
@@ -32,7 +32,7 @@
                 app:srcCompat="@drawable/ic_close_black_24dp"
                 app:tint="?attr/placeholder_color"
                 android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@null"/>
+                android:contentDescription="@string/button_close_tab"/>
 
             <TextView
                 android:id="@+id/tabArticleTitle"


### PR DESCRIPTION
### What does this do?
From the TalkBack, it will be described as "a X text" instead of "Close".
