### PR TITLE
Mark more non-translatable strings as non-translatable.

### DIFF
--- a/app/src/alpha/res/values/strings_no_translate.xml
+++ b/app/src/alpha/res/values/strings_no_translate.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">@string/app_name_alpha</string>
-    <string name="channel">Alpha Channel</string>
+    <string name="app_name" translatable="false">@string/app_name_alpha</string>
+    <string name="channel" translatable="false">Alpha Channel</string>
 
     <!-- The alpha build uses a different signature than beta and prod. -->
-    <string name="account_name">Wikimedia (Alpha)</string>
-    <string name="account_type">org.wikimedia.alpha</string>
+    <string name="account_name" translatable="false">Wikimedia (Alpha)</string>
+    <string name="account_type" translatable="false">org.wikimedia.alpha</string>
 
-    <string name="user_option_sync_label">Preferences (Alpha)</string>
+    <string name="user_option_sync_label" translatable="false">Preferences (Alpha)</string>
 
-    <string name="launcher_clip">M 21 10.57 C 20.862 11.81 19.814 12.749 18.566 12.75 C 17.214 12.749 16.118 11.653 16.117 10.3 C 16.118 9.27 16.763 8.351 17.732 8 L 7 8 L 7 20 L 21 20 Z</string>
+    <string name="launcher_clip" translatable="false">M 21 10.57 C 20.862 11.81 19.814 12.749 18.566 12.75 C 17.214 12.749 16.118 11.653 16.117 10.3 C 16.118 9.27 16.763 8.351 17.732 8 L 7 8 L 7 20 L 21 20 Z</string>
 
-    <string name="splash_clip_from">M 0 0 L 0 432 L 432 432 L 432 0 Z M 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 Z</string>
-    <string name="splash_clip_to">M 0 0 L 0 432 L 432 432 L 432 0 Z M 357.7 168.32 C 357.7 195.934 335.314 218.32 307.7 218.32 C 280.086 218.32 257.7 195.934 257.7 168.32 C 257.7 140.706 280.086 118.32 307.7 118.32 C 335.314 118.32 357.7 140.706 357.7 168.32 Z</string>
-    <string name="splash_star">M 307.7 128.32 C 300.68 128.32 293.78 130.18 287.7 133.68 C 281.624 137.196 276.576 142.244 273.06 148.32 C 269.56 154.4 267.7 161.3 267.7 168.32 C 267.7 178.94 271.92 189.12 279.42 196.62 C 286.92 204.1 297.1 208.32 307.7 208.32 C 318.32 208.32 328.5 204.1 336 196.62 C 343.5 189.12 347.7 178.94 347.7 168.32 C 347.7 157.72 343.5 147.54 336 140.04 C 328.5 132.54 318.32 128.32 307.7 128.32 M 307.7 139.82 L 313.18 155.16 L 327.86 148.16 L 320.88 162.86 L 336.22 168.32 L 320.88 173.8 L 327.86 188.48 L 313.18 181.48 L 307.7 196.84 L 302.24 181.48 L 287.56 188.48 L 294.54 173.8 L 279.2 168.32 L 294.54 162.86 L 287.56 148.16 L 302.24 155.16 Z</string>
+    <string name="splash_clip_from" translatable="false">M 0 0 L 0 432 L 432 432 L 432 0 Z M 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 Z</string>
+    <string name="splash_clip_to" translatable="false">M 0 0 L 0 432 L 432 432 L 432 0 Z M 357.7 168.32 C 357.7 195.934 335.314 218.32 307.7 218.32 C 280.086 218.32 257.7 195.934 257.7 168.32 C 257.7 140.706 280.086 118.32 307.7 118.32 C 335.314 118.32 357.7 140.706 357.7 168.32 Z</string>
+    <string name="splash_star" translatable="false">M 307.7 128.32 C 300.68 128.32 293.78 130.18 287.7 133.68 C 281.624 137.196 276.576 142.244 273.06 148.32 C 269.56 154.4 267.7 161.3 267.7 168.32 C 267.7 178.94 271.92 189.12 279.42 196.62 C 286.92 204.1 297.1 208.32 307.7 208.32 C 318.32 208.32 328.5 204.1 336 196.62 C 343.5 189.12 347.7 178.94 347.7 168.32 C 347.7 157.72 343.5 147.54 336 140.04 C 328.5 132.54 318.32 128.32 307.7 128.32 M 307.7 139.82 L 313.18 155.16 L 327.86 148.16 L 320.88 162.86 L 336.22 168.32 L 320.88 173.8 L 327.86 188.48 L 313.18 181.48 L 307.7 196.84 L 302.24 181.48 L 287.56 188.48 L 294.54 173.8 L 279.2 168.32 L 294.54 162.86 L 287.56 148.16 L 302.24 155.16 Z</string>
 </resources>

