### PR TITLE
Add "close other tabs" button to tab page menu.

### DIFF
--- a/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
+++ b/app/src/main/java/org/wikipedia/page/tabs/TabActivity.kt
@@ -90,6 +90,29 @@ class TabActivity : BaseActivity() {
                 openNewTab()
                 true
             }
+            R.id.menu_close_other_tabs -> {
+                if (app.tabList.count() > 1) {
+                    MaterialAlertDialogBuilder(this).run {
+                        setMessage(R.string.close_other_tabs_confirm)
+                        setPositiveButton(R.string.close_other_tabs_confirm_yes) { _, _ ->
+                            L.d("All other tabs removed.")
+                            val otherTabs = app.tabList.subList(0, app.tabList.lastIndex.coerceAtLeast(1)).toMutableList()
+                            val activeTab = app.tabList.last()
+                            app.tabList.clear()
+                            app.tabList.add(activeTab)
+                            binding.tabCountsView.updateTabCount(false)
+                            // Note that the tabRecyclerView expects items in displayed (last-to-first) order
+                            binding.tabRecyclerView.adapter?.notifyItemRangeRemoved(1, otherTabs.size)
+                            setResult(RESULT_LOAD_FROM_BACKSTACK)
+                            showUndoOtherSnackbar(otherTabs)
+                            cancelled = false
+                        }
+                        setNegativeButton(R.string.close_other_tabs_confirm_no, null)
+                            .show()
+                    }
+                }
+                true
+            }
             R.id.menu_close_all_tabs -> {
                 if (app.tabList.isNotEmpty()) {
                     MaterialAlertDialogBuilder(this).run {
@@ -166,6 +189,18 @@ class TabActivity : BaseActivity() {
                 app.tabList.addAll(appTabs)
                 appTabs.clear()
                 binding.tabRecyclerView.adapter?.notifyItemRangeInserted(0, app.tabList.size)
+                binding.tabCountsView.updateTabCount(false)
+            }
+            show()
+        }
+    }
+
+    private fun showUndoOtherSnackbar(otherTabs: MutableList<Tab>) {
+        FeedbackUtil.makeSnackbar(this, getString(R.string.other_tab_items_closed)).run {
+            setAction(R.string.reading_list_item_delete_undo) {
+                app.tabList.addAll(0, otherTabs)
+                binding.tabRecyclerView.adapter?.notifyItemRangeInserted(1, otherTabs.size)
+                otherTabs.clear()
                 binding.tabCountsView.updateTabCount(false)
             }
             show()

--- a/app/src/main/res/menu/menu_tabs.xml
+++ b/app/src/main/res/menu/menu_tabs.xml
@@ -7,6 +7,9 @@
     <item android:id="@+id/menu_save_all_tabs"
         android:title="@string/menu_save_all_tabs"
         app:showAsAction="never" />
+    <item android:id="@+id/menu_close_other_tabs"
+        android:title="@string/menu_close_other_tabs"
+        app:showAsAction="never" />
     <item android:id="@+id/menu_close_all_tabs"
         android:title="@string/menu_close_all_tabs"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,6 +370,10 @@
     <string name="gallery_not_available_offline_snackbar">Gallery view not available offline.</string>
     <string name="gallery_not_available_offline_snackbar_dismiss">Dismiss</string>
     <string name="menu_new_tab">New tab</string>
+    <string name="menu_close_other_tabs">Close other tabs</string>
+    <string name="close_other_tabs_confirm">Are you sure you want to close all but the currently selected tab?</string>
+    <string name="close_other_tabs_confirm_yes">Yes</string>
+    <string name="close_other_tabs_confirm_no">No</string>
     <string name="menu_close_all_tabs">Close all tabs</string>
     <string name="close_all_tabs_confirm">Are you sure you want to close all tabs?</string>
     <string name="close_all_tabs_confirm_yes">Yes</string>
@@ -377,6 +381,7 @@
     <string name="button_close_tab">Close tab</string>
     <string name="unnamed_tab_closed">Tab closed.</string>
     <string name="tab_item_closed">%s closed.</string>
+    <string name="other_tab_items_closed">Other tabs closed.</string>
     <string name="all_tab_items_closed">All tabs closed.</string>
     <string name="tool_tip_bookmark_icon_title">Add to reading list</string>
     <string name="tool_tip_bookmark_icon_text">Tap on the bookmark icon to save the article to a reading list.</string>


### PR DESCRIPTION
### What does this do?
Adds a "close other tabs" button to the tab page menu:

<img width="270" height="606" alt="Screenshot_20260815_225121" src="https://github.com/user-attachments/assets/d07f7469-ad78-4630-bbe7-b1ccdc7805bb" />
<img width="270" height="606" alt="Screenshot_20260815_225156" src="https://github.com/user-attachments/assets/6f199a1a-2bf5-42eb-9430-26e48d45b786" />
<img width="270" height="606" alt="Screenshot_20260815_225205" src="https://github.com/user-attachments/assets/7833a967-8fb6-4b85-9bd7-204349552b2a" />

Tested and working on Android 16. Undo works as expected.

Did not add integration tests as `ArticleTabTest` seems to be broken by explore feed changes at the moment. I may try to address that in a separate PR and update this one.

I have only added strings in English.

### Why is this needed?
The Phabricator ticket has a good summary.

I have also been wanting this for a couple years. I often find myself opening a Wikipedia link, seeing that I have 70+ tabs open, and then not being able to close them all without also losing the page I am on.

(It might also be nice to have this in the toolbar when looking at the article itself, but then it would need to make sense with the "customize toolbar" feature that allows actions to be pinned to the bottom of the screen at all times.)

**Phabricator:**
https://phabricator.wikimedia.org/T395550