### PR TITLE
Follow up: fixing missing editCount in EditAttemptStep events

### DIFF
--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -426,10 +426,11 @@ interface Service {
 
     // ------- Editing -------
 
-    @GET(MW_API_PREFIX + "action=query&prop=revisions|info&meta=siteinfo|userinfo&uiprop=editcount&siprop=general|autocreatetempuser&rvslots=main&rvprop=content|timestamp|ids&rvlimit=1&converttitles=&intestactions=edit&intestactionsdetail=full&inprop=editintro")
+    @GET(MW_API_PREFIX + "action=query&prop=revisions|info&meta=siteinfo&siprop=general|autocreatetempuser&rvslots=main&rvprop=content|timestamp|ids&rvlimit=1&converttitles=&intestactions=edit&intestactionsdetail=full&inprop=editintro&list=users&usprop=editcount")
     suspend fun getWikiTextForSectionWithInfo(
         @Query("titles") title: String,
-        @Query("rvsection") section: Int?
+        @Query("rvsection") section: Int?,
+        @Query("ususers") userNames: String? = null
     ): MwQueryResponse
 
     @FormUrlEncoded
@@ -537,10 +538,11 @@ interface Service {
         @Query("uselang") resultLang: String
     ): Search
 
-    @GET(MW_API_PREFIX + "action=query&prop=entityterms&meta=userinfo&uiprop=editcount")
+    @GET(MW_API_PREFIX + "action=query&prop=entityterms&&list=users&usprop=editcount")
     suspend fun getWikidataEntityTerms(
         @Query("titles") titles: String,
-        @Query("wbetlanguage") lang: String
+        @Query("wbetlanguage") lang: String,
+        @Query("ususers") userNames: String? = null
     ): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=wbgetclaims")
@@ -610,11 +612,11 @@ interface Service {
     suspend fun getWatchedStatusWithUserOptions(@Query("titles") titles: String): MwQueryResponse
 
     @Headers("Cache-Control: no-cache")
-    @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched&meta=userinfo&uiprop=rights|editcount")
+    @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched&uiprop=rights")
     suspend fun getWatchedStatusWithRights(@Query("titles") titles: String): MwQueryResponse
 
     @Headers("Cache-Control: no-cache")
-    @GET(MW_API_PREFIX + "action=query&meta=userinfo&uiprop=editcount&prop=info|categories&converttitles=&redirects=&inprop=watched&clshow=!hidden&cllimit=100")
+    @GET(MW_API_PREFIX + "action=query&prop=info|categories&converttitles=&redirects=&inprop=watched&clshow=!hidden&cllimit=100")
     suspend fun getWatchedStatusWithCategories(@Query("titles") titles: String): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query&list=watchlist&wllimit=500&wlprop=ids|title|flags|comment|parsedcomment|timestamp|sizes|user|loginfo&assert=user")
@@ -651,7 +653,7 @@ interface Service {
             @Query("rvstartid") revisionStartId: Long
     ): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&prop=info|revisions&rvslots=main&rvprop=ids|timestamp|size|flags|comment|parsedcomment|user|oresscores&rvdir=older&inprop=watched&meta=userinfo&uiprop=rights|editcount")
+    @GET(MW_API_PREFIX + "action=query&prop=info|revisions&rvslots=main&rvprop=ids|timestamp|size|flags|comment|parsedcomment|user|oresscores&rvdir=older&inprop=watched&meta=userinfo&uiprop=rights")
     suspend fun getRevisionDetailsWithUserInfo(
         @Query("pageids") pageIds: String,
         @Query("rvlimit") count: Int,

--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -151,7 +151,7 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&meta=globaluserinfo&guiprop=editcount&prop=info|description|pageimages&pilicense=any&inprop=varianttitles|displaytitle&redirects=1&assert=user&pithumbsize=" + PREFERRED_THUMB_SIZE)
     suspend fun getInfoByTitlesWithGlobalUserInfo(@Query("titles") titles: String? = null): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&meta=siteinfo&siprop=general|autocreatetempuser")
+    @GET(MW_API_PREFIX + "action=query&meta=siteinfo|userinfo&uiprop=editcount&siprop=general|autocreatetempuser")
     suspend fun getPageIds(@Query("titles") titles: String): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query&prop=imageinfo&iiprop=timestamp|user|url|mime|metadata|extmetadata&iiurlwidth=" + PREFERRED_THUMB_SIZE)
@@ -426,11 +426,10 @@ interface Service {
 
     // ------- Editing -------
 
-    @GET(MW_API_PREFIX + "action=query&prop=revisions|info&meta=siteinfo&siprop=general|autocreatetempuser&rvslots=main&rvprop=content|timestamp|ids&rvlimit=1&converttitles=&intestactions=edit&intestactionsdetail=full&inprop=editintro&list=users&usprop=editcount")
+    @GET(MW_API_PREFIX + "action=query&prop=revisions|info&meta=siteinfo|userinfo&uiprop=editcount&siprop=general|autocreatetempuser&rvslots=main&rvprop=content|timestamp|ids&rvlimit=1&converttitles=&intestactions=edit&intestactionsdetail=full&inprop=editintro")
     suspend fun getWikiTextForSectionWithInfo(
         @Query("titles") title: String,
-        @Query("rvsection") section: Int?,
-        @Query("ususers") userNames: String? = null
+        @Query("rvsection") section: Int?
     ): MwQueryResponse
 
     @FormUrlEncoded
@@ -541,8 +540,7 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&prop=entityterms&&list=users&usprop=editcount")
     suspend fun getWikidataEntityTerms(
         @Query("titles") titles: String,
-        @Query("wbetlanguage") lang: String,
-        @Query("ususers") userNames: String? = null
+        @Query("wbetlanguage") lang: String
     ): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=wbgetclaims")
@@ -612,11 +610,11 @@ interface Service {
     suspend fun getWatchedStatusWithUserOptions(@Query("titles") titles: String): MwQueryResponse
 
     @Headers("Cache-Control: no-cache")
-    @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched&meta=userinfo&uiprop=rights")
+    @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched&meta=userinfo&uiprop=rights|editcount")
     suspend fun getWatchedStatusWithRights(@Query("titles") titles: String): MwQueryResponse
 
     @Headers("Cache-Control: no-cache")
-    @GET(MW_API_PREFIX + "action=query&prop=info|categories&converttitles=&redirects=&inprop=watched&clshow=!hidden&cllimit=100")
+    @GET(MW_API_PREFIX + "action=query&meta=userinfo&uiprop=editcount&prop=info|categories&converttitles=&redirects=&inprop=watched&clshow=!hidden&cllimit=100")
     suspend fun getWatchedStatusWithCategories(@Query("titles") titles: String): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query&list=watchlist&wllimit=500&wlprop=ids|title|flags|comment|parsedcomment|timestamp|sizes|user|loginfo&assert=user")
@@ -653,7 +651,7 @@ interface Service {
             @Query("rvstartid") revisionStartId: Long
     ): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&prop=info|revisions&rvslots=main&rvprop=ids|timestamp|size|flags|comment|parsedcomment|user|oresscores&rvdir=older&inprop=watched&meta=userinfo&uiprop=rights")
+    @GET(MW_API_PREFIX + "action=query&prop=info|revisions&rvslots=main&rvprop=ids|timestamp|size|flags|comment|parsedcomment|user|oresscores&rvdir=older&inprop=watched&meta=userinfo&uiprop=rights|editcount")
     suspend fun getRevisionDetailsWithUserInfo(
         @Query("pageids") pageIds: String,
         @Query("rvlimit") count: Int,

--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -537,7 +537,7 @@ interface Service {
         @Query("uselang") resultLang: String
     ): Search
 
-    @GET(MW_API_PREFIX + "action=query&prop=entityterms&&list=users&usprop=editcount")
+    @GET(MW_API_PREFIX + "action=query&prop=entityterms&meta=userinfo&uiprop=editcount")
     suspend fun getWikidataEntityTerms(
         @Query("titles") titles: String,
         @Query("wbetlanguage") lang: String

--- a/app/src/main/java/org/wikipedia/dataclient/Service.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/Service.kt
@@ -151,7 +151,7 @@ interface Service {
     @GET(MW_API_PREFIX + "action=query&meta=globaluserinfo&guiprop=editcount&prop=info|description|pageimages&pilicense=any&inprop=varianttitles|displaytitle&redirects=1&assert=user&pithumbsize=" + PREFERRED_THUMB_SIZE)
     suspend fun getInfoByTitlesWithGlobalUserInfo(@Query("titles") titles: String? = null): MwQueryResponse
 
-    @GET(MW_API_PREFIX + "action=query&meta=siteinfo|userinfo&uiprop=editcount&siprop=general|autocreatetempuser")
+    @GET(MW_API_PREFIX + "action=query&meta=siteinfo&siprop=general|autocreatetempuser")
     suspend fun getPageIds(@Query("titles") titles: String): MwQueryResponse
 
     @GET(MW_API_PREFIX + "action=query&prop=imageinfo&iiprop=timestamp|user|url|mime|metadata|extmetadata&iiurlwidth=" + PREFERRED_THUMB_SIZE)
@@ -612,7 +612,7 @@ interface Service {
     suspend fun getWatchedStatusWithUserOptions(@Query("titles") titles: String): MwQueryResponse
 
     @Headers("Cache-Control: no-cache")
-    @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched&uiprop=rights")
+    @GET(MW_API_PREFIX + "action=query&prop=info&converttitles=&redirects=&inprop=watched&meta=userinfo&uiprop=rights")
     suspend fun getWatchedStatusWithRights(@Query("titles") titles: String): MwQueryResponse
 
     @Headers("Cache-Control: no-cache")

--- a/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import org.wikipedia.dataclient.mwapi.MwServiceError.BlockInfo
 import org.wikipedia.util.DateUtil
-import java.util.*
+import java.util.Date
 
 @Serializable
 class UserInfo : BlockInfo() {
@@ -14,7 +14,7 @@ class UserInfo : BlockInfo() {
     @SerialName("latestcontrib") private val latestContrib: String? = null
     @SerialName("registrationdate") private val regDate: String? = null
     @SerialName("registration") private val registration: String? = null
-    @SerialName("editcount") val editCount = -1
+    @SerialName("editcount") val editCount = 0
     val name: String = ""
     val anon: Boolean = false
     val messages: Boolean = false

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -126,25 +126,18 @@ class DescriptionEditFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        when (val editCountResource = viewModel.editCount.value) {
-            is Resource.Success -> {
-                EditAttemptStepEvent.logInit(
-                    pageTitle = viewModel.pageTitle,
-                    editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                    editCount = editCountResource.data
-                )
-            }
-            else -> {
-                EditAttemptStepEvent.logInit(
-                    pageTitle = viewModel.pageTitle,
-                    editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                    editCount = -1
-                )
-            }
-        }
-
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
+                launch {
+                    viewModel.editCount.collect {
+                        if (it is Resource.Loading) return@collect // send only if the API request is success or failed
+                        EditAttemptStepEvent.logInit(
+                            pageTitle = viewModel.pageTitle,
+                            editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
+                            editCount = if (it is Resource.Success) it.data else -1
+                        )
+                    }
+                }
                 launch {
                     viewModel.loadPageSummaryState.collect {
                         when (it) {
@@ -204,26 +197,12 @@ class DescriptionEditFragment : Fragment() {
                                             editSucceeded -> {
                                                 AnonymousNotificationHelper.onEditSubmitted()
                                                 viewModel.waitForRevisionUpdate(newRevId)
-
-                                                when (val editCountResource = viewModel.editCount.value) {
-                                                    is Resource.Success -> {
-                                                        EditAttemptStepEvent.logSaveSuccess(
-                                                            pageTitle = viewModel.pageTitle,
-                                                            revisionId = newRevId,
-                                                            editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                                                            editCount = editCountResource.data
-                                                        )
-                                                    }
-                                                    else -> {
-                                                        EditAttemptStepEvent.logSaveSuccess(
-                                                            pageTitle = viewModel.pageTitle,
-                                                            revisionId = newRevId,
-                                                            editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                                                            editCount = -1
-                                                        )
-                                                    }
-                                                }
-
+                                                EditAttemptStepEvent.logSaveSuccess(
+                                                    pageTitle = viewModel.pageTitle,
+                                                    revisionId = newRevId,
+                                                    editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
+                                                    editCount = (viewModel.totalEditCount + 1)
+                                                )
                                                 analyticsHelper.logSuccess(requireContext(), viewModel.pageTitle, newRevId)
                                                 ImageRecommendationsEvent.logEditSuccess(viewModel.action, viewModel.pageTitle.wikiSite.languageCode, newRevId)
                                             }
@@ -251,27 +230,14 @@ class DescriptionEditFragment : Fragment() {
                                         if (success > 0) {
                                             val revId = entity?.lastRevId ?: 0
                                             requireView().postDelayed(successRunnable, TimeUnit.SECONDS.toMillis(4))
+                                            EditAttemptStepEvent.logSaveSuccess(
+                                                pageTitle = viewModel.pageTitle,
+                                                revisionId = revId,
+                                                editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
+                                                editCount = (viewModel.totalEditCount + 1)
+                                            )
                                             analyticsHelper.logSuccess(requireContext(), viewModel.pageTitle, revId)
                                             ImageRecommendationsEvent.logEditSuccess(viewModel.action, viewModel.pageTitle.wikiSite.languageCode, revId)
-
-                                            when (val editCount = viewModel.editCount.value) {
-                                                is Resource.Success -> {
-                                                    EditAttemptStepEvent.logSaveSuccess(
-                                                        pageTitle = viewModel.pageTitle,
-                                                        revisionId = revId,
-                                                        editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                                                        editCount = editCount.data
-                                                    )
-                                                }
-                                                else -> {
-                                                    EditAttemptStepEvent.logSaveSuccess(
-                                                        pageTitle = viewModel.pageTitle,
-                                                        revisionId = revId,
-                                                        editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                                                        editCount = -1
-                                                    )
-                                                }
-                                            }
                                         } else {
                                             editFailed(RuntimeException("Received unrecognized description edit response"), true)
                                         }
@@ -380,24 +346,11 @@ class DescriptionEditFragment : Fragment() {
                 binding.fragmentDescriptionEditView.loadReviewContent(true)
             } else {
                 analyticsHelper.logAttempt(requireContext(), viewModel.pageTitle)
-
-                when (val editCount = viewModel.editCount.value) {
-                    is Resource.Success -> {
-                        EditAttemptStepEvent.logSaveAttempt(
-                            pageTitle = viewModel.pageTitle,
-                            editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                            editCount = editCount.data
-                        )
-                    }
-                    else -> {
-                        EditAttemptStepEvent.logSaveAttempt(
-                            pageTitle = viewModel.pageTitle,
-                            editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                            editCount = -1
-                        )
-                    }
-                }
-
+                EditAttemptStepEvent.logSaveAttempt(
+                    pageTitle = viewModel.pageTitle,
+                    editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
+                    editCount = viewModel.totalEditCount + 1
+                )
                 viewModel.postDescription(
                     currentDescription = binding.fragmentDescriptionEditView.description.orEmpty(),
                     editComment = getEditComment(),
@@ -487,22 +440,11 @@ class DescriptionEditFragment : Fragment() {
         FeedbackUtil.showError(requireActivity(), caught, wikiSite)
         L.e(caught)
         if (logError) {
-            when (val editCount = viewModel.editCount.value) {
-                is Resource.Success -> {
-                    EditAttemptStepEvent.logSaveFailure(
-                        pageTitle = viewModel.pageTitle,
-                        editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                        editCount = editCount.data
-                    )
-                }
-                else -> {
-                    EditAttemptStepEvent.logSaveFailure(
-                        pageTitle = viewModel.pageTitle,
-                        editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                        editCount = -1
-                    )
-                }
-            }
+            EditAttemptStepEvent.logSaveFailure(
+                pageTitle = viewModel.pageTitle,
+                editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
+                editCount = viewModel.totalEditCount
+            )
         }
     }
 

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -134,7 +134,7 @@ class DescriptionEditFragment : Fragment() {
                         EditAttemptStepEvent.logInit(
                             pageTitle = viewModel.pageTitle,
                             editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                            editCount = if (it is Resource.Success) it.data else -1
+                            editCount = if (it is Resource.Success) it.data else 0
                         )
                     }
                 }

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditFragment.kt
@@ -349,7 +349,7 @@ class DescriptionEditFragment : Fragment() {
                 EditAttemptStepEvent.logSaveAttempt(
                     pageTitle = viewModel.pageTitle,
                     editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                    editCount = viewModel.totalEditCount + 1
+                    editCount = viewModel.totalEditCount
                 )
                 viewModel.postDescription(
                     currentDescription = binding.fragmentDescriptionEditView.description.orEmpty(),

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -29,6 +29,7 @@ import org.wikipedia.util.L10nUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.StringUtil
 import org.wikipedia.util.log.L
+import kotlin.time.Duration.Companion.milliseconds
 
 class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
 
@@ -55,7 +56,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
     val waitForRevisionState = _waitForRevisionState.asStateFlow()
     private val _editCount = MutableStateFlow<Resource<Int>>(Resource.Loading())
     val editCount = _editCount.asStateFlow()
-    var totalEditCount = 0
+    var totalEditCount = -1
 
     init {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
@@ -88,6 +89,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
     }
 
     private suspend fun loadUserTotalEdits(): Int {
+        // get the edit count when necessary
         if (totalEditCount == -1) {
             val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getUserInfo()
             totalEditCount = userInfoResponse.query?.userInfo?.editCount ?: 0
@@ -164,7 +166,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
             var retry = 0
             var revision = -1L
             while (revision < newRevision && retry < 10) {
-                delay(2000)
+                delay(2000.milliseconds)
                 val pageSummary = ServiceFactory.getRest(pageTitle.wikiSite).getPageSummary(pageTitle.prefixedText, cacheControl = OkHttpConnectionFactory.CACHE_CONTROL_FORCE_NETWORK.toString())
                 revision = pageSummary.revision
                 retry++

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -56,14 +56,16 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
     val waitForRevisionState = _waitForRevisionState.asStateFlow()
     private val _editCount = MutableStateFlow<Resource<Int>>(Resource.Loading())
     val editCount = _editCount.asStateFlow()
-    var totalEditCount = -1
+    var totalEditCount = 0
 
     init {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             L.e(throwable)
             _editCount.value = Resource.Error(throwable)
         }) {
-            _editCount.value = Resource.Success(loadUserTotalEdits())
+            val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getUserInfo()
+            totalEditCount = userInfoResponse.query?.userInfo?.editCount ?: 0
+            _editCount.value = Resource.Success(totalEditCount)
         }
     }
 
@@ -88,30 +90,14 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
         }
     }
 
-    private suspend fun loadUserTotalEdits(): Int {
-        // get the edit count when necessary
-        if (totalEditCount == -1) {
-            val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getUserInfo()
-            totalEditCount = userInfoResponse.query?.userInfo?.editCount ?: 0
-        }
-        return totalEditCount
-    }
-
     fun requestSuggestion() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             L.e(throwable)
             _requestSuggestionState.value = Resource.Error(throwable)
         }) {
             _requestSuggestionState.value = Resource.Loading()
-            val responseCall = async { ServiceFactory[pageTitle.wikiSite, LiftWingModelService.API_URL, LiftWingModelService::class.java]
-                .getDescriptionSuggestion(DescriptionSuggestion.Request(pageTitle.wikiSite.languageCode, pageTitle.prefixedText, 2)) }
-
-            async {
-                loadUserTotalEdits()
-            }.await()
-
-            val response = responseCall.await()
-
+            val response = ServiceFactory[pageTitle.wikiSite, LiftWingModelService.API_URL, LiftWingModelService::class.java]
+                .getDescriptionSuggestion(DescriptionSuggestion.Request(pageTitle.wikiSite.languageCode, pageTitle.prefixedText, 2))
             // Perform some post-processing on the predictions.
             // 1) Capitalize them, if we're dealing with enwiki.
             // 2) Remove duplicates.

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -74,7 +74,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
             editingAllowed = false
             val summaryResponse = async { ServiceFactory.getRest(pageTitle.wikiSite).getPageSummary(pageTitle.prefixedText) }
             val infoResponse = async { ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName) }
-            totalEditCount = infoResponse.await().query?.users?.first()?.editCount ?: 0
+            totalEditCount = infoResponse.await().query?.users?.firstOrNull()?.editCount ?: 0
             val editError = infoResponse.await().query?.firstPage()?.getErrorForAction("edit")
             var error: MwServiceError? = null
             if (editError.isNullOrEmpty()) {
@@ -91,7 +91,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
         if (totalEditCount == -1) {
             val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
                 .userInfo(AccountUtil.userName)
-            totalEditCount = userInfoResponse.query?.users?.first()?.editCount ?: 0
+            totalEditCount = userInfoResponse.query?.users?.firstOrNull()?.editCount ?: 0
         }
         return totalEditCount
     }
@@ -183,7 +183,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
         val wikiSectionInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
             .getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName)
         val errorForAction = wikiSectionInfoResponse.query?.firstPage()?.getErrorForAction("edit")
-        totalEditCount = wikiSectionInfoResponse.query?.users?.first()?.editCount ?: 0
+        totalEditCount = wikiSectionInfoResponse.query?.users?.firstOrNull()?.editCount ?: 0
         if (!errorForAction.isNullOrEmpty()) {
             val error = errorForAction.first()
             throw MwException(error)
@@ -221,7 +221,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
                                                   editComment: String?,
                                                   editTags: String?): EntityPostResponse {
         val wikiSectionInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName)
-        totalEditCount = wikiSectionInfoResponse.query?.users?.first()?.editCount ?: 0
+        totalEditCount = wikiSectionInfoResponse.query?.users?.firstOrNull()?.editCount ?: 0
         val errorForAction = wikiSectionInfoResponse.query?.firstPage()?.getErrorForAction("edit")
         if (!errorForAction.isNullOrEmpty()) {
             val error = errorForAction.first()

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -55,7 +55,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
     val waitForRevisionState = _waitForRevisionState.asStateFlow()
     private val _editCount = MutableStateFlow<Resource<Int>>(Resource.Loading())
     val editCount = _editCount.asStateFlow()
-    var totalEditCount = -1
+    var totalEditCount = 0
 
     init {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -73,8 +73,8 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
             _loadPageSummaryState.value = Resource.Loading()
             editingAllowed = false
             val summaryResponse = async { ServiceFactory.getRest(pageTitle.wikiSite).getPageSummary(pageTitle.prefixedText) }
-            val infoResponse = async { ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName) }
-            totalEditCount = infoResponse.await().query?.users?.firstOrNull()?.editCount ?: 0
+            val infoResponse = async { ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0) }
+            totalEditCount = infoResponse.await().query?.userInfo?.editCount ?: 0
             val editError = infoResponse.await().query?.firstPage()?.getErrorForAction("edit")
             var error: MwServiceError? = null
             if (editError.isNullOrEmpty()) {
@@ -89,9 +89,8 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
 
     private suspend fun loadUserTotalEdits(): Int {
         if (totalEditCount == -1) {
-            val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
-                .userInfo(AccountUtil.userName)
-            totalEditCount = userInfoResponse.query?.users?.firstOrNull()?.editCount ?: 0
+            val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getUserInfo()
+            totalEditCount = userInfoResponse.query?.userInfo?.editCount ?: 0
         }
         return totalEditCount
     }
@@ -181,9 +180,9 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
                                                  captchaId: String?,
                                                  captchaWord: String?): Edit {
         val wikiSectionInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
-            .getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName)
+            .getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0)
         val errorForAction = wikiSectionInfoResponse.query?.firstPage()?.getErrorForAction("edit")
-        totalEditCount = wikiSectionInfoResponse.query?.users?.firstOrNull()?.editCount ?: 0
+        totalEditCount = wikiSectionInfoResponse.query?.userInfo?.editCount ?: 0
         if (!errorForAction.isNullOrEmpty()) {
             val error = errorForAction.first()
             throw MwException(error)
@@ -220,8 +219,8 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
                                                   currentDescription: String,
                                                   editComment: String?,
                                                   editTags: String?): EntityPostResponse {
-        val wikiSectionInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName)
-        totalEditCount = wikiSectionInfoResponse.query?.users?.firstOrNull()?.editCount ?: 0
+        val wikiSectionInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0)
+        totalEditCount = wikiSectionInfoResponse.query?.userInfo?.editCount ?: 0
         val errorForAction = wikiSectionInfoResponse.query?.firstPage()?.getErrorForAction("edit")
         if (!errorForAction.isNullOrEmpty()) {
             val error = errorForAction.first()

--- a/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
+++ b/app/src/main/java/org/wikipedia/descriptions/DescriptionEditViewModel.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wikipedia.Constants
 import org.wikipedia.R
-import org.wikipedia.WikipediaApp
 import org.wikipedia.auth.AccountUtil
 import org.wikipedia.csrf.CsrfTokenClient
 import org.wikipedia.dataclient.ServiceFactory
@@ -56,9 +55,15 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
     val waitForRevisionState = _waitForRevisionState.asStateFlow()
     private val _editCount = MutableStateFlow<Resource<Int>>(Resource.Loading())
     val editCount = _editCount.asStateFlow()
+    var totalEditCount = -1
 
     init {
-        loadUserTotalEdits()
+        viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
+            L.e(throwable)
+            _editCount.value = Resource.Error(throwable)
+        }) {
+            _editCount.value = Resource.Success(loadUserTotalEdits())
+        }
     }
 
     fun loadPageSummary() {
@@ -68,8 +73,8 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
             _loadPageSummaryState.value = Resource.Loading()
             editingAllowed = false
             val summaryResponse = async { ServiceFactory.getRest(pageTitle.wikiSite).getPageSummary(pageTitle.prefixedText) }
-            val infoResponse = async { ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0) }
-
+            val infoResponse = async { ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName) }
+            totalEditCount = infoResponse.await().query?.users?.first()?.editCount ?: 0
             val editError = infoResponse.await().query?.firstPage()?.getErrorForAction("edit")
             var error: MwServiceError? = null
             if (editError.isNullOrEmpty()) {
@@ -82,14 +87,13 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
         }
     }
 
-    private fun loadUserTotalEdits() {
-        viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
-            L.e(throwable)
-            _editCount.value = Resource.Error(throwable)
-        }) {
-            val userInfoResponse = ServiceFactory.get(WikipediaApp.instance.wikiSite).globalUserInfo(AccountUtil.userName)
-            _editCount.value = Resource.Success(userInfoResponse.query?.userInfo?.editCount ?: 0)
+    private suspend fun loadUserTotalEdits(): Int {
+        if (totalEditCount == -1) {
+            val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
+                .userInfo(AccountUtil.userName)
+            totalEditCount = userInfoResponse.query?.users?.first()?.editCount ?: 0
         }
+        return totalEditCount
     }
 
     fun requestSuggestion() {
@@ -101,6 +105,10 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
             val responseCall = async { ServiceFactory[pageTitle.wikiSite, LiftWingModelService.API_URL, LiftWingModelService::class.java]
                 .getDescriptionSuggestion(DescriptionSuggestion.Request(pageTitle.wikiSite.languageCode, pageTitle.prefixedText, 2)) }
 
+            async {
+                loadUserTotalEdits()
+            }.await()
+
             val response = responseCall.await()
 
             // Perform some post-processing on the predictions.
@@ -110,19 +118,7 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
                 response.prediction.map { StringUtil.capitalize(it)!! }
             } else response.prediction).distinct()
 
-            _editCount.collect { editCountResource ->
-                when (editCountResource) {
-                    is Resource.Success -> {
-                        _requestSuggestionState.value = Resource.Success(Triple(response, editCountResource.data, list))
-                    }
-                    is Resource.Error -> {
-                        _requestSuggestionState.value = Resource.Success(Triple(response, -1, list))
-                    }
-                    is Resource.Loading -> {
-                        _requestSuggestionState.value = Resource.Loading()
-                    }
-                }
-             }
+            _requestSuggestionState.value = Resource.Success(Triple(response, totalEditCount, list))
         }
     }
 
@@ -185,8 +181,9 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
                                                  captchaId: String?,
                                                  captchaWord: String?): Edit {
         val wikiSectionInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
-            .getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0)
+            .getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName)
         val errorForAction = wikiSectionInfoResponse.query?.firstPage()?.getErrorForAction("edit")
+        totalEditCount = wikiSectionInfoResponse.query?.users?.first()?.editCount ?: 0
         if (!errorForAction.isNullOrEmpty()) {
             val error = errorForAction.first()
             throw MwException(error)
@@ -223,7 +220,8 @@ class DescriptionEditViewModel(savedStateHandle: SavedStateHandle) : ViewModel()
                                                   currentDescription: String,
                                                   editComment: String?,
                                                   editTags: String?): EntityPostResponse {
-        val wikiSectionInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0)
+        val wikiSectionInfoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, 0, userNames = AccountUtil.userName)
+        totalEditCount = wikiSectionInfoResponse.query?.users?.first()?.editCount ?: 0
         val errorForAction = wikiSectionInfoResponse.query?.firstPage()?.getErrorForAction("edit")
         if (!errorForAction.isNullOrEmpty()) {
             val error = errorForAction.first()

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -77,6 +77,7 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
     private var _binding: FragmentArticleEditDetailsBinding? = null
     private val binding get() = _binding!!
     private val viewModel: ArticleEditDetailsViewModel by viewModels()
+    private var editAttemptInitLogged = false
 
     private val actionBarOffsetChangedListener =
         AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
@@ -149,7 +150,8 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
             if (it is Resource.Success) {
                 updateDiffCharCountView(viewModel.diffSize)
                 updateAfterRevisionFetchSuccess()
-                if (savedInstanceState == null) {
+                if (savedInstanceState == null && !editAttemptInitLogged) {
+                    editAttemptInitLogged = true
                     EditAttemptStepEvent.logInit(
                         pageTitle = viewModel.pageTitle,
                         editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsFragment.kt
@@ -131,14 +131,6 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
         setLoadingState()
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
-        if (savedInstanceState == null) {
-            EditAttemptStepEvent.logInit(
-                pageTitle = viewModel.pageTitle,
-                editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                editCount = viewModel.editCount
-            )
-        }
-
         if (!viewModel.fromRecentEdits) {
             (requireActivity() as AppCompatActivity).supportActionBar?.title = getString(R.string.revision_diff_compare)
             binding.articleTitleView.text = StringUtil.fromHtml(viewModel.pageTitle.displayText)
@@ -157,6 +149,13 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
             if (it is Resource.Success) {
                 updateDiffCharCountView(viewModel.diffSize)
                 updateAfterRevisionFetchSuccess()
+                if (savedInstanceState == null) {
+                    EditAttemptStepEvent.logInit(
+                        pageTitle = viewModel.pageTitle,
+                        editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
+                        editCount = viewModel.editCount
+                    )
+                }
             } else if (it is Resource.Error) {
                 setErrorState(it.throwable)
             }
@@ -194,15 +193,15 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
             binding.progressBar.isVisible = false
             if (it is Resource.Success) {
                 val revisionId = it.data.edit!!.newRevId
-                EditAttemptStepEvent.logSaveSuccess(
-                    pageTitle = viewModel.pageTitle, revisionId,
-                    editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                    editCount = viewModel.editCount
-                )
                 setLoadingState()
                 viewModel.getRevisionDetails(revisionId)
                 sendPatrollerExperienceEvent("undo_success", "pt_edit",
                     PatrollerExperienceEvent.getActionDataString(revisionId))
+                EditAttemptStepEvent.logSaveSuccess(
+                    pageTitle = viewModel.pageTitle, revisionId,
+                    editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
+                    editCount = (viewModel.editCount + 1)
+                )
                 showUndoSnackbar()
                 callback()?.onUndoSuccess()
             } else if (it is Resource.Error) {
@@ -230,15 +229,16 @@ class ArticleEditDetailsFragment : Fragment(), WatchlistExpiryDialog.Callback, M
             binding.progressBar.isVisible = false
             if (it is Resource.Success) {
                 val revisionId = it.data.rollback?.revision ?: 0
-                EditAttemptStepEvent.logSaveSuccess(
-                    pageTitle = viewModel.pageTitle,
-                    revisionId = revisionId,
-                    editorInterface = EditAttemptStepEvent.INTERFACE_OTHER
-                )
                 setLoadingState()
                 viewModel.getRevisionDetails(revisionId)
                 sendPatrollerExperienceEvent("rollback_success", "pt_edit",
                     PatrollerExperienceEvent.getActionDataString(revisionId))
+                EditAttemptStepEvent.logSaveSuccess(
+                    pageTitle = viewModel.pageTitle,
+                    revisionId = revisionId,
+                    editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
+                    editCount = (viewModel.editCount + 1)
+                )
                 showRollbackSnackbar()
                 callback()?.onRollbackSuccess()
             } else if (it is Resource.Error) {

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
+import org.wikipedia.auth.AccountUtil
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite
@@ -86,7 +87,6 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
                 watchedStatus.postValue(Resource.Success(page))
                 hasRollbackRights = query.userInfo?.rights?.contains("rollback") == true
                 rollbackRights.postValue(Resource.Success(hasRollbackRights))
-                editCount = query.userInfo?.editCount ?: 0
             }
             if (revisionIdFrom >= 0) {
                 val responseFrom = async { ServiceFactory.get(pageTitle.wikiSite).getRevisionDetailsWithInfo(pageId.toString(), 2, revisionIdFrom) }
@@ -108,6 +108,7 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
             revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
 
             revisionDetails.postValue(Resource.Success(Unit))
+            getUserEditCount()
             getDiffText(revisionFromId, revisionToId)
         }
     }
@@ -139,10 +140,15 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
             revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
 
             revisionDetails.postValue(Resource.Success(Unit))
+            getUserEditCount()
             getDiffText(revisionFromId, revisionToId)
-
-            editCount = response.query?.userInfo?.editCount ?: 0
         }
+    }
+
+    suspend fun getUserEditCount() {
+        val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
+            .userInfo(AccountUtil.userName)
+        editCount = userInfoResponse.query?.users?.first()?.editCount ?: 0
     }
 
     fun goBackward() {

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -148,7 +148,7 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
     suspend fun getUserEditCount() {
         val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
             .userInfo(AccountUtil.userName)
-        editCount = userInfoResponse.query?.users?.first()?.editCount ?: 0
+        editCount = userInfoResponse.query?.users?.firstOrNull()?.editCount ?: 0
     }
 
     fun goBackward() {

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -55,7 +55,7 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
     var hasRollbackRights = false
     var isWatched = false
     var ns = 0
-    var editCount = -1
+    var editCount = 0
 
     val diffSize get() = if (revisionFrom != null) revisionTo!!.size - revisionFrom!!.size else revisionTo!!.size
 

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -86,6 +86,7 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
                 isWatched = page.watched
                 watchedStatus.postValue(Resource.Success(page))
                 hasRollbackRights = query.userInfo?.rights?.contains("rollback") == true
+                editCount = query.userInfo?.editCount ?: 0
                 rollbackRights.postValue(Resource.Success(hasRollbackRights))
             }
             if (revisionIdFrom >= 0) {
@@ -107,7 +108,6 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
             revisionToId = revisionTo!!.revId
             revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
 
-            getUserEditCount()
             revisionDetails.postValue(Resource.Success(Unit))
             getDiffText(revisionFromId, revisionToId)
         }
@@ -130,6 +130,7 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
 
             watchedStatus.postValue(Resource.Success(page))
             hasRollbackRights = response.query?.userInfo?.rights?.contains("rollback") == true
+            editCount = response.query?.userInfo?.editCount ?: 0
             rollbackRights.postValue(Resource.Success(hasRollbackRights))
 
             revisionTo = revisions[0]
@@ -139,16 +140,9 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
             revisionToId = revisionTo!!.revId
             revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
 
-            getUserEditCount()
             revisionDetails.postValue(Resource.Success(Unit))
             getDiffText(revisionFromId, revisionToId)
         }
-    }
-
-    suspend fun getUserEditCount() {
-        val userInfoResponse = ServiceFactory.get(pageTitle.wikiSite)
-            .userInfo(AccountUtil.userName)
-        editCount = userInfoResponse.query?.users?.firstOrNull()?.editCount ?: 0
     }
 
     fun goBackward() {

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -107,8 +107,8 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
             revisionToId = revisionTo!!.revId
             revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
 
-            revisionDetails.postValue(Resource.Success(Unit))
             getUserEditCount()
+            revisionDetails.postValue(Resource.Success(Unit))
             getDiffText(revisionFromId, revisionToId)
         }
     }
@@ -139,8 +139,8 @@ class ArticleEditDetailsViewModel(savedStateHandle: SavedStateHandle) : ViewMode
             revisionToId = revisionTo!!.revId
             revisionFromId = if (revisionFrom != null) revisionFrom!!.revId else revisionTo!!.parentRevId
 
-            revisionDetails.postValue(Resource.Success(Unit))
             getUserEditCount()
+            revisionDetails.postValue(Resource.Success(Unit))
             getDiffText(revisionFromId, revisionToId)
         }
     }

--- a/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/diff/ArticleEditDetailsViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.wikipedia.Constants
 import org.wikipedia.Constants.InvokeSource
-import org.wikipedia.auth.AccountUtil
 import org.wikipedia.dataclient.Service
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.WikiSite

--- a/app/src/main/java/org/wikipedia/edit/EditHandler.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditHandler.kt
@@ -44,9 +44,7 @@ class EditHandler(private val fragment: PageFragment, bridge: CommunicationBridg
                     menu.setOnMenuItemClickListener(EditMenuClickListener())
                     menu.setOnDismissListener {
                         if (!menuItemClick) {
-                            fragment.title?.let { title ->
-                                fragment.logEditAttemptStepEvent(title)
-                            }
+                            fragment.dismissEditHandlerMenu(fragment.title)
                         }
                         (fragment.view as? ViewGroup)?.removeView(tempView)
                     }

--- a/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionActivity.kt
@@ -167,10 +167,6 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
         editSummaryFragment = supportFragmentManager.findFragmentById(R.id.edit_section_summary_fragment) as EditSummaryFragment
         editSummaryFragment.title = viewModel.pageTitle
 
-        // Only send the editing start log event if the activity is created for the first time
-        if (savedInstanceState == null) {
-            EditAttemptStepEvent.logInit(pageTitle = viewModel.pageTitle, editCount = viewModel.editCount)
-        }
         if (savedInstanceState != null) {
             if (savedInstanceState.containsKey(EXTRA_KEY_TEMPORARY_WIKITEXT_STORED)) {
                 viewModel.sectionWikitext = Prefs.temporaryWikitext
@@ -223,6 +219,10 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 launch {
                     viewModel.fetchSectionTextState.collectLatest {
+                        // Only send the editing start log event if the activity is created for the first time
+                        if (savedInstanceState == null && it !is Resource.Loading) {
+                            EditAttemptStepEvent.logInit(pageTitle = viewModel.pageTitle, editCount = viewModel.editCount)
+                        }
                         when (it) {
                             is Resource.Loading -> {
                                 showProgressBar(true)
@@ -369,7 +369,7 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
             EditAttemptStepEvent.logSaveSuccess(
                 pageTitle = viewModel.pageTitle,
                 revisionId = result.revID,
-                editCount = viewModel.editCount
+                editCount = (viewModel.editCount + 1)
             )
             // TODO: remove the artificial delay and use the new revision
             // ID returned to request the updated version of the page once
@@ -399,7 +399,10 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
     }
 
     private fun onEditFailure(caught: Throwable) {
-        EditAttemptStepEvent.logSaveFailure(pageTitle = viewModel.pageTitle, editCount = viewModel.editCount)
+        EditAttemptStepEvent.logSaveFailure(
+            pageTitle = viewModel.pageTitle,
+            editCount = viewModel.editCount
+        )
         showProgressBar(false)
         if (caught is MwException) {
             handleEditingException(caught)
@@ -464,7 +467,10 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
                         altTextAdd = !intent.getStringExtra(InsertMediaActivity.RESULT_IMAGE_ALT).isNullOrEmpty()), addImageTitle?.wikiSite?.languageCode.orEmpty())
                 }
                 doSave()
-                EditAttemptStepEvent.logSaveAttempt(pageTitle = viewModel.pageTitle, editCount = viewModel.editCount)
+                EditAttemptStepEvent.logSaveAttempt(
+                    pageTitle = viewModel.pageTitle,
+                    editCount = viewModel.editCount
+                )
                 supportActionBar?.title = getString(R.string.preview_edit_summarize_edit_title)
             }
             editPreviewFragment.isActive -> {
@@ -488,7 +494,10 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
                 DeviceUtil.hideSoftKeyboard(this)
                 binding.editSectionScroll.isVisible = false
                 editPreviewFragment.showPreview(viewModel.pageTitle, binding.editSectionText.text.toString())
-                EditAttemptStepEvent.logSaveIntent(pageTitle = viewModel.pageTitle, editCount = viewModel.editCount)
+                EditAttemptStepEvent.logSaveIntent(
+                    pageTitle = viewModel.pageTitle,
+                    editCount = viewModel.editCount
+                )
                 supportActionBar?.title = getString(R.string.edit_preview)
                 setNavigationBarColor(ResourceUtil.getThemedColor(this, R.attr.paper_color))
                 if (viewModel.invokeSource == Constants.InvokeSource.EDIT_ADD_IMAGE) {
@@ -770,7 +779,10 @@ class EditSectionActivity : BaseActivity(), ThemeChooserDialog.Callback, EditPre
             val alert = MaterialAlertDialogBuilder(this)
             alert.setMessage(getString(R.string.edit_abandon_confirm))
             alert.setPositiveButton(getString(R.string.edit_abandon_confirm_yes)) { dialog, _ ->
-                EditAttemptStepEvent.logAbort(pageTitle = viewModel.pageTitle, editCount = viewModel.editCount)
+                EditAttemptStepEvent.logAbort(
+                    pageTitle = viewModel.pageTitle,
+                    editCount = viewModel.editCount
+                )
                 dialog.dismiss()
                 action()
             }

--- a/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
@@ -59,7 +59,7 @@ class EditSectionViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
             _fetchSectionTextState.value = Resource.Loading()
 
             val infoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, if (sectionID >= 0) sectionID else null, userNames = AccountUtil.userName)
-            editCount = infoResponse.query?.users?.first()?.editCount ?: 0
+            editCount = infoResponse.query?.users?.firstOrNull()?.editCount ?: 0
             tempAccountsEnabled = infoResponse.query?.autoCreateTempUser?.enabled == true
 
             infoResponse.query?.firstPage()?.let { firstPage ->

--- a/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
@@ -58,8 +58,8 @@ class EditSectionViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
         }) {
             _fetchSectionTextState.value = Resource.Loading()
 
-            val infoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, if (sectionID >= 0) sectionID else null, userNames = AccountUtil.userName)
-            editCount = infoResponse.query?.users?.firstOrNull()?.editCount ?: 0
+            val infoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, if (sectionID >= 0) sectionID else null)
+            editCount = infoResponse.query?.userInfo?.editCount ?: 0
             tempAccountsEnabled = infoResponse.query?.autoCreateTempUser?.enabled == true
 
             infoResponse.query?.firstPage()?.let { firstPage ->

--- a/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
@@ -58,8 +58,8 @@ class EditSectionViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
         }) {
             _fetchSectionTextState.value = Resource.Loading()
 
-            val infoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, if (sectionID >= 0) sectionID else null)
-            editCount = infoResponse.query?.userInfo?.editCount ?: -1
+            val infoResponse = ServiceFactory.get(pageTitle.wikiSite).getWikiTextForSectionWithInfo(pageTitle.prefixedText, if (sectionID >= 0) sectionID else null, userNames = AccountUtil.userName)
+            editCount = infoResponse.query?.users?.first()?.editCount ?: 0
             tempAccountsEnabled = infoResponse.query?.autoCreateTempUser?.enabled == true
 
             infoResponse.query?.firstPage()?.let { firstPage ->

--- a/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
+++ b/app/src/main/java/org/wikipedia/edit/EditSectionViewModel.kt
@@ -31,7 +31,7 @@ class EditSectionViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     var sectionWikitextOriginal: String? = null
     var tempAccountsEnabled = true
     var editingAllowed = false
-    var editCount = -1
+    var editCount = 0
     val editNotices = mutableListOf<String>()
 
     // Current revision of the article, to be passed back to the server to detect possible edit conflicts.

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -1301,8 +1301,10 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
         requireActivity().finish()
     }
 
-    fun logEditAttemptStepEvent(title: PageTitle) {
-        EditAttemptStepEvent.logAbort(pageTitle = title, editCount = this.editCount)
+    fun dismissEditHandlerMenu(title: PageTitle?) {
+        title?.let {
+            EditAttemptStepEvent.logAbort(pageTitle = it, editCount = this.editCount)
+        }
     }
 
     private inner class AvCallback : AvPlayer.Callback {

--- a/app/src/main/java/org/wikipedia/page/PageFragment.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragment.kt
@@ -177,7 +177,7 @@ class PageFragment : Fragment(), BackPressedHandler, CommunicationBridge.Communi
     private var avPlayer: AvPlayer? = null
     private var avCallback: AvCallback? = null
     private var sections: MutableList<Section>? = null
-    private var editCount = -1
+    private var editCount = 0
     private var app = WikipediaApp.instance
 
     override lateinit var linkHandler: LinkHandler

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -190,7 +190,16 @@ class PageFragmentLoadState(private var model: PageViewModel,
                 }
             }
             val userInfoRequest = async {
-                ServiceFactory.get(title.wikiSite).userInfo(AccountUtil.userName)
+                try {
+                    if (makeWatchRequest) {
+                        ServiceFactory.get(title.wikiSite).userInfo(AccountUtil.userName)
+                    } else {
+                        MwQueryResponse()
+                    }
+                } catch (_: IOException) {
+                    L.w("Ignoring network error while fetching user info.")
+                    MwQueryResponse()
+                }
             }
             val pageSummaryResponse = pageSummaryRequest.await()
             val watchedResponse = watchedRequest.await()

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -205,7 +205,7 @@ class PageFragmentLoadState(private var model: PageViewModel,
             val watchedResponse = watchedRequest.await()
             val categoriesResponse = categoriesRequest.await()
             val isWatched = watchedResponse.query?.firstPage()?.watched == true
-            val editCount = userInfoRequest.await().query?.users?.first()?.editCount ?: 0
+            val editCount = userInfoRequest.await().query?.users?.firstOrNull()?.editCount ?: 0
             val hasWatchlistExpiry = watchedResponse.query?.firstPage()?.hasWatchlistExpiry() == true
             if (pageSummaryResponse.body() == null) {
                 throw RuntimeException("Summary response was invalid.")

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -189,23 +189,11 @@ class PageFragmentLoadState(private var model: PageViewModel,
                     MwQueryResponse()
                 }
             }
-            val userInfoRequest = async {
-                try {
-                    if (makeWatchRequest) {
-                        ServiceFactory.get(title.wikiSite).userInfo(AccountUtil.userName)
-                    } else {
-                        MwQueryResponse()
-                    }
-                } catch (_: IOException) {
-                    L.w("Ignoring network error while fetching user info.")
-                    MwQueryResponse()
-                }
-            }
             val pageSummaryResponse = pageSummaryRequest.await()
             val watchedResponse = watchedRequest.await()
             val categoriesResponse = categoriesRequest.await()
             val isWatched = watchedResponse.query?.firstPage()?.watched == true
-            val editCount = userInfoRequest.await().query?.users?.firstOrNull()?.editCount ?: 0
+            val editCount = watchedResponse.query?.userInfo?.editCount ?: 0
             val hasWatchlistExpiry = watchedResponse.query?.firstPage()?.hasWatchlistExpiry() == true
             if (pageSummaryResponse.body() == null) {
                 throw RuntimeException("Summary response was invalid.")

--- a/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
+++ b/app/src/main/java/org/wikipedia/page/PageFragmentLoadState.kt
@@ -43,7 +43,6 @@ class PageFragmentLoadState(private var model: PageViewModel,
                             private var leadImagesHandler: LeadImagesHandler,
                             private var currentTab: Tab) {
     private var pageLoadJob: Job? = null
-    var editCount = -1
 
     fun load(pushBackStack: Boolean) {
         if (pushBackStack && model.title != null && model.curEntry != null) {
@@ -190,11 +189,14 @@ class PageFragmentLoadState(private var model: PageViewModel,
                     MwQueryResponse()
                 }
             }
+            val userInfoRequest = async {
+                ServiceFactory.get(title.wikiSite).userInfo(AccountUtil.userName)
+            }
             val pageSummaryResponse = pageSummaryRequest.await()
             val watchedResponse = watchedRequest.await()
             val categoriesResponse = categoriesRequest.await()
             val isWatched = watchedResponse.query?.firstPage()?.watched == true
-            editCount = watchedResponse.query?.userInfo?.editCount ?: 0
+            val editCount = userInfoRequest.await().query?.users?.first()?.editCount ?: 0
             val hasWatchlistExpiry = watchedResponse.query?.firstPage()?.hasWatchlistExpiry() == true
             if (pageSummaryResponse.body() == null) {
                 throw RuntimeException("Summary response was invalid.")

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragment.kt
@@ -84,7 +84,11 @@ class SuggestedEditsImageRecsFragment : SuggestedEditsItemFragment(), MenuProvid
                 .show()
             ImageRecommendationsEvent.logAction("editsummary_success_confirm", "editsummary_dialog",
                 getActionStringForAnalytics(acceptanceState = "accepted", revisionId = revId, addTimeSpent = true), viewModel.langCode)
-            EditAttemptStepEvent.logSaveSuccess(pageTitle = viewModel.pageTitle, revisionId = revId, editCount = viewModel.editCount)
+            EditAttemptStepEvent.logSaveSuccess(
+                pageTitle = viewModel.pageTitle,
+                revisionId = revId,
+                editCount = (viewModel.editCount + 1)
+            )
             viewModel.acceptRecommendation(null, revId)
             callback().nextPage(this)
         }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragmentViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageRecsFragmentViewModel.kt
@@ -45,7 +45,7 @@ class SuggestedEditsImageRecsFragmentViewModel(savedStateHandle: SavedStateHandl
     val langCode = savedStateHandle.get<String>(SuggestedEditsImageRecsFragment.ARG_LANG)!!
     private val _uiState = MutableStateFlow(Resource<Unit>())
     val uiState = _uiState.asStateFlow()
-    var editCount = -1
+    var editCount = 0
 
     init {
         fetchRecommendation()

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsFragment.kt
@@ -152,7 +152,7 @@ class SuggestedEditsImageTagsFragment : SuggestedEditsItemFragment(), CompoundBu
                                             pageTitle = title,
                                             revisionId = it.data.lastRevId,
                                             editorInterface = EditAttemptStepEvent.INTERFACE_OTHER,
-                                            editCount = viewModel.editCount
+                                            editCount = (viewModel.editCount + 1)
                                         )
                                     }
                                 }

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsViewModel.kt
@@ -39,7 +39,7 @@ class SuggestedEditsImageTagsViewModel : ViewModel() {
             val caption = response.query?.firstPage()?.entityTerms?.label?.firstOrNull()
             _uiState.value = Resource.Success(mwQueryPage to caption)
 
-            editCount = response.query?.users?.first()?.editCount ?: 0
+            editCount = response.query?.users?.firstOrNull()?.editCount ?: 0
         }
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsViewModel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wikipedia.Constants
-import org.wikipedia.auth.AccountUtil
 import org.wikipedia.csrf.CsrfTokenClient
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.mwapi.MwQueryPage
@@ -34,12 +33,12 @@ class SuggestedEditsImageTagsViewModel : ViewModel() {
         }) {
             val mwQueryPage = page ?: EditingSuggestionsProvider.getNextImageWithMissingTags()
             val response = ServiceFactory.get(Constants.commonsWikiSite)
-                .getWikidataEntityTerms(mwQueryPage.title, LanguageUtil.convertToUselangIfNeeded(languageCode), userNames = AccountUtil.userName)
+                .getWikidataEntityTerms(mwQueryPage.title, LanguageUtil.convertToUselangIfNeeded(languageCode))
 
             val caption = response.query?.firstPage()?.entityTerms?.label?.firstOrNull()
             _uiState.value = Resource.Success(mwQueryPage to caption)
 
-            editCount = response.query?.users?.firstOrNull()?.editCount ?: 0
+            editCount = response.query?.userInfo?.editCount ?: 0
         }
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wikipedia.Constants
+import org.wikipedia.auth.AccountUtil
 import org.wikipedia.csrf.CsrfTokenClient
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.mwapi.MwQueryPage
@@ -33,12 +34,12 @@ class SuggestedEditsImageTagsViewModel : ViewModel() {
         }) {
             val mwQueryPage = page ?: EditingSuggestionsProvider.getNextImageWithMissingTags()
             val response = ServiceFactory.get(Constants.commonsWikiSite)
-                .getWikidataEntityTerms(mwQueryPage.title, LanguageUtil.convertToUselangIfNeeded(languageCode))
+                .getWikidataEntityTerms(mwQueryPage.title, LanguageUtil.convertToUselangIfNeeded(languageCode), userNames = AccountUtil.userName)
 
             val caption = response.query?.firstPage()?.entityTerms?.label?.firstOrNull()
             _uiState.value = Resource.Success(mwQueryPage to caption)
 
-            editCount = response.query?.userInfo?.editCount ?: 0
+            editCount = response.query?.users?.first()?.editCount ?: 0
         }
     }
 

--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsViewModel.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsImageTagsViewModel.kt
@@ -24,7 +24,7 @@ class SuggestedEditsImageTagsViewModel : ViewModel() {
 
     private val _actionState = MutableStateFlow(Resource<Entities.Entity?>())
     val actionState = _actionState.asStateFlow()
-    var editCount = -1
+    var editCount = 0
 
     fun findNextSuggestedEditsItem(languageCode: String, page: MwQueryPage?) {
         _uiState.value = Resource.Loading()

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyActivity.kt
@@ -197,6 +197,7 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
                     binding.footerContainer.tempAccountInfoContainer.isVisible = false
                 }
                 maybeShowTempAccountDialog()
+                EditAttemptStepEvent.logInit(pageTitle = viewModel.pageTitle, editCount = viewModel.editCount)
             }
         }
 
@@ -256,7 +257,6 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
             binding.replyInputView.editText.setSelection(binding.replyInputView.editText.text.toString().length)
         }
         shouldWatchText = true
-        EditAttemptStepEvent.logInit(pageTitle = viewModel.pageTitle, editCount = viewModel.editCount)
 
         setSaveButtonEnabled(binding.replyInputView.editText.text.isNotEmpty())
 
@@ -493,7 +493,11 @@ class TalkReplyActivity : BaseActivity(), UserMentionInputView.Listener, EditPre
 
         binding.progressBar.visibility = View.GONE
         setSaveButtonEnabled(true)
-        EditAttemptStepEvent.logSaveSuccess(pageTitle = viewModel.pageTitle, revisionId = newRevision, editCount = viewModel.editCount)
+        EditAttemptStepEvent.logSaveSuccess(
+            pageTitle = viewModel.pageTitle,
+            revisionId = newRevision,
+            editCount = (viewModel.editCount + 1)
+        )
 
         Intent().let {
             it.putExtra(RESULT_NEW_REVISION_ID, newRevision)

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
@@ -5,10 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.wikipedia.Constants
-import org.wikipedia.auth.AccountUtil
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.discussiontools.ThreadItem
@@ -54,15 +52,11 @@ class TalkReplyViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             L.e(throwable)
         }) {
-            async {
-                ServiceFactory.get(pageTitle.wikiSite).getPageIds(pageTitle.prefixedText).let {
-                    doesPageExist = (it.query?.pages?.firstOrNull()?.pageId ?: 0) > 0
-                    tempAccountsEnabled = it.query?.autoCreateTempUser?.enabled == true
-                }
-            }.await()
-            async {
-                editCount = ServiceFactory.get(pageTitle.wikiSite).userInfo(AccountUtil.userName).query?.users?.firstOrNull()?.editCount ?: 0
-            }.await()
+            ServiceFactory.get(pageTitle.wikiSite).getPageIds(pageTitle.prefixedText).let {
+                doesPageExist = (it.query?.pages?.firstOrNull()?.pageId ?: 0) > 0
+                tempAccountsEnabled = it.query?.autoCreateTempUser?.enabled == true
+                editCount = it.query?.userInfo?.editCount ?: 0
+            }
             pageExistsData.postValue(Resource.Success(doesPageExist))
         }
     }

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
@@ -48,7 +48,6 @@ class TalkReplyViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
         checkPageExists()
     }
 
-    @Suppress("KotlinConstantConditions")
     private fun checkPageExists() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             L.e(throwable)

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
@@ -39,7 +39,7 @@ class TalkReplyViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     val pageExistsData = MutableLiveData<Resource<Boolean>>()
     var doesPageExist = false
     var tempAccountsEnabled = true
-    var editCount = -1
+    var editCount = 0
 
     init {
         if (isFromDiff) {

--- a/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
+++ b/app/src/main/java/org/wikipedia/talk/TalkReplyViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.wikipedia.Constants
+import org.wikipedia.auth.AccountUtil
 import org.wikipedia.database.AppDatabase
 import org.wikipedia.dataclient.ServiceFactory
 import org.wikipedia.dataclient.discussiontools.ThreadItem
@@ -52,11 +54,15 @@ class TalkReplyViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
         viewModelScope.launch(CoroutineExceptionHandler { _, throwable ->
             L.e(throwable)
         }) {
-            ServiceFactory.get(pageTitle.wikiSite).getPageIds(pageTitle.prefixedText).let {
-                doesPageExist = (it.query?.pages?.firstOrNull()?.pageId ?: 0) > 0
-                tempAccountsEnabled = it.query?.autoCreateTempUser?.enabled == true
-                editCount = it.query?.userInfo?.editCount ?: 0
-            }
+            async {
+                ServiceFactory.get(pageTitle.wikiSite).getPageIds(pageTitle.prefixedText).let {
+                    doesPageExist = (it.query?.pages?.firstOrNull()?.pageId ?: 0) > 0
+                    tempAccountsEnabled = it.query?.autoCreateTempUser?.enabled == true
+                }
+            }.await()
+            async {
+                editCount = ServiceFactory.get(pageTitle.wikiSite).userInfo(AccountUtil.userName).query?.users?.firstOrNull()?.editCount ?: 0
+            }.await()
             pageExistsData.postValue(Resource.Success(doesPageExist))
         }
     }


### PR DESCRIPTION
### What does this do?
A follow-up PR to #6795,

This PR also optimized some logic of requesting APIs and moved `init` events to a proper place.

This feels a bit too much; maybe we can think about getting `editcount` once the app launches and saving it in memory, 
