### PR TITLE
DonationReminderV3: move bottom buttons to bottomBar in Scaffold

### DIFF
--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -102,6 +102,37 @@ fun DonationReminderScreen(
 ) {
     val uiState = viewModel.uiState.collectAsState().value
     var isNavigatingToExternalUrl by remember { mutableStateOf(false) }
+    var customAmountText by rememberSaveable {
+        mutableStateOf(
+            if (uiState.donationAmount.selectedSource is SelectedSource.Custom) {
+                uiState.donationAmount.selectedValue.toString()
+            } else {
+                ""
+            }
+        )
+    }
+    var customErrorMessage by rememberSaveable { mutableStateOf("") }
+    val donateGooglePayMinAmount = stringResource(R.string.donate_gpay_minimum_amount)
+    val donateGooglePayMaxAmount = stringResource(R.string.donate_gpay_maximum_amount)
+
+    fun customAmountErrorMessage(inputText: String): String {
+        val parsedCustomAmount = DonateUtil.getAmountFloat(inputText)
+        return when {
+            inputText.isBlank() || parsedCustomAmount < uiState.donationAmount.minimumAmount -> {
+                String.format(
+                    donateGooglePayMinAmount,
+                    uiState.donationAmount.displayFormatter(uiState.donationAmount.minimumAmount)
+                )
+            }
+            parsedCustomAmount >= uiState.donationAmount.maximumAmount -> {
+                String.format(
+                    donateGooglePayMaxAmount,
+                    uiState.donationAmount.displayFormatter(uiState.donationAmount.maximumAmount)
+                )
+            }
+            else -> ""
+        }
+    }
 
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
@@ -151,11 +182,34 @@ fun DonationReminderScreen(
                 )
             )
         },
