### PR TITLE
DonationReminderV3: change the abTestName to donationReminderV3 to get reassigned

### DIFF
--- a/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderAbTest.kt
+++ b/app/src/main/java/org/wikipedia/donate/donationreminder/DonationReminderAbTest.kt
@@ -2,7 +2,7 @@ package org.wikipedia.donate.donationreminder
 
 import org.wikipedia.analytics.ABTest
 
-class DonationReminderAbTest : ABTest("donationReminder", GROUP_SIZE_3) {
+class DonationReminderAbTest : ABTest("donationReminderV3", GROUP_SIZE_3) {
 
     override fun getGroupName(): String {
         return when (group) {


### PR DESCRIPTION
### What does this do?
If the user was assigned to a group before V3, then the existing user will not be able to be assigned to group C, since the group size has changed from `2` to `3`.