--- a/app/src/beta/res/values/strings_no_translate.xml
+++ b/app/src/beta/res/values/strings_no_translate.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">@string/app_name_beta</string>
-    <string name="channel">Google Play Beta Channel</string>
+    <string name="app_name" translatable="false">@string/app_name_beta</string>
+    <string name="channel" translatable="false">Google Play Beta Channel</string>
 
     <!-- TODO: remove and use the same account as prod when tokens are stored. -->
-    <string name="account_name">Wikimedia (Beta)</string>
-    <string name="account_type">org.wikimedia.beta</string>
+    <string name="account_name" translatable="false">Wikimedia (Beta)</string>
+    <string name="account_type" translatable="false">org.wikimedia.beta</string>
 
-    <string name="user_option_sync_label">Preferences (Beta)</string>
+    <string name="user_option_sync_label" translatable="false">Preferences (Beta)</string>
 
-    <string name="launcher_clip">M 21 10.57 C 20.862 11.81 19.814 12.749 18.566 12.75 C 17.214 12.749 16.118 11.653 16.117 10.3 C 16.118 9.27 16.763 8.351 17.732 8 L 7 8 L 7 20 L 21 20 Z</string>
+    <string name="launcher_clip" translatable="false">M 21 10.57 C 20.862 11.81 19.814 12.749 18.566 12.75 C 17.214 12.749 16.118 11.653 16.117 10.3 C 16.118 9.27 16.763 8.351 17.732 8 L 7 8 L 7 20 L 21 20 Z</string>
 
-    <string name="splash_clip_from">M 0 0 L 0 432 L 432 432 L 432 0 Z M 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 Z</string>
-    <string name="splash_clip_to">M 0 0 L 0 432 L 432 432 L 432 0 Z M 357.7 168.32 C 357.7 195.934 335.314 218.32 307.7 218.32 C 280.086 218.32 257.7 195.934 257.7 168.32 C 257.7 140.706 280.086 118.32 307.7 118.32 C 335.314 118.32 357.7 140.706 357.7 168.32 Z</string>
-    <string name="splash_star">M 307.7 128.32 C 300.68 128.32 293.78 130.18 287.7 133.68 C 281.624 137.196 276.576 142.244 273.06 148.32 C 269.56 154.4 267.7 161.3 267.7 168.32 C 267.7 178.94 271.92 189.12 279.42 196.62 C 286.92 204.1 297.1 208.32 307.7 208.32 C 318.32 208.32 328.5 204.1 336 196.62 C 343.5 189.12 347.7 178.94 347.7 168.32 C 347.7 157.72 343.5 147.54 336 140.04 C 328.5 132.54 318.32 128.32 307.7 128.32 M 307.7 139.82 L 313.18 155.16 L 327.86 148.16 L 320.88 162.86 L 336.22 168.32 L 320.88 173.8 L 327.86 188.48 L 313.18 181.48 L 307.7 196.84 L 302.24 181.48 L 287.56 188.48 L 294.54 173.8 L 279.2 168.32 L 294.54 162.86 L 287.56 148.16 L 302.24 155.16 Z</string>
+    <string name="splash_clip_from" translatable="false">M 0 0 L 0 432 L 432 432 L 432 0 Z M 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 Z</string>
+    <string name="splash_clip_to" translatable="false">M 0 0 L 0 432 L 432 432 L 432 0 Z M 357.7 168.32 C 357.7 195.934 335.314 218.32 307.7 218.32 C 280.086 218.32 257.7 195.934 257.7 168.32 C 257.7 140.706 280.086 118.32 307.7 118.32 C 335.314 118.32 357.7 140.706 357.7 168.32 Z</string>
+    <string name="splash_star" translatable="false">M 307.7 128.32 C 300.68 128.32 293.78 130.18 287.7 133.68 C 281.624 137.196 276.576 142.244 273.06 148.32 C 269.56 154.4 267.7 161.3 267.7 168.32 C 267.7 178.94 271.92 189.12 279.42 196.62 C 286.92 204.1 297.1 208.32 307.7 208.32 C 318.32 208.32 328.5 204.1 336 196.62 C 343.5 189.12 347.7 178.94 347.7 168.32 C 347.7 157.72 343.5 147.54 336 140.04 C 328.5 132.54 318.32 128.32 307.7 128.32 M 307.7 139.82 L 313.18 155.16 L 327.86 148.16 L 320.88 162.86 L 336.22 168.32 L 320.88 173.8 L 327.86 188.48 L 313.18 181.48 L 307.7 196.84 L 302.24 181.48 L 287.56 188.48 L 294.54 173.8 L 279.2 168.32 L 294.54 162.86 L 287.56 148.16 L 302.24 155.16 Z</string>
 </resources>