+        bottomBar = {
+            if (!uiState.isLoading && uiState.error == null && WindowInsets.ime.getBottom(LocalDensity.current) <= 0) {
+                DonationReminderBottomBar(
+                    isFromSettings = viewModel.isFromSettings,
+                    onConfirmButtonClick = {
+                        val isCustomSelected = uiState.donationAmount.selectedSource is SelectedSource.Custom
+                        val customAmountError = if (isCustomSelected) customAmountErrorMessage(customAmountText) else ""
+                        if (customAmountError.isNotEmpty()) {
+                            customErrorMessage = customAmountError
+                        } else {
+                            viewModel.toggleDonationReminders(true)
+                            viewModel.saveReminder()
+                            val message = DonationReminderHelper.thankYouMessageForSettings()
+                            onConfirmButtonClick(message)
+                        }
+                    },
+                    onFooterButtonClick = {
+                        isNavigatingToExternalUrl = true
+                        onFooterButtonClick()
+                    }
+                )
+            }
+        },
         containerColor = WikipediaTheme.colors.paperColor,
     ) { paddingValues ->
         if (uiState.isLoading) {
             Box(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
             ) {
@@ -193,10 +247,20 @@ fun DonationReminderScreen(
                 .fillMaxSize(),
             viewModel = viewModel,
             uiState = uiState,
-            onConfirmButtonClick = onConfirmButtonClick,
-            onFooterButtonClick = {
-                isNavigatingToExternalUrl = true
-                onFooterButtonClick()
+            customErrorMessage = customErrorMessage,
+            onCustomTextChanged = { newValue ->
+                customAmountText = newValue
+                customErrorMessage = customAmountErrorMessage(newValue)
+                if (customErrorMessage != "" && viewModel.isFromSettings) {
+                    // Keep the last valid amount in the field
+                    viewModel.updateDonationAmountState(uiState.donationAmount.selectedValue, uiState.donationAmount.selectedSource)
+                }
+            },
+            onCustomTextFocusedEmpty = {
+                customAmountText = ""
+            },
+            onClearCustomErrorMessage = {
+                customErrorMessage = ""
             }
         )
     }
@@ -319,166 +383,117 @@ fun DonationReminderContent(
     modifier: Modifier = Modifier,
     viewModel: DonationReminderViewModel,
     uiState: DonationReminderUiState,
-    onConfirmButtonClick: (String) -> Unit,
-    onFooterButtonClick: () -> Unit
+    customErrorMessage: String,
+    onCustomTextChanged: (String) -> Unit,
+    onCustomTextFocusedEmpty: () -> Unit,
+    onClearCustomErrorMessage: () -> Unit
 ) {
     val isDonationReminderEnabled = uiState.isDonationReminderEnabled
-    var customAmountText by rememberSaveable {
-        mutableStateOf(
-            if (uiState.donationAmount.selectedSource is SelectedSource.Custom) {
-                uiState.donationAmount.selectedValue.toString()
-            } else {
-                ""
-            }
-        )
-    }
-    var customErrorMessage by rememberSaveable { mutableStateOf("") }
-    val donateGooglePayMinAmount = stringResource(R.string.donate_gpay_minimum_amount)
-    val donateGooglePayMaxAmount = stringResource(R.string.donate_gpay_maximum_amount)
-
-    fun customAmountErrorMessage(inputText: String): String {
-        val parsedCustomAmount = DonateUtil.getAmountFloat(inputText)
-        return when {
-            inputText.isBlank() || parsedCustomAmount < uiState.donationAmount.minimumAmount -> {
-                String.format(
-                    donateGooglePayMinAmount,
-                    uiState.donationAmount.displayFormatter(uiState.donationAmount.minimumAmount)
-                )
-            }
-            parsedCustomAmount >= uiState.donationAmount.maximumAmount -> {
-                String.format(
-                    donateGooglePayMaxAmount,
-                    uiState.donationAmount.displayFormatter(uiState.donationAmount.maximumAmount)
-                )
-            }
-            else -> ""
-        }
-    }
 
     Column(
         modifier = modifier
             .imePadding()
-            .navigationBarsPadding()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
     ) {
-        Column(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .weight(1f)
-                .padding(16.dp)
-        ) {
-            DonationHeader()
-            if (viewModel.isFromSettings) {
-                DonationRemindersSwitch(
-                    modifier = Modifier
-                        .noRippleClickable {
-                            viewModel.toggleDonationReminders(!isDonationReminderEnabled)
-                        }
-                        .padding(top = 24.dp),
-                    isDonationRemindersEnabled = isDonationReminderEnabled,
-                    onCheckedChange = { viewModel.toggleDonationReminders(it) }
-                )
-            }
-            Spacer(modifier = Modifier.height(24.dp))
-            if (uiState.isDonationReminderEnabled || !viewModel.isFromSettings) {
-                ReadFrequencyView(
-                    option = uiState.readFrequency,
-                    onOptionSelected = { option, source ->
-                        when (option) {
-                            is OptionItem.Preset -> {
-                                viewModel.updateReadFrequencyState(option.value, source)
-                            }
-
-                            is OptionItem.Custom -> { }
-                        }
-                    }
-                )
-                Spacer(modifier = Modifier.height(24.dp))
-                DonationAmountView(
-                    option = uiState.donationAmount,
-                    currencySymbol = DonateUtil.currencySymbol,
-                    customErrorMessage = customErrorMessage,
-                    onCustomTextChanged = { newValue ->
-                        customAmountText = newValue
-                        customErrorMessage = customAmountErrorMessage(newValue)
-                        if (customErrorMessage != "" && viewModel.isFromSettings) {
-                            // Keep the last valid amount in the field
-                            viewModel.updateDonationAmountState(uiState.donationAmount.selectedValue, uiState.donationAmount.selectedSource)
-                        }
-                    },
-                    onCustomTextFocusedEmpty = {
-                        customAmountText = ""
-                    },
-                    onOptionSelected = { option, source ->
-                        when (option) {
-                            is OptionItem.Preset -> {
-                                customErrorMessage = ""
-                                viewModel.updateDonationAmountState(option.value, source)
-                            }
-
-                            is OptionItem.Custom -> {
-                                if (option.displayText.isBlank() && viewModel.isFromSettings) {
-                                    // Keep previous amount value but switch selected source to custom.
-                                    viewModel.updateDonationAmountState(
-                                        uiState.donationAmount.selectedValue,
-                                        source
-                                    )
-                                    return@DonationAmountView
-                                }
-                                val customValue = DonateUtil.getAmountFloat(option.displayText)
-                                viewModel.updateDonationAmountState(customValue, source)
-                            }
-                        }
-                    }
-                )
-            }
-        }
-        if (WindowInsets.ime.getBottom(LocalDensity.current) <= 0) {
-            if (uiState.isDonationReminderEnabled || !viewModel.isFromSettings) {
-                if (!viewModel.isFromSettings) {
-                    AppButton(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp)
-                            .padding(top = 16.dp),
-                        onClick = {
-                            val isCustomSelected = uiState.donationAmount.selectedSource is SelectedSource.Custom
-                            if (isCustomSelected) {
-                                val customAmountError = customAmountErrorMessage(customAmountText)
-                                if (customAmountError.isNotEmpty()) {
-                                    customErrorMessage = customAmountError
-                                    return@AppButton
-                                }
-                            }
-                            viewModel.toggleDonationReminders(true)
-                            viewModel.saveReminder()
-                            val message = DonationReminderHelper.thankYouMessageForSettings()
-                            onConfirmButtonClick(message)
-                        },
-                        content = {
-                            Text(
-                                stringResource(R.string.donation_reminders_settings_confirm_btn_label)
-                            )
-                        }
-                    )
-                }
-            }
-
-            val footerButtonText = if (viewModel.isFromSettings) stringResource(R.string.donation_reminders_settings_about_experiment_btn_label)
-            else stringResource(R.string.donation_reminders_settings_no_thanks_btn_label)
-            TextButton(
+        DonationHeader()
+        if (viewModel.isFromSettings) {
+            DonationRemindersSwitch(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 16.dp),
-                onClick = onFooterButtonClick,
+                    .noRippleClickable {
+                        viewModel.toggleDonationReminders(!isDonationReminderEnabled)
+                    }
+                    .padding(top = 24.dp),
+                isDonationRemindersEnabled = isDonationReminderEnabled,
+                onCheckedChange = { viewModel.toggleDonationReminders(it) }
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        if (uiState.isDonationReminderEnabled || !viewModel.isFromSettings) {
+            ReadFrequencyView(
+                option = uiState.readFrequency,
+                onOptionSelected = { option, source ->
+                    when (option) {
+                        is OptionItem.Preset -> {
+                            viewModel.updateReadFrequencyState(option.value, source)
+                        }
+
+                        is OptionItem.Custom -> { }
+                    }
+                }
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            DonationAmountView(
+                option = uiState.donationAmount,
+                currencySymbol = DonateUtil.currencySymbol,
+                customErrorMessage = customErrorMessage,
+                onCustomTextChanged = onCustomTextChanged,
+                onCustomTextFocusedEmpty = onCustomTextFocusedEmpty,
+                onOptionSelected = { option, source ->
+                    when (option) {
+                        is OptionItem.Preset -> {
+                            onClearCustomErrorMessage()
+                            viewModel.updateDonationAmountState(option.value, source)
+                        }
+
+                        is OptionItem.Custom -> {
+                            if (option.displayText.isBlank() && viewModel.isFromSettings) {
+                                // Keep previous amount value but switch selected source to custom.
+                                viewModel.updateDonationAmountState(
+                                    uiState.donationAmount.selectedValue,
+                                    source
+                                )
+                                return@DonationAmountView
+                            }
+                            val customValue = DonateUtil.getAmountFloat(option.displayText)
+                            viewModel.updateDonationAmountState(customValue, source)
+                        }
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun DonationReminderBottomBar(
+    modifier: Modifier = Modifier,
+    isFromSettings: Boolean,
+    onConfirmButtonClick: () -> Unit,
+    onFooterButtonClick: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(WikipediaTheme.colors.paperColor)
+            .navigationBarsPadding()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (!isFromSettings) {
+            AppButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onConfirmButtonClick,
                 content = {
                     Text(
-                        text = footerButtonText,
-                        color = WikipediaTheme.colors.progressiveColor
+                        stringResource(R.string.donation_reminders_settings_confirm_btn_label)
                     )
                 }
             )
         }
+
+        val footerButtonText = if (isFromSettings) stringResource(R.string.donation_reminders_settings_about_experiment_btn_label)
+        else stringResource(R.string.donation_reminders_settings_no_thanks_btn_label)
+        TextButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onFooterButtonClick,
+            content = {
+                Text(
+                    text = footerButtonText,
+                    color = WikipediaTheme.colors.progressiveColor
+                )
+            }
+        )
     }
 }
 
@@ -830,6 +845,34 @@ private fun DonationReminderAppBarPreview() {
                     onClick = {}
                 )
             )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DonationReminderBottomBarPreview() {
+    BaseTheme(
+        currentTheme = Theme.LIGHT
+    ) {
+        DonationReminderBottomBar(
+            isFromSettings = false,
+            onConfirmButtonClick = {},
+            onFooterButtonClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DonationReminderBottomBarSettingsPreview() {
+    BaseTheme(
+        currentTheme = Theme.LIGHT
+    ) {
+        DonationReminderBottomBar(
+            isFromSettings = true,
+            onConfirmButtonClick = {},
+            onFooterButtonClick = {}
         )
     }
 }

--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -4,6 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -67,6 +68,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -392,6 +394,7 @@ fun DonationReminderContent(
 
     Column(
         modifier = modifier
+            .focusable() // Intercepts Android's fallback focus in API 24
             .imePadding()
             .verticalScroll(rememberScrollState())
             .padding(16.dp)
@@ -519,6 +522,7 @@ fun DonationAmountView(
     var selectedOption by remember { mutableStateOf(initialSelectedOption) }
     var textFieldValue by remember { mutableStateOf(initialCustomText) }
     val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val coroutineScope = rememberCoroutineScope()
@@ -544,6 +548,7 @@ fun DonationAmountView(
             textFieldValue = ""
             onOptionSelected(option, source)
             focusManager.clearFocus()
+            keyboardController?.hide()
         },
     )
 


### PR DESCRIPTION
### What does this do?
Currently, we put the bottom buttons inside the `DonationReminderContent`, but sometimes this introduces an issue where there is more space at the top on different devices. 

This PR moves the bottom buttons to a separate function and puts them in the `bottomBar`.

**Before:**

<img width="200"  alt="Screenshot_20260903_160618" src="https://github.com/user-attachments/assets/1ba65dcb-a450-471b-bcc2-b22097025cbb" />
<img width="200" alt="Screenshot_20260903_160541" src="https://github.com/user-attachments/assets/6c1c59ab-6f9b-44ae-b0d6-2e8b0f52d1ee" />

**After:**

<img width="200" alt="Screenshot_20260903_160658" src="https://github.com/user-attachments/assets/3c02250a-3235-4910-920c-35eb6daa2e00" />
<img width="200" alt="Screenshot_20260903_160803" src="https://github.com/user-attachments/assets/34c24727-ab73-4fc1-9251-3493fb2fbfc8" />
<img width="200" alt="Screenshot_20260903_160447" src="https://github.com/user-attachments/assets/92724f4d-0140-47cb-a223-b27ea6d5b9ec" />
<img width="200" alt="Screenshot_20260903_160405" src="https://github.com/user-attachments/assets/ce567092-ed3a-4dba-b864-86369c99453c" />
<img width="200" alt="Screenshot_20260903_160246" src="https://github.com/user-attachments/assets/6624dfc4-e264-4511-a632-945135e6fc97" />


