### PR TITLE
[Explore feed] code cleanup

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
@@ -394,12 +394,6 @@ class HomeFragment : Fragment() {
         // TODO: start new funnel for analytics
     }
 
-    fun refreshForYouContent() {
-        if (Prefs.homeForYouModulesToday.isEmpty()) {
-            viewModel.refreshForYouContent()
-        }
-    }
-
     fun getCurrentTab(): HomeTab {
         return viewModel.selectedTab.value
     }

--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -603,7 +603,6 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, FeedFragment.
     private fun refreshContents() {
         when (val fragment = currentFragment) {
             is FeedFragment -> fragment.refresh()
-            is HomeFragment -> fragment.refreshForYouContent()
             is ReadingListsFragment -> fragment.updateLists()
             is HistoryFragment -> fragment.refresh()
             is SuggestedEditsTasksFragment -> fragment.refreshContents()

--- a/app/src/main/java/org/wikipedia/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/wikipedia/settings/SettingsActivity.kt
@@ -33,7 +33,7 @@ class SettingsActivity : BaseSettingsActivity<SettingsFragment>() {
                 finalLanguageList != initialLanguageList) {
             setResult(ACTIVITY_RESULT_LANGUAGE_CHANGED)
         } else if (requestCode == Constants.ACTIVITY_REQUEST_FEED_CONFIGURE &&
-                (resultCode == RESULT_OK || Prefs.feedCardsEnabled != initialFeedCardsEnabled || Prefs.feedCardsOrder != initialFeedCardsOrder || Prefs.feedCardsOrder != initialFeedCardsLangDisabled)) {
+                (Prefs.feedCardsEnabled != initialFeedCardsEnabled || Prefs.feedCardsOrder != initialFeedCardsOrder || Prefs.feedCardsOrder != initialFeedCardsLangDisabled)) {
             setResult(ACTIVITY_RESULT_FEED_CONFIGURATION_CHANGED)
         }
     }

--- a/app/src/main/java/org/wikipedia/settings/homefeed/HomeFeedSettingsNavHost.kt
+++ b/app/src/main/java/org/wikipedia/settings/homefeed/HomeFeedSettingsNavHost.kt
@@ -36,7 +36,6 @@ fun HomeFeedSettingsNavHost(
             if (it.resultCode == PersonalizationActivity.RESULT_INTERESTS_UPDATED) {
                 FeedbackUtil.showMessage(context, org.wikipedia.R.string.home_feed_settings_feed_configuration_interests_updated_message)
             }
-            context.setResult(RESULT_OK)
         }
     }
     NavHost(


### PR DESCRIPTION
### What does this do?
- removes the code that automatically refreshes the “For You” content when interests are changed in Settings

