### PR TITLE
DonationReminderV3: missing translation

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -2151,6 +2151,7 @@
   <string name="donation_reminders_wrap_up_survey_option_remove_it">Label for the option to remove the donation reminder.</string>
   <string name="donation_reminders_wrap_up_survey_option_not_sure">Label for the option indicating uncertainty about the donation reminder.</string>
   <string name="donation_reminders_wrap_up_survey_optional_hint">Hint text indicating that users can provide optional feedback.</string>
+  <string name="donation_reminders_wrap_up_survey_thank_you_message">Snackbar message that indicates the feedback has been submitted.</string>
   <string name="donation_reminders_eoe_title">Title shown at the end of the experiment for the donation reminder.</string>
   <string name="donation_reminders_eoe_message">Message shown at the end of the experiment for the donation reminder. %s is replaced by the pledged amount.</string>
   <string name="donation_reminders_eoe_give_monthly_button">Label for the button that allows the user to give monthly.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2395,6 +2395,7 @@
     <string name="donation_reminders_wrap_up_survey_option_remove_it">Remove it</string>
     <string name="donation_reminders_wrap_up_survey_option_not_sure">Not sure</string>
     <string name="donation_reminders_wrap_up_survey_optional_hint">Anything else? (Optional)</string>
+    <string name="donation_reminders_wrap_up_survey_thank_you_message">Thank you for your feedback. Your answer helps us decide what to build next.</string>
     <string name="donation_reminders_eoe_title">This is the end of the experiment</string>
     <string name="donation_reminders_eoe_message">We will no longer show in-app reminders but you can still support by donating your pledged amount %s monthly.</string>
     <string name="donation_reminders_eoe_give_monthly_button">Give monthly</string>


### PR DESCRIPTION
### What does this do?
One missing string item from the Variant B screen 😓 
