### PR TITLE
Fix potential crash when displaying overflow menu in Notifications.

### DIFF
--- a/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
+++ b/app/src/main/java/org/wikipedia/views/NotificationActionsOverflowView.kt
@@ -73,8 +73,8 @@ class NotificationActionsOverflowView(context: Context) : FrameLayout(context) {
                     val pageTitle = PageTitle.titleForUri(uri, WikiSite(uri))
                     if (pageTitle.isUserPage) {
                         binding.overflowViewSecondaryTalk.visibility = View.VISIBLE
-                        binding.overflowViewSecondaryTalk.text = String.format(anchorView.context.getString(StringUtil.dbNameToLangCode(container.notification.wiki),
-                            R.string.notifications_menu_user_talk_page), secondary.first().label)
+                        binding.overflowViewSecondaryTalk.text = anchorView.context.getString(StringUtil.dbNameToLangCode(container.notification.wiki),
+                            R.string.notifications_menu_user_talk_page, secondary.first().label)
                         binding.overflowViewSecondaryTalk.setOnClickListener {
                             if (UriUtil.isAppSupportedLink(uri)) {
                                 context.startActivity(TalkTopicsActivity.newIntent(context, pageTitle, Constants.InvokeSource.NOTIFICATION))


### PR DESCRIPTION
Even though this crash is relatively rare, it is currently the topmost crash in the Play Store console. Let's fix it and release it in our next update.

This was incorrectly calling the `context.getString()` extension function without passing the format parameter into it.