### PR TITLE
Suppress Evergreen account temporarily

### DIFF
--- a/app/src/main/java/org/wikipedia/createaccount/CreateAccountEncourageViewModel.kt
+++ b/app/src/main/java/org/wikipedia/createaccount/CreateAccountEncourageViewModel.kt
@@ -54,6 +54,7 @@ class CreateAccountEncourageViewModel : ViewModel() {
         private const val RETURN_DAYS_REQUIRED = 2
 
         suspend fun shouldShow(): Boolean {
+            return false // TODO: remove this after getting translations from translatewiki
             if (AccountUtil.isLoggedIn && !AccountUtil.isTemporaryAccount) {
                 return false
             }


### PR DESCRIPTION
### What does this do?
Since we do not have enough translations from volunteers for this newly introduced screen, we should hide it until we have enough translations.
