### PR TITLE
Wire up Exposure events, and auto-show AB tests in Developer Settings.

### DIFF
--- a/app/src/main/java/org/wikipedia/analytics/ABTest.kt
+++ b/app/src/main/java/org/wikipedia/analytics/ABTest.kt
@@ -8,12 +8,17 @@ abstract class ABTest(private val abTestName: String, private val abTestGroupCou
 
     val name get() = abTestName
 
+    val groupCount get() = abTestGroupCount
+
+    val preferenceKey get() = AB_TEST_KEY_PREFIX + abTestName
+    val exposureEventSentKey get() = AB_TEST_EXPOSURE_SENT_PREFIX + abTestName
+
     val group: Int
         get() {
-            testGroup = PrefsIoUtil.getInt(AB_TEST_KEY_PREFIX + abTestName, -1)
+            testGroup = PrefsIoUtil.getInt(preferenceKey, -1)
             if (testGroup == -1) {
                 assignGroup()
-                PrefsIoUtil.setInt(AB_TEST_KEY_PREFIX + abTestName, testGroup)
+                PrefsIoUtil.setInt(preferenceKey, testGroup)
             }
             return testGroup
         }
@@ -31,10 +36,10 @@ abstract class ABTest(private val abTestName: String, private val abTestGroupCou
     }
 
     fun maybeSendExposureEvent() {
-        PrefsIoUtil.getInt(AB_TEST_EXPOSURE_SENT_PREFIX + abTestName, 0).let { sentCount ->
+        PrefsIoUtil.getInt(exposureEventSentKey, 0).let { sentCount ->
             if (sentCount < AB_TEST_EXPOSURE_SENT_MAX_TIMES) {
                 TestKitchenAdapter.submitExperimentExposure(this)
-                PrefsIoUtil.setInt(AB_TEST_EXPOSURE_SENT_PREFIX + abTestName, sentCount + 1)
+                PrefsIoUtil.setInt(exposureEventSentKey, sentCount + 1)
             }
         }
     }

--- a/app/src/main/java/org/wikipedia/analytics/ABTest.kt
+++ b/app/src/main/java/org/wikipedia/analytics/ABTest.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.analytics
 
+import org.wikipedia.analytics.testkitchen.TestKitchenAdapter
 import org.wikipedia.settings.PrefsIoUtil
 import kotlin.random.Random
 
@@ -29,8 +30,20 @@ abstract class ABTest(private val abTestName: String, private val abTestGroupCou
         return true
     }
 
+    fun maybeSendExposureEvent() {
+        PrefsIoUtil.getInt(AB_TEST_EXPOSURE_SENT_PREFIX + abTestName, 0).let { sentCount ->
+            if (sentCount < AB_TEST_EXPOSURE_SENT_MAX_TIMES) {
+                TestKitchenAdapter.submitExperimentExposure(this)
+                PrefsIoUtil.setInt(AB_TEST_EXPOSURE_SENT_PREFIX + abTestName, sentCount + 1)
+            }
+        }
+    }
+
     companion object {
         private const val AB_TEST_KEY_PREFIX = "ab_test_"
+        private const val AB_TEST_EXPOSURE_SENT_PREFIX = "ab_test_exposure_sent_"
+        private const val AB_TEST_EXPOSURE_SENT_MAX_TIMES = 3
+
         const val GROUP_SIZE_2 = 2
         const val GROUP_SIZE_3 = 3
         const val GROUP_1 = 0

--- a/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
+++ b/app/src/main/java/org/wikipedia/feed/HomeViewModel.kt
@@ -671,6 +671,7 @@ class HomeViewModel : ViewModel() {
                 }
             }
 
+            NewWithinInterestABTest().maybeSendExposureEvent()
             val newWithinInterestTopics = if (NewWithinInterestABTest().isTestGroupUser())
                 AppDatabase.instance.topicInterestDao().getAllRandom().distinctBy { it.topicId }.take(4)
             else emptyList()

--- a/app/src/main/java/org/wikipedia/feed/interests/NewWithinInterestABTest.kt
+++ b/app/src/main/java/org/wikipedia/feed/interests/NewWithinInterestABTest.kt
@@ -2,7 +2,7 @@ package org.wikipedia.feed.interests
 
 import org.wikipedia.analytics.ABTest
 
-class NewWithinInterestABTest : ABTest("newWithinInterest", GROUP_SIZE_2) {
+class NewWithinInterestABTest : ABTest("new-within-interest", GROUP_SIZE_2) {
     override fun getGroupName(): String {
         return when (group) {
             GROUP_2 -> "treatment"

--- a/app/src/main/java/org/wikipedia/settings/dev/DeveloperSettingsPreferenceLoader.kt
+++ b/app/src/main/java/org/wikipedia/settings/dev/DeveloperSettingsPreferenceLoader.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.ListPreference
 import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceGroup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -18,7 +19,9 @@ import org.wikipedia.R
 import org.wikipedia.WikipediaApp
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.dataclient.WikiSite
+import org.wikipedia.donate.donationreminder.DonationReminderAbTest
 import org.wikipedia.donate.donationreminder.DonationReminderConfig
+import org.wikipedia.feed.interests.NewWithinInterestABTest
 import org.wikipedia.feed.personalization.homepreference.HomePreferenceType
 import org.wikipedia.games.onthisday.OnThisDayGameNotificationManager
 import org.wikipedia.games.onthisday.OnThisDayGameNotificationState
@@ -30,7 +33,9 @@ import org.wikipedia.page.PageTitle
 import org.wikipedia.readinglist.database.ReadingListPage
 import org.wikipedia.readinglist.recommended.RecommendedReadingListNotificationManager
 import org.wikipedia.readinglist.recommended.RecommendedReadingListUpdateFrequency
+import org.wikipedia.search.HybridSearchAbCTest
 import org.wikipedia.settings.BasePreferenceLoader
+import org.wikipedia.settings.IntPreference
 import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.dev.playground.CategoryDeveloperPlayGround
 import org.wikipedia.settings.dev.playground.ReadingChallengePlayGroundDialog
@@ -297,6 +302,33 @@ internal class DeveloperSettingsPreferenceLoader(fragment: PreferenceFragmentCom
                 true
             }
         }
+        addABTestPreferences()
+    }
+
+    private fun addABTestPreferences() {
+        val screen = fragment.preferenceScreen
+        if (screen.findPreference<PreferenceCategory>(AB_TEST_CATEGORY_KEY) != null) {
+            return
+        }
+        val category = PreferenceCategory(screen.context).apply {
+            key = AB_TEST_CATEGORY_KEY
+            title = "A/B tests (restart required)"
+        }
+        screen.addPreference(category)
+        listOf(
+            DonationReminderAbTest(),
+            HybridSearchAbCTest(),
+            NewWithinInterestABTest()
+        ).forEach { abTest ->
+            category.addPreference(IntPreference(screen.context).apply {
+                key = abTest.preferenceKey
+                title = "${abTest.name} (groups 0 - ${abTest.groupCount - 1})"
+            })
+            category.addPreference(IntPreference(screen.context).apply {
+                key = abTest.exposureEventSentKey
+                title = "${abTest.name} exposure events sent"
+            })
+        }
     }
 
     private fun setUpMediaWikiSettings() {
@@ -360,5 +392,6 @@ internal class DeveloperSettingsPreferenceLoader(fragment: PreferenceFragmentCom
     companion object {
         private const val TEXT_OF_TEST_READING_LIST = "Test reading list"
         private const val TEXT_OF_READING_LIST = "Reading list"
+        private const val AB_TEST_CATEGORY_KEY = "ab_test_category"
     }
 }

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -501,11 +501,6 @@
         <ListPreference
             android:key="@string/preference_key_recommended_reading_list_notification_simulator"
             android:title="Notification frequency Simulator"/>
-      
-        <org.wikipedia.settings.IntPreference
-            style="@style/IntPreference"
-            android:key="ab_test_recommendedReadingList"
-            android:title="AB test group" />
 
     </PreferenceCategory>
 
@@ -525,11 +520,6 @@
             android:key="@string/preference_key_yir_survey_state"
             android:title="Yir Survey State"/>
 
-        <org.wikipedia.settings.IntPreference
-            style="@style/IntPreference"
-            android:key="ab_test_yirReadingList"
-            android:title="Yir Reading List test group (require restart)" />
-
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Donation Reminder">
@@ -547,11 +537,6 @@
             android:key="@string/preference_key_donation_reminder_config"
             android:title="@string/preference_key_donation_reminder_config"/>
 
-        <org.wikipedia.settings.IntPreference
-            style="@style/IntPreference"
-            android:key="ab_test_donationReminder"
-            android:title="Donation Reminder test group (require restart)"/>
-
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Activity tab">
@@ -567,11 +552,6 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Hybrid Search">
-
-        <org.wikipedia.settings.IntPreference
-            style="@style/IntPreference"
-            android:key="ab_test_apps_hybridsearch"
-            android:title="Hybrid Search test group (require restart)"/>
 
         <org.wikipedia.settings.SwitchPreferenceMultiLine
             android:key="@string/preference_key_hybrid_search_onboarding_shown"
@@ -610,11 +590,6 @@
         <org.wikipedia.settings.SwitchPreferenceMultiLine
             android:key="@string/preference_key_randomizer_shake_prompt_shown"
             android:title="@string/preference_key_randomizer_shake_prompt_shown"/>
-
-        <org.wikipedia.settings.IntPreference
-            style="@style/IntPreference"
-            android:key="ab_test_newWithinInterest"
-            android:title="New articles by Topic test group" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
* For any AB test that we make, this will _automatically_ put it into Developer preferences!
* Any AB test can now send its own exposure event, with a maximum of 3 times. (It's OK to send an exposure event more than once, and this will minimize the chance of an exposure event getting lost or dropped.)
* Finally, actually send an exposure event for the New Articles AB test, which will prove out this functionality in GrowthBook.

https://phabricator.wikimedia.org/T434941
https://phabricator.wikimedia.org/T432385
