### PR TITLE
Fix possible minor crash due to positional parameters in string.

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -653,12 +653,12 @@
     <item quantity="other">%d مقالة أزيلة من القائمة</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="zero">%d مقالة أُزيلت من  %s\n</item>
-    <item quantity="one">مقالة واحدة أُزيلت من  %s\n</item>
-    <item quantity="two">مقالتان أُزيلت من  %s\n</item>
-    <item quantity="few">%d مقالات أُزيلت من  %s\n</item>
-    <item quantity="many">%d مقالة أُزيلت من  %s\n</item>
-    <item quantity="other">%d مقالة أُزيلت من  %s\n</item>
+    <item quantity="zero">%1$d مقالة أُزيلت من  %2$s\n</item>
+    <item quantity="one">مقالة واحدة أُزيلت من  %2$s\n</item>
+    <item quantity="two">مقالتان أُزيلت من  %2$s\n</item>
+    <item quantity="few">%1$d مقالات أُزيلت من  %2$s\n</item>
+    <item quantity="many">%1$d مقالة أُزيلت من  %2$s\n</item>
+    <item quantity="other">%1$d مقالة أُزيلت من  %2$s\n</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="zero">%d قائمة محذوفة\n</item>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -553,8 +553,8 @@
     <item quantity="other">%d məqalə siyahıdan silindi</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d məqalə %s siyahısından silindi</item>
-    <item quantity="other">%d məqalə %s siyahısından silindi</item>
+    <item quantity="one">%1$d məqalə %2$s siyahısından silindi</item>
+    <item quantity="other">%1$d məqalə %2$s siyahısından silindi</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d siyahı silindi</item>

--- a/app/src/main/res/values-b+isv+Latn/strings.xml
+++ b/app/src/main/res/values-b+isv+Latn/strings.xml
@@ -564,10 +564,10 @@
     <item quantity="other">%d člankov odstranjenyh iz spiska</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d članok odstranjeny iz spiska %s</item>
-    <item quantity="few">%d članky odstranjene iz spiska %s</item>
-    <item quantity="many">%d člankov odstranjenyh iz spiska %s</item>
-    <item quantity="other">%d člankov odstranjenyh iz spiska %s</item>
+    <item quantity="one">%1$d članok odstranjeny iz spiska %2$s</item>
+    <item quantity="few">%1$d članky odstranjene iz spiska %2$s</item>
+    <item quantity="many">%1$d člankov odstranjenyh iz spiska %2$s</item>
+    <item quantity="other">%1$d člankov odstranjenyh iz spiska %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d spisok odstranjeny</item>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -484,8 +484,8 @@
     <item quantity="other">%d članaka je uklonjeno iz liste</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d članak je uklonjen iz %s</item>
-    <item quantity="other">%d članaka je uklonjeno iz %s</item>
+    <item quantity="one">%1$d članak je uklonjen iz %2$s</item>
+    <item quantity="other">%1$d članaka je uklonjeno iz %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista je obrisana</item>

--- a/app/src/main/res/values-b+tt+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+tt+Cyrl/strings.xml
@@ -536,8 +536,8 @@
     <item quantity="other">%d мәкаләләр исемлектән бетерелгән</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d мәкаләсе бетерелде %s</item>
-    <item quantity="other">%d мәкаләләре бетерелде %s</item>
+    <item quantity="one">%1$d мәкаләсе бетерелде %2$s</item>
+    <item quantity="other">%1$d мәкаләләре бетерелде %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d исемлек бетерелде</item>

--- a/app/src/main/res/values-ba/strings.xml
+++ b/app/src/main/res/values-ba/strings.xml
@@ -540,8 +540,8 @@
     <item quantity="other">%d мәҡәләләр исемлектән юйылған</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d мәҡәлә %s исемлектән юйылған</item>
-    <item quantity="other">%d мәҡәләләр %s исемлектән юйылған</item>
+    <item quantity="one">%1$d мәҡәлә %2$s исемлектән юйылған</item>
+    <item quantity="other">%1$d мәҡәләләр %2$s исемлектән юйылған</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d исемлек юйылған</item>

--- a/app/src/main/res/values-ban/strings.xml
+++ b/app/src/main/res/values-ban/strings.xml
@@ -480,8 +480,8 @@
     <item quantity="other">%d suratan kausap saking lis</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d suratan kausap saking %s</item>
-    <item quantity="other">%d suratan kausap saking %s</item>
+    <item quantity="one">%1$d suratan kausap saking %2$s</item>
+    <item quantity="other">%1$d suratan kausap saking %2$s</item>
   </plurals>
   <string name="reading_list_items_deleted">%d suratan kaapus saking lis</string>
   <string name="reading_lists_item_deleted">%s kaapus saking lis</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -573,10 +573,10 @@
     <item quantity="other">%d артыкулаў выдалена са спіса</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d артыкул выдалены з %s </item>
