### PR TITLE
fix: getStatusBarInsets return type Insets? - Insets; simplify call site

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeScreen.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeScreen.kt
@@ -114,7 +114,7 @@ fun HomeScreen(
 ) {
     val context = LocalContext.current
     val topInset = if (context is MainActivity) {
-        DimenUtil.roundedPxToDp((context.getStatusBarInsets()?.top ?: 0).toFloat())
+        DimenUtil.roundedPxToDp(context.getStatusBarInsets().top.toFloat())
     } else 64
     val pullToRefreshState = rememberPullToRefreshState()
     val isRefreshing = pullToRefreshState.isAnimating && (communityContentState.isInitialLoading || forYouContentState.isInitialLoading)

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -236,7 +236,7 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
         return binding.mainToolbar
     }
 
-    fun getStatusBarInsets(): Insets? {
+    fun getStatusBarInsets(): Insets {
         return statusBarInsets
     }
 


### PR DESCRIPTION
### What does this do?
Changes the return type of `getStatusBarInsets()` in MainActivity from Insets? to Insets, and simplifies the call site in `HomeScreen.kt` by removing the unnecessary null-safe operator and fallback (?.top ?: 0 -> .top).

### Why is this needed?

The backing field `statusBarInsets` is initialized to Insets.NONE and only ever assigned from `insetsCompat.getInsets(...)`, both of which are guaranteed non-null. The nullable return type was incorrect and forced callers to handle a null case that can never occur.

**Phabricator:**
https://phabricator.wikimedia.org/T...
