### PR TITLE
Improve appearance of App Shortcut icons.

### DIFF
--- a/app/src/main/res/drawable/appshortcut_ic_continue_reading.xml
+++ b/app/src/main/res/drawable/appshortcut_ic_continue_reading.xml
@@ -1,15 +1,3 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <size android:width="@dimen/app_shortcut_icon_size"
-                android:height="@dimen/app_shortcut_icon_size"/>
-            <solid android:color="@color/gray200"/>
-        </shape>
-    </item>
-
-    <item android:top="@dimen/app_shortcut_icon_margin"
-        android:bottom="@dimen/app_shortcut_icon_margin"
-        android:left="@dimen/app_shortcut_icon_margin"
-        android:right="@dimen/app_shortcut_icon_margin"
-        android:drawable="@drawable/ic_arrow_forward_accent50_24dp"/>
+    <item android:drawable="@drawable/ic_arrow_forward_accent50_24dp"/>
 </layer-list>

--- a/app/src/main/res/drawable/appshortcut_ic_places.xml
+++ b/app/src/main/res/drawable/appshortcut_ic_places.xml
@@ -1,15 +1,3 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <size android:width="@dimen/app_shortcut_icon_size"
-                android:height="@dimen/app_shortcut_icon_size"/>
-            <solid android:color="@color/gray200"/>
-        </shape>
-    </item>
-
-    <item android:top="@dimen/app_shortcut_icon_margin"
-        android:bottom="@dimen/app_shortcut_icon_margin"
-        android:left="@dimen/app_shortcut_icon_margin"
-        android:right="@dimen/app_shortcut_icon_margin"
-        android:drawable="@drawable/baseline_location_on_accent50"/>
+    <item android:drawable="@drawable/baseline_location_on_accent50"/>
 </layer-list>

--- a/app/src/main/res/drawable/appshortcut_ic_random.xml
+++ b/app/src/main/res/drawable/appshortcut_ic_random.xml
@@ -1,15 +1,3 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <size android:width="@dimen/app_shortcut_icon_size"
-                android:height="@dimen/app_shortcut_icon_size"/>
-            <solid android:color="@color/gray200"/>
-        </shape>
-    </item>
-
-    <item android:top="@dimen/app_shortcut_icon_margin"
-        android:bottom="@dimen/app_shortcut_icon_margin"
-        android:left="@dimen/app_shortcut_icon_margin"
-        android:right="@dimen/app_shortcut_icon_margin"
-        android:drawable="@drawable/ic_casino_accent50_24dp"/>
+    <item android:drawable="@drawable/ic_casino_accent50_24dp"/>
 </layer-list>

--- a/app/src/main/res/drawable/appshortcut_ic_search.xml
+++ b/app/src/main/res/drawable/appshortcut_ic_search.xml
@@ -1,15 +1,3 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <size android:width="@dimen/app_shortcut_icon_size"
-                android:height="@dimen/app_shortcut_icon_size"/>
-            <solid android:color="@color/gray200"/>
-        </shape>
-    </item>
-
-    <item android:top="@dimen/app_shortcut_icon_margin"
-        android:bottom="@dimen/app_shortcut_icon_margin"
-        android:left="@dimen/app_shortcut_icon_margin"
-        android:right="@dimen/app_shortcut_icon_margin"
-        android:drawable="@drawable/ic_search_accent50_24dp"/>
+    <item android:drawable="@drawable/ic_search_accent50_24dp"/>
 </layer-list>


### PR DESCRIPTION
I noticed recently that our "app shortcut" icons are looking a bit weird on newer API versions (very tiny icons inside a gray circle):

<img width="400" height="898" alt="image" src="https://github.com/user-attachments/assets/27f1e190-3387-409e-baee-d593fef22ccc" />

The explicit gray circle is entirely unnecessary, and here are the icons without it:

<img width="400" height="898" alt="image" src="https://github.com/user-attachments/assets/dabe075b-d4ff-48b0-bc4f-20bfe41022da" />


On older API versions, the icons look every bit as good:

<img width="400" height="822" alt="image" src="https://github.com/user-attachments/assets/0db5ef2d-9ccb-4ed3-9322-90b2d32975e9" />
