### PR TITLE
Home feed: Add tooltip explaining recent updates.

### DIFF
--- a/app/src/main/java/org/wikipedia/main/MainFragment.kt
+++ b/app/src/main/java/org/wikipedia/main/MainFragment.kt
@@ -195,6 +195,9 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, HistoryFragme
 
         binding.mainNavTabLayout.setOverlayDot(NavTab.EDITS, !Prefs.isActivityTabOnboardingShown)
 
+        maybeShowFeedNewModulesTooltip()
+        Prefs.incrementExploreFeedVisitCount()
+
         notificationButtonView = NotificationButtonView(requireActivity())
 
         if (savedInstanceState == null) {
@@ -568,6 +571,21 @@ class MainFragment : Fragment(), BackPressedHandler, MenuProvider, HistoryFragme
                 .setNegativeButton(R.string.shareable_reading_lists_new_install_dialog_got_it, null)
                 .show()
             Prefs.importReadingListsNewInstallDialogShown = true
+        }
+    }
+
+    private fun maybeShowFeedNewModulesTooltip() {
+        if (Prefs.exploreFeedVisitCount == 0) {
+            // Explicitly consider this tooltip "shown", since we only want to show it to users
+            // who have used the Feed already, instead of completely new users.
+            Prefs.isHomeFeedUpdateTooltipShown = true
+        } else if (!Prefs.isHomeFeedUpdateTooltipShown) {
+            Prefs.isHomeFeedUpdateTooltipShown = true
+            binding.root.post {
+                if (isAdded) {
+                    FeedbackUtil.showTooltip(requireActivity(), binding.mainNavTabLayout.findViewById(NavTab.HOME.id), getString(R.string.home_feed_update_tooltip1), aboveOrBelow = true, autoDismiss = false, showDismissButton = true)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -963,4 +963,8 @@ object Prefs {
     var isHomeSwipeToExplorePromptShown
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_home_swipe_to_explore_prompt_shown, false)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_home_swipe_to_explore_prompt_shown, value)
+
+    var isHomeFeedUpdateTooltipShown
+        get() = PrefsIoUtil.getBoolean(R.string.preference_key_home_feed_update_tooltip_shown, false)
+        set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_home_feed_update_tooltip_shown, value)
 }

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -2273,6 +2273,7 @@
   <string name="home_feed_for_you_screen_empty_ways_to_start">Header introducing suggested actions for getting started with the “For you” feed.</string>
   <string name="home_feed_for_you_screen_empty_add_interests">Link text prompting the user to add new interests to personalize the “For you” feed. Please keep the anchor link around the word \"some interests\"</string>
   <string name="home_feed_for_you_screen_empty_see_community">Link text prompting the user to explore the Community feed for additional content. Please keep the anchor link around the word \"community\"</string>
+  <string name="home_feed_update_tooltip1">Message that explains new features introduced into the Home Feed.</string>
   <string name="home_feed_random_title">Title for the Random Article module in the For You feed.</string>
   <string name="home_feed_random_subtitle">Description of the Random Article module in the For You feed.</string>
   <string name="home_feed_random_shuffle_button">Button label for going to the Randomizer feature in the app.</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -223,4 +223,5 @@
     <string name="preference_key_home_preference_selection">exploreFeedPreferenceSelection</string>
     <string name="preference_key_home_for_you_modules_today">homeForYouModulesToday</string>
     <string name="preference_key_home_swipe_to_explore_prompt_shown">homeSwipeToExplorePromptShown</string>
+    <string name="preference_key_home_feed_update_tooltip_shown">homeFeedUpdateTooltipShown</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2534,6 +2534,7 @@
     <string name="home_feed_for_you_screen_empty_ways_to_start">Ways to get started:</string>
     <string name="home_feed_for_you_screen_empty_add_interests"><![CDATA[Add <a href="#add_interests">some interests</a>]]></string>
     <string name="home_feed_for_you_screen_empty_see_community"><![CDATA[See what\'s happening in <a href="#community_tab">community</a>]]></string>
+    <string name="home_feed_update_tooltip1">New: \"Random Article\" and \"Places of Interest\" are available in For You and \"Did You Know\" is in the Community Tab.</string>
     <string name="home_feed_random_title">Random</string>
     <string name="home_feed_random_subtitle">Random article to spark your curiosity</string>
     <string name="home_feed_random_shuffle_button">Shuffle</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -590,6 +590,9 @@
         <org.wikipedia.settings.SwitchPreferenceMultiLine
             android:key="@string/preference_key_home_swipe_to_explore_prompt_shown"
             android:title="@string/preference_key_home_swipe_to_explore_prompt_shown"/>
+        <org.wikipedia.settings.SwitchPreferenceMultiLine
+            android:key="@string/preference_key_home_feed_update_tooltip_shown"
+            android:title="@string/preference_key_home_feed_update_tooltip_shown"/>
         <ListPreference
             android:key="@string/preference_key_home_preference_selection"
             android:title="Feed Preference Selection"/>


### PR DESCRIPTION
This shows a tooltip that tells the user about our new additions to the feed, but _only_ if the user has already been using the feed (`exploreFeedVisitCount > 0`).

https://phabricator.wikimedia.org/T428681
