### PR TITLE
Fix: image caption and license should be visible by default

### DIFF
--- a/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
+++ b/app/src/main/java/org/wikipedia/gallery/GalleryActivity.kt
@@ -615,6 +615,7 @@ class GalleryActivity : BaseActivity(), LinkPreviewDialog.LoadPageCallback, Gall
 
         // if we couldn't find an attribution string, then default to unknown
         binding.creditText.text = StringUtil.fromHtml(creditStr.ifBlank { getString(R.string.gallery_uploader_unknown) })
+        binding.infoContainer.isVisible = true
     }
 
     override fun onProvideAssistContent(outContent: AssistContent) {


### PR DESCRIPTION
### What does this do?
This was removed from the previous fix in #6305 


**Phabricator:**
https://phabricator.wikimedia.org/T427225
