### PR TITLE
PageTitle: Properly encode special characters in page URLs

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageTitle.java
+++ b/app/src/main/java/org/wikipedia/page/PageTitle.java
@@ -325,17 +325,13 @@ public class PageTitle implements Parcelable {
     }
 
     private String getUriForDomain(String domain) {
-        try {
-            return String.format(
-                    "%1$s://%2$s/wiki/%3$s%4$s",
-                    getWikiSite().scheme(),
-                    domain,
-                    URLEncoder.encode(getPrefixedText(), "utf-8"),
-                    (this.fragment != null && this.fragment.length() > 0) ? ("#" + this.fragment) : ""
-            );
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return String.format(
+                "%1$s://%2$s/wiki/%3$s%4$s",
+                getWikiSite().scheme(),
+                domain,
+                android.net.Uri.encode(getPrefixedText(), ":/"),
+                (this.fragment != null && this.fragment.length() > 0) ? ("#" + this.fragment) : ""
+        );
     }
 
     private PageTitle(Parcel in) {

--- a/app/src/test/java/org/wikipedia/page/PageTitleTest.java
+++ b/app/src/test/java/org/wikipedia/page/PageTitleTest.java
@@ -56,6 +56,8 @@ import static org.mockito.Mockito.when;
         assertThat(enwiki.titleForInternalLink("/wiki/India").getCanonicalUri(), is("https://en.wikipedia.org/wiki/India"));
         assertThat(enwiki.titleForInternalLink("/wiki/India Gate").getCanonicalUri(), is("https://en.wikipedia.org/wiki/India_Gate"));
         assertThat(enwiki.titleForInternalLink("/wiki/India's Gate").getCanonicalUri(), is("https://en.wikipedia.org/wiki/India%27s_Gate"));
+        assertThat(enwiki.titleForInternalLink("/wiki/File:William_Frederick_Yeames_-_And_when_did_you_last_see_your_father?_-_Google_Art_Project.jpg").getCanonicalUri(), 
+                is("https://en.wikipedia.org/wiki/File:William_Frederick_Yeames_-_And_when_did_you_last_see_your_father%3F_-_Google_Art_Project.jpg"));
     }
 
     @Test public void testWikiSite() throws Throwable {


### PR DESCRIPTION
PageTitle: Properly encode special characters in page URLs

Question marks in file titles were not escaped when constructing page URLs, causing links to Commons file pages to fail.

Replace URLEncoder with Uri.encode() when building page URLs and add a regression test for file titles containing question marks.

Bug: T430056
Change-Id: I55cff23e5c70af7b06384233f61f779257a61f65

### What does this do?
This commit replaces the usage of `java.net.URLEncoder.encode()` with `android.net.Uri.encode(..., ":/")` when constructing page URLs in `PageTitle.java`. It also adds a regression test to `PageTitleTest.java` to ensure correct encoding of filenames containing question marks.

### Why is this needed?
When constructing MediaWiki URLs, `URLEncoder` aggressively escapes structural characters like the namespace colon (`:`) into `%3A`. This forces the MediaWiki server to perform a 301 Redirect to the canonical, unescaped path. 

During this redirect, actual query delimiters like question marks (`?`) inside filenames are incorrectly unescaped, causing the link to break because the browser treats everything after the `?` as a query parameter rather than part of the filename. 

By using `Uri.encode(..., ":/")`, the colons and slashes are preserved, bypassing the redirect loop entirely while successfully encoding the question mark to `%3F`.

**Phabricator:**
https://phabricator.wikimedia.org/T430056
