### PR TITLE
Show announcements by allowlist, not denylist.

### DIFF
--- a/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
+++ b/app/src/main/java/org/wikipedia/activity/BaseActivity.kt
@@ -38,15 +38,12 @@ import org.wikipedia.events.ReadingListsNoLongerSyncedEvent
 import org.wikipedia.events.SplitLargeListsEvent
 import org.wikipedia.events.ThemeFontChangeEvent
 import org.wikipedia.events.UnreadNotificationsEvent
-import org.wikipedia.feed.onboarding.ExploreFeedBuildingActivity
-import org.wikipedia.feed.onboarding.ExploreFeedUpdatePromptActivity
-import org.wikipedia.feed.personalization.PersonalizationActivity
 import org.wikipedia.games.onthisday.OnThisDayGameResultFragment
 import org.wikipedia.login.LoginActivity
 import org.wikipedia.main.MainActivity
 import org.wikipedia.notifications.NotificationPresenter
-import org.wikipedia.onboarding.InitialOnboardingActivity
 import org.wikipedia.page.ExclusiveBottomSheetPresenter
+import org.wikipedia.page.PageActivity
 import org.wikipedia.readinglist.ReadingListSyncBehaviorDialogs
 import org.wikipedia.readinglist.sync.ReadingListSyncAdapter
 import org.wikipedia.readinglist.sync.ReadingListSyncEvent
@@ -61,7 +58,6 @@ import org.wikipedia.views.ImageZoomHelper
 import org.wikipedia.widgets.readingchallenge.ReadingChallengeInstallWidgetDialog
 import org.wikipedia.widgets.readingchallenge.ReadingChallengeOnboardingActivity
 import org.wikipedia.widgets.readingchallenge.ReadingChallengeWidgetRepository
-import org.wikipedia.yearinreview.YearInReviewActivity
 import org.wikipedia.yearinreview.YearInReviewOnboardingActivity
 import org.wikipedia.yearinreview.YearInReviewViewModel
 
@@ -349,22 +345,15 @@ abstract class BaseActivity : AppCompatActivity(), ConnectionStateMonitor.Callba
         imageZoomHelper = ImageZoomHelper(this)
     }
 
-    // Announcements must never show while these activities are on screen.
-    // They all extend BaseActivity, so without this guard, launching any of them
-    // would re-trigger maybeShowAnnouncement and could show an announcement on top of or immediately after
-    // an onboarding or announcement screen. This can cause user to see announcements back to back.
-    private val blockedActivities = setOf(
-        InitialOnboardingActivity::class.java,
-        ExploreFeedBuildingActivity::class.java,
-        ExploreFeedUpdatePromptActivity::class.java,
-        PersonalizationActivity::class.java,
-        YearInReviewOnboardingActivity::class.java,
-        YearInReviewActivity::class.java,
-        ReadingChallengeOnboardingActivity::class.java
-    )
-
     fun maybeShowAnnouncement(activity: BaseActivity) {
-        if (activity::class.java in blockedActivities) return
+        // Announcements may only be shown on top of these activities:
+        if (listOf(
+                MainActivity::class,
+                PageActivity::class
+        ).none { it.isInstance(activity) }) {
+            return
+        }
+
         if (Prefs.isInitialOnboardingEnabled) return
         if (!Prefs.isExploreFeedUpdatePromptShown) return
 


### PR DESCRIPTION
According to https://phabricator.wikimedia.org/T426267#11946386, we should show announcements only when MainActivity or PageActivity is showing, not any other activity.
Therefore it's cleaner to gate announcements by using an allowlist.