### PR TITLE
Test kitchen: Limit max number of languages in performerData.

### DIFF
--- a/analytics/testkitchen/src/main/java/org/wikimedia/testkitchen/ContextController.kt
+++ b/analytics/testkitchen/src/main/java/org/wikimedia/testkitchen/ContextController.kt
@@ -57,14 +57,7 @@ class ContextController {
                 ContextValue.PERFORMER_SESSION_ID -> newPerformerData.sessionId = clientData.performerData?.sessionId
                 ContextValue.PERFORMER_PAGEVIEW_ID -> newPerformerData.pageviewId = clientData.performerData?.pageviewId
                 ContextValue.PERFORMER_GROUPS -> newPerformerData.groups = clientData.performerData?.groups
-                ContextValue.PERFORMER_LANGUAGE_GROUPS -> {
-                    var languageGroups = clientData.performerData?.languageGroups
-                    if (languageGroups != null && languageGroups.length > 255) {
-                        languageGroups = languageGroups.take(255)
-                    }
-                    newPerformerData.languageGroups = languageGroups
-                }
-
+                ContextValue.PERFORMER_LANGUAGE_GROUPS -> newPerformerData.languageGroups = clientData.performerData?.languageGroups
                 ContextValue.PERFORMER_LANGUAGE_PRIMARY -> newPerformerData.languagePrimary = clientData.performerData?.languagePrimary
                 ContextValue.PERFORMER_REGISTRATION_DT -> newPerformerData.registrationDt = clientData.performerData?.registrationDt
                 else -> throw IllegalArgumentException("Unknown property: $requestedValue")

--- a/app/src/main/java/org/wikipedia/analytics/testkitchen/TestKitchenAdapter.kt
+++ b/app/src/main/java/org/wikipedia/analytics/testkitchen/TestKitchenAdapter.kt
@@ -70,7 +70,7 @@ object TestKitchenAdapter : ClientDataCallback, EventSender {
             isLoggedIn = AccountUtil.isLoggedIn,
             isTemp = AccountUtil.isTemporaryAccount,
             sessionId = client.sessionController.sessionId,
-            languageGroups = WikipediaApp.instance.languageState.appLanguageCodes.joinToString(","),
+            languageGroups = WikipediaApp.instance.languageState.appLanguageCodes.take(10).joinToString(","),
             languagePrimary = WikipediaApp.instance.appOrSystemLanguageCode
         )
     }


### PR DESCRIPTION
This limits the number of languages sent to `performerData` to 10, and we no longer need to check the length of this field in `ContextController`.