-    <item quantity="few">%d артыкулы выдалены з %s</item>
-    <item quantity="many">%d артыкулаў выдалена з %s</item>
-    <item quantity="other">%d артыкулаў выдалена з %s</item>
+    <item quantity="one">%1$d артыкул выдалены з %2$s </item>
+    <item quantity="few">%1$d артыкулы выдалены з %2$s</item>
+    <item quantity="many">%1$d артыкулаў выдалена з %2$s</item>
+    <item quantity="other">%1$d артыкулаў выдалена з %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d спіс выдалены</item>

--- a/app/src/main/res/values-bew/strings.xml
+++ b/app/src/main/res/values-bew/strings.xml
@@ -490,8 +490,8 @@
     <item quantity="other">%d makalah dibuang deri daptar</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d makalah dibuang deri daptar %s</item>
-    <item quantity="other">%d makalah dibuang deri daptar %s</item>
+    <item quantity="one">%1$d makalah dibuang deri daptar %2$s</item>
+    <item quantity="other">%1$d makalah dibuang deri daptar %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d daptar diapus</item>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -553,8 +553,8 @@
     <item quantity="other">%d статии са премахнати от списъка</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d статия е премахната от %s</item>
-    <item quantity="other">%d статии са премахнати от %s</item>
+    <item quantity="one">%1$d статия е премахната от %2$s</item>
+    <item quantity="other">%1$d статии са премахнати от %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d списък е изтрит</item>

--- a/app/src/main/res/values-blk/strings.xml
+++ b/app/src/main/res/values-blk/strings.xml
@@ -444,8 +444,8 @@
     <item quantity="other">အဝ်ႏစာႏရင်ꩻကို ဖုဲင်းထန်ႏထွူလဲဉ်း ရောမ်ဖြုဲင်ꩻဖိုင်ႏ %d</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">အဝ်ႏ%sကို ဖုဲင်းထန်ႏထွူလဲဉ်း ရောမ်ဖြုဲင်ꩻ %d</item>
-    <item quantity="other">အဝ်ႏ%sကို ဖုဲင်းထန်ႏထွူလဲဉ်း ရောမ်ဖြုဲင်ꩻဖိုင်ႏ %d</item>
+    <item quantity="one">အဝ်ႏ%2$sကို ဖုဲင်းထန်ႏထွူလဲဉ်း ရောမ်ဖြုဲင်ꩻ %1$d</item>
+    <item quantity="other">အဝ်ႏ%2$sကို ဖုဲင်းထန်ႏထွူလဲဉ်း ရောမ်ဖြုဲင်ꩻဖိုင်ႏ %1$d</item>
   </plurals>
   <string name="reading_list_items_deleted">အဝ်ႏစာႏရင်ꩻကို ဖုဲင်းထန်ႏထွူလဲဉ်း ရောမ်ဖြုဲင်ꩻဖိုင်ႏ %d</string>
   <string name="reading_lists_item_deleted">အဝ်ႏစာႏရင်ꩻဖိုင်ႏကို ဖုဲင်းထန်ႏထွူလဲဉ်း %s</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -519,11 +519,11 @@
     <item quantity="other">%d a bennadoù lamet diouzh ar roll</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d pennad lamet diouzh %s</item>
-    <item quantity="two">%d bennad lamet diouzh %s</item>
-    <item quantity="few">%d a bennadoù lamet diouzh %s</item>
-    <item quantity="many">%d a bennadoù lamet diouzh %s</item>
-    <item quantity="other">%d a bennadoù lamet diouzh %s</item>
+    <item quantity="one">%1$d pennad lamet diouzh %2$s</item>
+    <item quantity="two">%1$d bennad lamet diouzh %2$s</item>
+    <item quantity="few">%1$d a bennadoù lamet diouzh %2$s</item>
+    <item quantity="many">%1$d a bennadoù lamet diouzh %2$s</item>
+    <item quantity="other">%1$d a bennadoù lamet diouzh %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d roll dilamet</item>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -547,8 +547,8 @@
     <item quantity="other">%d articles suprimits de la llista</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d article suprimit de %s</item>
-    <item quantity="other">%d articles suprimits de %s</item>
+    <item quantity="one">%1$d article suprimit de %2$s</item>
+    <item quantity="other">%1$d articles suprimits de %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d llista suprimida</item>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -509,8 +509,8 @@
     <item quantity="other">%d وتار سڕایەوە لە پێڕست</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d وتار سڕدرایەوە لە %s</item>
-    <item quantity="other">%d وتار سڕدرایەوە لە %s</item>
+    <item quantity="one">%1$d وتار سڕدرایەوە لە %2$s</item>
+    <item quantity="other">%1$d وتار سڕدرایەوە لە %2$s</item>
   </plurals>
   <string name="reading_list_items_deleted">%d وتار سڕایەوە لە پێڕست</string>
   <string name="reading_lists_item_deleted">%s سڕایەوە لە پێڕست</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -593,10 +593,10 @@
     <item quantity="other">%d článků odstraněno ze seznamu</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d článek odstraněn ze seznamu %s</item>
