### PR TITLE
Home feed: Design updates for Did You Know

### DIFF
--- a/app/src/main/java/org/wikipedia/Constants.kt
+++ b/app/src/main/java/org/wikipedia/Constants.kt
@@ -115,6 +115,7 @@ object Constants {
         ACTIVITY_TAB("activityTab"),
         GAMES_HUB("gamesHub"),
         FEED_INTEREST_SELECTION("feedInterestSelection"),
+        DID_YOU_KNOW("didYouKnow"),
     }
 
     enum class ImageEditType(name: String) {

--- a/app/src/main/java/org/wikipedia/compose/components/HtmlText.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/HtmlText.kt
@@ -28,8 +28,6 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
-import kotlin.math.roundToInt
-import kotlinx.coroutines.withTimeoutOrNull
 import org.wikipedia.WikipediaApp
 import org.wikipedia.compose.extensions.composeFromHtml
 import org.wikipedia.compose.theme.BaseTheme
@@ -37,6 +35,7 @@ import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.dataclient.WikiSite
 import org.wikipedia.theme.Theme
 import org.wikipedia.util.UriUtil
+import kotlin.math.roundToInt
 
 @Composable
 fun HtmlText(
@@ -88,26 +87,24 @@ fun HtmlText(
                             }
                         }
                         if (isLongPress) {
+                            var didLongPress = false
                             layoutResult?.let { layout ->
                                 val charPosition = layout.getOffsetForPosition(down.position)
                                 annotatedString.getLinkAnnotations(charPosition, charPosition)
                                     .firstOrNull()?.let { range ->
                                         (range.item as? LinkAnnotation.Url)?.url?.let { url ->
-                                            onLongClickLink(
-                                                url,
-                                                IntOffset(
-                                                    down.position.x.roundToInt(),
-                                                    down.position.y.roundToInt()
-                                                )
-                                            )
+                                            onLongClickLink(url, IntOffset(down.position.x.roundToInt(), down.position.y.roundToInt()))
+                                            didLongPress = true
                                         }
                                     }
                             }
-                            var stillDown = true
-                            while (stillDown) {
-                                val event = awaitPointerEvent(PointerEventPass.Initial)
-                                event.changes.forEach { it.consume() }
-                                stillDown = event.changes.any { it.pressed }
+                            if (didLongPress) {
+                                var stillDown = true
+                                while (stillDown) {
+                                    val event = awaitPointerEvent(PointerEventPass.Initial)
+                                    event.changes.forEach { it.consume() }
+                                    stillDown = event.changes.any { it.pressed }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/org/wikipedia/compose/components/HtmlText.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/HtmlText.kt
@@ -1,23 +1,35 @@
 package org.wikipedia.compose.components
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
+import kotlin.math.roundToInt
+import kotlinx.coroutines.withTimeoutOrNull
 import org.wikipedia.WikipediaApp
 import org.wikipedia.compose.extensions.composeFromHtml
 import org.wikipedia.compose.theme.BaseTheme
@@ -45,16 +57,65 @@ fun HtmlText(
     overflow: TextOverflow = TextOverflow.Ellipsis,
     lineHeight: TextUnit = 1.6.em,
     linkInteractionListener: LinkInteractionListener = defaultLinkInteractionListener(),
+    onLongClickLink: ((url: String, offset: IntOffset) -> Unit)? = null,
     textAlign: TextAlign = TextAlign.Start,
     autoSize: TextAutoSize? = null
 ) {
+    val annotatedString = AnnotatedString.composeFromHtml(
+        htmlString = text,
+        linkStyles = linkStyle,
+        linkInteractionListener = linkInteractionListener
+    )
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+
     Text(
-        modifier = modifier,
-        text = AnnotatedString.composeFromHtml(
-            htmlString = text,
-            linkStyles = linkStyle,
-            linkInteractionListener = linkInteractionListener
+        modifier = modifier.then(
+            if (onLongClickLink != null) {
+                // Use PointerEventPass.Initial so our handler fires BEFORE Text's internal link
+                // handler (which uses Main pass, inner-to-outer). On short taps we leave events
+                // unconsumed so Text handles clicks normally. On long press we fire the callback
+                // and consume the eventual up event to prevent Text from also triggering a click.
+                Modifier.pointerInput(text) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                        var isLongPress = true
+                        withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
+                            while (isLongPress) {
+                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                if (event.changes.any { !it.pressed && it.previousPressed }) {
+                                    isLongPress = false
+                                }
+                            }
+                        }
+                        if (isLongPress) {
+                            layoutResult?.let { layout ->
+                                val charPosition = layout.getOffsetForPosition(down.position)
+                                annotatedString.getLinkAnnotations(charPosition, charPosition)
+                                    .firstOrNull()?.let { range ->
+                                        (range.item as? LinkAnnotation.Url)?.url?.let { url ->
+                                            onLongClickLink(
+                                                url,
+                                                IntOffset(
+                                                    down.position.x.roundToInt(),
+                                                    down.position.y.roundToInt()
+                                                )
+                                            )
+                                        }
+                                    }
+                            }
+                            var stillDown = true
+                            while (stillDown) {
+                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                event.changes.forEach { it.consume() }
+                                stillDown = event.changes.any { it.pressed }
+                            }
+                        }
+                    }
+                }
+            } else Modifier
         ),
+        text = annotatedString,
+        onTextLayout = { result -> layoutResult = result },
         lineHeight = lineHeight,
         style = style,
         color = color,

--- a/app/src/main/java/org/wikipedia/compose/components/menu/PageOverflowMenu.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/menu/PageOverflowMenu.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import org.wikipedia.compose.theme.WikipediaTheme
@@ -23,8 +22,7 @@ fun PageOverflowMenu(
     menuKey: String,
     overflowMenuState: PageOverflowMenuViewModel.PageOverflowMenuState?,
     onDismiss: () -> Unit,
-    items: List<Pair<String, () -> Unit>>,
-    offset: DpOffset = DpOffset.Zero
+    items: List<Pair<String, () -> Unit>>
 ) {
     val expanded = menuKey == overflowMenuState?.menuKey
     var animatedExpanded by remember(menuKey) { mutableStateOf(false) }
@@ -48,7 +46,6 @@ fun PageOverflowMenu(
         modifier = modifier,
         expanded = animatedExpanded,
         onDismissRequest = { animatedExpanded = false },
-        offset = offset,
         containerColor = WikipediaTheme.colors.paperColor,
     ) {
         items.forEach { (label, action) ->

--- a/app/src/main/java/org/wikipedia/compose/components/menu/PageOverflowMenu.kt
+++ b/app/src/main/java/org/wikipedia/compose/components/menu/PageOverflowMenu.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import org.wikipedia.compose.theme.WikipediaTheme
@@ -22,7 +23,8 @@ fun PageOverflowMenu(
     menuKey: String,
     overflowMenuState: PageOverflowMenuViewModel.PageOverflowMenuState?,
     onDismiss: () -> Unit,
-    items: List<Pair<String, () -> Unit>>
+    items: List<Pair<String, () -> Unit>>,
+    offset: DpOffset = DpOffset.Zero
 ) {
     val expanded = menuKey == overflowMenuState?.menuKey
     var animatedExpanded by remember(menuKey) { mutableStateOf(false) }
@@ -46,6 +48,7 @@ fun PageOverflowMenu(
         modifier = modifier,
         expanded = animatedExpanded,
         onDismissRequest = { animatedExpanded = false },
+        offset = offset,
         containerColor = WikipediaTheme.colors.paperColor,
     ) {
         items.forEach { (label, action) ->

--- a/app/src/main/java/org/wikipedia/feed/CommunityContentTab.kt
+++ b/app/src/main/java/org/wikipedia/feed/CommunityContentTab.kt
@@ -270,13 +270,12 @@ fun CommunityContentTab(
                                         },
                                         onFooterClick = { onCardFooterClick(card) },
                                         onCardImpression = { onCardImpression(card, cardIndex) },
-                                        pageOverflowContent = { index, offset ->
+                                        pageOverflowContent = { index ->
                                             PageOverflowMenu(
                                                 menuKey = "dyk-${card.date}-$index",
                                                 overflowMenuState = overflowMenuState,
                                                 onDismiss = onPageOverflowDismiss,
-                                                items = overflowMenuState?.items.orEmpty(),
-                                                offset = offset
+                                                items = overflowMenuState?.items.orEmpty()
                                             )
                                         },
                                         onPageOverflowClick = { pageSummary, index ->

--- a/app/src/main/java/org/wikipedia/feed/CommunityContentTab.kt
+++ b/app/src/main/java/org/wikipedia/feed/CommunityContentTab.kt
@@ -270,12 +270,13 @@ fun CommunityContentTab(
                                         },
                                         onFooterClick = { onCardFooterClick(card) },
                                         onCardImpression = { onCardImpression(card, cardIndex) },
-                                        pageOverflowContent = { index ->
+                                        pageOverflowContent = { index, offset ->
                                             PageOverflowMenu(
                                                 menuKey = "dyk-${card.date}-$index",
                                                 overflowMenuState = overflowMenuState,
                                                 onDismiss = onPageOverflowDismiss,
-                                                items = overflowMenuState?.items.orEmpty()
+                                                items = overflowMenuState?.items.orEmpty(),
+                                                offset = offset
                                             )
                                         },
                                         onPageOverflowClick = { pageSummary, index ->

--- a/app/src/main/java/org/wikipedia/feed/CommunityContentTab.kt
+++ b/app/src/main/java/org/wikipedia/feed/CommunityContentTab.kt
@@ -269,7 +269,18 @@ fun CommunityContentTab(
                                             onPageClick(card, HistoryEntry(it, HistoryEntry.SOURCE_FEED_DID_YOU_KNOW))
                                         },
                                         onFooterClick = { onCardFooterClick(card) },
-                                        onCardImpression = { onCardImpression(card, cardIndex) }
+                                        onCardImpression = { onCardImpression(card, cardIndex) },
+                                        pageOverflowContent = { index ->
+                                            PageOverflowMenu(
+                                                menuKey = "dyk-${card.date}-$index",
+                                                overflowMenuState = overflowMenuState,
+                                                onDismiss = onPageOverflowDismiss,
+                                                items = overflowMenuState?.items.orEmpty()
+                                            )
+                                        },
+                                        onPageOverflowClick = { pageSummary, index ->
+                                            onPageOverflowClick(card, pageSummary, HistoryEntry.SOURCE_FEED_MOST_READ, "dyk-${card.date}-$index")
+                                        }
                                     )
                                 }
                             }

--- a/app/src/main/java/org/wikipedia/feed/CommunityContentTab.kt
+++ b/app/src/main/java/org/wikipedia/feed/CommunityContentTab.kt
@@ -279,7 +279,7 @@ fun CommunityContentTab(
                                             )
                                         },
                                         onPageOverflowClick = { pageSummary, index ->
-                                            onPageOverflowClick(card, pageSummary, HistoryEntry.SOURCE_FEED_MOST_READ, "dyk-${card.date}-$index")
+                                            onPageOverflowClick(card, pageSummary, HistoryEntry.SOURCE_FEED_DID_YOU_KNOW, "dyk-${card.date}-$index")
                                         }
                                     )
                                 }

--- a/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowActivity.kt
+++ b/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowActivity.kt
@@ -164,7 +164,7 @@ fun DidYouKnowScreen(
                                 items = overflowMenuState?.items.orEmpty()
                             )
                         },
-                        onPageOverflowClick = { onPageOverflowClick(it, HistoryEntry.SOURCE_FEED_MOST_READ, "dyk-$index") }
+                        onPageOverflowClick = { onPageOverflowClick(it, HistoryEntry.SOURCE_ACTIVITY_DID_YOU_KNOW, "dyk-$index") }
                     )
                 }
             }

--- a/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowActivity.kt
+++ b/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowActivity.kt
@@ -156,12 +156,13 @@ fun DidYouKnowScreen(
                         wikiSite = wikiSite,
                         dykHtml = html,
                         onClick = onPageClick,
-                        pageOverflowContent = {
+                        pageOverflowContent = { offset ->
                             PageOverflowMenu(
                                 menuKey = "dyk-$index",
                                 overflowMenuState = overflowMenuState,
                                 onDismiss = onPageOverflowDismiss,
-                                items = overflowMenuState?.items.orEmpty()
+                                items = overflowMenuState?.items.orEmpty(),
+                                offset = offset
                             )
                         },
                         onPageOverflowClick = { onPageOverflowClick(it, HistoryEntry.SOURCE_FEED_MOST_READ, "dyk-$index") }

--- a/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowActivity.kt
+++ b/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowActivity.kt
@@ -156,13 +156,12 @@ fun DidYouKnowScreen(
                         wikiSite = wikiSite,
                         dykHtml = html,
                         onClick = onPageClick,
-                        pageOverflowContent = { offset ->
+                        pageOverflowContent = {
                             PageOverflowMenu(
                                 menuKey = "dyk-$index",
                                 overflowMenuState = overflowMenuState,
                                 onDismiss = onPageOverflowDismiss,
-                                items = overflowMenuState?.items.orEmpty(),
-                                offset = offset
+                                items = overflowMenuState?.items.orEmpty()
                             )
                         },
                         onPageOverflowClick = { onPageOverflowClick(it, HistoryEntry.SOURCE_FEED_MOST_READ, "dyk-$index") }

--- a/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowActivity.kt
+++ b/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowActivity.kt
@@ -2,8 +2,11 @@ package org.wikipedia.feed.didyouknow
 
 import android.content.Context
 import android.content.Intent
+import android.icu.text.ListFormatter
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -15,20 +18,32 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wikipedia.Constants
+import org.wikipedia.Constants.InvokeSource
 import org.wikipedia.R
 import org.wikipedia.activity.BaseActivity
 import org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent
 import org.wikipedia.compose.components.WikiTopAppBar
+import org.wikipedia.compose.components.menu.PageOverflowMenu
+import org.wikipedia.compose.components.menu.PageOverflowMenuViewModel
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.extensions.parcelableExtra
 import org.wikipedia.history.HistoryEntry
 import org.wikipedia.page.PageActivity
 import org.wikipedia.page.PageTitle
+import org.wikipedia.readinglist.ReadingListBehaviorsUtil
+import org.wikipedia.readinglist.RemoveFromReadingListsDialog
 import org.wikipedia.theme.Theme
+import org.wikipedia.util.ClipboardUtil
+import org.wikipedia.util.FeedbackUtil
+import org.wikipedia.util.ShareUtil
+import kotlin.collections.orEmpty
+import kotlin.getValue
 
 class DidYouKnowActivity : BaseActivity() {
+    private val pageOverflowMenuViewModel: PageOverflowMenuViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,6 +59,52 @@ class DidYouKnowActivity : BaseActivity() {
                     onPageClick = {
                         val entry = HistoryEntry(it, HistoryEntry.SOURCE_ACTIVITY_DID_YOU_KNOW)
                         startActivity(PageActivity.newIntentForNewTab(this, entry, entry.title))
+                    },
+                    overflowMenuState = pageOverflowMenuViewModel.pageOverflowMenuState,
+                    onPageOverflowDismiss = {
+                        pageOverflowMenuViewModel.dismissPageOverflowMenu()
+                    },
+                    onPageOverflowClick = { pageSummary, source, menuKey ->
+                        pageOverflowMenuViewModel.onPageOverflowClick(
+                            context = this,
+                            wikiSite = wikiSite,
+                            pageSummary = pageSummary,
+                            source = source,
+                            menuKey = menuKey,
+                            onOpenPage = { entry ->
+                                startActivity(PageActivity.newIntentForCurrentTab(this, entry, entry.title))
+                            },
+                            onOpenInNewTab = { entry ->
+                                startActivity(PageActivity.newIntentForNewTab(this, entry, entry.title))
+                            },
+                            onAddRequest = { entry, addToDefault ->
+                                ReadingListBehaviorsUtil.addToDefaultList(this, entry.title, addToDefault, InvokeSource.DID_YOU_KNOW)
+                            },
+                            onMoveRequest = { id, entry ->
+                                ReadingListBehaviorsUtil.moveToList(this, id, entry.title, InvokeSource.FEED)
+                            },
+                            onRemoveRequest = { entry, lists ->
+                                RemoveFromReadingListsDialog(lists).deleteOrShowDialog(this) { readingLists, _ ->
+                                    if (!this.isDestroyed) {
+                                        val names = readingLists.map { it.title }.run {
+                                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                                ListFormatter.getInstance().format(this)
+                                            } else {
+                                                joinToString(separator = ", ")
+                                            }
+                                        }
+                                        FeedbackUtil.showMessage(this, getString(R.string.reading_list_item_deleted_from_list, entry.title.displayText, names))
+                                    }
+                                }
+                            },
+                            onShareRequest = { entry ->
+                                ShareUtil.shareText(this, entry.title.displayText, entry.title.uri)
+                            },
+                            onLinkCopyRequest = { entry ->
+                                ClipboardUtil.setPlainText(this, text = entry.title.uri)
+                                FeedbackUtil.showMessage(this, R.string.address_copied)
+                            }
+                        )
                     }
                 )
             }
@@ -66,6 +127,9 @@ fun DidYouKnowScreen(
     dykHtmlList: List<String>,
     onNavigateBack: () -> Unit,
     onPageClick: (PageTitle) -> Unit,
+    overflowMenuState: PageOverflowMenuViewModel.PageOverflowMenuState? = null,
+    onPageOverflowDismiss: () -> Unit = {},
+    onPageOverflowClick: (pageSummary: PageSummary, source: Int, menuKey: String) -> Unit = { _, _, _ -> },
 ) {
     val context = LocalContext.current
     Scaffold(
@@ -86,12 +150,21 @@ fun DidYouKnowScreen(
             modifier = Modifier.padding(horizontal = 16.dp),
             contentPadding = paddingValues
         ) {
-            dykHtmlList.forEach {
+            dykHtmlList.forEachIndexed { index, html ->
                 item {
                     DidYouKnowListItem(
                         wikiSite = wikiSite,
-                        dykHtml = it,
+                        dykHtml = html,
                         onClick = onPageClick,
+                        pageOverflowContent = {
+                            PageOverflowMenu(
+                                menuKey = "dyk-$index",
+                                overflowMenuState = overflowMenuState,
+                                onDismiss = onPageOverflowDismiss,
+                                items = overflowMenuState?.items.orEmpty()
+                            )
+                        },
+                        onPageOverflowClick = { onPageOverflowClick(it, HistoryEntry.SOURCE_FEED_MOST_READ, "dyk-$index") }
                     )
                 }
             }

--- a/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowModule.kt
@@ -56,7 +56,7 @@ fun DidYouKnowModule(
     onPageClick: (PageTitle) -> Unit,
     onFooterClick: () -> Unit,
     onCardImpression: () -> Unit = {},
-    pageOverflowContent: @Composable (Int) -> Unit = {},
+    pageOverflowContent: @Composable (Int, DpOffset) -> Unit = { _, _ -> },
     onPageOverflowClick: (PageSummary, Int) -> Unit = { _, _ -> },
 ) {
     val maxDidYouKnowItems = 3
@@ -80,7 +80,7 @@ fun DidYouKnowModule(
                     wikiSite = wikiSite,
                     dykHtml = item.html,
                     onClick = onPageClick,
-                    pageOverflowContent = { pageOverflowContent(index) },
+                    pageOverflowContent = { offset -> pageOverflowContent(index, offset) },
                     onPageOverflowClick = { onPageOverflowClick(it, index) }
                 )
             }
@@ -113,7 +113,7 @@ fun DidYouKnowListItem(
     wikiSite: WikiSite,
     dykHtml: String,
     onClick: (PageTitle) -> Unit,
-    pageOverflowContent: @Composable () -> Unit,
+    pageOverflowContent: @Composable (DpOffset) -> Unit,
     onPageOverflowClick: (PageSummary) -> Unit = {}
 ) {
     var menuOffset by remember { mutableStateOf(DpOffset.Zero) }
@@ -162,7 +162,7 @@ fun DidYouKnowListItem(
                             title.extract, title.thumbUrl, title.wikiSite.languageCode))
                     }
                 )
-                pageOverflowContent()
+                pageOverflowContent(menuOffset)
             }
         }
         Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowModule.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
@@ -47,6 +48,7 @@ import org.wikipedia.extensions.getString
 import org.wikipedia.feed.CommunityModuleContainer
 import org.wikipedia.page.PageTitle
 import org.wikipedia.theme.Theme
+import org.wikipedia.util.StringUtil
 
 @Composable
 fun DidYouKnowModule(
@@ -117,7 +119,7 @@ fun DidYouKnowListItem(
     pageOverflowContent: @Composable () -> Unit,
     onPageOverflowClick: (PageSummary) -> Unit = {}
 ) {
-    var menuOffset by remember { mutableStateOf(DpOffset.Zero) }
+    var longPressOffset by remember { mutableStateOf(DpOffset.Zero) }
     val density = LocalDensity.current
 
     Column {
@@ -148,7 +150,7 @@ fun DidYouKnowListItem(
 
             Box {
                 HtmlText(
-                    text = dykHtml,
+                    text = StringUtil.removeBoldTags(dykHtml),
                     color = WikipediaTheme.colors.primaryColor,
                     style = MaterialTheme.typography.bodyMedium,
                     linkInteractionListener = {
@@ -156,16 +158,15 @@ fun DidYouKnowListItem(
                         onClick(PageTitle.titleForUri(url.toUri(), wikiSite))
                     },
                     onLongClickLink = { url, intOffset ->
-                        menuOffset = with(density) { DpOffset(intOffset.x.toDp(), intOffset.y.toDp()) }
+                        longPressOffset = with(density) { DpOffset(intOffset.x.toDp(), intOffset.y.toDp()) }
                         val title = PageTitle.titleForUri(url.toUri(), wikiSite)
                         onPageOverflowClick(PageSummary(title.displayText, title.prefixedText, title.description,
                             title.extract, title.thumbUrl, title.wikiSite.languageCode))
                     }
                 )
                 // Zero-size anchor positioned at the tap point. DropdownMenu anchors to
-                // this box so it opens exactly at the long-press location regardless of
-                // whether it expands above or below the tap.
-                Box(modifier = Modifier.offset(x = menuOffset.x, y = menuOffset.y)) {
+                // this box so it opens exactly at the long-press location.
+                Box(modifier = Modifier.offset { IntOffset(longPressOffset.x.roundToPx(), longPressOffset.y.roundToPx()) }) {
                     pageOverflowContent()
                 }
             }

--- a/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowModule.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -56,7 +57,7 @@ fun DidYouKnowModule(
     onPageClick: (PageTitle) -> Unit,
     onFooterClick: () -> Unit,
     onCardImpression: () -> Unit = {},
-    pageOverflowContent: @Composable (Int, DpOffset) -> Unit = { _, _ -> },
+    pageOverflowContent: @Composable (Int) -> Unit = {},
     onPageOverflowClick: (PageSummary, Int) -> Unit = { _, _ -> },
 ) {
     val maxDidYouKnowItems = 3
@@ -80,7 +81,7 @@ fun DidYouKnowModule(
                     wikiSite = wikiSite,
                     dykHtml = item.html,
                     onClick = onPageClick,
-                    pageOverflowContent = { offset -> pageOverflowContent(index, offset) },
+                    pageOverflowContent = { pageOverflowContent(index) },
                     onPageOverflowClick = { onPageOverflowClick(it, index) }
                 )
             }
@@ -113,7 +114,7 @@ fun DidYouKnowListItem(
     wikiSite: WikiSite,
     dykHtml: String,
     onClick: (PageTitle) -> Unit,
-    pageOverflowContent: @Composable (DpOffset) -> Unit,
+    pageOverflowContent: @Composable () -> Unit,
     onPageOverflowClick: (PageSummary) -> Unit = {}
 ) {
     var menuOffset by remember { mutableStateOf(DpOffset.Zero) }
@@ -156,13 +157,17 @@ fun DidYouKnowListItem(
                     },
                     onLongClickLink = { url, intOffset ->
                         menuOffset = with(density) { DpOffset(intOffset.x.toDp(), intOffset.y.toDp()) }
-
                         val title = PageTitle.titleForUri(url.toUri(), wikiSite)
                         onPageOverflowClick(PageSummary(title.displayText, title.prefixedText, title.description,
                             title.extract, title.thumbUrl, title.wikiSite.languageCode))
                     }
                 )
-                pageOverflowContent(menuOffset)
+                // Zero-size anchor positioned at the tap point. DropdownMenu anchors to
+                // this box so it opens exactly at the long-press location regardless of
+                // whether it expands above or below the tap.
+                Box(modifier = Modifier.offset(x = menuOffset.x, y = menuOffset.y)) {
+                    pageOverflowContent()
+                }
             }
         }
         Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowModule.kt
+++ b/app/src/main/java/org/wikipedia/feed/didyouknow/DidYouKnowModule.kt
@@ -16,17 +16,23 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
@@ -35,6 +41,7 @@ import org.wikipedia.compose.components.HtmlText
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.dataclient.page.PageSummary
 import org.wikipedia.extensions.getString
 import org.wikipedia.feed.CommunityModuleContainer
 import org.wikipedia.page.PageTitle
@@ -48,7 +55,9 @@ fun DidYouKnowModule(
     onHideModuleClick: () -> Unit,
     onPageClick: (PageTitle) -> Unit,
     onFooterClick: () -> Unit,
-    onCardImpression: () -> Unit = {}
+    onCardImpression: () -> Unit = {},
+    pageOverflowContent: @Composable (Int) -> Unit = {},
+    onPageOverflowClick: (PageSummary, Int) -> Unit = { _, _ -> },
 ) {
     val maxDidYouKnowItems = 3
     val context = LocalContext.current
@@ -66,11 +75,13 @@ fun DidYouKnowModule(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            dyk.take(maxDidYouKnowItems).forEach { item ->
+            dyk.take(maxDidYouKnowItems).forEachIndexed { index, item ->
                 DidYouKnowListItem(
                     wikiSite = wikiSite,
                     dykHtml = item.html,
                     onClick = onPageClick,
+                    pageOverflowContent = { pageOverflowContent(index) },
+                    onPageOverflowClick = { onPageOverflowClick(it, index) }
                 )
             }
         }
@@ -101,8 +112,13 @@ fun DidYouKnowModule(
 fun DidYouKnowListItem(
     wikiSite: WikiSite,
     dykHtml: String,
-    onClick: (PageTitle) -> Unit
+    onClick: (PageTitle) -> Unit,
+    pageOverflowContent: @Composable () -> Unit,
+    onPageOverflowClick: (PageSummary) -> Unit = {}
 ) {
+    var menuOffset by remember { mutableStateOf(DpOffset.Zero) }
+    val density = LocalDensity.current
+
     Column {
         Row(
             modifier = Modifier.fillMaxWidth()
@@ -129,15 +145,25 @@ fun DidYouKnowListItem(
 
             Spacer(modifier = Modifier.width(8.dp))
 
-            HtmlText(
-                text = dykHtml,
-                color = WikipediaTheme.colors.primaryColor,
-                style = MaterialTheme.typography.bodyMedium,
-                linkInteractionListener = {
-                    val url = (it as LinkAnnotation.Url).url
-                    onClick(PageTitle.titleForUri(url.toUri(), wikiSite))
-                }
-            )
+            Box {
+                HtmlText(
+                    text = dykHtml,
+                    color = WikipediaTheme.colors.primaryColor,
+                    style = MaterialTheme.typography.bodyMedium,
+                    linkInteractionListener = {
+                        val url = (it as LinkAnnotation.Url).url
+                        onClick(PageTitle.titleForUri(url.toUri(), wikiSite))
+                    },
+                    onLongClickLink = { url, intOffset ->
+                        menuOffset = with(density) { DpOffset(intOffset.x.toDp(), intOffset.y.toDp()) }
+
+                        val title = PageTitle.titleForUri(url.toUri(), wikiSite)
+                        onPageOverflowClick(PageSummary(title.displayText, title.prefixedText, title.description,
+                            title.extract, title.thumbUrl, title.wikiSite.languageCode))
+                    }
+                )
+                pageOverflowContent()
+            }
         }
         Spacer(modifier = Modifier.height(24.dp))
     }

--- a/app/src/main/java/org/wikipedia/util/StringUtil.kt
+++ b/app/src/main/java/org/wikipedia/util/StringUtil.kt
@@ -78,6 +78,10 @@ object StringUtil {
         return fromHtml(text).toString()
     }
 
+    fun removeBoldTags(text: String): String {
+        return text.replace("</?b(?:\\s+[^>]*)?>".toRegex(), "")
+    }
+
     fun removeStyleTags(text: String): String {
         return text.replace("<style.*?</style>".toRegex(), "")
     }

--- a/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
+++ b/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
@@ -92,8 +92,9 @@ class StringUtilTest {
         assertEquals("te_st", StringUtil.removeHTMLTags("<tag>te_st</tag>"))
     }
 
+    @Test
     fun testRemoveBoldTags() {
-        assertEquals("Lorem <i>ipsum</i>", StringUtil.removeStyleTags("Lorem <b data=\"123\"><i>ipsum</i></b>"))
+        assertEquals("Lorem <i>ipsum</i>", StringUtil.removeBoldTags("Lorem <b data=\"123\"><i>ipsum</i></b>"))
     }
 
     @Test

--- a/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
+++ b/app/src/test/java/org/wikipedia/util/StringUtilTest.kt
@@ -92,6 +92,10 @@ class StringUtilTest {
         assertEquals("te_st", StringUtil.removeHTMLTags("<tag>te_st</tag>"))
     }
 
+    fun testRemoveBoldTags() {
+        assertEquals("Lorem <i>ipsum</i>", StringUtil.removeStyleTags("Lorem <b data=\"123\"><i>ipsum</i></b>"))
+    }
+
     @Test
     fun testRemoveStyleTags() {
         assertEquals("Lorem  <i>ipsum</i>", StringUtil.removeStyleTags("Lorem <style data=\"123\">test</style> <i>ipsum</i>"))


### PR DESCRIPTION
* This introduces the ability to _long-press_ links inside a `HtmlText` composable.
* Wire up long-pressing in both `DidYouKnowModule` and `DidYouKnowActivity` (with the same PageOverflowMenu logic as the rest of the feed). There is a bit of code duplication in `DidYouKnowActivity`, but this can be cleaned up and refactored as we go.
* Introduce a tiny function to strip away bold `<b>` tags from html strings, when necessary.

https://phabricator.wikimedia.org/T418898
