### PR TITLE
DonationReminderV3: update presets for the experiment

### DIFF
--- a/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
+++ b/app/src/extra/java/org/wikipedia/donate/GooglePayActivity.kt
@@ -29,6 +29,7 @@ import org.wikipedia.analytics.eventplatform.DonorExperienceEvent
 import org.wikipedia.databinding.ActivityDonateBinding
 import org.wikipedia.dataclient.donate.CampaignCollection
 import org.wikipedia.dataclient.donate.DonationConfig
+import org.wikipedia.donate.donationreminder.DonationReminderHelper
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.Resource
 import org.wikipedia.util.ResourceUtil
@@ -251,6 +252,8 @@ class GooglePayActivity : BaseActivity() {
 
         val viewIds = mutableListOf<Int>()
         val presets = donationConfig.currencyAmountPresets[DonateUtil.currencyCode]?.toMutableSet()
+        // TODO: remove this when experiment is completed in November 2026.
+        DonationReminderHelper.updateDonationPresets(presets)
         if (viewModel.filledAmount > 0f) {
             presets?.add(viewModel.filledAmount)
         }

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderHelper.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderHelper.kt
@@ -25,7 +25,8 @@ object DonationReminderHelper {
     private val isInDateRange get() = LocalDate.now() <= LocalDate.of(2026, 11, 9) // TODO: confirm with PM
     val isInEligibleCountry get() = ReleaseUtil.isDevRelease || enabledCountries.contains(GeoUtil.geoIPCountry.orEmpty())
     val defaultReadFrequencyOptions = listOf(5, 10, 20)
-    val defaultDonateAmountOptions = listOf(1, 3, 5) // V3 only.
+    val presetsToRemoveFromConfig = listOf(2f, 10f, 15f) // V3 only.
+    val defaultDonateAmountOptions = listOf(1f, 3f, 5f) // V3 only.
 
     val isEnabled
         get() = (ReleaseUtil.isDevRelease || isInEligibleCountry && isInDateRange) && isTestGroupUser
@@ -43,6 +44,13 @@ object DonationReminderHelper {
             } // TODO: confirm with Shay
         } else {
             campaignIdOriginal
+        }
+    }
+
+    fun updateDonationPresets(presets: MutableSet<Float>?) {
+        if (isEnabled) {
+            presets?.removeAll(presetsToRemoveFromConfig.toSet())
+            presets?.addAll(defaultDonateAmountOptions)
         }
     }
 

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderHelper.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderHelper.kt
@@ -51,6 +51,7 @@ object DonationReminderHelper {
         if (isEnabled) {
             presets?.removeAll(presetsToRemoveFromConfig.toSet())
             presets?.addAll(defaultDonateAmountOptions)
+            presets?.sorted()
         }
     }
 

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderViewModel.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderViewModel.kt
@@ -138,7 +138,9 @@ class DonationReminderViewModel(savedStateHandle: SavedStateHandle) : ViewModel(
         }
 
         val context = WikipediaApp.instance
-        val presets = donationConfig?.currencyAmountPresets[currencyCode]?.take(maxPresetItemsInDropdown) ?: listOf(minimumAmount)
+        val presets = (donationConfig?.currencyAmountPresets[currencyCode]?.take(maxPresetItemsInDropdown) ?: listOf(minimumAmount)).toMutableSet()
+        // TODO: remove this when experiment is completed in November 2026.
+        DonationReminderHelper.updateDonationPresets(presets)
         val options = presets.map {
             OptionItem.Preset(it, DonateUtil.currencyFormat.format(it).replace(formatRegex, ""))
         } + OptionItem.Custom(context.getString(R.string.donation_reminders_settings_option_custom))


### PR DESCRIPTION
### What does this do?
We pull the donation presets from `MediaWiki:AppsDonationConfig.json`, but for this experiment, we will need to show smaller amounts to users in the test groups.

This PR hardcoded the list and replaced the presets with the desired ones.
