### PR TITLE
Introduce preview conveniences for PageTitle and PageSummary.

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/page/PageSummary.kt
@@ -101,5 +101,19 @@ open class PageSummary(
         const val TYPE_STANDARD = "standard"
         const val TYPE_DISAMBIGUATION = "disambiguation"
         const val TYPE_MAIN_PAGE = "mainpage"
+
+        /**
+         * For use in Composable previews.
+         */
+        fun preview(withThumbnail: Boolean = true): PageSummary {
+            return PageSummary(
+                displayTitle = "Lorem <i>ipsum</i>",
+                prefixTitle = "Lorem_ipsum",
+                description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                thumbnail = if (withThumbnail) "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/1200px-Commons-logo.svg.png" else null,
+                lang = "en"
+            )
+        }
     }
 }

--- a/app/src/main/java/org/wikipedia/feed/ForYouCard.kt
+++ b/app/src/main/java/org/wikipedia/feed/ForYouCard.kt
@@ -466,19 +466,10 @@ fun ForYouCardDropdownMenu(
 @Preview
 @Composable
 fun ForYouModulePreviewWithImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = "https://example.com/thumb.jpg"
-    )
     BaseTheme(currentTheme = Theme.LIGHT) {
         ForYouCardContent(
-            wikiSite = wikiSite,
-            title = title,
+            wikiSite = WikiSite.preview(),
+            title = PageTitle.preview(),
             footerText = "Lorem ipsum"
         )
     }
@@ -487,19 +478,10 @@ fun ForYouModulePreviewWithImage() {
 @Preview
 @Composable
 fun ForYouModulePreviewNoImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = null
-    )
     BaseTheme(currentTheme = Theme.LIGHT) {
         ForYouCardContent(
-            wikiSite = wikiSite,
-            title = title,
+            wikiSite = WikiSite.preview(),
+            title = PageTitle.preview(withThumbnail = false),
             footerText = "Lorem ipsum"
         )
     }
