### PR TITLE
Post to Phabricator when a task link is added after the PR is opened

### DIFF
--- a/.github/workflows/android_phab.yml
+++ b/.github/workflows/android_phab.yml
@@ -2,25 +2,75 @@ name: Post to Phabricator
 
 on:
   pull_request:
-    types: [opened, closed]
+    types: [opened, edited, closed]
 
 jobs:
   post_to_phab:
     runs-on: ubuntu-latest
     steps:
-    - name: Post to Phabricator when pull request is opened or closed
-      if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'closed') }}
+    - name: Post to Phabricator when pull request is opened, linked, or closed
       env:
+        ACTION: ${{ github.event.action }}
+        ACTOR: ${{ github.actor }}
+        PR_URL: ${{ github.event.pull_request._links.html.href }}
         PR_BODY: ${{ github.event.pull_request.body }}
+        PR_BODY_BEFORE: ${{ github.event.changes.body.from }}
+        BODY_CHANGES: ${{ toJSON(github.event.changes.body) }}
+        PHAB_API_TOKEN: ${{ secrets.PHAB_BOT_API_KEY }}
       run: |
-        message="${{ github.actor }} ${{ github.event.action }} ${{ github.event.pull_request._links.html.href }}"
-        echo -e "${PR_BODY}" | grep -oEi "(^Bug:\s*T[0-9]+)|(^([*]*phabricator[*]*:[*]*\s*)?https:\/\/phabricator\.wikimedia\.org\/T[0-9]+)" | grep -oEi "T[0-9]+" | while IFS= read -r line; do
-          echo "Processing: $line"
+        # Task IDs referenced at the start of a line, either as a "Bug: T123" trailer
+        # or as a phabricator.wikimedia.org URL (optionally behind the "**Phabricator:**"
+        # label from the PR template).
+        #
+        # `|| true`: a body with no task reference is normal, not an error. It is
+        # harmless under the default `bash -e {0}` shell, but required if this step
+        # ever gains an explicit `shell: bash`, which adds `-o pipefail` and would
+        # otherwise fail the step on grep's no-match exit 1.
+        task_ids() {
+          printf '%s' "$1" \
+            | tr -d '\r' \
+            | grep -oEi "(^Bug:[[:space:]]*T[0-9]+)|(^([*]*phabricator[*]*:[*]*[[:space:]]*)?https://phabricator\.wikimedia\.org/T[0-9]+)" \
+            | grep -oEi "T[0-9]+" \
+            | sort -u || true
+        }
+
+        case "$ACTION" in
+          opened|closed)
+            verb="$ACTION"
+            ids=$(task_ids "$PR_BODY")
+            ;;
+          edited)
+            # `edited` also fires for title and base-branch changes; only a body edit
+            # carries a changes.body object. Post only for tasks the edit added, so
+            # unrelated body edits don't re-notify an already-linked task.
+            if [ "$BODY_CHANGES" = "null" ]; then
+              echo "Body unchanged, nothing to do."
+              exit 0
+            fi
+            verb="linked"
+            before=$(task_ids "$PR_BODY_BEFORE")
+            after=$(task_ids "$PR_BODY")
+            if [ -n "$before" ]; then
+              ids=$(printf '%s\n' "$after" | grep -Fxv -f <(printf '%s\n' "$before") || true)
+            else
+              ids="$after"
+            fi
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+
+        message="$ACTOR $verb $PR_URL"
+
+        printf '%s\n' "$ids" | while IFS= read -r task; do
+          [ -n "$task" ] || continue
+          echo "Processing: $task"
           curl --header "User-Agent: GitHubPRBot/1.0 (https://phabricator.wikimedia.org/p/GitHubPRBot)" \
               https://phabricator.wikimedia.org/api/maniphest.edit \
-              -d api.token=${{ secrets.PHAB_BOT_API_KEY }} \
+              -d api.token="${PHAB_API_TOKEN}" \
               -d transactions[0][type]=comment \
               -d transactions[0][value]="${message}" \
-              -d objectIdentifier=${line}
+              -d objectIdentifier="${task}"
           sleep 10
         done

--- a/.github/workflows/android_phab.yml
+++ b/.github/workflows/android_phab.yml
@@ -18,9 +18,12 @@ jobs:
         BODY_CHANGES: ${{ toJSON(github.event.changes.body) }}
         PHAB_API_TOKEN: ${{ secrets.PHAB_BOT_API_KEY }}
       run: |
-        # Task IDs referenced at the start of a line, either as a "Bug: T123" trailer
-        # or as a phabricator.wikimedia.org URL (optionally behind the "**Phabricator:**"
-        # label from the PR template).
+        # Task IDs referenced at the start of a line, in either shape:
+        #   - a "Bug:" or "Phabricator:" label, optionally markdown-bolded, followed by
+        #     a bare T123 or a phabricator.wikimedia.org URL
+        #   - a bare phabricator.wikimedia.org URL with no label
+        # A bare "T123" with neither a label nor a URL deliberately does NOT match --
+        # that would be too loose to be safe in prose.
         #
         # The match is case-insensitive, so IDs are upper-cased before `sort -u` and
         # before the added-task diff below -- otherwise "T123" and "t123" count as two