-    <item quantity="few">%d články odstraněny ze seznamu %s</item>
-    <item quantity="many">%d článků odstraněno ze seznamu %s</item>
-    <item quantity="other">%d článků odstraněno ze seznamu %s</item>
+    <item quantity="one">%1$d článek odstraněn ze seznamu %2$s</item>
+    <item quantity="few">%1$d články odstraněny ze seznamu %2$s</item>
+    <item quantity="many">%1$d článků odstraněno ze seznamu %2$s</item>
+    <item quantity="other">%1$d článků odstraněno ze seznamu %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d seznam odstraněn</item>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -568,8 +568,8 @@
     <item quantity="other">%d artikler fjernet fra listen</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artikel fjernet fra %s</item>
-    <item quantity="other">%d artikler fjernet fra %s</item>
+    <item quantity="one">%1$d artikel fjernet fra %2$s</item>
+    <item quantity="other">%1$d artikler fjernet fra %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d liste slettet</item>

--- a/app/src/main/res/values-dag/strings.xml
+++ b/app/src/main/res/values-dag/strings.xml
@@ -524,8 +524,8 @@
     <item quantity="other">%d lahabaya yihi ya kpɛ</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d lahabali nyɛla din yihi kpɛ %s</item>
-    <item quantity="other">%d lahabaya yihi ya kpɛ %s</item>
+    <item quantity="one">%1$d lahabali nyɛla din yihi kpɛ %2$s</item>
+    <item quantity="other">%1$d lahabaya yihi ya kpɛ %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d yuli nyahiya</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -605,8 +605,8 @@
     <item quantity="other">%d Artikel aus Liste entfernt</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d Artikel entfernt von %s</item>
-    <item quantity="other">%d Artikel entfernt von %s</item>
+    <item quantity="one">%1$d Artikel entfernt von %2$s</item>
+    <item quantity="other">%1$d Artikel entfernt von %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d Liste gelöscht</item>

--- a/app/src/main/res/values-dga/strings.xml
+++ b/app/src/main/res/values-dga/strings.xml
@@ -491,8 +491,8 @@
     <item quantity="other">%d ba iri la aatekelehi yi a yoe poɔ</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d ba iri la aatekele a yi %s</item>
-    <item quantity="other">%d ba iri la aatekelehi a yi %s</item>
+    <item quantity="one">%1$d ba iri la aatekele a yi %2$s</item>
+    <item quantity="other">%1$d ba iri la aatekelehi a yi %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d ba sãâ la gane yoe bare</item>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -545,8 +545,8 @@
     <item quantity="other">%d λήμματα αφαιρέθηκαν από τη λίστα</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d λήμμα αφαιρέθηκε από %s</item>
-    <item quantity="other">%d λήμματα αφαιρέθηκαν από %s</item>
+    <item quantity="one">%1$d λήμμα αφαιρέθηκε από %2$s</item>
+    <item quantity="other">%1$d λήμματα αφαιρέθηκαν από %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d λίστα διαγράφηκε</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -650,8 +650,8 @@
     <item quantity="other">%d artículos eliminados de la lista</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artículo eliminado de %s</item>
-    <item quantity="other">%d artículos eliminados de %s</item>
+    <item quantity="one">%1$d artículo eliminado de %2$s</item>
+    <item quantity="other">%1$d artículos eliminados de %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista eliminada</item>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -552,8 +552,8 @@
     <item quantity="other">%d artikulu kendu dira zerrendatik</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">artikulu %d kendu da %s zerrendatik</item>
-    <item quantity="other">%d artikulu kendu dira %s zerrendatik</item>
+    <item quantity="one">artikulu %1$d kendu da %2$s zerrendatik</item>
+    <item quantity="other">%1$d artikulu kendu dira %2$s zerrendatik</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">zerrenda %d ezabatuta</item>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -570,8 +570,8 @@
     <item quantity="other">%d مقاله از فهرست حذف شدند</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d مقاله از %s حذف شد</item>
-    <item quantity="other">%d مقاله از %s حذف شدند</item>
+    <item quantity="one">%1$d مقاله از %2$s حذف شد</item>
+    <item quantity="other">%1$d مقاله از %2$s حذف شدند</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d فهرست حذف شد</item>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -578,8 +578,8 @@
     <item quantity="other">%d artikkelia poistettu listalta</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artikkeli poistettu lukulistalta %s</item>
-    <item quantity="other">%d artikkelia poistettu lukulistalta %s</item>
+    <item quantity="one">%1$d artikkeli poistettu lukulistalta %2$s</item>
+    <item quantity="other">%1$d artikkelia poistettu lukulistalta %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista poistettu</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -626,8 +626,8 @@
     <item quantity="other">%d articles supprimés de la liste</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d article supprimé de %s</item>
-    <item quantity="other">%d articles supprimés de %s</item>
+    <item quantity="one">%1$d article supprimé de %2$s</item>
+    <item quantity="other">%1$d articles supprimés de %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d liste supprimée</item>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -591,11 +591,11 @@
     <item quantity="other">%d alt bainte den liosta</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">one=%d alt bainte as %s</item>