--- a/app/src/dev/res/values/strings_no_translate.xml
+++ b/app/src/dev/res/values/strings_no_translate.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Wikipedia Dev</string>
-    <string name="channel">Developer Channel</string>
+    <string name="app_name" translatable="false">Wikipedia Dev</string>
+    <string name="channel" translatable="false">Developer Channel</string>
 
     <!-- TODO: remove and use the same account as alpha when tokens are stored. -->
-    <string name="account_name">Wikimedia (Dev)</string>
-    <string name="account_type">org.wikimedia.dev</string>
+    <string name="account_name" translatable="false">Wikimedia (Dev)</string>
+    <string name="account_type" translatable="false">org.wikimedia.dev</string>
 
-    <string name="user_option_sync_label">Preferences (Dev)</string>
+    <string name="user_option_sync_label" translatable="false">Preferences (Dev)</string>
 
-    <string name="launcher_clip">M 21 10.57 C 20.862 11.81 19.814 12.749 18.566 12.75 C 17.214 12.749 16.118 11.653 16.117 10.3 C 16.118 9.27 16.763 8.351 17.732 8 L 7 8 L 7 20 L 21 20 Z</string>
+    <string name="launcher_clip" translatable="false">M 21 10.57 C 20.862 11.81 19.814 12.749 18.566 12.75 C 17.214 12.749 16.118 11.653 16.117 10.3 C 16.118 9.27 16.763 8.351 17.732 8 L 7 8 L 7 20 L 21 20 Z</string>
 
-    <string name="splash_clip_from">M 0 0 L 0 432 L 432 432 L 432 0 Z M 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 Z</string>
-    <string name="splash_clip_to">M 0 0 L 0 432 L 432 432 L 432 0 Z M 357.7 168.32 C 357.7 195.934 335.314 218.32 307.7 218.32 C 280.086 218.32 257.7 195.934 257.7 168.32 C 257.7 140.706 280.086 118.32 307.7 118.32 C 335.314 118.32 357.7 140.706 357.7 168.32 Z</string>
-    <string name="splash_star">M 307.7 128.32 C 300.68 128.32 293.78 130.18 287.7 133.68 C 281.624 137.196 276.576 142.244 273.06 148.32 C 269.56 154.4 267.7 161.3 267.7 168.32 C 267.7 178.94 271.92 189.12 279.42 196.62 C 286.92 204.1 297.1 208.32 307.7 208.32 C 318.32 208.32 328.5 204.1 336 196.62 C 343.5 189.12 347.7 178.94 347.7 168.32 C 347.7 157.72 343.5 147.54 336 140.04 C 328.5 132.54 318.32 128.32 307.7 128.32 M 307.7 139.82 L 313.18 155.16 L 327.86 148.16 L 320.88 162.86 L 336.22 168.32 L 320.88 173.8 L 327.86 188.48 L 313.18 181.48 L 307.7 196.84 L 302.24 181.48 L 287.56 188.48 L 294.54 173.8 L 279.2 168.32 L 294.54 162.86 L 287.56 148.16 L 302.24 155.16 Z</string>
+    <string name="splash_clip_from" translatable="false">M 0 0 L 0 432 L 432 432 L 432 0 Z M 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 C 307.7 168.32 307.7 168.32 307.7 168.32 Z</string>
+    <string name="splash_clip_to" translatable="false">M 0 0 L 0 432 L 432 432 L 432 0 Z M 357.7 168.32 C 357.7 195.934 335.314 218.32 307.7 218.32 C 280.086 218.32 257.7 195.934 257.7 168.32 C 257.7 140.706 280.086 118.32 307.7 118.32 C 335.314 118.32 357.7 140.706 357.7 168.32 Z</string>
+    <string name="splash_star" translatable="false">M 307.7 128.32 C 300.68 128.32 293.78 130.18 287.7 133.68 C 281.624 137.196 276.576 142.244 273.06 148.32 C 269.56 154.4 267.7 161.3 267.7 168.32 C 267.7 178.94 271.92 189.12 279.42 196.62 C 286.92 204.1 297.1 208.32 307.7 208.32 C 318.32 208.32 328.5 204.1 336 196.62 C 343.5 189.12 347.7 178.94 347.7 168.32 C 347.7 157.72 343.5 147.54 336 140.04 C 328.5 132.54 318.32 128.32 307.7 128.32 M 307.7 139.82 L 313.18 155.16 L 327.86 148.16 L 320.88 162.86 L 336.22 168.32 L 320.88 173.8 L 327.86 188.48 L 313.18 181.48 L 307.7 196.84 L 302.24 181.48 L 287.56 188.48 L 294.54 173.8 L 279.2 168.32 L 294.54 162.86 L 287.56 148.16 L 302.24 155.16 Z</string>
 </resources>


### PR DESCRIPTION
Whoops - looks like I missed a few string resources in my previous PR when marking strings as `translatable="false"`