@@ -508,19 +490,10 @@ fun ForYouModulePreviewNoImage() {
 @Preview
 @Composable
 fun ForYouModulePreviewTextOnlyWithImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = "test.jpg"
-    )
     BaseTheme(currentTheme = Theme.LIGHT) {
         ForYouCardContent(
-            wikiSite = wikiSite,
-            title = title,
+            wikiSite = WikiSite.preview(),
+            title = PageTitle.preview(),
             footerText = "Lorem ipsum",
             variation = CardVariation.VARIATION_TEXT_ONLY,
             backgroundColorIndex = 2

--- a/app/src/main/java/org/wikipedia/feed/HomeScreen.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeScreen.kt
@@ -510,8 +510,8 @@ private fun HomeScreenCommunityAllModulesOffPreview() {
         HomeScreen(
             wikiSite = WikiSite.preview(),
             selectedTab = HomeTab.COMMUNITY,
-            communityContentState = CommunityContentState(emptyState = FeedEmptyState.ALL_MODULES_HIDDEN),
-            forYouContentState = ForYouContentState(isInitialLoading = true),
+            communityContentState = CommunityContentState(emptyState = FeedEmptyState.ALL_MODULES_HIDDEN, wikiSite = WikiSite.preview()),
+            forYouContentState = ForYouContentState(isInitialLoading = true, wikiSite = WikiSite.preview()),
             tabsState = TabsState(1, false),
             notificationBellState = NotificationBellState(unreadCount = 5, canShow = true)
         )
@@ -525,8 +525,8 @@ private fun HomeScreenForYouAllModulesOffPreview() {
         HomeScreen(
             wikiSite = WikiSite.preview(),
             selectedTab = HomeTab.FOR_YOU,
-            communityContentState = CommunityContentState(isInitialLoading = true),
-            forYouContentState = ForYouContentState(emptyState = FeedEmptyState.ALL_MODULES_HIDDEN),
+            communityContentState = CommunityContentState(isInitialLoading = true, wikiSite = WikiSite.preview()),
+            forYouContentState = ForYouContentState(emptyState = FeedEmptyState.ALL_MODULES_HIDDEN, wikiSite = WikiSite.preview()),
             tabsState = TabsState(1, false),
             notificationBellState = NotificationBellState(unreadCount = 5, canShow = true)
         )
@@ -540,8 +540,8 @@ fun HomeScreenCommunityPreview() {
         HomeScreen(
             wikiSite = WikiSite.preview(),
             selectedTab = HomeTab.COMMUNITY,
-            communityContentState = CommunityContentState(isInitialLoading = true),
-            forYouContentState = ForYouContentState(isInitialLoading = true),
+            communityContentState = CommunityContentState(isInitialLoading = true, wikiSite = WikiSite.preview()),
+            forYouContentState = ForYouContentState(isInitialLoading = true, wikiSite = WikiSite.preview()),
             tabsState = TabsState(1, false),
             notificationBellState = NotificationBellState(unreadCount = 5, canShow = true)
         )
@@ -555,8 +555,8 @@ fun HomeScreenForYouPreview() {
         HomeScreen(
             wikiSite = WikiSite.preview(),
             selectedTab = HomeTab.FOR_YOU,
-            communityContentState = CommunityContentState(isInitialLoading = true),
-            forYouContentState = ForYouContentState(isInitialLoading = true),
+            communityContentState = CommunityContentState(isInitialLoading = true, wikiSite = WikiSite.preview()),
+            forYouContentState = ForYouContentState(isInitialLoading = true, wikiSite = WikiSite.preview()),
             tabsState = TabsState(1, false),
             notificationBellState = NotificationBellState(unreadCount = 99, canShow = true)
         )

--- a/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/becauseyouread/BecauseYouReadModule.kt
@@ -66,19 +66,10 @@ fun BecauseYouReadModule(
 @Preview
 @Composable
 fun BecauseYouReadCardPreviewWithImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = "https://example.com/thumb.jpg"
-    )
-    val card = BecauseYouReadCard(title, sourceDisplayTitle = "<i>Test Article</i>")
+    val card = BecauseYouReadCard(PageTitle.preview(), sourceDisplayTitle = "<i>Test Article</i>")
     BaseTheme(currentTheme = Theme.LIGHT) {
         BecauseYouReadModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.BecauseYouRead(0, 0, mutableListOf(card, card, card, card))
         )
     }
@@ -87,19 +78,10 @@ fun BecauseYouReadCardPreviewWithImage() {
 @Preview
 @Composable
 fun BecauseYouReadCardPreviewNoImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = null
-    )
-    val card = BecauseYouReadCard(title, sourceDisplayTitle = "Test Article")
+    val card = BecauseYouReadCard(PageTitle.preview(withThumbnail = false), sourceDisplayTitle = "Test Article")
     BaseTheme(currentTheme = Theme.LIGHT) {
         BecauseYouReadModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.BecauseYouRead(0, 0, mutableListOf(card, card, card, card))
         )
     }
@@ -108,19 +90,10 @@ fun BecauseYouReadCardPreviewNoImage() {
 @Preview
 @Composable
 fun BecauseYouReadCardPreviewTextOnlyWithImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = "test.jpg"
-    )
-    val card = BecauseYouReadCard(title, sourceDisplayTitle = "Test Article")
+    val card = BecauseYouReadCard(PageTitle.preview(), sourceDisplayTitle = "Test Article")
     BaseTheme(currentTheme = Theme.LIGHT) {
         BecauseYouReadModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.BecauseYouRead(0, 0, mutableListOf(card, card, card, card))
         )
     }

--- a/app/src/main/java/org/wikipedia/feed/continuereading/ContinueReadingModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/continuereading/ContinueReadingModule.kt
@@ -66,19 +66,10 @@ fun ContinueReadingModule(
 @Preview
 @Composable
 fun ContinueReadingCardPreviewWithImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = "https://example.com/thumb.jpg"
-    )
-    val card = ContinueReadingCard(title, HistoryEntry.SOURCE_HISTORY)
+    val card = ContinueReadingCard(PageTitle.preview(), HistoryEntry.SOURCE_HISTORY)
     BaseTheme(currentTheme = Theme.LIGHT) {
         ContinueReadingModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.ContinueReading(0, 0, mutableListOf(card, card, card, card))
         )
     }
@@ -87,19 +78,10 @@ fun ContinueReadingCardPreviewWithImage() {
 @Preview
 @Composable
 fun ContinueReadingCardPreviewNoImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = null
-    )
-    val card = ContinueReadingCard(title, HistoryEntry.SOURCE_HISTORY)
+    val card = ContinueReadingCard(PageTitle.preview(withThumbnail = false), HistoryEntry.SOURCE_HISTORY)
     BaseTheme(currentTheme = Theme.LIGHT) {
         ContinueReadingModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.ContinueReading(0, 0, mutableListOf(card, card, card, card))
         )
     }
@@ -108,19 +90,10 @@ fun ContinueReadingCardPreviewNoImage() {
 @Preview
 @Composable
 fun ContinueReadingCardPreviewTextOnlyWithImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = "test.jpg"
-    )
-    val card = ContinueReadingCard(title, HistoryEntry.SOURCE_HISTORY)
+    val card = ContinueReadingCard(PageTitle.preview(), HistoryEntry.SOURCE_HISTORY)
     BaseTheme(currentTheme = Theme.LIGHT) {
         ContinueReadingModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.ContinueReading(0, 0, mutableListOf(card, card, card, card))
         )
     }