-    <item quantity="two">one=%d alt bainte as %s</item>
-    <item quantity="few">one=%d alt bainte as %s</item>
-    <item quantity="many">one=%d alt bainte as %s</item>
-    <item quantity="other">%d alt bainte as %s</item>
+    <item quantity="one">one=%1$d alt bainte as %2$s</item>
+    <item quantity="two">one=%1$d alt bainte as %2$s</item>
+    <item quantity="few">one=%1$d alt bainte as %2$s</item>
+    <item quantity="many">one=%1$d alt bainte as %2$s</item>
+    <item quantity="other">%1$d alt bainte as %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d liosta scriosta</item>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -500,8 +500,8 @@
     <item quantity="other"> %d an cire labarai daga jeri</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d an cire makala daga %s</item>
-    <item quantity="other">%d an cire makala daga %s</item>
+    <item quantity="one">%1$d an cire makala daga %2$s</item>
+    <item quantity="other">%1$d an cire makala daga %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d list deleted</item>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -573,8 +573,8 @@
     <item quantity="other"> %d लेख सूची से हटाए गए</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d लेख को %s से हटाया गया</item>
-    <item quantity="other">%d लेखों को %s से हटाया गया</item>
+    <item quantity="one">%1$d लेख को %2$s से हटाया गया</item>
+    <item quantity="other">%1$d लेखों को %2$s से हटाया गया</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d सूची हटाई गई</item>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -569,8 +569,8 @@
     <item quantity="other">%d szócikk eltávolítva a listáról</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d szócikk eltávolítva a(z) %s listáról</item>
-    <item quantity="other">%d szócikk eltávolítva a(z) %s listáról</item>
+    <item quantity="one">%1$d szócikk eltávolítva a(z) %2$s listáról</item>
+    <item quantity="other">%1$d szócikk eltávolítva a(z) %2$s listáról</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista törölve</item>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -548,8 +548,8 @@
     <item quantity="other">%d articulos removite del lista</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d articulo removite de %s</item>
-    <item quantity="other">%d articulos removite de %s</item>
+    <item quantity="one">%1$d articulo removite de %2$s</item>
+    <item quantity="other">%1$d articulos removite de %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista delite</item>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -574,7 +574,7 @@
   <string name="reading_list_item_deleted_from_list">%1$s dihapus dari %2$s</string>
   <string name="reading_list_articles_deleted">%d artikel dihapus dari daftar</string>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="other">%d artikel dihapus dari %s</item>
+    <item quantity="other">%1$d artikel dihapus dari %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="other">%d daftar dihapus</item>

--- a/app/src/main/res/values-inh/strings.xml
+++ b/app/src/main/res/values-inh/strings.xml
@@ -503,8 +503,8 @@
     <item quantity="other">%d оагӀув дӀаяьккхай листама чура</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d лустам дӀабаьккхаб %s яха чура</item>
-    <item quantity="other">%d лустам дӀабаьккхаб %s яха чура</item>
+    <item quantity="one">%1$d лустам дӀабаьккхаб %2$s яха чура</item>
+    <item quantity="other">%1$d лустам дӀабаьккхаб %2$s яха чура</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d листам дӀабаьккхаб</item>

--- a/app/src/main/res/values-io/strings.xml
+++ b/app/src/main/res/values-io/strings.xml
@@ -513,8 +513,8 @@
     <item quantity="other">%d artikli efacita de listo</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artiklo efacita de %s</item>
-    <item quantity="other">%d artikli efacita de %s</item>
+    <item quantity="one">%1$d artiklo efacita de %2$s</item>
+    <item quantity="other">%1$d artikli efacita de %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d listo efacita</item>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -494,8 +494,8 @@
     <item quantity="other">%d greinar fjarlægðar af lista</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d grein fjarlægð af %s</item>
-    <item quantity="other">%d greinar fjarlægðar af %s</item>
+    <item quantity="one">%1$d grein fjarlægð af %2$s</item>
+    <item quantity="other">%1$d greinar fjarlægðar af %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista eytt</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -610,8 +610,8 @@
     <item quantity="other">%d voci rimosse dall\'elenco</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d voce rimossa da %s</item>
-    <item quantity="other">%d voci rimosse da %s</item>
+    <item quantity="one">%1$d voce rimossa da %2$s</item>
+    <item quantity="other">%1$d voci rimosse da %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d elenco cancellato</item>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -593,10 +593,10 @@
     <item quantity="other">%d ערכים הוסרו מהרשימה</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">ערך אחד הוסר מהרשימה %s</item>
-    <item quantity="two">שני ערכים הוסרו מהרשימה %s</item>
-    <item quantity="many">%d ערכים הוסרו מהרשימה %s</item>
-    <item quantity="other">%d ערכים הוסרו מהרשימה %s</item>
+    <item quantity="one">ערך אחד הוסר מהרשימה %2$s</item>
+    <item quantity="two">שני ערכים הוסרו מהרשימה %2$s</item>
+    <item quantity="many">%1$d ערכים הוסרו מהרשימה %2$s</item>
+    <item quantity="other">%1$d ערכים הוסרו מהרשימה %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">נמחקה רשימה אחת</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -607,8 +607,8 @@
     <item quantity="other">%d件の記事をリストから削除しました</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d件の記事を%sから削除しました</item>