@@ -34,7 +37,7 @@ jobs:
         task_ids() {
           printf '%s' "$1" \
             | tr -d '\r' \
-            | grep -oEi "(^Bug:[[:space:]]*T[0-9]+)|(^([*]*phabricator[*]*:[*]*[[:space:]]*)?https://phabricator\.wikimedia\.org/T[0-9]+)" \
+            | grep -oEi "(^[*]*(bug|phabricator)[*]*:[*]*[[:space:]]*(https://phabricator\.wikimedia\.org/)?T[0-9]+)|(^https://phabricator\.wikimedia\.org/T[0-9]+)" \
             | grep -oEi "T[0-9]+" \
             | tr '[:lower:]' '[:upper:]' \
             | sort -u || true

--- a/.github/workflows/android_phab.yml
+++ b/.github/workflows/android_phab.yml
@@ -22,6 +22,11 @@ jobs:
         # or as a phabricator.wikimedia.org URL (optionally behind the "**Phabricator:**"
         # label from the PR template).
         #
+        # The match is case-insensitive, so IDs are upper-cased before `sort -u` and
+        # before the added-task diff below -- otherwise "T123" and "t123" count as two
+        # distinct tasks, double-posting on one body and re-notifying when an edit only
+        # changes the casing. Upper case is also the canonical form to send Phabricator.
+        #
         # `|| true`: a body with no task reference is normal, not an error. It is
         # harmless under the default `bash -e {0}` shell, but required if this step
         # ever gains an explicit `shell: bash`, which adds `-o pipefail` and would
@@ -31,6 +36,7 @@ jobs:
             | tr -d '\r' \
             | grep -oEi "(^Bug:[[:space:]]*T[0-9]+)|(^([*]*phabricator[*]*:[*]*[[:space:]]*)?https://phabricator\.wikimedia\.org/T[0-9]+)" \
             | grep -oEi "T[0-9]+" \
+            | tr '[:lower:]' '[:upper:]' \
             | sort -u || true
         }
 


### PR DESCRIPTION
### What does this do?

Subscribes `android_phab.yml` to the `edited` pull request event, and posts to Phabricator only for task IDs that the edit actually **added** — diffing `github.event.changes.body.from` (the pre-edit body) against the current body.

| Event | Behavior |
|---|---|
| `opened` | unchanged — notifies every task in the body, verb `opened` |
| `edited`, task added | posts `<actor> linked <PR url>` for the new task(s) only |
| `edited`, task already present | **nothing** |
| `edited`, title/base-branch only | exits early (no `changes.body` in the payload) |
| `closed` | unchanged — notifies every task, verb `closed` |

The 10s pause between posts is unchanged.

### Why is this needed?

The workflow only listened for `opened` and `closed`, reading the task ID from the PR body at event time. If a PR was created before the `**Phabricator:**` line was filled in, the task never got an "opened" notification — `edited` wasn't subscribed to, and re-running the original job replays the original task-less payload. The task only heard about the PR when it closed.

This repo's PR template ships a `https://phabricator.wikimedia.org/T...` placeholder, which doesn't match `T[0-9]+`. So every PR opened before that placeholder is replaced with a real task ID hits this case.

Naively adding `edited` would over-correct: every later body edit — filling in sections, fixing a typo — would re-post to an already-linked task. Hence the set difference.

One subtlety worth flagging for review: the "was the body actually edited" check is done in bash against `toJSON(...)` rather than as a GitHub expression. `github.event.changes.body.from != null` looks equivalent but isn't — an edit *from an empty body* yields `''`, which compares equal to `null` under GitHub's type casting, and would skip exactly the case this fixes.

Also carried along:

- `printf '%s'` instead of `echo -e`, which was interpreting backslash escapes in the body before matching
- strip CR and `sort -u`, so a CRLF body naming one task twice posts once rather than twice
- `|| true` on the extraction pipeline, so a body with no task reference isn't an error under a `pipefail` shell (harmless under the current `bash -e {0}`, but one `shell: bash` away from breaking)
- API token moved out of the inlined `curl` argument into `env:`
- dropped the step-level `if:`, which re-checked what `on:` already guarantees

### Test Steps

Verified locally by extracting the `run:` block and driving it with stubbed `curl`/`sleep` — 16 cases, all passing, including:

| Case | Expected |
|---|---|
| template untouched (`T...` placeholder) | silent |
| template with real ID, URL on its own line | posts |
| edit replacing placeholder with real ID | posts `linked` once |
| later edit, ID already present | silent |
| edit adding a second task | posts only the new one |
| title-only edit | silent |
| edit from an empty body | posts |
| task removed by an edit | silent |
| CRLF body naming one task twice | one comment |
| `closed` with two tasks | both, `sleep 10` between |

Confirmed exit 0 under both `bash -e` (what actually runs) and `bash -eo pipefail`.

This PR can also serve as a live test: it was opened with the template placeholder intact, so no comment should have been posted. Editing the description to add a real task ID should post exactly one `linked` comment to that task, and any edit after that should post nothing. **Note this posts to Phabricator for real — use a scratch task.**

**Phabricator:**
https://phabricator.wikimedia.org/T...

---

This mirrors the same change made to `post_phab.yml` in [wikipedia-ios#6079](https://github.com/wikimedia/wikipedia-ios/pull/6079).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyimsJL4PymoNhpfWeQ5DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyimsJL4PymoNhpfWeQ5DG)_