### PR TITLE
Update address for bvibber

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,6 @@
 # See: https://git-scm.com/docs/git-shortlog#_mapping_authors
 #
-Brooke Vibber <bvibber@wikimedia.org>
-Brooke Vibber <bvibber@wikimedia.org> <brion@wikimedia.org>
-Brooke Vibber <bvibber@wikimedia.org> <brion@pobox.com>
+Brooke Vibber <bvibber@pobox.com>
+Brooke Vibber <bvibber@pobox.com> <bvibber@wikimedia.org>
+Brooke Vibber <bvibber@pobox.com> <brion@wikimedia.org>
+Brooke Vibber <bvibber@pobox.com> <brion@pobox.com>


### PR DESCRIPTION
Update address for bvibber in .mailmap

### What does this do?

Updates the authorship info in git logs for commits by Brooke to her current address. <3

### Why is this needed?

Can no longer receive mail at the previous addresses.