-    <item quantity="other">%d件の記事を%sから削除しました</item>
+    <item quantity="one">%1$d件の記事を%2$sから削除しました</item>
+    <item quantity="other">%1$d件の記事を%2$sから削除しました</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="other">%d件のリストが削除されました</item>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -576,8 +576,8 @@
     <item quantity="other">목록에서 제거된 문서 %d개</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%s에서 제거된 문서 %d개</item>
-    <item quantity="other">%s에서 제거된 문서 %d개</item>
+    <item quantity="one">%2$s에서 제거된 문서 %1$d개</item>
+    <item quantity="other">%2$s에서 제거된 문서 %1$d개</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="other">목록 %d개 삭제됨</item>

--- a/app/src/main/res/values-krc/strings.xml
+++ b/app/src/main/res/values-krc/strings.xml
@@ -527,8 +527,8 @@
     <item quantity="other">%d статья тизмеден къоратлды</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d бет %s тизмеден къоратылды</item>
-    <item quantity="other">%d бет %s тизмеден къоратылды</item>
+    <item quantity="one">%1$d бет %2$s тизмеден къоратылды</item>
+    <item quantity="other">%1$d бет %2$s тизмеден къоратылды</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d тизме кетерилди</item>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -489,7 +489,7 @@
     <item quantity="other">%d gotar ji lîstê hate rakirin</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="other">%d gotar ji %s hate rakirin</item>
+    <item quantity="other">%1$d gotar ji %2$s hate rakirin</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lîst hate jêbirin</item>

--- a/app/src/main/res/values-kus/strings.xml
+++ b/app/src/main/res/values-kus/strings.xml
@@ -469,8 +469,8 @@
     <item quantity="other">%d yis atikilnam la\'adin</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d ba yis atikili yi %s</item>
-    <item quantity="other">%d ba yis atikilnami yi %s</item>
+    <item quantity="one">%1$d ba yis atikili yi %2$s</item>
+    <item quantity="other">%1$d ba yis atikilnami yi %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d list deleted</item>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -531,8 +531,8 @@
     <item quantity="other">%d Artikele vun der Lëscht erofgeholl</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d Artikel vu(n) %s erofgeholl</item>
-    <item quantity="other">%d Artikele vu(n) %s erofgeholl</item>
+    <item quantity="one">%1$d Artikel vu(n) %2$s erofgeholl</item>
+    <item quantity="other">%1$d Artikele vu(n) %2$s erofgeholl</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d Lëscht geläscht</item>

--- a/app/src/main/res/values-lkt/strings.xml
+++ b/app/src/main/res/values-lkt/strings.xml
@@ -420,7 +420,7 @@
     <item quantity="other">čhašówapi etáŋhaŋ wówapi %d yuȟéyab ičú</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="other">%s etáŋhaŋ wówapi %d yuȟéyab ičú</item>
+    <item quantity="other">%2$s etáŋhaŋ wówapi %1$d yuȟéyab ičú</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="other">čhašówapi  %d iháŋgya</item>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -555,8 +555,8 @@
     <item quantity="other">Отстранети %d статии од списокот</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">Отстранета %d статија од %s</item>
-    <item quantity="other">Отстранети %d статии од %s</item>
+    <item quantity="one">Отстранета %1$d статија од %2$s</item>
+    <item quantity="other">Отстранети %1$d статии од %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d избришан список</item>

--- a/app/src/main/res/values-mnw/strings.xml
+++ b/app/src/main/res/values-mnw/strings.xml
@@ -462,8 +462,8 @@
     <item quantity="other">လိက်ပရေင် %d ပ္တိတ်လဝ် နူ စရင်</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d လိက်ပရေင်တအ် ပ္တိတ်လဝ် နူ %s</item>
-    <item quantity="other">%d လိက်ပရေင်တအ် ပ္တိတ်လဝ် နူ %s</item>
+    <item quantity="one">%1$d လိက်ပရေင်တအ် ပ္တိတ်လဝ် နူ %2$s</item>
+    <item quantity="other">%1$d လိက်ပရေင်တအ် ပ္တိတ်လဝ် နူ %2$s</item>
   </plurals>
   <string name="reading_list_items_deleted">%d လိက်ပရေင် ပတိတ်ထောအ် နူစရင်</string>
   <string name="reading_lists_item_deleted">%s ပတိတ်ထောအ် နူ စရင်</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -563,8 +563,8 @@
     <item quantity="other">%d artikler fjernet fra listen</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artikkel fjernet fra %s</item>
-    <item quantity="other">%d artikler fjernet fra %s</item>
+    <item quantity="one">%1$d artikkel fjernet fra %2$s</item>
+    <item quantity="other">%1$d artikler fjernet fra %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d liste slettet</item>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -590,8 +590,8 @@
     <item quantity="other">%d pagina\'s verwijderd uit lijst</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d pagina verwijderd uit %s</item>
