### PR TITLE
Improve display of Blocked messages, and make snackbar selectable.

### DIFF
--- a/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/FeedbackUtil.kt
@@ -53,9 +53,9 @@ object FeedbackUtil {
 
     fun showError(activity: Activity, e: Throwable, wikiSite: WikiSite = WikipediaApp.instance.wikiSite) {
         val error = ThrowableUtil.getAppError(activity, e)
-        makeSnackbar(activity, error.error, wikiSite = wikiSite).also {
-            if (error.error.length > 200) {
-                it.duration = Snackbar.LENGTH_INDEFINITE
+        val isIndefinite = error.error.length > 200
+        makeSnackbar(activity, error.error, duration = if (isIndefinite) Snackbar.LENGTH_INDEFINITE else LENGTH_DEFAULT, wikiSite = wikiSite).also {
+            if (isIndefinite) {
                 it.setAction(android.R.string.ok) { _ ->
                     it.dismiss()
                 }
@@ -149,6 +149,10 @@ object FeedbackUtil {
         val textView = snackbar.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
         textView.setLinkTextColor(ResourceUtil.getThemedColor(view.context, R.attr.progressive_color))
         textView.movementMethod = LinkMovementMethodExt.getExternalLinkMovementMethod(wikiSite)
+        if (duration == Snackbar.LENGTH_INDEFINITE) {
+            // For indefinite snackbars, allow the user to select and copy text.
+            textView.setTextIsSelectable(true)
+        }
         return snackbar
     }
 

--- a/app/src/main/java/org/wikipedia/util/ThrowableUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/ThrowableUtil.kt
@@ -111,7 +111,7 @@ object ThrowableUtil {
             .replace("$4", "") // unknown parameter (unused?)
             .replace("$5", info.blockId.toString())
             .replace("$6", parseBlockedDate(info.blockExpiry))
-            .replace("$7", "<a href=\"${StringUtil.userPageTitleFromName(userName, WikipediaApp.instance.wikiSite).uri}\">$userName</a>")
+            .replace("$7", userName)
             .replace("$8", parseBlockedDate(info.blockTimeStamp))
     }
 


### PR DESCRIPTION
* When a snackbar has a duration of INDEFINITE, let's make the text highlightable and copiable.
* For Blocked messages, it's actually not correct for us to wrap the username parameter in an anchor element, since this can mess with the template logic in certain language wikis. It's totally fine to leave the username un-wrapped, and let the template do its own thing.

https://phabricator.wikimedia.org/T413516
