### PR TITLE
Add default `null` for nullable variables in PageMetaData

### DIFF
--- a/app/src/main/java/org/wikipedia/page/PageMetadata.kt
+++ b/app/src/main/java/org/wikipedia/page/PageMetadata.kt
@@ -12,13 +12,13 @@ class PageMetadata(
 ) {
     @Serializable
     class Topic(
-        val topic: String?,
+        val topic: String? = null,
         val score: Double = 0.0
     )
 
     @Serializable
     class LeadImage(
-        val source: String?,
+        val source: String? = null,
         val width: Int = 0,
         val height: Int = 0
     )


### PR DESCRIPTION
### What does this do?
When resuming the app from an external browser, if the article does not have a lead image, the app will post a warning message about the missing `source` in `LeadImage`.

This PR adds a default `null` for those nullable variables. 