-    <item quantity="other">%d pagina\'s verwijderd uit %s</item>
+    <item quantity="one">%1$d pagina verwijderd uit %2$s</item>
+    <item quantity="other">%1$d pagina\'s verwijderd uit %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lijst verwijderd</item>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -528,8 +528,8 @@
     <item quantity="other"> ਸੂਚੀ ਵਿੱਚੋਂ %d ਲੇਖ ਹਟਾਏ ਗਏ</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%s ਤੋਂ %d ਲੇਖ ਹਟਾਇਆ ਗਿਆ</item>
-    <item quantity="other">%s ਤੋਂ %d ਲੇਖ ਹਟਾਏ ਗਏ</item>
+    <item quantity="one">%2$s ਤੋਂ %1$d ਲੇਖ ਹਟਾਇਆ ਗਿਆ</item>
+    <item quantity="other">%2$s ਤੋਂ %1$d ਲੇਖ ਹਟਾਏ ਗਏ</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d ਸੂਚੀ ਮਿਟਾਈ ਗਈ</item>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -605,10 +605,10 @@
     <item quantity="other">Usunięto %d artykułów z listy</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">Usunięto %d artykuł z listy %s</item>
-    <item quantity="few">Usunięto %d artykuły z listy %s</item>
-    <item quantity="many">Usunięto %d artykułów z listy %s</item>
-    <item quantity="other">Usunięto %d artykułów z listy %s</item>
+    <item quantity="one">Usunięto %1$d artykuł z listy %2$s</item>
+    <item quantity="few">Usunięto %1$d artykuły z listy %2$s</item>
+    <item quantity="many">Usunięto %1$d artykułów z listy %2$s</item>
+    <item quantity="other">Usunięto %1$d artykułów z listy %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">Usunięto %d listę</item>

--- a/app/src/main/res/values-ps/strings.xml
+++ b/app/src/main/res/values-ps/strings.xml
@@ -550,8 +550,8 @@
     <item quantity="other">%d ليکنې له لړليک لرې شوې</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d ليکنه له %s لرې شوه</item>
-    <item quantity="other">%d ليکنې له%s لرې شوې</item>
+    <item quantity="one">%1$d ليکنه له %2$s لرې شوه</item>
+    <item quantity="other">%1$d ليکنې له%2$s لرې شوې</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d لړليک ړنگ شو</item>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -601,8 +601,8 @@
     <item quantity="other">%d artigos removidos da lista</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artigo removido de %s</item>
-    <item quantity="other">%d artigos removidos de %s</item>
+    <item quantity="one">%1$d artigo removido de %2$s</item>
+    <item quantity="other">%1$d artigos removidos de %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista excluída</item>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -570,8 +570,8 @@
     <item quantity="other">%d artigos removidos da lista</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artigo removido de %s</item>
-    <item quantity="other">%d artigos removidos de %s</item>
+    <item quantity="one">%1$d artigo removido de %2$s</item>
+    <item quantity="other">%1$d artigos removidos de %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista eliminada</item>

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -590,8 +590,8 @@
     <item quantity="other">Message shown when multiple articles are removed from a reading list. The \"%d\" symbol is replaced with the number of articles removed.</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">Message shown when one article is removed from a reading list.The \"%d\" symbol is replaced with the number of articles removed.The \"%s\" symbol is replaced with the reading list name.</item>
-    <item quantity="other">Message shown when multiple articles are removed from a reading list. The \"%d\" symbol is replaced with the number of articles removed.The \"%s\" symbol is replaced with the reading list name.</item>
+    <item quantity="one">Message shown when one article is removed from a reading list.The \"%1$d\" symbol is replaced with the number of articles removed.The \"%2$s\" symbol is replaced with the reading list name.</item>
+    <item quantity="other">Message shown when multiple articles are removed from a reading list. The \"%1$d\" symbol is replaced with the number of articles removed.The \"%2$s\" symbol is replaced with the reading list name.</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">Toast message shown when one reading list is deleted. The \"%d\" symbol is replaced with the number of the lists deleted.</item>

--- a/app/src/main/res/values-rki/strings.xml
+++ b/app/src/main/res/values-rki/strings.xml
@@ -543,8 +543,8 @@
     <item quantity="other"> စရင်းက ဆောင်းပါး %d ခုကို ဖယ်ယှားလိုက်တေ</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d ဆောင်းပါးကို %s</item>
-    <item quantity="other">%d ဆောင်းပါးကို %s က ဖယ်ယှားလိုက်တေ</item>
+    <item quantity="one">%1$d ဆောင်းပါးကို %2$s</item>
+    <item quantity="other">%1$d ဆောင်းပါးကို %2$s က ဖယ်ယှားလိုက်တေ</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d စရင်းကို ဖျက်လိုက်ပါယာ</item>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -552,9 +552,9 @@
     <item quantity="other">%d articole eliminate din listă</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d articol eliminat din %s</item>
-    <item quantity="few">%d articole eliminate din %s</item>
-    <item quantity="other">%d articole eliminate din %s</item>
+    <item quantity="one">%1$d articol eliminat din %2$s</item>
+    <item quantity="few">%1$d articole eliminate din %2$s</item>
+    <item quantity="other">%1$d articole eliminate din %2$s</item>
   </plurals>
   <string name="reading_list_items_deleted">%d articole eliminate din listă</string>
   <string name="reading_lists_item_deleted">%s eliminat din liste</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -658,10 +658,10 @@
     <item quantity="other">Статей удалено из списка: %d</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">Статей удалено из %s: %d</item>
