### PR TITLE
Home feed: Tweak/improve Continue Reading logic.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -39,6 +39,7 @@ import org.wikipedia.history.HistoryEntry
 import org.wikipedia.json.JsonUtil
 import org.wikipedia.json.LocalDateTimeSerializer
 import org.wikipedia.page.PageTitle
+import org.wikipedia.readinglist.database.ReadingListPage
 import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.SettingsRepository
 import org.wikipedia.settings.homefeed.CommunityModuleType
@@ -522,37 +523,6 @@ class HomeViewModel : ViewModel() {
             }
         }
 
-        // --- Continue reading ---
-
-        val continueReadingCards = buildList {
-            val lastReadEntries = AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(age + 1, 30, wikiSite.value.languageCode)
-            if (lastReadEntries.size > age) {
-                add(ContinueReadingCard(lastReadEntries[age].title, HistoryEntry.SOURCE_HISTORY))
-            }
-            val readingListPageTitles = AppDatabase.instance.readingListPageDao().getPagesByRandomByLang(wikiSite.value.languageCode, 10).take(3)
-                .map { it.apiTitle }
-                .fastJoinToString("|")
-            if (readingListPageTitles.isNotEmpty()) {
-                ServiceFactory.get(wikiSite.value).getInfoWithExtractsByPageTitles(readingListPageTitles)
-                    .query?.pages?.forEach { page ->
-                        add(ContinueReadingCard(PageTitle(
-                            text = page.title,
-                            wiki = wikiSite.value,
-                            thumbUrl = page.thumbUrl(),
-                            description = page.description,
-                            displayText = page.displayTitle(wikiSite.value.languageCode),
-                        ).also {
-                            if (!page.sectionTitle.isNullOrEmpty()) it.fragment = StringUtil.addUnderscores(page.sectionTitle)
-                            it.extract = page.extract
-                        }, HistoryEntry.SOURCE_READING_LIST))
-                    }
-            }
-        }.filterNot { hiddenCards.contains(it.hideKey) }.take(4)
-        if (continueReadingCards.isNotEmpty()) {
-            // The index for this module is always 0 because there is always a single instance of this module, per age.
-            modules.add(ForYouModule.ContinueReading(age, 0, continueReadingCards))
-        }
-
         // --- Because you read ---
 
         val becauseYouReadCards = buildList {
@@ -582,6 +552,34 @@ class HomeViewModel : ViewModel() {
         if (becauseYouReadCards.isNotEmpty()) {
             // The index for this module is always 0 because there is always a single instance of this module, per age.
             modules.add(ForYouModule.BecauseYouRead(age, 0, becauseYouReadCards))
+        }
+
+        // --- Continue reading ---
+
+        val continueReadingCards = buildList {
+            val lastReadEntries = AppDatabase.instance.historyEntryWithImageDao().findEntryForReadMore(age + 1, 30, wikiSite.value.languageCode)
+            if (lastReadEntries.size > age) {
+                add(ContinueReadingCard(lastReadEntries[age].title, HistoryEntry.SOURCE_HISTORY))
+            }
+            AppDatabase.instance.readingListPageDao().getMostRecentSavedPagesByLang(wikiSite.value.languageCode, 10).take(2)
+                .forEach {
+                    add(ContinueReadingCard(ReadingListPage.toPageTitle(it), HistoryEntry.SOURCE_READING_LIST))
+                }
+        }.filterNot { hiddenCards.contains(it.hideKey) }.take(4)
+        if (continueReadingCards.isNotEmpty()) {
+            ServiceFactory.get(wikiSite.value).getInfoWithExtractsByPageTitles(continueReadingCards.map { it.title.prefixedText }.fastJoinToString("|"))
+                .query?.pages?.forEach { page ->
+                    continueReadingCards.find { it.title.prefixedText == StringUtil.addUnderscores(page.title) }?.let {
+                        it.title.description = page.description
+                        it.title.thumbUrl = page.thumbUrl()
+                        it.title.displayText = page.displayTitle(wikiSite.value.languageCode)
+                        it.title.extract = page.extract
+                    }
+                }
+        }
+        if (continueReadingCards.isNotEmpty()) {
+            // The index for this module is always 0 because there is always a single instance of this module, per age.
+            modules.add(ForYouModule.ContinueReading(age, 0, continueReadingCards))
         }
 
         forYouCollectionSaved = ForYouCollectionSaved(

--- a/app/src/main/java/org/wikipedia/feed/personalization/interest/InterestSelectionRepository.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/interest/InterestSelectionRepository.kt
@@ -54,8 +54,8 @@ class InterestSelectionRepository(
         // get most recent history entries
         val historyTitles = historyEntryWithImageDao.findEntryForReadMore(maxItems, 0, wikiSite.languageCode)
             .map { it.title }
-        // and a random sampling of reading list pages
-        val readingListTitles = readingListPageDao.getPagesByRandomByLang(wikiSite.languageCode, maxItems)
+        // and the most recent reading list pages
+        val readingListTitles = readingListPageDao.getMostRecentSavedPagesByLang(wikiSite.languageCode, maxItems)
             .map { ReadingListPage.toPageTitle(it) }
         // take the two lists and interleave them
         for (i in 0 until maxItems) {

--- a/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
@@ -62,9 +62,6 @@ interface ReadingListPageDao {
     @Query("SELECT * FROM ReadingListPage ORDER BY RANDOM() DESC LIMIT :limit")
     suspend fun getPagesByRandom(limit: Int): List<ReadingListPage>
 
-    @Query("SELECT * FROM ReadingListPage WHERE lang = :langCode ORDER BY RANDOM() DESC LIMIT :limit")
-    suspend fun getPagesByRandomByLang(langCode: String, limit: Int): List<ReadingListPage>
-
     @Query("SELECT * FROM ReadingListPage WHERE listId = :listId AND status != :excludedStatus")
     suspend fun getPagesByListId(listId: Long, excludedStatus: Long): List<ReadingListPage>
 
@@ -100,6 +97,9 @@ interface ReadingListPageDao {
 
     @Query("SELECT * FROM ReadingListPage WHERE atime > 0 ORDER BY atime DESC LIMIT 1")
     suspend fun getMostRecentSavedPage(): ReadingListPage?
+
+    @Query("SELECT * FROM ReadingListPage WHERE lang = :langCode ORDER BY atime DESC LIMIT :limit")
+    suspend fun getMostRecentSavedPagesByLang(langCode: String, limit: Int): List<ReadingListPage>
 
     @Query("SELECT * FROM ReadingListPage WHERE atime > 0 ORDER BY atime DESC LIMIT :limit OFFSET :offset")
     suspend fun getPagesBySavedTime(limit: Int, offset: Int): List<ReadingListPage>


### PR DESCRIPTION
* Fixes a [QA item](https://phabricator.wikimedia.org/T419691#:~:text=%E2%9D%8CAC2%3A-,The%20Continue%20Reading%20card%20displays%20the%20reason%20label%2C%20article%20title%2C%20card%20position%20indicator%2C%20three%2Ddot%20more%20menu%2C%20and%20short%20excerpt,-.).
  * "Continue reading" (based on reading history) cards should be properly showing an excerpt (were showing a short description only)
  * "Continue reading" (based on reading lists) cards should be in most-recent order (were in random order).
  * Up to **two** reading list cards, not three.
* The Continue Reading and Because You Read modules were in the wrong order (Because You Read should come first).

