### PR TITLE
[Game Module Improvement] Only shows module for supported language

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -307,7 +307,7 @@ class HomeViewModel : ViewModel() {
     private val gameModule: StateFlow<ForYouModule.Games?> =
         _wikiSite.flatMapLatest { site ->
             val supportedGames = getSupportedGames(site.languageCode)
-            // short-circuit so that we don't observe if we don't have access to GamesHub
+            // short-circuit if no games are supported for this language
             if (supportedGames.isEmpty()) {
                 return@flatMapLatest flowOf(null)
             }

--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -306,8 +306,9 @@ class HomeViewModel : ViewModel() {
     @OptIn(ExperimentalCoroutinesApi::class)
     private val gameModule: StateFlow<ForYouModule.Games?> =
         _wikiSite.flatMapLatest { site ->
+            val supportedGames = getSupportedGames(site.languageCode)
             // short-circuit so that we don't observe if we don't have access to GamesHub
-            if (!hasGamesHubAccess()) {
+            if (supportedGames.isEmpty()) {
                 return@flatMapLatest flowOf(null)
             }
             val today = LocalDate.now()
@@ -320,7 +321,7 @@ class HomeViewModel : ViewModel() {
             )
             .transformLatest<DailyGameHistory?, ForYouModule.Games?> {
                 emit(ForYouModule.Games(age = 0, index = 0, cards = emptyList(), isLoading = true))
-                emit(buildGameModule())
+                emit(buildGameModule(supportedGames))
             }
         }
         .catch {
@@ -817,10 +818,9 @@ class HomeViewModel : ViewModel() {
         return ForYouModule.PlacesOfInterest(age = 0, index = 0, cards = cards, hasLocationPermission = true)
     }
 
-    private suspend fun buildGameModule(): ForYouModule.Games {
+    private suspend fun buildGameModule(supportedGames: List<WikiGames>): ForYouModule.Games {
         val today = LocalDate.now()
-        val gameCards = WikiGames.entries
-            .filter { it.isLangSupported(wikiSite.value.languageCode) }
+        val gameCards = supportedGames
             .mapNotNull { buildWikiGame(it, today)?.let { game -> WikiGameCard(game, today.toString()) } }
         val cards = gameCards + GamesModulePromptCard()
 
@@ -864,8 +864,8 @@ class HomeViewModel : ViewModel() {
             }
     }
 
-    private fun hasGamesHubAccess(): Boolean {
-        return WikiGames.WHICH_CAME_FIRST.isLangSupported(*WikipediaApp.instance.languageState.appLanguageCodes.toTypedArray())
+    private fun getSupportedGames(languageCode: String): List<WikiGames> {
+        return WikiGames.entries.filter { it.isLangSupported(languageCode) }
     }
 
     private fun hasLocationPermission(): Boolean {


### PR DESCRIPTION
### What does this do?
- only show game module for supported language

### Why is this needed?
From [Discussion](https://phabricator.wikimedia.org/T419756#12092407:~:text=Signed%20off-,One%20nice%2Dto%2Dhave%20change%3A,-I%27m%20realizing%20this), 
> If I'm viewing the feed in Greek, I have a game available in English but not in Greek. I would expect my game availability to match the current language of my feed. Currently, I see the "Want to play more games" game hub here, which leads to the game hub with only English available. Preferred would be to have the entire module hide when viewing the feed in Greek.
