### PR TITLE
Don't use SubcomposeAsyncImage unnecessarily.

### DIFF
--- a/app/src/main/java/org/wikipedia/feed/ForYouContentTab.kt
+++ b/app/src/main/java/org/wikipedia/feed/ForYouContentTab.kt
@@ -46,10 +46,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil3.compose.SubcomposeAsyncImage
-import coil3.compose.SubcomposeAsyncImageContent
+import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
-import coil3.request.allowHardware
 import org.wikipedia.R
 import org.wikipedia.compose.ComposeColors
 import org.wikipedia.compose.components.HtmlText
@@ -530,13 +528,11 @@ fun ForYouFeedMessageView(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
     ) {
-        SubcomposeAsyncImage(
+        AsyncImage(
             modifier = Modifier.size(125.dp),
             model = ImageRequest.Builder(context)
                 .data(illustrationResId)
-                .allowHardware(false)
                 .build(),
-            success = { SubcomposeAsyncImageContent() },
             contentDescription = null
         )
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/org/wikipedia/feed/personalization/OnboardingCuriosityScreen.kt
+++ b/app/src/main/java/org/wikipedia/feed/personalization/OnboardingCuriosityScreen.kt
@@ -18,15 +18,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
-import coil3.compose.SubcomposeAsyncImageContent
+import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
-import coil3.request.allowHardware
 import org.wikipedia.R
 import org.wikipedia.compose.theme.BaseTheme
 import org.wikipedia.compose.theme.WikipediaTheme
 import org.wikipedia.theme.Theme
-import org.wikipedia.yearinreview.LoadingIndicator
 
 @Composable
 fun OnboardingCuriosityScreen(
@@ -41,17 +38,12 @@ fun OnboardingCuriosityScreen(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        SubcomposeAsyncImage(
+        AsyncImage(
             modifier = Modifier
                 .size(125.dp),
             model = ImageRequest.Builder(LocalContext.current)
                 .data(R.drawable.yir_puzzle_browser)
-                .allowHardware(false)
                 .build(),
-            loading = { LoadingIndicator() },
-            success = {
-                SubcomposeAsyncImageContent()
-            },
             contentDescription = stringResource(R.string.explore_feed_onboarding_curiosity_title),
         )
 

--- a/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingScreen.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingScreen.kt
@@ -41,10 +41,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil3.compose.SubcomposeAsyncImage
-import coil3.compose.SubcomposeAsyncImageContent
+import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
-import coil3.request.allowHardware
 import org.wikipedia.R
 import org.wikipedia.compose.components.HtmlText
 import org.wikipedia.compose.extensions.lazyColumnScrollbar
@@ -54,7 +52,6 @@ import org.wikipedia.extensions.instrument
 import org.wikipedia.language.AppLanguageState
 import org.wikipedia.theme.Theme
 import org.wikipedia.util.FeedbackUtil
-import org.wikipedia.yearinreview.LoadingIndicator
 
 @Composable
 fun InitialOnboardingScreen(
@@ -225,17 +222,12 @@ fun InitialOnboardingDataPrivacyContent(
         verticalArrangement = Arrangement.Center
     ) {
 
-        SubcomposeAsyncImage(
+        AsyncImage(
             modifier = Modifier
                 .size(124.dp),
             model = ImageRequest.Builder(LocalContext.current)
                 .data(R.drawable.ic_onboarding_puzzle)
-                .allowHardware(false)
                 .build(),
-            loading = { LoadingIndicator() },
-            success = {
-                SubcomposeAsyncImageContent()
-            },
             contentDescription = stringResource(R.string.onboarding_data_privacy_title),
         )
 
@@ -295,17 +287,11 @@ fun InitialOnboardingLanguagesScreen(
                 .fillMaxWidth(),
             contentAlignment = Alignment.Center
         ) {
-            SubcomposeAsyncImage(
-                modifier = Modifier
-                    .size(124.dp),
+            AsyncImage(
+                modifier = Modifier.size(124.dp),
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(R.drawable.yir_puzzle_stone)
-                    .allowHardware(false)
                     .build(),
-                loading = { LoadingIndicator() },
-                success = {
-                    SubcomposeAsyncImageContent()
-                },
                 contentDescription = stringResource(R.string.onboarding_app_languages_title),
             )
         }

--- a/app/src/main/java/org/wikipedia/yearinreview/YearInReviewOnboardingScreen.kt
+++ b/app/src/main/java/org/wikipedia/yearinreview/YearInReviewOnboardingScreen.kt
@@ -35,10 +35,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import coil3.compose.SubcomposeAsyncImage
-import coil3.compose.SubcomposeAsyncImageContent
+import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
-import coil3.request.allowHardware
 import org.wikipedia.R
 import org.wikipedia.analytics.eventplatform.YearInReviewEvent
 import org.wikipedia.compose.theme.BaseTheme
@@ -109,13 +107,10 @@ fun YearInReviewOnboardingContent(
                     .clip(RoundedCornerShape(16.dp)),
                 contentAlignment = Alignment.Center
             ) {
-                SubcomposeAsyncImage(
+                AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(R.drawable.yir_puzzle_pinch)
-                        .allowHardware(false)
                         .build(),
-                    loading = { LoadingIndicator() },
-                    success = { SubcomposeAsyncImageContent() },
                     contentDescription = stringResource(R.string.year_in_review_screendeck_image_content_description),
                     modifier = Modifier.fillMaxSize()
                 )


### PR DESCRIPTION
Using `SubcomposeAsyncImage` is only necessary in Year-in-Review, where we need it in order to pause the animation and grab a screenshot. It should not be used for any other purpose, because it's much worse for performance, particularly the obvious `allowHardware(false)` part.