### PR TITLE
Fix minor crash from WebViewZygoteInit isolated process.

### DIFF
--- a/app/src/main/java/org/wikipedia/WikipediaApp.kt
+++ b/app/src/main/java/org/wikipedia/WikipediaApp.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
+import android.os.Process
+import android.os.UserManager
 import android.speech.RecognizerIntent
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatDelegate
@@ -138,6 +140,14 @@ class WikipediaApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        // The system WebView's sandboxed renderer can get bound to the app and run onCreate()
+        // in an isolated process, where UserManager (and thus SharedPreferences) is not available.
+        // In such a case, there's no point continuing initialization.
+        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && Process.isIsolated()) ||
+            getSystemService(UserManager::class.java) == null) {
+            return
+        }
 
         WikiSite.setDefaultBaseUrl(Prefs.mediaWikiBaseUrl)
 


### PR DESCRIPTION
There is a very minor background crash that seems to be coming from WebViewZygoteInit (not related to any code we've built recently):

https://play.google.com/console/u/0/developers/6169333749249604352/app/4976363884102945010/vitals/crashes/6111f35f12119a577cd6622f558586aa/details?days=28

[Apparently](https://chromium.googlesource.com/chromium/src/+/HEAD/android_webview/renderer/README.md#:~:text=create%20sandboxed%20processes%20which%20run%20in%20the%20embedding%20app%27s%20context%20rather%20than%20the%20WebView%20provider%27s%20context) the System WebView renderer's service class can potentially run _in the embedding app's context_ rather than the WebView provider's context. So when the WebView needs a renderer, it binds to an isolated instance of our process (even though it doesn't need the process to execute any code).

Therefore AFAICT it's safe for us to just detect if we're running as an isolated process, and if so, bail as early as possible in `onCreate()`, since nothing else will work anyway, and nothing else is needed for the WebView renderer process.