### PR TITLE
T427507: Standardize feed requests to use UTC dates.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -423,7 +423,6 @@ class HomeViewModel : ViewModel() {
             val content = ServiceFactory.getRest(wikiSite.value)
                 .getFeedFeatured(date.year, date.month, date.day, wikiSite.value.languageCode)
 
-
             // Construct Card objects based on the day's content
             val cardsForDay = buildList<Card> {
                 content.tfa?.let {

--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -70,6 +69,7 @@ import org.wikipedia.settings.homefeed.CommunityModuleType
 import org.wikipedia.settings.homefeed.ForYouModuleType
 import org.wikipedia.staticdata.MainPageNameData
 import org.wikipedia.topics.ArticleTopics
+import org.wikipedia.util.DateUtil
 import org.wikipedia.util.GeoUtil
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
@@ -419,9 +419,10 @@ class HomeViewModel : ViewModel() {
             )
 
             val age = nextCommunityAge
-            val date = LocalDate.now().minusDays(nextCommunityAge.toLong())
+            val date = DateUtil.getUtcRequestDateFor(nextCommunityAge)
             val content = ServiceFactory.getRest(wikiSite.value)
-                .getFeedFeatured(date.year.toString(), "%02d".format(date.monthValue), "%02d".format(date.dayOfMonth), wikiSite.value.languageCode)
+                .getFeedFeatured(date.year, date.month, date.day, wikiSite.value.languageCode)
+
 
             // Construct Card objects based on the day's content
             val cardsForDay = buildList<Card> {
@@ -536,7 +537,7 @@ class HomeViewModel : ViewModel() {
             withContext(Dispatchers.Default) {
                 forYouCollectionSaved = JsonUtil.decodeFromString<ForYouCollectionSaved>(Prefs.homeForYouModulesToday)!!
             }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             L.e("Failed to load modules from cache.")
         }
 

--- a/app/src/main/java/org/wikipedia/feed/model/UtcDate.kt
+++ b/app/src/main/java/org/wikipedia/feed/model/UtcDate.kt
@@ -15,4 +15,6 @@ class UtcDate(private val age: Int) {
     val month get() = (baseCalendar[Calendar.MONTH] + 1).toString().padStart(2, '0')
 
     val day get() = baseCalendar[Calendar.DATE].toString().padStart(2, '0')
+
+    override fun toString(): String = "$year-$month-$day"
 }

--- a/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/onthisday/OnThisDayViewModel.kt
@@ -28,7 +28,7 @@ class OnThisDayViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     private val _uiState = MutableStateFlow(Resource<List<OnThisDay.Event>>())
     val uiState = _uiState.asStateFlow()
 
-    fun loadOnThisDay(calendar: Calendar = DateUtil.getDefaultDateFor(age)) {
+    fun loadOnThisDay(calendar: Calendar = DateUtil.getUtcRequestDateFor(age).baseCalendar) {
         _uiState.value = Resource.Loading()
         viewModelScope.launch(handler) {
             val response = ServiceFactory.getRest(wikiSite).getOnThisDay(calendar[Calendar.MONTH] + 1, calendar[Calendar.DATE])

--- a/app/src/main/java/org/wikipedia/feed/personalization/homepreference/HomePreferenceRepository.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/homepreference/HomePreferenceRepository.kt
@@ -8,8 +8,8 @@ import org.wikipedia.extensions.getString
 import org.wikipedia.history.db.HistoryEntryWithImageDao
 import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
+import org.wikipedia.util.DateUtil
 import org.wikipedia.util.StringUtil
-import java.time.LocalDate
 
 class HomePreferenceRepository(
     private val context: Context,
@@ -17,12 +17,12 @@ class HomePreferenceRepository(
     private val wikiSite: WikiSite
 ) {
     suspend fun getCommunityPreviewContent(): List<HomePreferenceContent> {
-        val currentDate = LocalDate.now()
+        val currentDate = DateUtil.getUtcRequestDateFor(0)
 
         val response = ServiceFactory.getRest(wikiSite).getFeedFeatured(
-            year = currentDate.year.toString(),
-            month = "%02d".format(currentDate.monthValue),
-            day = "%02d".format(currentDate.dayOfMonth),
+            year = currentDate.year,
+            month = currentDate.month,
+            day = currentDate.day,
             lang = wikiSite.languageCode
         )
 


### PR DESCRIPTION
### What does this do?
* Update `HomePreferenceRepository`, `HomeViewModel`, and `OnThisDayViewModel` to use `DateUtil.getUtcRequestDateFor()` for feed content fetching.
* Simplify API parameter formatting by using `UtcDate` properties for year, month, and day.
* Add a `toString()` implementation to the `UtcDate` class for easier debugging.

### Why is this needed?
Standardizing feed requests to use UTC dates ensures consistent and predictable date handling across the app, regardless of device timezone settings. This prevents bugs related to timezone-dependent formatting and makes the codebase more maintainable by centralizing date logic through DateUtil.getUtcRequestDateFor(). By using the UtcDate properties (year, month, day), we simplify API parameter formatting and reduce the chance of date-related bugs in feed content fetching.


**Phabricator:**
https://phabricator.wikimedia.org/T427507
