### PR TITLE
DonationReminderV3: add developer preferences for overriding dates

### DIFF
--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderHelper.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderHelper.kt
@@ -16,15 +16,19 @@ import java.time.LocalDate
 
 object DonationReminderHelper {
     const val MAX_REMINDER_PROMPTS = 2
+    private val EXPERIMENT_END_DATE get() = Prefs.donationReminderEndDateOverride.ifEmpty { "2026-11-09" }
+    private val WRAP_UP_START_DATE get() = Prefs.donationReminderWrapUpStartDateOverride.ifEmpty { "2026-11-10" }
+    private val WRAP_UP_END_DATE get() = Prefs.donationReminderWrapUpEndDateOverride.ifEmpty { "2026-11-15" }
     private val validReadCountOnSeconds = if (ReleaseUtil.isDevRelease) 1 else 5
 
     private val isTestGroupUser = DonationReminderAbTest().isTestGroupUser()
     private val enabledCountries = listOf(
         "NL"
     )
-    private val isInDateRange get() = LocalDate.now() <= LocalDate.of(2026, 11, 9)
-    val isInWrapUpDateRange get() = LocalDate.now() <= LocalDate.of(2026, 11, 15) &&
-            LocalDate.now() >= LocalDate.of(2026, 11, 10)
+
+    private val isInDateRange get() = LocalDate.now() <= LocalDate.parse(EXPERIMENT_END_DATE)
+    val isInWrapUpDateRange get() = LocalDate.now() <= LocalDate.parse(WRAP_UP_END_DATE) &&
+            LocalDate.now() >= LocalDate.parse(WRAP_UP_START_DATE)
     val isInEligibleCountry get() = ReleaseUtil.isDevRelease || enabledCountries.contains(GeoUtil.geoIPCountry.orEmpty())
     val defaultReadFrequencyOptions = listOf(5, 10, 20)
     val presetsToRemoveFromConfig = listOf(2f, 10f, 15f) // V3 only.

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -920,6 +920,18 @@ object Prefs {
         get() = PrefsIoUtil.getBoolean(R.string.preference_key_donation_reminders_dev_wrap_up_enabled, false)
         set(value) = PrefsIoUtil.setBoolean(R.string.preference_key_donation_reminders_dev_wrap_up_enabled, value)
 
+    var donationReminderEndDateOverride
+        get() = PrefsIoUtil.getString(R.string.preference_key_donation_reminders_end_date_override, null).orEmpty()
+        set(value) = PrefsIoUtil.setString(R.string.preference_key_donation_reminders_end_date_override, value)
+
+    var donationReminderWrapUpStartDateOverride
+        get() = PrefsIoUtil.getString(R.string.preference_key_donation_reminders_wrap_up_start_date_override, null).orEmpty()
+        set(value) = PrefsIoUtil.setString(R.string.preference_key_donation_reminders_wrap_up_start_date_override, value)
+
+    var donationReminderWrapUpEndDateOverride
+        get() = PrefsIoUtil.getString(R.string.preference_key_donation_reminders_wrap_up_end_date_override, null).orEmpty()
+        set(value) = PrefsIoUtil.setString(R.string.preference_key_donation_reminders_wrap_up_end_date_override, value)
+
     var activityTabModules: ActivityTabModules
         get() = JsonUtil.decodeFromString<ActivityTabModules>(PrefsIoUtil.getString(R.string.preference_key_activity_tab_modules, null))
             ?: ActivityTabModules()

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -205,6 +205,9 @@
     <string name="preference_key_donation_reminders_dev_reset" translatable="false">donationReminderDevReset</string>
     <string name="preference_key_donation_reminders_dev_reset_seen_date" translatable="false">donationReminderDevResetSeenDate</string>
     <string name="preference_key_donation_reminders_dev_wrap_up_enabled" translatable="false">donationReminderDevWrapUpEnabled</string>
+    <string name="preference_key_donation_reminders_end_date_override" translatable="false">donationReminderEndDateOverride</string>
+    <string name="preference_key_donation_reminders_wrap_up_start_date_override" translatable="false">donationReminderWrapUpStartDateOverride</string>
+    <string name="preference_key_donation_reminders_wrap_up_end_date_override" translatable="false">donationReminderWrapUpEndDateOverride</string>
     <string name="preference_category_donations" translatable="false">donations</string>
     <string name="preference_key_activity_tab_modules" translatable="false">activityTabModules</string>
     <string name="preference_key_activity_tab_onboarding_shown" translatable="false">activityTabOnboardingShown</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -546,6 +546,21 @@
 
         <org.wikipedia.settings.EditTextAutoSummarizePreference
             style="@style/EditTextAutoSummarizePreference"
+            android:key="@string/preference_key_donation_reminders_end_date_override"
+            android:title="Donation reminder end date override (i.e. 2026-11-09)" />
+
+        <org.wikipedia.settings.EditTextAutoSummarizePreference
+            style="@style/EditTextAutoSummarizePreference"
+            android:key="@string/preference_key_donation_reminders_wrap_up_start_date_override"
+            android:title="Donation reminder wrap up start date override (i.e. 2026-11-10)" />
+
+        <org.wikipedia.settings.EditTextAutoSummarizePreference
+            style="@style/EditTextAutoSummarizePreference"
+            android:key="@string/preference_key_donation_reminders_wrap_up_end_date_override"
+            android:title="Donation reminder wrap up end date override (i.e. 2026-11-15)" />
+
+        <org.wikipedia.settings.EditTextAutoSummarizePreference
+            style="@style/EditTextAutoSummarizePreference"
             android:key="@string/preference_key_donation_reminder_config"
             android:title="@string/preference_key_donation_reminder_config"/>
 


### PR DESCRIPTION
### What does this do?
This PR is for QA to test date configurations, since changing the device date will not work when fetching the API (because of the SSL certificate).


<img width="400" alt="Screenshot_20260903_125154_Wikipedia Alpha" src="https://github.com/user-attachments/assets/1f67d7c6-cf47-4f52-b4e7-494be60bb52a" />
