### PR TITLE
Donation reminder v3 maybe later punchlist

### DIFF
--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -693,8 +694,8 @@ fun <T : Number> OptionSelector(
             }
         }
         Spacer(modifier = Modifier.width(16.dp))
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
+        FlowRow(
+            itemVerticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             option.options.forEachIndexed { index, currentOption ->
@@ -712,6 +713,7 @@ fun <T : Number> OptionSelector(
                     ) {
                         Text(
                             text = currentOption.displayText,
+                            maxLines = 1,
                             color = if (isSelected) WikipediaTheme.colors.paperColor
                             else WikipediaTheme.colors.primaryColor,
                             style = MaterialTheme.typography.titleMedium

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -698,7 +698,8 @@ fun <T : Number> OptionSelector(
         Spacer(modifier = Modifier.width(16.dp))
         FlowRow(
             itemVerticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             option.options.forEachIndexed { index, currentOption ->
                 if (currentOption is OptionItem.Preset) {

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -545,13 +545,13 @@ fun DonationAmountView(
         prefix = { Text(
             text = currencySymbol,
             style = MaterialTheme.typography.bodyLarge,
-            color = WikipediaTheme.colors.primaryColor
+            color = WikipediaTheme.colors.secondaryColor
         ) },
         placeholder = {
             Text(
                 text = stringResource(R.string.donation_reminders_settings_custom_amount_label),
                 style = MaterialTheme.typography.bodyLarge,
-                color = WikipediaTheme.colors.placeholderColor
+                color = WikipediaTheme.colors.secondaryColor
             )
         },
         trailingIcon = {

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -703,7 +703,7 @@ fun <T : Number> OptionSelector(
                             text = currentOption.displayText,
                             color = if (isSelected) WikipediaTheme.colors.paperColor
                             else WikipediaTheme.colors.primaryColor,
-                            style = MaterialTheme.typography.bodyLarge
+                            style = MaterialTheme.typography.titleMedium
                         )
                     }
                 }

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
@@ -206,6 +207,9 @@ fun DonationReminderAppBar(
     menuItems: List<DonationReminderDropDownMenuItem> = emptyList()
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val iconSize = with(LocalDensity.current) {
+        16.sp.toDp()
+    }
 
     Column(
         modifier = modifier,
@@ -295,7 +299,7 @@ fun DonationReminderAppBar(
             ) {
                 Icon(
                     modifier = Modifier
-                        .size(16.dp),
+                        .size(iconSize),
                     painter = painterResource(R.drawable.ic_experiment_24dp),
                     tint = WikipediaTheme.colors.inactiveColor,
                     contentDescription = null
@@ -658,6 +662,10 @@ fun <T : Number> OptionSelector(
     showInfo: Boolean = false,
     showArticleLabel: Boolean = false,
 ) {
+    val iconSize = with(LocalDensity.current) {
+        24.sp.toDp()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -668,7 +676,8 @@ fun <T : Number> OptionSelector(
             Icon(
                 painter = painterResource(headerIcon),
                 tint = WikipediaTheme.colors.inactiveColor,
-                contentDescription = null
+                contentDescription = null,
+                modifier = Modifier.size(iconSize)
             )
             Text(
                 text = title,
@@ -678,7 +687,8 @@ fun <T : Number> OptionSelector(
             if (showInfo) {
                 InfoTooltip(
                     modifier = Modifier,
-                    plainTooltipText = stringResource(R.string.donation_reminders_settings_tooltip_info_label)
+                    plainTooltipText = stringResource(R.string.donation_reminders_settings_tooltip_info_label),
+                    iconSize = iconSize
                 )
             }
         }
@@ -762,7 +772,8 @@ private fun DonationRemindersSwitch(
 @Composable
 fun InfoTooltip(
     modifier: Modifier = Modifier,
-    plainTooltipText: String
+    plainTooltipText: String,
+    iconSize: Dp? = null
 ) {
     val tooltipState = rememberTooltipState()
     val scope = rememberCoroutineScope()
@@ -787,6 +798,7 @@ fun InfoTooltip(
         content = {
             Icon(
                 modifier = Modifier
+                    .size(iconSize ?: 24.dp)
                     .noRippleClickable(onClick = {
                         scope.launch {
                             tooltipState.show()

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -661,7 +661,8 @@ fun <T : Number> OptionSelector(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
                 painter = painterResource(headerIcon),

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -281,6 +281,7 @@ fun DonationReminderAppBar(
                     .size(24.dp)
             )
             Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .background(
                         color = WikipediaTheme.colors.paperColor,

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -161,7 +161,9 @@ fun DonationReminderScreen(
                     .padding(paddingValues)
             ) {
                 LinearProgressIndicator(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .fillMaxWidth(),
                     color = WikipediaTheme.colors.progressiveColor,
                     trackColor = WikipediaTheme.colors.borderColor
                 )

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -73,7 +73,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
@@ -210,9 +209,6 @@ fun DonationReminderAppBar(
     menuItems: List<DonationReminderDropDownMenuItem> = emptyList()
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val iconSize = with(LocalDensity.current) {
-        16.sp.toDp()
-    }
 
     Column(
         modifier = modifier,
@@ -301,8 +297,7 @@ fun DonationReminderAppBar(
                     .padding(horizontal = 8.dp, vertical = 4.dp)
             ) {
                 Icon(
-                    modifier = Modifier
-                        .size(iconSize),
+                    modifier = Modifier,
                     painter = painterResource(R.drawable.ic_experiment_24dp),
                     tint = WikipediaTheme.colors.inactiveColor,
                     contentDescription = null
@@ -665,9 +660,6 @@ fun <T : Number> OptionSelector(
     showInfo: Boolean = false,
     showArticleLabel: Boolean = false,
 ) {
-    val iconSize = with(LocalDensity.current) {
-        24.sp.toDp()
-    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -680,7 +672,6 @@ fun <T : Number> OptionSelector(
                 painter = painterResource(headerIcon),
                 tint = WikipediaTheme.colors.inactiveColor,
                 contentDescription = null,
-                modifier = Modifier.size(iconSize)
             )
             Text(
                 text = title,
@@ -691,7 +682,6 @@ fun <T : Number> OptionSelector(
                 InfoTooltip(
                     modifier = Modifier,
                     plainTooltipText = stringResource(R.string.donation_reminders_settings_tooltip_info_label),
-                    iconSize = iconSize
                 )
             }
         }
@@ -777,8 +767,7 @@ private fun DonationRemindersSwitch(
 @Composable
 fun InfoTooltip(
     modifier: Modifier = Modifier,
-    plainTooltipText: String,
-    iconSize: Dp? = null
+    plainTooltipText: String
 ) {
     val tooltipState = rememberTooltipState()
     val scope = rememberCoroutineScope()
@@ -803,7 +792,6 @@ fun InfoTooltip(
         content = {
             Icon(
                 modifier = Modifier
-                    .size(iconSize ?: 24.dp)
                     .noRippleClickable(onClick = {
                         scope.launch {
                             tooltipState.show()

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -671,7 +671,7 @@ fun <T : Number> OptionSelector(
             )
             Text(
                 text = title,
-                style = MaterialTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.labelLarge,
                 color = WikipediaTheme.colors.primaryColor,
             )
             if (showInfo) {


### PR DESCRIPTION
### What does this do?
This PR addresses UI punch list created from design review of the maybe later screen

- updates to m3 label large for pill headers
- updates type token for pills
- color matching for placeholder text and currency symbol in the custom amount field
- adds spacing below the `beta` tag in the loading state
- aligns icons/tooltip with the text & and makes sizing dynamic with font size changes
- prevents line breaks inside the pill, adds flowrow to allow pills to stack.


### Why is this needed?
There are several UI issues that need to be fixed

**Phabricator:**
https://phabricator.wikimedia.org/T435345
