### PR TITLE
Fix: avoid showing duplicate continue reading articles in Home feed.

### DIFF
--- a/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
+++ b/app/src/main/java/org/wikipedia/readinglist/db/ReadingListPageDao.kt
@@ -98,7 +98,7 @@ interface ReadingListPageDao {
     @Query("SELECT * FROM ReadingListPage WHERE atime > 0 ORDER BY atime DESC LIMIT 1")
     suspend fun getMostRecentSavedPage(): ReadingListPage?
 
-    @Query("SELECT * FROM ReadingListPage WHERE lang = :langCode ORDER BY atime DESC LIMIT :limit")
+    @Query("SELECT * FROM ReadingListPage WHERE lang = :langCode GROUP BY apiTitle ORDER BY atime DESC LIMIT :limit")
     suspend fun getMostRecentSavedPagesByLang(langCode: String, limit: Int): List<ReadingListPage>
 
     @Query("SELECT * FROM ReadingListPage WHERE atime > 0 ORDER BY atime DESC LIMIT :limit OFFSET :offset")


### PR DESCRIPTION
### What does this do?
If you save the same article in multiple different reading lists recently, you will duplicate cards in the "From your reading list" module.