--- a/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/featured/FeaturedArticleModule.kt
@@ -198,7 +198,7 @@ fun FeaturedArticleCardWithImagePreview() {
     BaseTheme(currentTheme = Theme.LIGHT) {
         FeaturedArticleModule(
             wikiSite = WikiSite.preview(),
-            article = PageSummary("Lorem ipsum", "Lorem ipsum", "Lorem ipsum", "Lorem ipsum", thumbnail = "test.jpg", "")
+            article = PageSummary.preview()
         )
     }
 }
@@ -209,7 +209,7 @@ fun FeaturedArticleCardNoImagePreview() {
     BaseTheme(currentTheme = Theme.LIGHT) {
         FeaturedArticleModule(
             wikiSite = WikiSite.preview(),
-            article = PageSummary("Lorem ipsum", "Lorem ipsum", "Lorem ipsum", "Lorem ipsum", thumbnail = null, "")
+            article = PageSummary.preview(withThumbnail = false)
         )
     }
 }

--- a/app/src/main/java/org/wikipedia/feed/interests/BasedOnInterestModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/interests/BasedOnInterestModule.kt
@@ -72,19 +72,10 @@ fun BasedOnInterestModule(
 @Preview
 @Composable
 fun BasedOnInterestCardPreviewWithImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = "https://example.com/thumb.jpg"
-    )
-    val card = BasedOnInterestCard(title)
+    val card = BasedOnInterestCard(PageTitle.preview())
     BaseTheme(currentTheme = Theme.LIGHT) {
         BasedOnInterestModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.BasedOnInterest(0, 0, mutableListOf(card, card, card, card))
         )
     }
@@ -93,19 +84,10 @@ fun BasedOnInterestCardPreviewWithImage() {
 @Preview
 @Composable
 fun BasedOnInterestCardPreviewNoImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = null
-    )
-    val card = BasedOnInterestCard(title)
+    val card = BasedOnInterestCard(PageTitle.preview(withThumbnail = false))
     BaseTheme(currentTheme = Theme.LIGHT) {
         BasedOnInterestModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.BasedOnInterest(0, 0, mutableListOf(card, card, card, card))
         )
     }
