### PR TITLE
Feed: Put back Home Preference selection when customizing interests.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/personalization/PersonalizationActivity.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/PersonalizationActivity.kt
@@ -37,7 +37,8 @@ class PersonalizationActivity : BaseActivity() {
 
         val pages = if (showInterestsOnly) {
             listOf(
-                PersonalizationPage.INTERESTS
+                PersonalizationPage.INTERESTS,
+                PersonalizationPage.HOME_PREFERENCE
             )
         } else {
             listOf(


### PR DESCRIPTION
At some point, the `HOME_PREFERENCE` page was removed from the personalization activity (when customizing interests after already onboarded).
But this means that the user will never be able to change their default preference of Community vs. For You. We need to add back this selection.