### PR TITLE
[Explore Feed] Empty module string update

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2523,7 +2523,7 @@
     <string name="home_feed_settings_empty_dialog_text">Turn on at least one module to see content.</string>
     <string name="home_feed_settings_empty_dialog_positive">Continue anyway</string>
     <string name="home_feed_screen_empty_state_label">Your feed is empty</string>
-    <string name="home_feed_community_screen_all_modules_disabled_description"><![CDATA[Turn on the <b>From the community</b> modules to start seeing content curated by contributors across the Wikimedia movement.]]></string>
+    <string name="home_feed_community_screen_all_modules_disabled_description"><![CDATA[Turn on <b>Community</b> modules to start seeing content curated by and about the Wikimedia community.]]></string>
     <string name="home_feed_for_you_screen_all_modules_disabled_description"><![CDATA[Turn on the <b>For you</b> modules to start seeing content based on your preferences.]]></string>
     <string name="home_feed_screen_all_modules_disabled_btn_label">Manage modules</string>
     <string name="home_feed_for_you_screen_empty_title">Your feed is empty for now</string>


### PR DESCRIPTION
### What does this do?
- string update according to https://phabricator.wikimedia.org/T419771#:~:text=the%20Wikimedia%20movement.%22-,Should%20read,-%22Turn%20on%20Community