### PR TITLE
DonationReminderV3: properly show up the numbers in the chip in large font size

### DIFF
--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -715,20 +716,19 @@ fun <T : Number> OptionSelector(
                 if (currentOption is OptionItem.Preset) {
                     val isSelected = (option.selectedSource is SelectedSource.Preset) &&
                             (option.selectedSource.key == index)
-
                     Button(
                         colors = ButtonDefaults.buttonColors(
                             containerColor = if (isSelected) WikipediaTheme.colors.progressiveColor
                             else WikipediaTheme.colors.backgroundColor
                         ),
                         onClick = { onOptionSelected(currentOption, SelectedSource.Preset(index)) },
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f, fill = false)
                     ) {
                         Text(
+                            modifier = Modifier.fillMaxWidth(),
                             text = currentOption.displayText,
-                            maxLines = 1,
-                            color = if (isSelected) WikipediaTheme.colors.paperColor
-                            else WikipediaTheme.colors.primaryColor,
+                            textAlign = TextAlign.Center,
+                            color = if (isSelected) WikipediaTheme.colors.paperColor else WikipediaTheme.colors.primaryColor,
                             style = MaterialTheme.typography.titleMedium
                         )
                     }
@@ -736,6 +736,7 @@ fun <T : Number> OptionSelector(
             }
             if (showArticleLabel) {
                 Text(
+                    modifier = Modifier.weight(1f),
                     text = stringResource(R.string.donation_reminders_settings_article_number_selection_label),
                     style = MaterialTheme.typography.bodyLarge,
                     color = WikipediaTheme.colors.primaryColor,


### PR DESCRIPTION
### What does this do?
Removes the `maxLines` and makes sure the buttons are equally distributed.

<img width="200" alt="Screenshot_20260904_094412" src="https://github.com/user-attachments/assets/9f1aaf34-da17-4899-a3c1-a27ac6408b01" />
<img width="200" alt="Screenshot_20260904_094401" src="https://github.com/user-attachments/assets/af0f3430-67ba-4716-876e-3cd105ac4cbc" />
<img width="200" alt="Screenshot_20260904_094345" src="https://github.com/user-attachments/assets/aaff8cc4-44f7-436c-a114-49f8bfac30d0" />



**Phabricator:**
https://phabricator.wikimedia.org/T435345#12287467
