### PR TITLE
[NewExploreFeed] Fix: use the proper wikiSite for the interests selection screen

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -224,7 +224,7 @@ interface Service {
         @Query("grnlimit") count: Int = 50,
     ): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&generator=random&grnfilterredir=nonredirects&grnnamespace=0&prop=pageprops|pageimages|description|info|extracts&exchars=500&exintro=1&explaintext=1&piprop=thumbnail&pilicense=any&pithumbsize=" + PREFERRED_THUMB_SIZE)
+    @GET(MW_API_PREFIX + "action=query&generator=random&grnfilterredir=nonredirects&grnnamespace=0&prop=pageprops|pageimages|description|info|extracts&exchars=500&exintro=1&explaintext=1&piprop=thumbnail&pilicense=any&inprop=varianttitles|displaytitle&pithumbsize=" + PREFERRED_THUMB_SIZE)
     suspend fun getRandomPagesWithExtract(
         @Query("grnlimit") count: Int = 10,
     ): MwQueryResponse

--- a/app/src/main/java/org/wikipedia/feed/personalization/PersonalizationViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/PersonalizationViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.wikipedia.WikipediaApp
 import org.wikipedia.database.AppDatabase
+import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.feed.personalization.homepreference.HomeContentState
 import org.wikipedia.feed.personalization.homepreference.HomePreferenceContent
 import org.wikipedia.feed.personalization.homepreference.HomePreferenceRepository
@@ -358,18 +359,19 @@ class PersonalizationViewModel(
             initializer {
                 val appDatabase = AppDatabase.instance
                 val instance = WikipediaApp.instance
+                val wikiSite = WikiSite.forLanguageCode(Prefs.homeLanguageCode)
                 PersonalizationViewModel(
                     interestSelectionRepository = InterestSelectionRepository(
                         interestTopicDao = appDatabase.topicInterestDao(),
                         interestArticleDao = appDatabase.articleInterestDao(),
                         historyEntryWithImageDao = appDatabase.historyEntryWithImageDao(),
                         readingListPageDao = appDatabase.readingListPageDao(),
-                        wikiSite = instance.wikiSite
+                        wikiSite = wikiSite
                     ),
                     homePreferenceRepository = HomePreferenceRepository(
                         context = instance,
-                        historyEntryWithImageDao = AppDatabase.instance.historyEntryWithImageDao(),
-                        wikiSite = instance.wikiSite
+                        historyEntryWithImageDao = appDatabase.historyEntryWithImageDao(),
+                        wikiSite = wikiSite
                     )
                 )
             }

--- a/app/src/main/java/org/wikipedia/feed/personalization/interest/InterestSelectionRepository.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/interest/InterestSelectionRepository.kt
@@ -52,10 +52,10 @@ class InterestSelectionRepository(
         val results = mutableListOf<PageTitle>()
 
         // get most recent history entries
-        val historyTitles = historyEntryWithImageDao.findEntryForReadMore(maxItems, 0)
+        val historyTitles = historyEntryWithImageDao.findEntryForReadMore(maxItems, 0, wikiSite.languageCode)
             .map { it.title }
         // and a random sampling of reading list pages
-        val readingListTitles = readingListPageDao.getPagesByRandom(maxItems)
+        val readingListTitles = readingListPageDao.getPagesByRandomByLang(wikiSite.languageCode, maxItems)
             .map { ReadingListPage.toPageTitle(it) }
         // take the two lists and interleave them
         for (i in 0 until maxItems) {
@@ -74,6 +74,7 @@ class InterestSelectionRepository(
                 .query?.pages.orEmpty()
             pageList.forEach { page ->
                 results.find { it.prefixedText == StringUtil.addUnderscores(page.title) }?.let { title ->
+                    title.displayText = page.displayTitle(site.languageCode)
                     title.description = page.description
                     title.thumbUrl = page.thumbUrl()
                 }

--- a/app/src/main/java/org/wikipedia/feed/random/RandomClient.kt
+++ b/app/src/main/java/org/wikipedia/feed/random/RandomClient.kt
@@ -61,7 +61,7 @@ class RandomClient(
 
     companion object {
         suspend fun getRandomPages(wikiSite: WikiSite, count: Int): List<PageTitle> {
-            return ServiceFactory.get(wikiSite).getRandomPagesWithExtract(max(count, 10) * 4).query?.pages.orEmpty().filter {
+            return ServiceFactory.get(wikiSite).getRandomPagesWithExtract(max(count, 10) * 4).query?.pages.orEmpty().asSequence().filter {
                 it.pageProps?.disambiguation == null
             }.filter {
                 wikiSite.languageCode != "en" || (!it.description.orEmpty().contains("list article", ignoreCase = true) && !it.description.orEmpty().contains("list of", ignoreCase = true))
@@ -76,7 +76,7 @@ class RandomClient(
                     if (!page.sectionTitle.isNullOrEmpty()) it.fragment = StringUtil.addUnderscores(page.sectionTitle)
                     it.extract = page.extract
                 }
-            }.sortedBy { it.thumbUrl == null }.take(count)
+            }.sortedBy { it.thumbUrl == null }.take(count).toList()
         }
     }
 }


### PR DESCRIPTION
### What does this do?
There is [an issue ](https://github.com/wikimedia/apps-android-wikipedia/pull/6601#pullrequestreview-4323055343)where if you have multiple app languages, the "add interests" does not work properly if the language you select for the tab is "not" the primary language. 

We should use the selected language code in the interests selection screen for the feed recommendation.

This PR also updates the logic of putting initial articles, which we should always align with the selected language code. 