@@ -114,19 +96,10 @@ fun BasedOnInterestCardPreviewNoImage() {
 @Preview
 @Composable
 fun BasedOnInterestCardPreviewTextOnlyWithImage() {
-    val wikiSite = WikiSite.preview()
-    val title = PageTitle(
-        text = "Test Article",
-        displayText = "Test Article",
-        wiki = WikiSite.preview(),
-        description = "This is a test article",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbUrl = "test.jpg"
-    )
-    val card = BasedOnInterestCard(title)
+    val card = BasedOnInterestCard(PageTitle.preview())
     BaseTheme(currentTheme = Theme.LIGHT) {
         BasedOnInterestModule(
-            wikiSite = wikiSite,
+            wikiSite = WikiSite.preview(),
             module = ForYouModule.BasedOnInterest(0, 0, mutableListOf(card, card, card, card))
         )
     }

--- a/app/src/main/java/org/wikipedia/feed/news/NewsModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/news/NewsModule.kt
@@ -151,29 +151,21 @@ private fun removeItalicParenthetical(text: String): String {
 @Preview(showBackground = true)
 @Composable
 fun NewsCardPreviewWithImage() {
-    val pageSummary = PageSummary(
-        displayTitle = "Dog and Cat",
-        prefixTitle = "Dog_and_Cat",
-        description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbnail = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/1200px-Commons-logo.svg.png",
-        lang = "en"
-    )
     BaseTheme(currentTheme = Theme.LIGHT) {
         NewsModule(
             wikiSite = WikiSite.preview(),
             newsItems = listOf(
                 NewsItem(
                     story = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-                    links = listOf(pageSummary)
+                    links = listOf(PageSummary.preview())
                 ),
                 NewsItem(
                     story = "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-                    links = listOf(pageSummary)
+                    links = listOf(PageSummary.preview())
                 ),
                 NewsItem(
                     story = "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-                    links = listOf(pageSummary)
+                    links = listOf(PageSummary.preview())
                 )
             )
         )
@@ -183,29 +175,21 @@ fun NewsCardPreviewWithImage() {
 @Preview(showBackground = true)
 @Composable
 fun NewsCardPreviewNoImage() {
-    val pageSummary = PageSummary(
-        displayTitle = "Dog and Cat",
-        prefixTitle = "Dog_and_Cat",
-        description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbnail = null,
-        lang = "en"
-    )
     BaseTheme(currentTheme = Theme.LIGHT) {
         NewsModule(
             wikiSite = WikiSite.preview(),
             newsItems = listOf(
                 NewsItem(
                     story = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-                    links = listOf(pageSummary)
+                    links = listOf(PageSummary.preview())
                 ),
                 NewsItem(
                     story = "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-                    links = listOf(pageSummary)
+                    links = listOf(PageSummary.preview())
                 ),
                 NewsItem(
                     story = "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-                    links = listOf(pageSummary)
+                    links = listOf(PageSummary.preview())
                 )
             )
         )

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayModule.kt
@@ -304,20 +304,12 @@ private fun OnThisDayPageItem(
 @Preview
 @Composable
 fun OnThisDayPageItemPreview() {
-    val pageSummary = PageSummary(
-        displayTitle = "Dog and Cat",
-        prefixTitle = "Dog_and_Cat",
-        description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbnail = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/1200px-Commons-logo.svg.png",
-        lang = "en"
-    )
     BaseTheme(currentTheme = Theme.LIGHT) {
         OnThisDayPageItem(
             LocalContext.current,
             viewPortSize = DpSize(360.dp, 80.dp),
             wikiSite = WikiSite.preview(),
-            pageSummary = pageSummary,
+            pageSummary = PageSummary.preview(),
             pageOverflowContent = {},
             onPageClick = {},
             onPageOverflowClick = {}
@@ -328,19 +320,10 @@ fun OnThisDayPageItemPreview() {
 @Preview
 @Composable
 fun OnThisDayModulePreview() {
-    val pageSummary = PageSummary(
-        displayTitle = "Lorem ipsum",
-        prefixTitle = "Lorem_ipsum",
-        description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbnail = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/1200px-Commons-logo.svg.png",
-        lang = "en"
-    )
-
     val event = OnThisDay.Event(
         year = 2023,
         text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-        pages = listOf(pageSummary, pageSummary, pageSummary)
+        pages = listOf(PageSummary.preview(), PageSummary.preview(), PageSummary.preview())
     )
 
     BaseTheme(currentTheme = Theme.LIGHT) {

--- a/app/src/main/java/org/wikipedia/feed/topread/TopReadModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/topread/TopReadModule.kt
@@ -238,14 +238,7 @@ fun TopReadItem(
 @Preview(showBackground = true)
 @Composable
 fun TopReadCardPreview() {
-    val article = PageSummary(
-        displayTitle = "Test Article",
-        prefixTitle = "Test_Article",
-        description = "This is a test article.",
-        extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        thumbnail = null,
-        lang = "en"
-    )
+    val article = PageSummary.preview()
     BaseTheme(currentTheme = Theme.LIGHT) {
         TopReadModule(
             wikiSite = WikiSite.preview(),

--- a/app/src/main/java/org/wikipedia/page/PageTitle.kt
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.kt
@@ -239,5 +239,19 @@ data class PageTitle(
             }
             return titleForInternalLink(path, wiki)
         }
+
+        /**
+         * For use in Composable previews.
+         */
+        fun preview(withThumbnail: Boolean = true): PageTitle {
+            return PageTitle(
+                text = "Test Article",
+                displayText = "Test <i>Article</i>",
+                wiki = WikiSite.preview(),
+                description = "This is a test article",
+                extract = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                thumbUrl = if (withThumbnail) "https://example.com/thumb.jpg" else null
+            )
+        }
     }
 }


### PR DESCRIPTION
We've got tons of repetition of `PageTitle(...)` and `PageSummary(...)` objects in Composable previews. Let's consolidate these into a convenience function, and reduce a bunch of code.