### PR TITLE
Fix: refresh the feed if the selected language is not in the list

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
@@ -370,6 +370,7 @@ class HomeFragment : Fragment() {
         super.onResume()
         (requireActivity() as? MainActivity)?.onTabChanged(NavTab.HOME)
         viewModel.updateTabCount()
+        viewModel.updateSelectedLanguageIfNeeded()
         instrument.startFunnel("home_feed")
         refreshNotification()
         // TODO: start new funnel for analytics

--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -225,6 +225,12 @@ class HomeViewModel : ViewModel() {
         _tabsState.value = TabsState(WikipediaApp.instance.tabCount, pulse)
     }
 
+    fun updateSelectedLanguageIfNeeded() {
+        if (!WikipediaApp.instance.languageState.appLanguageCodes.contains(wikiSite.value.languageCode)) {
+            updateLanguage(WikipediaApp.instance.languageState.appLanguageCode)
+        }
+    }
+
     /**
      * Loads the next day's community content (today on first call, then progressively older).
      * Safe to call as a retry — the age only advances after a successful fetch.


### PR DESCRIPTION
### What does this do?
When you remove the "selected" language from the app languages list, the feed will still show the content based on the selected language.

This PR adds another check to see if the language still exists in the app languages list; if not, then update it to the primary language. 
