### PR TITLE
DonationReminderV3: add the missing string for "Update reminder" action

### DIFF
--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -2160,6 +2160,7 @@
   <string name="donation_reminders_snackbar_modify_button_label">Label for the button that allows the user to modify the donation reminder.</string>
   <string name="donation_reminders_settings_article_number_selection_label">Label for the button row that allows a user to set the desired number of article for a donation reminder.</string>
   <string name="donation_reminders_settings_custom_amount_label">Placeholder text for the custom amount.</string>
+  <string name="donation_reminders_settings_update_reminder_button">Label for the button that allows the user to update the donation reminder.</string>
   <string name="donation_reminders_beta_label">Header label to indicate the screen is part of a Beta.</string>
   <string name="donation_reminders_wrap_up_title">Title of the wrap up message card for the donation reminder.</string>
   <string name="donation_reminders_wrap_up_message">Message of the wrap up message card for the donation reminder.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2404,6 +2404,7 @@
     <string name="donation_reminders_snackbar_modify_button_label">Modify</string>
     <string name="donation_reminders_settings_article_number_selection_label">Articles</string>
     <string name="donation_reminders_settings_custom_amount_label">Custom amount</string>
+    <string name="donation_reminders_settings_update_reminder_button">Update reminder</string>
     <string name="donation_reminders_beta_label">Beta</string>
     <string name="donation_reminders_wrap_up_title">That\'s a wrap on donation reminders</string>
     <string name="donation_reminders_wrap_up_message">Thanks for testing donation reminders based on the articles you read. Your feedback decides if this becomes a permanent way to give on Wikipedia. It only takes a minute, and no donation is required.</string>


### PR DESCRIPTION
### What does this do?
For the V3 version, we will keep showing the button if coming from Settings.