-    <item quantity="few">Статей удалено из %s: %d</item>
-    <item quantity="many">Статей удалено из %s: %d</item>
-    <item quantity="other">Статей удалено из %s: %d</item>
+    <item quantity="one">Статей удалено из %2$s: %1$d</item>
+    <item quantity="few">Статей удалено из %2$s: %1$d</item>
+    <item quantity="many">Статей удалено из %2$s: %1$d</item>
+    <item quantity="other">Статей удалено из %2$s: %1$d</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d список удалён</item>

--- a/app/src/main/res/values-sd/strings.xml
+++ b/app/src/main/res/values-sd/strings.xml
@@ -516,8 +516,8 @@
     <item quantity="other">%d مضمونَ فھرست کان ختم ڪيا ويا</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d مضمون %s مان ھٽايو ويو</item>
-    <item quantity="other">%d مضمون %s مان ھٽايا ويا</item>
+    <item quantity="one">%1$d مضمون %2$s مان ھٽايو ويو</item>
+    <item quantity="other">%1$d مضمون %2$s مان ھٽايا ويا</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d فھرست ڊاٿي وئي</item>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -535,9 +535,9 @@
     <item quantity="other">%d artihkkala sihkkojuvvon listtus</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artihkal sihkkojuvvon %s:s</item>
-    <item quantity="two">%d artihkkala sihkkojuvvon %s:s</item>
-    <item quantity="other">%d artihkkala sihkkojuvvon %s:s</item>
+    <item quantity="one">%1$d artihkal sihkkojuvvon %2$s:s</item>
+    <item quantity="two">%1$d artihkkala sihkkojuvvon %2$s:s</item>
+    <item quantity="other">%1$d artihkkala sihkkojuvvon %2$s:s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d listu sihkkojuvvon</item>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -533,10 +533,10 @@
     <item quantity="other">%d článkov odstránených zo zoznamu</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d článok odstránený zv%s</item>
-    <item quantity="few">%d články odstránené z %s</item>
-    <item quantity="many">%d článkov odstránených z %s</item>
-    <item quantity="other">%d článkov odstránených z %s</item>
+    <item quantity="one">%1$d článok odstránený zv%2$s</item>
+    <item quantity="few">%1$d články odstránené z %2$s</item>
+    <item quantity="many">%1$d článkov odstránených z %2$s</item>
+    <item quantity="other">%1$d článkov odstránených z %2$s</item>
   </plurals>
   <string name="reading_list_items_deleted">Zo zoznamu na prečítanie bolo odstránených %d článkov</string>
   <string name="reading_lists_item_deleted">%s bol odstránený zo zoznamov</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -573,10 +573,10 @@
     <item quantity="other">%d člankov odstranjenih s seznama</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d članek odstranjen s seznama %s</item>
-    <item quantity="two">%d članka odstranjena s seznama %s</item>
-    <item quantity="few">%d članki odstranjeni s seznama %s</item>
-    <item quantity="other">%d člankov odstranjenih s seznama %s</item>
+    <item quantity="one">%1$d članek odstranjen s seznama %2$s</item>
+    <item quantity="two">%1$d članka odstranjena s seznama %2$s</item>
+    <item quantity="few">%1$d članki odstranjeni s seznama %2$s</item>
+    <item quantity="other">%1$d člankov odstranjenih s seznama %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d seznam izbrisan</item>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -552,8 +552,8 @@
     <item quantity="other">%d чланака је уклоњено из листе</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d чланак је уклоњен из %s</item>
-    <item quantity="other">%d чланака је уклоњено из %s</item>
+    <item quantity="one">%1$d чланак је уклоњен из %2$s</item>
+    <item quantity="other">%1$d чланака је уклоњено из %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d листа је обрисана</item>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -569,8 +569,8 @@
     <item quantity="other">%d artiklar togs bort från listan</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d artikel togs bort från %s</item>
-    <item quantity="other">%d artiklar togs bort från %s</item>
+    <item quantity="one">%1$d artikel togs bort från %2$s</item>
+    <item quantity="other">%1$d artiklar togs bort från %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d lista raderades</item>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -486,8 +486,8 @@
     <item quantity="other">%d వ్యాసాలను జాబితా నుండి తీసేసాం</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%s నుండి %d వ్యాసాన్ని తీసేసాం</item>
-    <item quantity="other">%s నుండి %d వ్యాసాలను తీసేసాం</item>
+    <item quantity="one">%2$s నుండి %1$d వ్యాసాన్ని తీసేసాం</item>
+    <item quantity="other">%2$s నుండి %1$d వ్యాసాలను తీసేసాం</item>
   </plurals>
   <string name="reading_list_items_deleted">%d వ్యాసాలను జాబితా నుండి తీసేసాం</string>
   <string name="reading_lists_item_deleted">%s ని జాబితాల నుండి తీసేసాం</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -471,7 +471,7 @@
     <item quantity="other">เอา %d บทความออกจากรายการแล้ว</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="other">เอา %d บทความออกจาก %s แล้ว</item>
