### PR TITLE
Explore feed reload places when feed language changes

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -197,12 +197,13 @@ class HomeViewModel : ViewModel() {
     /**
      * The Places of Interest module is loaded differently from the other "For you" modules, because it depends on location permission
      * and the user's saved location from Places. So it lives in its own flow that reacts to those changes directly.
-     * Whenever the saved location changes, we rebuild just this module (emitting a loading placeholder first
-     * when permission is granted) rather than reloading the entire tab. The result is merged into forYouState
-     * and sorted into its usual position by using ForYouModuleType enum ordinal.
+     * Whenever the saved location or the feed language changes, we rebuild just this module (emitting a loading
+     * placeholder first when permission is granted) rather than reloading the entire tab. The result is merged into
+     * forYouState and sorted into its usual position by using ForYouModuleType enum ordinal.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    private val placesModule: StateFlow<ForYouModule.PlacesOfInterest?> = Prefs.placesLastLocationFlow
+    private val placesModule: StateFlow<ForYouModule.PlacesOfInterest?> =
+        combine(Prefs.placesLastLocationFlow, _wikiSite) { _, _ -> }
         .transformLatest {
             if (hasLocationPermission()) {
                 emit(ForYouModule.PlacesOfInterest(age = 0, index = 0, cards = emptyList(), isLoading = true, hasLocationPermission = true))

--- a/app/src/main/java/org/wikipedia/feed/personalization/PersonalizationViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/PersonalizationViewModel.kt
@@ -282,6 +282,8 @@ class PersonalizationViewModel(
                 state.update { it.copy(articlesError = throwable) }
             }
         ) {
+            interestsUpdated = true
+            clearForYouCache()
             interestSelectionRepository.saveArticle(title, interestSelectionRepository.wikiSite.languageCode)
             state.update {
                 val newItems = listOf(title) + it.articles


### PR DESCRIPTION
### What does this do?
Currently, the Places module does not reload when the feed language changes. This PR fixes that issue and also clears the cache when the user updates their interests from the search bar. 

