### PR TITLE
Fix: update the homeLanguage during onboarding and undo the changes in updateSelectedLanguageIfNeeded

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeFragment.kt
@@ -307,7 +307,7 @@ class HomeFragment : Fragment() {
                         },
                         onLanguageSelected = { languageCode ->
                             instrument.submitInteraction("click", "language_menu", elementId = "language_change", actionContext = mapOf("selected_tab" to selectedTab.name, "language_code" to languageCode))
-                            viewModel.updateLanguage(languageCode)
+                            updateLanguage(languageCode)
                         },
                         onManageLanguagesClick = {
                             instrument.submitInteraction("click", "language_menu", elementId = "manage_languages", actionContext = mapOf("selected_tab" to selectedTab.name))
@@ -407,6 +407,10 @@ class HomeFragment : Fragment() {
 
     fun refreshNotification() {
         viewModel.refreshUnreadNotificationCount()
+    }
+
+    fun updateLanguage(languageCode: String) {
+        viewModel.updateLanguage(languageCode)
     }
 
     fun selectTab(tab: HomeTab) {

--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -249,8 +249,7 @@ class HomeViewModel : ViewModel() {
     }
 
     fun updateSelectedLanguageIfNeeded() {
-        val primaryLanguage = WikipediaApp.instance.languageState.appLanguageCode
-        if (!WikipediaApp.instance.languageState.appLanguageCodes.contains(wikiSite.value.languageCode) || (primaryLanguage != wikiSite.value.languageCode)) {
+        if (!WikipediaApp.instance.languageState.appLanguageCodes.contains(wikiSite.value.languageCode)) {
             updateLanguage(WikipediaApp.instance.languageState.appLanguageCode)
         }
     }

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -58,6 +58,7 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
         }
         if (fragment is HomeFragment) {
             val tab = if (Prefs.homePreferenceSelection == HomePreferenceType.PERSONALIZED) HomeTab.FOR_YOU else HomeTab.COMMUNITY
+            fragment.updateLanguage(Prefs.homeLanguageCode)
             fragment.selectTab(tab)
         }
     }

--- a/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingActivity.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingActivity.kt
@@ -33,6 +33,7 @@ class InitialOnboardingActivity : BaseActivity() {
 
     private val languagesLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         appLanguageCodesState.value = WikipediaApp.instance.languageState.appLanguageCodes.toList()
+        Prefs.homeLanguageCode = WikipediaApp.instance.languageState.appLanguageCode
         setResult(RESULT_LANGUAGE_CHANGED)
     }
 


### PR DESCRIPTION
### What does this do?
Undo the change in `updateSelectedLanguageIfNeeded()`, and make sure to update the `Prefs.homeLanguageCode` when the app languages are updated. 