+    <item quantity="other">เอา %1$d บทความออกจาก %2$s แล้ว</item>
   </plurals>
   <string name="reading_list_items_deleted">ลบ %d บทความออกจากรายการแล้ว</string>
   <string name="reading_lists_item_deleted">เอา %s ออกจากรายการแล้ว</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -532,8 +532,8 @@
     <item quantity="other">Tinanggal na ang %d (na) artikulo</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">Tinanggal na ang %d artikulo sa %s</item>
-    <item quantity="other">Tinanggal na ang %d (na) artikulo sa %s</item>
+    <item quantity="one">Tinanggal na ang %1$d artikulo sa %2$s</item>
+    <item quantity="other">Tinanggal na ang %1$d (na) artikulo sa %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">Nabura na ang %d listahan</item>

--- a/app/src/main/res/values-tly/strings.xml
+++ b/app/src/main/res/values-tly/strings.xml
@@ -432,8 +432,8 @@
     <item quantity="other">%d gylə məǧolon ce sijohiku molə byə</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d gylə məǧolə molə byə cyjo %s</item>
-    <item quantity="other">%d gylə məǧolə molə byə cyjo %s</item>
+    <item quantity="one">%1$d gylə məǧolə molə byə cyjo %2$s</item>
+    <item quantity="other">%1$d gylə məǧolə molə byə cyjo %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d gylə sijohi molə byə</item>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -601,8 +601,8 @@
     <item quantity="other">%d madde listeden kaldırıldı</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d sayfa %s listesinden çıkarıldı</item>
-    <item quantity="other">%d sayfa %s listesinden çıkarıldı</item>
+    <item quantity="one">%1$d sayfa %2$s listesinden çıkarıldı</item>
+    <item quantity="other">%1$d sayfa %2$s listesinden çıkarıldı</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d liste silindi</item>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -598,10 +598,10 @@
     <item quantity="other">%d статей вилучено зі списку</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d статтю вилучено з %s</item>
-    <item quantity="few">%d статті вилучено з %s</item>
-    <item quantity="many">%d статей вилучено з %s</item>
-    <item quantity="other">%d статей вилучено з %s</item>
+    <item quantity="one">%1$d статтю вилучено з %2$s</item>
+    <item quantity="few">%1$d статті вилучено з %2$s</item>
+    <item quantity="many">%1$d статей вилучено з %2$s</item>
+    <item quantity="other">%1$d статей вилучено з %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d список вилучено</item>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -507,8 +507,8 @@
     <item quantity="other">%d ta maqola roʻyxatdan oʻchirldi</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">%d ta maqola %s dan oʻchirildi</item>
-    <item quantity="other">%d ta maqola %s dan oʻchirildi</item>
+    <item quantity="one">%1$d ta maqola %2$s dan oʻchirildi</item>
+    <item quantity="other">%1$d ta maqola %2$s dan oʻchirildi</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">%d ta roʻyxat oʻchirildi</item>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -570,7 +570,7 @@
     <item quantity="other">%d bài viết bị xóa khỏi danh sách</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="other">%d bài viết bị xóa khỏi danh sách %s</item>
+    <item quantity="other">%1$d bài viết bị xóa khỏi danh sách %2$s</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="other">%d danh sách đã xóa</item>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -584,8 +584,8 @@
     <item quantity="other">從清單移除 %d 個條目</item>
   </plurals>
   <plurals name="reading_list_articles_deleted_from_list">
-    <item quantity="one">已從%s移除 %d 個條目</item>
-    <item quantity="other">已從%s移除 %d 個條目</item>
+    <item quantity="one">已從%2$s移除 %1$d 個條目</item>
+    <item quantity="other">已從%2$s移除 %1$d 個條目</item>
   </plurals>
   <plurals name="reading_lists_deleted_message">
     <item quantity="one">已刪除 %d 個清單</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -575,8 +575,8 @@
         <item quantity="other">%d articles removed from list</item>
     </plurals>
     <plurals name="reading_list_articles_deleted_from_list">
-        <item quantity="one">%d article removed from %s</item>
-        <item quantity="other">%d articles removed from %s</item>
+        <item quantity="one">%1$d article removed from %2$s</item>
+        <item quantity="other">%1$d articles removed from %2$s</item>
     </plurals>
     <plurals name="reading_lists_deleted_message">
         <item quantity="one">%d list deleted</item>


### PR DESCRIPTION
This fixes a very [minor crash](https://play.google.com/console/u/0/developers/6169333749249604352/app/4976363884102945010/vitals/crashes/cdb7f4a7c9d1b1c6c2291bfc36f834be/details?days=28&versionCode=50595), due to a string resource having multiple parameters without positional formatting.

When making a string with more than one parameter (e.g. `%d` ... `%s`), we must _always_ make it with positional formatting: `%1$d` ... `%2$s`

This is because certain languages might have grammatical structure that rearranges the order of the parameters, which will confuse the string formatter and cause a potential crash.