### PR TITLE
Fix: prevent the app crashes when the queueSize is `0`for EventPlatform

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -83,7 +83,7 @@ object EventPlatformClient {
             synchronized(INITIAL_QUEUE) {
                 // We want the queue to work as a circular buffer, so if it's full, remove the oldest item.
                 if (INITIAL_QUEUE.size >= Prefs.analyticsQueueSize) {
-                    INITIAL_QUEUE.removeAt(0)
+                    INITIAL_QUEUE.removeFirstOrNull()
                 }
                 INITIAL_QUEUE.add(event)
             }


### PR DESCRIPTION
### What does this do?
In the developer settings, we can update the batch size for sending events to the Event Platform to `0`, but there's a possibility to lead to app crashes.

See log below:
```
Caused by: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.util.Objects.checkIndex(Objects.java:391)
	at java.util.ArrayList.remove(ArrayList.java:558)
	at org.wikipedia.analytics.eventplatform.EventPlatformClient.submit(EventPlatformClient.kt:86)
	at org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent$Companion.logScreenShown(BreadCrumbLogEvent.kt:65)
	at org.wikipedia.analytics.eventplatform.BreadCrumbLogEvent$Companion.logScreenShown$default(BreadCrumbLogEvent.kt:63)
	at org.wikipedia.activity.BaseActivity.onResume(BaseActivity.kt:227)
	at org.wikipedia.main.MainActivity.onResume(MainActivity.kt:101)
	at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1740)
	at android.app.Activity.performResume(Activity.java:9930)
	at android.app.ActivityThread.performResumeActivity(ActivityThread.java:6602)
```

We can update `INITIAL_QUEUE.removeAt(0)` to `INITIAL_QUEUE.removeFirstOrNull()` to avoid removing an empty queue in this case.