### PR TITLE
Fix feed API calls when device locale is Persian.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -478,7 +478,7 @@ class HomeViewModel : ViewModel() {
             val age = nextCommunityAge
             val date = LocalDate.now().minusDays(nextCommunityAge.toLong())
             val content = ServiceFactory.getRest(wikiSite.value)
-                .getFeedFeatured(date.year.toString(), "%02d".format(date.monthValue), "%02d".format(date.dayOfMonth), wikiSite.value.languageCode)
+                .getFeedFeatured(date.year.toString(), "%02d".format(Locale.ROOT, date.monthValue), "%02d".format(Locale.ROOT, date.dayOfMonth), wikiSite.value.languageCode)
 
             // Construct Card objects based on the day's content
             val cardsForDay = buildList<Card> {

--- a/app/src/main/java/org/wikipedia/feed/personalization/homepreference/HomePreferenceRepository.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/homepreference/HomePreferenceRepository.kt
@@ -10,6 +10,7 @@ import org.wikipedia.page.PageTitle
 import org.wikipedia.settings.Prefs
 import org.wikipedia.util.StringUtil
 import java.time.LocalDate
+import java.util.Locale
 
 class HomePreferenceRepository(
     private val context: Context,
@@ -21,8 +22,8 @@ class HomePreferenceRepository(
 
         val response = ServiceFactory.getRest(wikiSite).getFeedFeatured(
             year = currentDate.year.toString(),
-            month = "%02d".format(currentDate.monthValue),
-            day = "%02d".format(currentDate.dayOfMonth),
+            month = "%02d".format(Locale.ROOT, currentDate.monthValue),
+            day = "%02d".format(Locale.ROOT, currentDate.dayOfMonth),
             lang = wikiSite.languageCode
         )
 


### PR DESCRIPTION
The `String.format(...)` extension takes the current user's locale when formatting numbers. This is correct when formatting UI strings, but _incorrect_ when formatting strings for consumption by the API. For formatting numbers to be used by the API, the root locale must be used.

If we set the device locale to Persian, and then call our `feed/featured` API, it formats the numbers as Persian numerals, which the API doesn't understand. Instead of `/feed/featured/2026/07/16` it becomes `/feed/featured/2026/۰۷/۱۴`

https://phabricator.wikimedia.org/T432459
